### PR TITLE
Add an `ls` module to unify arguments and outputs for `-ls` scripts

### DIFF
--- a/nselib/ls.lua
+++ b/nselib/ls.lua
@@ -195,7 +195,7 @@ function end_vol(output)
     vol["info"] = output["curvol"]["info"]
     empty = false
   end
-  if config("empty") or not empty then
+  if not empty or config("empty") then
     table.insert(output["volumes"], vol)
   end
   output["total"]["files"] = output["total"]["files"] + output["curvol"]["count"]
@@ -204,11 +204,27 @@ function end_vol(output)
 end
 
 function end_listing(output)
+  local empty = true
   if #output["errors"] == 0 then
     output["errors"] = nil
+  else
+    empty = false
   end
   if #output["info"] == 0 then
     output["info"] = nil
+  else
+    empty = false
+  end
+  if #output["volumes"] == 0 then
+    output["volumes"] = nil
+    output["total"] = nil
+  else
+    empty = false
+  end
+  if empty then
+    return nil
+  else
+    return output
   end
 end
 

--- a/nselib/ls.lua
+++ b/nselib/ls.lua
@@ -1,0 +1,156 @@
+---
+-- Implements reports of file listings.
+--
+-- TODO: report files as structured data with the same human readable
+-- output.
+--
+-- Scripts that use this module can use the script arguments listed below:
+-- @args ls.maxdepth [optional] the maximum depth to recurse into a directory
+--                   (default: no recursion).
+-- @args ls.maxfiles [optional] the maximum number of files to return
+--                   (default: 1, no recursion).
+-- @args ls.pattern  [optional] return only files that match the given pattern
+-- @args ls.checksum [optional] download each file and calculate a SHA1 checksum
+-- @args ls.errors   [optional] report connection errors
+--
+-- These arguments can either be set for all the scripts using this
+-- module (--script-args ls.arg=value) or for one particular script
+-- (--script-args afp-ls.arg=value). If both are specified for the
+-- same argument, the script-specific value is used.
+--
+-- @author Pierre Lalet <pierre@droids-corp.org>
+-- @copyright Same as Nmap--See http://nmap.org/book/man-legal.html
+-----------------------------------------------------------------------
+
+local LIBRARY_NAME = "ls"
+
+local stdnse = require "stdnse"
+local tab = require "tab"
+local table = require "table"
+
+_ENV = stdnse.module("ls", stdnse.seeall)
+
+local config_values = {
+  ["maxdepth"] = 1,
+  ["maxfiles"] = 10,
+  ["pattern"] = "*",
+  ["checksum"] = false,
+  ["errors"] = false,
+}
+local config_types = {
+  ["pattern"] = "string",
+  ["maxdepth"] = "number",
+  ["maxfiles"] = "number",
+  ["checksum"] = "boolean",
+  ["errors"] = "boolean",
+}
+
+local function convert_arg(argval, argtype)
+  if argtype == "number" then
+    return tonumber(argval)
+  elseif argtype == "boolean" then
+    if argval == "true" or argval == "yes" then
+      return true
+    else
+      return false
+    end
+  end
+  return argval
+end
+
+for argname, argtype in pairs(config_types) do
+  local argval = stdnse.get_script_args(LIBRARY_NAME .. "." .. argname)
+  if argval ~= nil then
+    config_values[argname] = convert_arg(argval, argtype)
+  end
+end
+
+function config(argname)
+  -- get a config value from (by order or priority):
+  --   1. a script-specific argument (e.g., http-ls.*)
+  --   2. a module argument (ls.*)
+  --   3. the default value
+  local argval = stdnse.get_script_args(stdnse.getid() .. "." .. argname)
+  if argval == nil then
+    return config_values[argname]
+  else
+    return convert_arg(argval, config_types[argname])
+  end
+end
+
+function new_listing()
+  local output = {}
+  output['curvol'] = nil
+  return output
+end
+
+function new_vol(output, name, hasperms)
+  local curvol = {}
+  local files = tab.new()
+  local i = 1
+  if hasperms then
+     tab.add(files, 1, "PERMISSION")
+     tab.add(files, 2, "UID")
+     tab.add(files, 3, "GID")
+     i = 4
+  end
+  tab.add(files, i, "SIZE")
+  tab.add(files, i + 1, "TIME")
+  tab.add(files, i + 2, "FILENAME")
+  if config("checksum") then
+    tab.add(files, i + 3, "CHECKSUM")
+  end
+  tab.nextrow(files)
+  curvol['files'] = files
+  curvol['name'] = name
+  curvol['count'] = 0
+  curvol['errors'] = {}
+  output['curvol'] = curvol
+end
+
+function report_error(output, err)
+  stdnse.debug1(err)
+  if config('errors') then
+    if output["curvol"] == nil then
+      table.insert(output, err)
+    else
+       table.insert(output["curvol"]["errors"], err)
+    end
+  end
+end
+
+function report_info(output, info)
+  stdnse.debug1(info)
+  if output["curvol"] == nil then
+    table.insert(output, info)
+  else
+    table.insert(output["curvol"]["info"], info)
+  end
+end
+
+function add_file(output, file)
+  -- returns true iff script should continue
+  local files = output["curvol"]["files"]
+  for i, info in ipairs(file) do
+    tab.add(files, i, info)
+  end
+  output["curvol"]["count"] = output["curvol"]["count"] + 1
+  tab.nextrow(files)
+  return (config("maxfiles") == 0 or config("maxfiles") == nil
+	    or config("maxfiles") > output["curvol"]["count"])
+end
+
+function end_vol(output)
+  local vol = {volume = output["curvol"]["name"],
+	       files = "\n" .. tab.dump(output["curvol"]["files"])}
+  if #output["curvol"]["errors"] ~= 0 then
+    vol["error"] = output["curvol"]["errors"]
+  end
+  if #output["curvol"]["info"] ~= 0 then
+    vol["info"] = output["curvol"]["info"]
+  end
+  table.insert(output, vol)
+  output["curvol"] = nil
+end
+
+return _ENV

--- a/nselib/ls.lua
+++ b/nselib/ls.lua
@@ -70,6 +70,8 @@ end
 -- 1. a script-specific argument (e.g., http-ls.argname)
 -- 2. a module argument (ls.argname)
 -- 3. the default value
+-- @param argname The name of the configuration parameter
+-- @return The configuration value
 function config(argname)
   local argval = stdnse.get_script_args(stdnse.getid() .. "." .. argname)
   if argval == nil then
@@ -80,6 +82,7 @@ function config(argname)
 end
 
 --- Create a new script output.
+-- @return The ls output object to be passed to other functions
 function new_listing()
   local output = stdnse.output_table()
   output['curvol'] = nil
@@ -94,6 +97,9 @@ function new_listing()
 end
 
 --- Create a new volume within the provided output
+-- @param output The ls output object, from new_listing()
+-- @param name The name of the volume
+-- @param hasperms Boolean true if the volume listing will include permissions
 function new_vol(output, name, hasperms)
   local curvol = stdnse.output_table()
   local files = tab.new()
