### PR TITLE
ncat datagram connect only if not in recvonly mode

### DIFF
--- a/ncat/ncat_listen.c
+++ b/ncat/ncat_listen.c
@@ -818,7 +818,9 @@ static int ncat_listen_dgram(int proto)
          * We're using connected udp. This has the down side of only
          * being able to handle one udp client at a time
          */
-        Connect(socket_n, &remotess.sockaddr, sslen);
+        /* Connect only if not recvonly */
+        if (!o.recvonly)
+            Connect(socket_n, &remotess.sockaddr, sslen);
 
         /* clean slate for buf */
         zmem(buf, sizeof(buf));


### PR DESCRIPTION
I am trying to use ncat to listen on a unix domain datagram socket in
receive only mode. I am using this as a simple syslog receiving server for
testing.

When I use the following command:

`ncat --recv-only -luU /tmp/test.socket`

and then try to log a message using logger with the following command:

`logger -d -u /tmp/test.socket "this is a test"`

I get the following error on the ncat side:

`connect: Invalid argument`

From looking at the ncat_listen.c code it looks like ncat tries to connect
a sending socket even when in recv-only mode. I added a check to connect
only when not in recv-only mode and then ncat worked as expected.

I've also sent this out a few days back to the dev mailing list:  http://seclists.org/nmap-dev/2014/q4/343 .

Hope this fix is something you can merge in.

Thanks,

Guy