### PR TITLE
Fix NULL pointer dereference

### DIFF
--- a/portlist.cc
+++ b/portlist.cc
@@ -910,6 +910,11 @@ bool PortList::isTCPwrapped(u16 portno) const {
       log_write(LOG_STDOUT, "PortList::isTCPwrapped(%d) requested but port has not been service scanned yet", portno);
     }
     return false;
+  } else if (port->service->name == NULL) {
+    if (o.debugging > 1) {
+      log_write(LOG_STDOUT, "PortList::isTCPwrapped(%d) requested but service has no name", portno);
+    }
+    return false;
   } else {
     return (strcmp(port->service->name,"tcpwrapped")==0);
   }


### PR DESCRIPTION
This was triggered when running a scan without `-sV` but with a script that identifies a service (in my case, `enip-info.nse`), causing nmap to segfault.