@@ -123,6 +129,8 @@ end
 
 --- Report an error, using stdnse.debug1() and (depending on the
 -- configuration settings) adding the error message to the output.
+-- @param output The ls output object, from new_listing()
+-- @param err The error message to report
 function report_error(output, err)
   if output["curvol"] == nil then
     stdnse.debug1(string.format("error: %s", err))
@@ -141,6 +149,8 @@ end
 
 --- Report information, using stdnse.debug1() and adding the message
 -- to the output.
+-- @param output The ls output object, from new_listing()
+-- @param info The info message to report
 function report_info(output, info)
   if output["curvol"] == nil then
     stdnse.debug1(string.format("info: %s", info))
@@ -177,6 +187,8 @@ local function get_size(size)
 end
 
 --- Add a new file to the current volume.
+-- @param output The ls output object, from new_listing()
+-- @param file A table containing the information about the file
 function add_file(output, file)
   -- returns true iff script should continue
   local files = output["curvol"]["files"]
@@ -208,6 +220,7 @@ end
 
 --- Close the current volume. It is mandatory to call this function
 -- before calling new_vol() again or before calling end_listing().
+-- @param output The ls output object, from new_listing()
 function end_vol(output)
   local vol = {["volume"] = output["curvol"]["name"]}
   local empty = true
@@ -285,6 +298,9 @@ end
 
 --- Close current listing. Return buth the structured and the human
 -- readable outputs.
+-- @param output The ls output object, from new_listing()
+-- @return Structured output
+-- @return Human readable output
 function end_listing(output)
   assert(output["curvol"] == nil)
   local line

--- a/nselib/ls.lua
+++ b/nselib/ls.lua
@@ -9,7 +9,11 @@
 --                   (default: no recursion).
 -- @args ls.maxfiles [optional] the maximum number of files to return
 --                   (default: 1, no recursion).
--- @args ls.checksum [optional] download each file and calculate a SHA1 checksum
+-- @args ls.checksum [optional] download each file and calculate a
+--                   SHA1 checksum. Although this is a module
+--                   argument, the implementation is done in each
+--                   script and is currently only supported by smb-ls
+--                   and http-ls
 -- @args ls.errors   [optional] report errors
 -- @args ls.empty    [optional] report empty volumes (with no information
 --                   or error)

--- a/nselib/ls.lua
+++ b/nselib/ls.lua
@@ -76,7 +76,7 @@ function config(argname)
 end
 
 function new_listing()
-  local output = {}
+  local output = stdnse.output_table()
   output['curvol'] = nil
   output['volumes'] = {}
   output['errors'] = {}
@@ -89,7 +89,7 @@ function new_listing()
 end
 
 function new_vol(output, name, hasperms)
-  local curvol = {}
+  local curvol = stdnse.output_table()
   local files = tab.new()
   local i = 1
   if hasperms then
@@ -105,8 +105,8 @@ function new_vol(output, name, hasperms)
     tab.add(files, i + 3, "CHECKSUM")
   end
   tab.nextrow(files)
-  curvol['files'] = files
   curvol['name'] = name
+  curvol['files'] = files
   curvol['count'] = 0
   curvol['bytes'] = 0
   curvol['errors'] = {}
@@ -145,13 +145,41 @@ local units = {
   ["m"] = 1048576,
   ["g"] = 1073741824,
   ["t"] = 1099511627776,
+  ["p"] = 1125899906842624,
 }
+
+local function get_size(size)
+  local bsize
+  bsize = tonumber(size)
+  if bsize == nil then
+    local unit = string.lower(string.sub(size, -1, -1))
+    bsize = tonumber(string.sub(size, 0, -2))
+    if units[unit] ~= nil and bsize ~= nil then
+      bsize = bsize * units[unit]
+    else
+      bsize = nil
+    end
+  end
+  return bsize
+end
 
 function add_file(output, file)
   -- returns true iff script should continue
   local files = output["curvol"]["files"]
-  local size, bsize
+  local size, isize
+  if output["curvol"]["hasperms"] then
+    isize = 4
+  else
+    isize = 1
+  end
   for i, info in ipairs(file) do
+    if i == isize then
+      size = get_size(info)
+      if size then
+	output["curvol"]["bytes"] = output["curvol"]["bytes"] + size
+	info = size
+      end
+    end
     if type(info) == "number" then
       tab.add(files, i, tostring(info))
     else
@@ -160,22 +188,6 @@ function add_file(output, file)
   end
   tab.nextrow(files)
   output["curvol"]["count"] = output["curvol"]["count"] + 1
-  if output["curvol"]["hasperms"] then
-    size = file[4]
-  else
-    size = file[1]
-  end
-  bsize = tonumber(size)
-  if bsize == nil then
-    local unit = string.lower(string.sub(size, -1, -1))
-    bsize = tonumber(string.sub(size, 0, -2))
-    if units[unit] ~= nil and bsize ~= nil then
-      bsize = bsize * units[unit]
-    else
-      bsize = 0
-    end
-  end
-  output["curvol"]["bytes"] = output["curvol"]["bytes"] + bsize
   return (config("maxfiles") == 0 or config("maxfiles") == nil
 	    or config("maxfiles") > output["curvol"]["count"])
 end
@@ -184,7 +196,7 @@ function end_vol(output)
   local vol = {["volume"] = output["curvol"]["name"]}
   local empty = true
   if #output["curvol"]["files"] ~= 1 then
-    vol["files"] = "\n" .. tab.dump(output["curvol"]["files"])
+    vol["files"] = output["curvol"]["files"]
     empty = false
   end
   if #output["curvol"]["errors"] ~= 0 then
@@ -203,28 +215,105 @@ function end_vol(output)
   output["curvol"] = nil
 end
 
-function end_listing(output)
-  local empty = true
-  if #output["errors"] == 0 then
-    output["errors"] = nil
-  else
-    empty = false
+local function files_to_structured(files)
+  local result = {}
+  local fields = table.remove(files, 1)
+  for i, file in ipairs(files) do
+    result[i] = stdnse.output_table()
+    for j, value in ipairs(file) do
+      result[i][string.lower(fields[j])] = value
+    end
   end
+  return result
+end
+
+local function files_to_readable(files)
+  local outtab = tab.new()
+  local fields = files[1]
+  local file, size, isize, unit, units, outfile
+  tab.addrow(outtab, unpack(fields))
+  for i, field in ipairs(fields) do
+    if string.lower(field) == "size" then
+      isize = i
+      break
+    end
+  end
+  for i = 2, #files do
+    file = files[i]
+    outfile = {}
+    for j, value in ipairs(file) do
+      outfile[j] = value
+    end
+    if config("human") then
+      size = tonumber(outfile[isize])
+      unit = nil
+      units = {"k", "M", "G", "T", "P"}
+      if size ~= nil then
+	while size > 1024 and #units > 0 do
+	  unit = table.remove(units, 1)
+	  size = size / 1024
+	end
+	if unit == nil then
+	  outfile[isize] = tostring(size)
+	else
+	  outfile[isize] = string.format("%.1f %s", size, unit)
+	end
+      end
+    end
+    tab.addrow(outtab, unpack(outfile))
+  end
+  return tab.dump(outtab)
+end
+
+function end_listing(output)
+  assert(output["curvol"] == nil)
+  local line
+  local text = "\n"
+  local empty = true
   if #output["info"] == 0 then
     output["info"] = nil
   else
