### PR TITLE
Added Adobe LiveCycle Console fingerprint

### DIFF
--- a/nselib/data/http-default-accounts-fingerprints.lua
+++ b/nselib/data/http-default-accounts-fingerprints.lua
@@ -167,6 +167,23 @@ table.insert(fingerprints, {
 })
 
 table.insert(fingerprints, {
+  name = "Adobe LiveCycle Management Console",
+  category = "web",
+  paths = {
+    {path = "/lc/system/console"}
+  },
+  target_check = function (host, port, path, response)
+    return http_auth_realm(response) == "OSGi Management Console"
+  end,
+  login_combos = {
+    {username = "admin", password = "admin"}
+  },
+  login_check = function (host, port, path, user, pass)
+    return try_http_basic_login(host, port, path, user, pass, false)
+  end
+})
+
+table.insert(fingerprints, {
   name = "Apache Axis2",
   category = "web",
   paths = {

--- a/nselib/data/http-fingerprints.lua
+++ b/nselib/data/http-fingerprints.lua
@@ -5145,7 +5145,7 @@ table.insert(fingerprints, {
     },
     matches = {
       {
-        match = 'OSGi Mangement Console',
+        match = 'OSGi Management Console',
         output = 'Adobe LiveCycle Managment Console'
       }
     }

--- a/nselib/data/http-fingerprints.lua
+++ b/nselib/data/http-fingerprints.lua
@@ -5139,6 +5139,22 @@ table.insert(fingerprints, {
     category = 'management',
     probes = {
       {
+        path = '/lc/system/console',
+        method = 'HEAD'
+      },
+    },
+    matches = {
+      {
+        match = 'OSGi Mangement Console',
+        output = 'Adobe LiveCycle Managment Console'
+      }
+    }
+  });
+
+table.insert(fingerprints, {
+    category = 'management',
+    probes = {
+      {
         path = '/dm-albums/dm-albums.php',
         method = 'HEAD'
       }


### PR DESCRIPTION
Added fingerprint for Adobe LiveCycle Console. The scripting console typically has a default password admin:admin and allows for remote shell per my blog @ http://www.rvrsh3ll.net/blog/offensive/leveraging-adobe-livecycle/