### PR TITLE
Add `--no-shutdown` option.

### DIFF
--- a/ncat/docs/ncat.xml
+++ b/ncat/docs/ncat.xml
@@ -777,6 +777,19 @@
 
       <varlistentry>
         <term>
+          <option>--no-shutdown</option> (Do not shutdown into half-duplex mode)
+          <indexterm><primary><option>--no-shutdown</option> (Ncat option)</primary></indexterm>
+        </term>
+        <listitem>
+          <para>If this option is passed, Ncat will not invoke shutdown on a
+          socket aftering seeing EOF on stdin. This is provided for
+          backward-compatibility with OpenBSD netcat, which exhibits this
+          behavior when executed with its '-d' option.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>
           <option>-t</option>,
           <option>--telnet</option> (Answer Telnet negotiations)
           <indexterm><primary><option>-t</option> (Ncat option)</primary></indexterm>

--- a/ncat/ncat_core.c
+++ b/ncat/ncat_core.c
@@ -168,6 +168,7 @@ void options_init(void)
     o.keepopen = 0;
     o.sendonly = 0;
     o.recvonly = 0;
+    o.noshutdown = 0;
     o.telnet = 0;
     o.linedelay = 0;
     o.chat = 0;

--- a/ncat/ncat_core.h
+++ b/ncat/ncat_core.h
@@ -161,6 +161,7 @@ struct options {
     int keepopen;
     int sendonly;
     int recvonly;
+    int noshutdown;
     int telnet;
     int linedelay;
     int chat;

--- a/ncat/ncat_listen.c
+++ b/ncat/ncat_listen.c
@@ -393,7 +393,7 @@ static int ncat_listen_stream(int proto)
                                receiving anything, we can quit here. */
                             return 0;
                         }
-                        shutdown_sockets(SHUT_WR);
+                        if (!o.noshutdown) shutdown_sockets(SHUT_WR);
                     }
                     if (rc < 0)
                         return 1;

--- a/ncat/ncat_main.c
+++ b/ncat/ncat_main.c
@@ -286,6 +286,7 @@ int main(int argc, char *argv[])
         {"source-port",     required_argument,  NULL,         'p'},
         {"source",          required_argument,  NULL,         's'},
         {"send-only",       no_argument,        &o.sendonly,  1},
+        {"no-shutdown",     no_argument,        &o.noshutdown,1},
         {"broker",          no_argument,        NULL,         0},
         {"chat",            no_argument,        NULL,         0},
         {"talk",            no_argument,        NULL,         0},


### PR DESCRIPTION
This option solves issue #142. It prevents Ncat from putting the connection in
half-duplex mode after seeing EOF on stdin. This emulates the behavior of
OpenBSD-netcat's `-d` option. The `-d` option itself prevents a bug affecting
some versions of that program in which the sender closes the connection
prematurely upon receiving a FIN packet from a receiver.

If you'll merge this, please advise on how to regenerate docs and manpages.