+    for _, line in ipairs(output["info"]) do
+      text = text .. line .. "\n"
+    end
+    empty = false
+  end
+  if #output["errors"] == 0 then
+    output["errors"] = nil
+  else
+    for _, line in ipairs(output["errors"]) do
+      text = text .. "ERROR: " .. line .. "\n"
+    end
     empty = false
   end
   if #output["volumes"] == 0 then
     output["volumes"] = nil
     output["total"] = nil
   else
+    for _, volume in ipairs(output["volumes"]) do
+      text = text .. "Volume " .. volume["volume"] .. "\n"
+      if volume["info"] then
+	for _, line in ipairs(volume["info"]) do
+	  text = "  " .. text .. line .. "\n"
+	end
+      end
+      if volume["errors"] then
+	for _, line in ipairs(volume["errors"]) do
+	  text = "  " .. text .. "ERROR: " .. line .. "\n"
+	end
+      end
+      if volume["files"] then
+	text = text .. files_to_readable(volume["files"])
+	volume["files"] = files_to_structured(volume["files"])
+      end
+      text = text .. "\n"
+    end
     empty = false
   end
   if empty then
     return nil
   else
-    return output
+    return output, text
   end
 end
 

--- a/nselib/ls.lua
+++ b/nselib/ls.lua
@@ -27,6 +27,7 @@
 local LIBRARY_NAME = "ls"
 
 local stdnse = require "stdnse"
+local string = require "string"
 local tab = require "tab"
 local table = require "table"
 

--- a/nselib/ls.lua
+++ b/nselib/ls.lua
@@ -9,7 +9,6 @@
 --                   (default: no recursion).
 -- @args ls.maxfiles [optional] the maximum number of files to return
 --                   (default: 1, no recursion).
--- @args ls.pattern  [optional] return only files that match the given pattern
 -- @args ls.checksum [optional] download each file and calculate a SHA1 checksum
 -- @args ls.errors   [optional] report errors
 -- @args ls.empty    [optional] report empty volumes (with no information
@@ -36,7 +35,6 @@ _ENV = stdnse.module("ls", stdnse.seeall)
 local config_values = {
   ["maxdepth"] = 1,
   ["maxfiles"] = 10,
-  ["pattern"] = "*",
   ["checksum"] = false,
   ["errors"] = false,
   ["empty"] = false,

--- a/nselib/ls.lua
+++ b/nselib/ls.lua
@@ -125,9 +125,10 @@ end
 -- configuration settings) adding the error message to the output.
 function report_error(output, err)
   if output["curvol"] == nil then
-    stdnse.debug1("error: " .. err)
+    stdnse.debug1(string.format("error: %s", err))
   else
-    stdnse.debug1("error [" .. output["curvol"]["name"] .. "]: " .. err)
+    stdnse.debug1(string.format("error [%s]: %s",
+				output["curvol"]["name"], err))
   end
   if config('errors') then
     if output["curvol"] == nil then
@@ -142,10 +143,11 @@ end
 -- to the output.
 function report_info(output, info)
   if output["curvol"] == nil then
-    stdnse.debug1("info: " .. info)
+    stdnse.debug1(string.format("info: %s", info))
     table.insert(output["info"], info)
   else
-    stdnse.debug1("info [" .. output["curvol"]["name"] .. "]: " .. info)
+    stdnse.debug1(string.format("info [%s]: %s",
+				output["curvol"]["name"],  info))
     table.insert(output["curvol"]["info"], info)
   end
 end
@@ -286,13 +288,13 @@ end
 function end_listing(output)
   assert(output["curvol"] == nil)
   local line
-  local text = "\n"
+  local text = {}
   local empty = true
   if #output["info"] == 0 then
     output["info"] = nil
   else
     for _, line in ipairs(output["info"]) do
-      text = text .. line .. "\n"
+      text[#text + 1] = line
     end
     empty = false
   end
@@ -300,7 +302,7 @@ function end_listing(output)
     output["errors"] = nil
   else
     for _, line in ipairs(output["errors"]) do
-      text = text .. "ERROR: " .. line .. "\n"
+      text[#text + 1] = string.format("ERROR: %s", line)
     end
     empty = false
   end
@@ -309,29 +311,29 @@ function end_listing(output)
     output["total"] = nil
   else
     for _, volume in ipairs(output["volumes"]) do
-      text = text .. "Volume " .. volume["volume"] .. "\n"
+      text[#text + 1] = string.format("Volume %s", volume["volume"])
       if volume["info"] then
 	for _, line in ipairs(volume["info"]) do
-	  text = "  " .. text .. line .. "\n"
+	  text[#text + 1] = string.format("  %s", line)
 	end
       end
       if volume["errors"] then
 	for _, line in ipairs(volume["errors"]) do
-	  text = "  " .. text .. "ERROR: " .. line .. "\n"
+	  text[#text + 1] = string.format("  ERROR: %s", line)
 	end
       end
       if volume["files"] then
-	text = text .. files_to_readable(volume["files"])
+	text[#text + 1] = files_to_readable(volume["files"])
 	volume["files"] = files_to_structured(volume["files"])
       end
-      text = text .. "\n"
+      text[#text + 1] = ""
     end
     empty = false
   end
   if empty then
     return nil
   else
-    return output, text
+    return output, table.concat(text, "\n")
   end
 end
 

--- a/scripts/afp-ls.nse
+++ b/scripts/afp-ls.nse
@@ -11,45 +11,90 @@ The output is intended to resemble the output of <code>ls</code>.
 
 ---
 --
---@output
+-- @usage
+-- nmap -sS -sV -p 548 --script=afp-ls target
+--
+-- @args afp-ls.maxfiles maximum number of files to report (default 10)
+--
+-- @output
 -- PORT    STATE SERVICE
 -- 548/tcp open  afp     syn-ack
 -- | afp-ls:
--- |   Macintosh HD
--- |     PERMISSION  UID  GID  SIZE    TIME              FILENAME
--- |     -rw-r--r--  501  80   15364   2010-06-13 17:52  .DS_Store
--- |     ----------  0    80   0       2009-10-05 07:42  .file
--- |     drwx------  501  20   0       2009-11-04 17:28  .fseventsd
--- |     -rw-------  0    0    393216  2010-06-14 01:49  .hotfiles.btree
--- |     drwx------  0    80   0       2009-11-04 18:19  .Spotlight-V100
--- |     d-wx-wx-wx  0    80   0       2009-11-04 18:25  .Trashes
--- |     drwxr-xr-x  0    0    0       2009-05-18 21:29  .vol
--- |     drwxrwxr-x  0    80   0       2009-04-28 00:06  Applications
--- |     drwxr-xr-x  0    0    0       2009-05-18 21:43  bin
--- |     drwxr-xr-x  501  80   0       2010-08-10 22:55  bundles
--- |   Patrik Karlsson's Public Folder
--- |     PERMISSION  UID  GID  SIZE  TIME              FILENAME
--- |     -rw-------  501  20   6148  2010-12-27 23:45  .DS_Store
--- |     -rw-r--r--  501  20   0     2007-07-24 21:17  .localized
--- |     drwx-wx-wx  501  20   0     2009-06-19 04:01  Drop Box
--- |   patrik
--- |     PERMISSION  UID  GID  SIZE   TIME              FILENAME
--- |     -rw-------  501  20   11281  2010-06-14 22:51  .bash_history
--- |     -rw-r--r--  501  20   33     2011-01-19 20:11  .bashrc
--- |     -rw-------  501  20   3      2007-07-24 21:17  .CFUserTextEncoding
--- |     drwx------  501  20   0      2010-09-12 14:52  .config
--- |     drwx------  501  20   0      2010-09-12 12:29  .cups
--- |     -rw-r--r--  501  20   15364  2010-06-13 18:34  .DS_Store
--- |     drwxr-xr-x  501  20   0      2010-09-12 14:13  .fontconfig
--- |     -rw-------  501  20   102    2010-06-14 01:46  .lesshst
--- |     -rw-r--r--  501  20   241    2010-06-14 01:45  .profile
--- |     -rw-------  501  20   218    2010-09-12 16:35  .recently-used.xbel
+-- |   Information retrieved as patrik
+-- |   Volume Macintosh HD
+-- |   maxfiles limit reached (10)
+-- |   PERMISSION  UID  GID  SIZE    TIME              FILENAME
+-- |   -rw-r--r--  501  80   15364   2010-06-13 17:52  .DS_Store
+-- |   ----------  0    80   0       2009-10-05 07:42  .file
+-- |   drwx------  501  20   0       2009-11-04 17:28  .fseventsd
+-- |   -rw-------  0    0    393216  2010-06-14 01:49  .hotfiles.btree
+-- |   drwx------  0    80   0       2009-11-04 18:19  .Spotlight-V100
+-- |   d-wx-wx-wx  0    80   0       2009-11-04 18:25  .Trashes
+-- |   drwxr-xr-x  0    0    0       2009-05-18 21:29  .vol
+-- |   drwxrwxr-x  0    80   0       2009-04-28 00:06  Applications
+-- |   drwxr-xr-x  0    0    0       2009-05-18 21:43  bin
+-- |   drwxr-xr-x  501  80   0       2010-08-10 22:55  bundles
 -- |
--- |   Information retrieved as: patrik
--- |_  Output restricted to 10 entries per volume. (See afp-ls.maxfiles)
+-- |   Volume Patrik Karlsson's Public Folder
+-- |   PERMISSION  UID  GID  SIZE  TIME              FILENAME
+-- |   -rw-------  501  20   6148  2010-12-27 23:45  .DS_Store
+-- |   -rw-r--r--  501  20   0     2007-07-24 21:17  .localized
+-- |   drwx-wx-wx  501  20   0     2009-06-19 04:01  Drop Box
+-- |
+-- |   Volume patrik
+-- |   maxfiles limit reached (10)
+-- |   PERMISSION  UID  GID  SIZE   TIME              FILENAME
+-- |   -rw-------  501  20   11281  2010-06-14 22:51  .bash_history
+-- |   -rw-r--r--  501  20   33     2011-01-19 20:11  .bashrc
+-- |   -rw-------  501  20   3      2007-07-24 21:17  .CFUserTextEncoding
+-- |   drwx------  501  20   0      2010-09-12 14:52  .config
+-- |   drwx------  501  20   0      2010-09-12 12:29  .cups
+-- |   -rw-r--r--  501  20   15364  2010-06-13 18:34  .DS_Store
+-- |   drwxr-xr-x  501  20   0      2010-09-12 14:13  .fontconfig
+-- |   -rw-------  501  20   102    2010-06-14 01:46  .lesshst
+-- |   -rw-r--r--  501  20   241    2010-06-14 01:45  .profile
+-- |   -rw-------  501  20   218    2010-09-12 16:35  .recently-used.xbel
+-- |_
 --
--- @args afp-ls.maxfiles If set, limits the amount of files returned by the script (default 10).
---
+-- @xmloutput
+-- <table key="volumes">
+--   <table>
+--     <elem key="volume">Storage01</elem>
+--     <table key="files">
+--       <table>
+--         <elem key="permission">drwx-&#45;&#45;&#45;&#45;&#45;</elem>
+--         <elem key="uid">0</elem>
+--         <elem key="gid">100</elem>
+--         <elem key="size">0</elem>
+--         <elem key="time">2015-06-26 17:17</elem>
+--         <elem key="filename">Backups</elem>
+--       </table>
+--       <table>
+--         <elem key="permission">drwxr-xr-x</elem>
+--         <elem key="uid">0</elem>
+--         <elem key="gid">37</elem>
+--         <elem key="size">0</elem>
+--         <elem key="time">2015-06-19 06:36</elem>
+--         <elem key="filename">Network Trash Folder</elem>
+--       </table>
+--       <table>
+--         <elem key="permission">drwxr-xr-x</elem>
+--         <elem key="uid">0</elem>
+--         <elem key="gid">37</elem>
+--         <elem key="size">0</elem>
+--         <elem key="time">2015-06-19 06:36</elem>
+--         <elem key="filename">Temporary Items</elem>
+--       </table>
+--     </table>
+--   </table>
+-- </table>
+-- <table key="info">
+--   <elem>information retrieved as nil</elem>
+-- </table>
+-- <table key="total">
+--   <elem key="files">3</elem>
+--   <elem key="bytes">0</elem>
+-- </table>
 
 -- Version 0.1
 -- Created 04/03/2011 - v0.1 - created by Patrik Karlsson

--- a/scripts/afp-ls.nse
+++ b/scripts/afp-ls.nse
@@ -105,7 +105,7 @@ license = "Same as Nmap--See http://nmap.org/book/man-legal.html"
 categories = {"discovery", "safe"}
 dependencies = {"afp-brute"}
 
-portrule = shortport.portnumber(548, "tcp")
+portrule = shortport.port_or_service(548, {"afp"})
 
 action = function(host, port)
 

--- a/scripts/afp-ls.nse
+++ b/scripts/afp-ls.nse
@@ -147,9 +147,8 @@ action = function(host, port)
 
     -- stop after first successful attempt
     if #output["volumes"] > 0 then
-      ls.end_listing(output)
       ls.report_info(output, ("information retrieved as %s"):format(username))
-      return output
+      return ls.end_listing(output)
     end
   end
   return

--- a/scripts/http-ls.nse
+++ b/scripts/http-ls.nse
@@ -7,39 +7,108 @@ local ls = require "ls"
 description = [[
 Shows the content of an "index" Web page.
 
-Example:
-
-    $ nmap -n -p 80 --script http-ls test-debit.free.fr
-
-    Starting Nmap 6.47SVN ( http://nmap.org ) at 2015-05-01 16:43 CEST
-    Nmap scan report for test-debit.free.fr (212.27.42.153)
-    Host is up (0.019s latency).
-    PORT   STATE SERVICE
-    80/tcp open  http
-    | http-ls:
-    | Volume /
-    | maxfiles limit reached (10)
-    | SIZE        TIME               FILENAME
-    | 524288      02-Oct-2013 18:26  512.rnd
-    | 1048576     02-Oct-2013 18:26  1024.rnd
-    | 2097152     02-Oct-2013 18:26  2048.rnd
-    | 4194304     02-Oct-2013 18:26  4096.rnd
-    | 8388608     02-Oct-2013 18:26  8192.rnd
-    | 16777216    02-Oct-2013 18:26  16384.rnd
-    | 33554432    02-Oct-2013 18:26  32768.rnd
-    | 67108864    02-Oct-2013 18:26  65536.rnd
-    | 1073741824  03-Oct-2013 16:46  1048576.rnd
-    | 188         03-Oct-2013 17:15  README.html
-    |_
-
 TODO:
-  - support more page formats
-
+  - add support for more page formats
 ]]
 
 author = "Pierre Lalet"
 license = "Same as Nmap--See http://nmap.org/book/man-legal.html"
 categories = {"default", "discovery", "safe"}
+
+---
+-- @usage
+-- nmap -n -p 80 --script http-ls test-debit.free.fr
+--
+-- @args http-ls.checksum compute a checksum for each listed file
+--       (default: false)
+-- @args http-ls.maxdepth maximum recursion level (default: no recursion)
+-- @args http-ls.maxfiles maximum number of files to report (default: 10)
+-- @args http-ls.url base URL path to use (default: /)
+--
+-- @output
+-- PORT   STATE SERVICE
+-- 80/tcp open  http
+-- | http-ls:
+-- | Volume /
+-- | maxfiles limit reached (10)
+-- | SIZE        TIME               FILENAME
+-- | 524288      02-Oct-2013 18:26  512.rnd
+-- | 1048576     02-Oct-2013 18:26  1024.rnd
+-- | 2097152     02-Oct-2013 18:26  2048.rnd
+-- | 4194304     02-Oct-2013 18:26  4096.rnd
+-- | 8388608     02-Oct-2013 18:26  8192.rnd
+-- | 16777216    02-Oct-2013 18:26  16384.rnd
+-- | 33554432    02-Oct-2013 18:26  32768.rnd
+-- | 67108864    02-Oct-2013 18:26  65536.rnd
+-- | 1073741824  03-Oct-2013 16:46  1048576.rnd
+-- | 188         03-Oct-2013 17:15  README.html
+-- |_
+--
+-- @xmloutput
+-- <table key="volumes">
+--   <table>
+--     <elem key="volume">/</elem>
+--     <table key="files">
+--       <table>
+--         <elem key="size">524288</elem>
+--         <elem key="time">02-Oct-2013 18:26</elem>
+--         <elem key="filename">512.rnd</elem>
+--       </table>
+--       <table>
+--         <elem key="size">1048576</elem>
+--         <elem key="time">02-Oct-2013 18:26</elem>
+--         <elem key="filename">1024.rnd</elem>
+--       </table>
+--       <table>
+--         <elem key="size">2097152</elem>
+--         <elem key="time">02-Oct-2013 18:26</elem>
+--         <elem key="filename">2048.rnd</elem>
+--       </table>
+--       <table>
+--         <elem key="size">4194304</elem>
+--         <elem key="time">02-Oct-2013 18:26</elem>
+--         <elem key="filename">4096.rnd</elem>
+--       </table>
+--       <table>
+--         <elem key="size">8388608</elem>
+--         <elem key="time">02-Oct-2013 18:26</elem>
+--         <elem key="filename">8192.rnd</elem>
+--       </table>
+--       <table>
+--         <elem key="size">16777216</elem>
+--         <elem key="time">02-Oct-2013 18:26</elem>
+--         <elem key="filename">16384.rnd</elem>
+--       </table>
+--       <table>
+--         <elem key="size">33554432</elem>
+--         <elem key="time">02-Oct-2013 18:26</elem>
+--         <elem key="filename">32768.rnd</elem>
+--       </table>
+--       <table>
+--         <elem key="size">67108864</elem>
+--         <elem key="time">02-Oct-2013 18:26</elem>
+--         <elem key="filename">65536.rnd</elem>
+--       </table>
+--       <table>
+--         <elem key="size">1073741824</elem>
+--         <elem key="time">03-Oct-2013 16:46</elem>
+--         <elem key="filename">1048576.rnd</elem>
+--       </table>
+--       <table>
+--         <elem key="size">188</elem>
+--         <elem key="time">03-Oct-2013 17:15</elem>
+--         <elem key="filename">README.html</elem>
+--       </table>
+--     </table>
+--     <table key="info">
+--       <elem>maxfiles limit reached (10)</elem>
+--     </table>
+--   </table>
+-- </table>
+-- <table key="total">
+--   <elem key="files">10</elem>
+--   <elem key="bytes">1207435452</elem>
+-- </table>
 
 portrule = shortport.http
 

--- a/scripts/http-ls.nse
+++ b/scripts/http-ls.nse
@@ -1,0 +1,136 @@
+local http = require "http"
+local shortport = require "shortport"
+local stdnse = require "stdnse"
+local openssl = require "openssl"
+local ls = require "ls"
+
+description = [[
+Shows the content of an "index" Web page.
+
+Example:
+
+    $ nmap -n -p 80 --script http-ls test-debit.free.fr
+
+    Starting Nmap 6.47SVN ( http://nmap.org ) at 2015-05-01 16:43 CEST
+    Nmap scan report for test-debit.free.fr (212.27.42.153)
+    Host is up (0.019s latency).
+    PORT   STATE SERVICE
+    80/tcp open  http
+    | http-ls:
+    | Volume /
+    | maxfiles limit reached (10)
+    | SIZE        TIME               FILENAME
+    | 524288      02-Oct-2013 18:26  512.rnd
+    | 1048576     02-Oct-2013 18:26  1024.rnd
+    | 2097152     02-Oct-2013 18:26  2048.rnd
+    | 4194304     02-Oct-2013 18:26  4096.rnd
+    | 8388608     02-Oct-2013 18:26  8192.rnd
+    | 16777216    02-Oct-2013 18:26  16384.rnd
+    | 33554432    02-Oct-2013 18:26  32768.rnd
+    | 67108864    02-Oct-2013 18:26  65536.rnd
+    | 1073741824  03-Oct-2013 16:46  1048576.rnd
+    | 188         03-Oct-2013 17:15  README.html
+    |_
+
+TODO:
+  - support more page formats
+
+]]
+
+author = "Pierre Lalet"
+license = "Same as Nmap--See http://nmap.org/book/man-legal.html"
+categories = {"default", "discovery", "safe"}
+
+portrule = shortport.http
+
+local function isdir(fname, size)
+  -- we consider a file is (probably) a directory if its name
+  -- terminates with a '/' or if the string representing its size is
+  -- either empty or a single dash ('-').
+  if string.sub(fname, -1, -1) == '/' then
+    return true
+  end
+  if size == '' or size == '-' then
+    return true
+  end
+  return false
+end
+
+local function list_files(host, port, url, output, maxdepth, basedir)
+  local resp, title
+  basedir = basedir or ""
+
+  resp = http.get(host, port, url)
+
+  -- stolen from http-title.nse
+
+  -- check for a redirect
+  if resp.location then
+    return
+  end
+
+  if not resp.body then
+    return
+  end
+
+  if not string.match(resp.body, "<[Tt][Ii][Tt][Ll][Ee][^>]*> *[Ii][Nn][Dd][Ee][Xx] +[Oo][Ff]") then
+    return
+  end
+
+  local patterns, pattern, directory, continue
+  patterns = {
+    '<[Aa] [Hh][Rr][Ee][Ff]="([^"]+)">[^<]+</[Aa]></[Tt][Dd]><[Tt][Dd][^>]*> *([0-9]+-[A-Za-z0-9]+-[0-9]+ [0-9]+:[0-9]+) *</[Tt][Dd]><[Tt][Dd][^>]*> *([^<]*)</[Tt][Dd]>',
+    '<[Aa] [Hh][Rr][Ee][Ff]="([^"]+)">[^<]+</[Aa]> *([0-9]+-[A-Za-z0-9]+-[0-9]+ [0-9]+:[0-9]+) *([^ \n]+)',
+  }
+  for _, pattern in ipairs(patterns) do
+    for fname, date, size in string.gmatch(resp.body, pattern) do
+      directory = isdir(fname, size)
+      if ls.config('checksum') and not directory then
+	local checksum
+	resp = http.get(host, port, url .. fname)
+	if not resp.location and resp.body then
+	  checksum = stdnse.tohex(openssl.sha1(resp.body))
+	else
+	  checksum = nil
+	end
+	continue = ls.add_file(output, {size, date, basedir .. fname, checksum})
+      else
+	continue = ls.add_file(output, {size, date, basedir .. fname})
+      end
+      if not continue then
+	return false
+      end
+      if directory then
+	if string.sub(fname, -1, -1) ~= "/" then fname = fname .. '/' end
+	continue = true
+	if maxdepth > 1 then
+	  continue = list_files(host, port, url .. fname, output, maxdepth - 1,
+				basedir .. fname)
+	elseif maxdepth == 0 then
+	  continue = list_files(host, port, url .. fname, output, 0,
+				basedir .. fname)
+	end
+	if not continue then
+	  return false
+	end
+      end
+    end
+  end
+  return true
+end
+
+action = function(host, port)
+  local url, output, continue
+  url = stdnse.get_script_args(SCRIPT_NAME .. '.url') or "/"
+
+  output = ls.new_listing()
+  ls.new_vol(output, url, false)
+  continue = list_files(host, port, url, output, ls.config('maxdepth'))
+  if not continue then
+    ls.report_info(
+      output,
+      string.format("maxfiles limit reached (%d)", ls.config('maxfiles')))
+  end
+  ls.end_vol(output)
+  return output
+end

--- a/scripts/http-ls.nse
+++ b/scripts/http-ls.nse
@@ -125,6 +125,5 @@ action = function(host, port)
       string.format("maxfiles limit reached (%d)", ls.config('maxfiles')))
   end
   ls.end_vol(output)
-  ls.end_listing(output)
-  return output
+  return ls.end_listing(output)
 end

--- a/scripts/http-ls.nse
+++ b/scripts/http-ls.nse
@@ -62,19 +62,12 @@ local function list_files(host, port, url, output, maxdepth, basedir)
 
   resp = http.get(host, port, url)
 
-  -- stolen from http-title.nse
-
-  -- check for a redirect
-  if resp.location then
-    return
-  end
-
-  if not resp.body then
-    return
+  if resp.location or not resp.body then
+    return true
   end
 
   if not string.match(resp.body, "<[Tt][Ii][Tt][Ll][Ee][^>]*> *[Ii][Nn][Dd][Ee][Xx] +[Oo][Ff]") then
-    return
+    return true
   end
 
   local patterns, pattern, directory, continue
@@ -132,5 +125,6 @@ action = function(host, port)
       string.format("maxfiles limit reached (%d)", ls.config('maxfiles')))
   end
   ls.end_vol(output)
+  ls.end_listing(output)
   return output
 end

--- a/scripts/http-ls.nse
+++ b/scripts/http-ls.nse
@@ -1,6 +1,7 @@
 local http = require "http"
 local shortport = require "shortport"
 local stdnse = require "stdnse"
+local string = require "string"
 local openssl = require "openssl"
 local ls = require "ls"
 

--- a/scripts/nfs-ls.nse
+++ b/scripts/nfs-ls.nse
@@ -327,8 +327,7 @@ local mainaction = function(host)
     ls.end_vol(output)
   end
 
-  ls.end_listing(output)
-  return output
+  return ls.end_listing(output)
 end
 
 hostaction = function(host)

--- a/scripts/nfs-ls.nse
+++ b/scripts/nfs-ls.nse
@@ -35,32 +35,9 @@ These access permissions are shown only with NFSv3:
 -- @usage
 -- nmap -p 111 --script=nfs-ls <target>
 -- nmap -sV --script=nfs-ls <target>
--- @output
--- PORT    STATE SERVICE
--- 111/tcp open  rpcbind
--- | nfs-ls:
--- |   Arguments:
--- |     maxfiles: 10 (file listing output limited)
--- |
--- |   NFS Export: /mnt/nfs/files
--- |   NFS Access: Read Lookup NoModify NoExtend NoDelete NoExecute
--- |     PERMISSION  UID   GID   SIZE     MODIFICATION TIME  FILENAME
--- |     drwxr-xr-x  1000  100   4096     2010-06-17 12:28   /mnt/nfs/files
--- |     drwxr--r--  1000  1002  4096     2010-05-14 12:58   sources
--- |     -rw-------  1000  1002  23606    2010-06-17 12:28   notes
--- |
--- |   NFS Export: /home/storage/backup
--- |   NFS Access: Read Lookup Modify Extend Delete NoExecute
--- |     PERMISSION  UID   GID   SIZE     MODIFICATION TIME  FILENAME
--- |     drwxr-xr-x  1000  100   4096     2010-06-11 22:31   /home/storage/backup
--- |     -rw-r--r--  1000  1002  0        2010-06-10 08:34   filetest
--- |     drwx------  1000  100   16384    2010-02-05 17:05   lost+found
--- |     -rw-r--r--  0     0     5        2010-06-10 11:32   rootfile
--- |_    lrwxrwxrwx  1000  1002  8        2010-06-10 08:34   symlink
 --
 -- @args nfs-ls.maxfiles If set, limits the amount of files returned by
---       the script. If set to 0
---       or less, all files are shown. The default value is 10.
+--       the script. If set to 0 or less, all files are shown. (default: 10)
 -- @args nfs-ls.human If set to <code>1</code> or <code>true</code>,
 --       shows file sizes in a human readable format with suffixes like
 --       <code>KB</code> and <code>MB</code>.
@@ -70,6 +47,84 @@ These access permissions are shown only with NFSv3:
 -- * <code>a</code>: last access time (atime)
 -- * <code>c</code>: last change time (ctime)
 -- The default value is <code>m</code> (mtime).
+-- @args nfs.version The NFS protocol version to use
+--
+-- @output
+-- PORT    STATE SERVICE
+-- 111/tcp open  rpcbind
+-- | nfs-ls:
+-- |   Volume /mnt/nfs/files
+-- |   access: Read Lookup NoModify NoExtend NoDelete NoExecute
+-- |   PERMISSION  UID   GID   SIZE     MODIFICATION TIME  FILENAME
+-- |   drwxr-xr-x  1000  100   4096     2010-06-17 12:28   /mnt/nfs/files
+-- |   drwxr--r--  1000  1002  4096     2010-05-14 12:58   sources
+-- |   -rw-------  1000  1002  23606    2010-06-17 12:28   notes
+-- |
+-- |   Volume /home/storage/backup
+-- |   access: Read Lookup Modify Extend Delete NoExecute
+-- |   PERMISSION  UID   GID   SIZE     MODIFICATION TIME  FILENAME
+-- |   drwxr-xr-x  1000  100   4096     2010-06-11 22:31   /home/storage/backup
+-- |   -rw-r--r--  1000  1002  0        2010-06-10 08:34   filetest
+-- |   drwx------  1000  100   16384    2010-02-05 17:05   lost+found
+-- |   -rw-r--r--  0     0     5        2010-06-10 11:32   rootfile
+-- |   lrwxrwxrwx  1000  1002  8        2010-06-10 08:34   symlink
+-- |_
+--
+-- @xmloutput
+-- <table key="volumes">
+--   <table>
+--     <elem key="volume">/mnt/nfs/files</elem>
+--     <table key="files">
+--       <table>
+--         <elem key="permission">drwxr-xr-x</elem>
+--         <elem key="uid">1000</elem>
+--         <elem key="gid">100</elem>
+--         <elem key="size">4096</elem>
+--         <elem key="time">2010-06-11 22:31</elem>
+--         <elem key="filename">/mnt/nfs/files</elem>
+--       </table>
+--       <table>
+--         <elem key="permission">-rw-r-&#45;r-&#45;</elem>
+--         <elem key="uid">1000</elem>
+--         <elem key="gid">1002</elem>
+--         <elem key="size">0</elem>
+--         <elem key="time">2010-06-10 08:34</elem>
+--         <elem key="filename">filetest</elem>
+--       </table>
+--       <table>
+--         <elem key="permission">drwx-&#45;&#45;&#45;&#45;&#45;</elem>
+--         <elem key="uid">0</elem>
+--         <elem key="gid">0</elem>
+--         <elem key="size">16384</elem>
+--         <elem key="time">2010-02-05 17:05</elem>
+--         <elem key="filename">lost+found</elem>
+--       </table>
+--       <table>
+--         <elem key="permission">-rw-r-&#45;r-&#45;</elem>
+--         <elem key="uid">0</elem>
+--         <elem key="gid">0</elem>
+--         <elem key="size">5</elem>
+--         <elem key="time">2010-06-10 11:32</elem>
+--         <elem key="filename">rootfile</elem>
+--       </table>
+--       <table>
+--         <elem key="permission">lrwxrwxrwx</elem>
+--         <elem key="uid">1000</elem>
+--         <elem key="gid">1002</elem>
+--         <elem key="size">8</elem>
+--         <elem key="time">2010-06-10 08:34</elem>
+--         <elem key="filename">symlink</elem>
+--       </table>
+--     </table>
+--     <table key="info">
+--       <elem>access: Read Lookup NoModify NoExtend NoDelete NoExecute</elem>
+--     </table>
+--   </table>
+-- </table>
+-- <table key="total">
+--   <elem key="files">5</elem>
+--   <elem key="bytes">20493</elem>
+-- </table>
 
 -- Created 05/28/2010 - v0.1 - combined nfs-dirlist and nfs-acls scripts
 -- Revised 06/04/2010 - v0.2 - make NFS exports listing with their acls

--- a/scripts/script.db
+++ b/scripts/script.db
@@ -186,6 +186,7 @@ Entry { filename = "http-iis-short-name-brute.nse", categories = { "brute", "int
 Entry { filename = "http-iis-webdav-vuln.nse", categories = { "intrusive", "vuln", } }
 Entry { filename = "http-joomla-brute.nse", categories = { "brute", "intrusive", } }
 Entry { filename = "http-litespeed-sourcecode-download.nse", categories = { "exploit", "intrusive", "vuln", } }
+Entry { filename = "http-ls.nse", categories = { "default", "discovery", "safe", } }
 Entry { filename = "http-majordomo2-dir-traversal.nse", categories = { "exploit", "intrusive", "vuln", } }
 Entry { filename = "http-malware-host.nse", categories = { "malware", "safe", } }
 Entry { filename = "http-method-tamper.nse", categories = { "auth", "vuln", } }

--- a/scripts/smb-ls.nse
+++ b/scripts/smb-ls.nse
@@ -135,7 +135,8 @@ local function is_dir(fe)
   return ( bit.band(fe.attrs, 16) == 16 )
 end
 
-local function list_files(smbstate, path, options, output, maxdepth, basedir)
+local function list_files(host, share, smbstate, path, options, output,
+			  maxdepth, basedir)
   basedir = basedir or ""
   local continue
 
@@ -160,11 +161,13 @@ local function list_files(smbstate, path, options, output, maxdepth, basedir)
         continue = true
         if maxdepth > 1 then
           stdnse.debug1("YYY " .. tostring(maxdepth))
-          continue = list_files(smbstate, path .. '\\' .. fe.fname, options,
+          continue = list_files(host, share, smbstate,
+				path .. '\\' .. fe.fname, options,
                                 output, maxdepth - 1,
                                 basedir .. fe.fname .. '\\')
         elseif maxdepth == 0 then
-          continue = list_files(smbstate, path .. '\\' .. fe.fname, options,
+          continue = list_files(host, share, smbstate,
+				path .. '\\' .. fe.fname, options,
                                 output, 0,
                                 basedir .. fe.fname .. '\\')
         end
@@ -221,7 +224,7 @@ action = function(host)
           output,
           '\\\\' .. stdnse.get_hostname(host) .. '\\' .. share .. path,
           false)
-        continue = list_files(smbstate, path, options,
+        continue = list_files(host, share, smbstate, path, options,
                               output, ls.config('maxdepth'))
         if not continue then
           ls.report_info(

--- a/scripts/smb-ls.nse
+++ b/scripts/smb-ls.nse
@@ -163,6 +163,5 @@ action = function(host)
      end
   end
 
-  ls.end_listing(output)
-  return output
+  return ls.end_listing(output)
 end

--- a/scripts/smb-ls.nse
+++ b/scripts/smb-ls.nse
@@ -13,32 +13,101 @@ The output is intended to resemble the output of the UNIX <code>ls</code> comman
 ---
 -- @usage
 -- nmap -p 445 <ip> --script smb-ls --script-args 'share=c$,path=\temp'
+-- nmap -p 445 <ip> --script smb-enum-shares,smb-ls
+--
+-- @args smb-ls.share (or smb-ls.shares) the share (or a colon-separated list
+--       of shares) to connect to (default: use shares found by smb-enum-shares)
+-- @args smb-ls.path the path, relative to the share to list the contents from
+--       (default: root of the share)
+-- @args smb-ls.pattern the search pattern to execute (default: *)
+-- @args smb-ls.maxdepth the maximum depth to recurse into a directory
+--       (default: no recursion)
+-- @args smb-ls.maxfiles maximum number of files to report (default 10)
+-- @args smb-ls.checksum download each file and calculate a checksum
+--       (default: false)
+-- @args smb-ls.errors report connection errors
 --
 -- @output
 -- Host script results:
 -- | smb-ls:
--- |   Directory of \\192.168.56.101\c$\
--- |     2007-12-02 00:20:09  0      AUTOEXEC.BAT
--- |     2007-12-02 00:20:09  0      CONFIG.SYS
--- |     2007-12-02 00:53:39  <DIR>  Documents and Settings
--- |     2009-09-08 13:26:10  <DIR>  e5a6b742d36facb19c5192852c43
--- |     2008-12-01 02:06:29  <DIR>  Inetpub
--- |     2007-02-18 00:31:38  94720  msizap.exe
--- |     2007-12-02 00:55:01  <DIR>  Program Files
--- |     2008-12-01 02:05:52  <DIR>  temp
--- |     2011-12-16 14:40:18  <DIR>  usr
--- |     2007-12-02 00:42:40  <DIR>  WINDOWS
--- |_    2007-12-02 00:22:38  <DIR>  wmpub
+-- |   Volume \\192.168.56.101\c$\
+-- |   SIZE   TIME                 FILENAME
+-- |   0      2007-12-02 00:20:09  AUTOEXEC.BAT
+-- |   0      2007-12-02 00:20:09  CONFIG.SYS
+-- |   <DIR>  2007-12-02 00:53:39  Documents and Settings
+-- |   <DIR>  2009-09-08 13:26:10  e5a6b742d36facb19c5192852c43
+-- |   <DIR>  2008-12-01 02:06:29  Inetpub
+-- |   94720  2007-02-18 00:31:38  msizap.exe
+-- |   <DIR>  2007-12-02 00:55:01  Program Files
+-- |   <DIR>  2008-12-01 02:05:52  temp
+-- |   <DIR>  2011-12-16 14:40:18  usr
+-- |   <DIR>  2007-12-02 00:42:40  WINDOWS
+-- |   <DIR>  2007-12-02 00:22:38  wmpub
+-- |_
 --
--- @args smb-ls.share [optional] the share to connect to
--- @args smb-ls.shares [optional] a colon-separated list of shares to connect to
--- @args smb-ls.path [optional] the path, relative to the share to list the contents from
--- @args smb-ls.pattern [optional] the search pattern to execute (default: *)
--- @args smb-ls.maxdepth [optional] the maximum depth to recurse into a directory (default: no recursion)
--- @args smb-ls.maxfiles [optional] return only a certain amount of files
--- @args smb-ls.checksum [optional] download each file and calculate a SHA1 checksum
--- @args smb-ls.errors [optional] report connection errors
---
+-- @xmloutput
+-- <table key="volumes">
+--   <table>
+--     <table key="files">
+--       <table>
+--         <elem key="size">0</elem>
+--         <elem key="time">2007-12-02 00:20:09</elem>
+--         <elem key="filename">AUTOEXEC.BAT</elem>
+--       </table>
+--       <table>
+--         <elem key="size">0</elem>
+--         <elem key="time">2007-12-02 00:20:09</elem>
+--         <elem key="filename">CONFIG.SYS</elem>
+--       </table>
+--       <table>
+--         <elem key="size">&lt;DIR&gt;</elem>
+--         <elem key="time">2007-12-02 00:53:39</elem>
+--         <elem key="filename">Documents and Settings</elem>
+--       </table>
+--       <table>
+--         <elem key="size">&lt;DIR&gt;</elem>
+--         <elem key="time">2009-09-08 13:26:10</elem>
+--         <elem key="filename">e5a6b742d36facb19c5192852c43</elem>
+--       </table>
+--       <table>
+--         <elem key="size">&lt;DIR&gt;</elem>
+--         <elem key="time">2008-12-01 02:06:29</elem>
+--         <elem key="filename">Inetpub</elem>
+--       </table>
+--       <table>
+--         <elem key="size">94720</elem>
+--         <elem key="time">2007-02-18 00:31:38</elem>
+--         <elem key="filename">msizap.exe</elem>
+--       </table>
+--       <table>
+--         <elem key="size">&lt;DIR&gt;</elem>
+--         <elem key="time">2007-12-02 00:55:01</elem>
+--         <elem key="filename">Program Files</elem>
+--       </table>
+--       <table>
+--         <elem key="size">&lt;DIR&gt;</elem>
+--         <elem key="time">2008-12-01 02:05:52</elem>
+--         <elem key="filename">temp</elem>
+--       </table>
+--       <table>
+--         <elem key="size">&lt;DIR&gt;</elem>
+--         <elem key="time">2011-12-16 14:40:18</elem>
+--         <elem key="filename">usr</elem>
+--       </table>
+--       <table>
+--         <elem key="size">&lt;DIR&gt;</elem>
+--         <elem key="time">2007-12-02 00:42:40</elem>
+--         <elem key="filename">WINDOWS</elem>
+--       </table>
+--       <table>
+--         <elem key="size">&lt;DIR&gt;</elem>
+--         <elem key="time">2007-12-02 00:22:38</elem>
+--         <elem key="filename">wmpub</elem>
+--       </table>
+--     </table>
+--     <elem key="volume">\\192.168.1.2\Downloads</elem>
+--   </table>
+-- </table>
 
 author = "Patrik Karlsson"
 license = "Same as Nmap--See http://nmap.org/book/man-legal.html"

--- a/scripts/smb-ls.nse
+++ b/scripts/smb-ls.nse
@@ -1,5 +1,6 @@
 local bit    = require 'bit'
 local smb    = require 'smb'
+local string = require 'string'
 local stdnse = require 'stdnse'
 local ls     = require 'ls'
 

--- a/scripts/smb-ls.nse
+++ b/scripts/smb-ls.nse
@@ -140,7 +140,7 @@ local function list_files(host, share, smbstate, path, options, output,
   basedir = basedir or ""
   local continue
 
-  for fe in smb.find_files(smbstate, path .. '\\' .. ls.config("pattern"),
+  for fe in smb.find_files(smbstate, path .. '\\' .. arg_pattern,
                            options) do
     if basedir == "" or (fe.fname ~= "." and fe.fname ~= "..") then
       if ls.config('checksum') and not(is_dir(fe)) then


### PR DESCRIPTION
This PR adds a new module called `ls` and uses it to unify arguments and outputs from `*-ls` scripts (so far, `afp-ls`, `nfs-ls` and `smb-ls` plus a new script, `http-ls`).

What remains to do is add `ftp-anon` (I'm working on that part), but I think it's OK to merge this first so that it can be tested by more people.

I'm running scans to tests these scripts against random hosts and have seen no problem so far.