### PR TITLE
Fix usage of unix sockets on OSX

### DIFF
--- a/ncat/ncat_core.c
+++ b/ncat/ncat_core.c
@@ -569,6 +569,13 @@ void setup_environment(struct fdinfo *info)
     if (getpeername(info->fd, &su.sockaddr, &alen) != 0) {
         bye("getpeername failed: %s", socket_strerror(socket_errno()));
     }
+#ifdef HAVE_SYS_UN_H
+    if (su.sockaddr.sa_family == AF_UNIX) {
+        /* say localhost to keep it backwards compatible */
+        setenv_portable("NCAT_REMOTE_ADDR", "localhost");
+        setenv_portable("NCAT_REMOTE_PORT", "");
+    } else
+#endif
     if (getnameinfo((struct sockaddr *)&su, alen, ip, sizeof(ip),
             port, sizeof(port), NI_NUMERICHOST | NI_NUMERICSERV) == 0) {
         setenv_portable("NCAT_REMOTE_ADDR", ip);
@@ -580,6 +587,13 @@ void setup_environment(struct fdinfo *info)
     if (getsockname(info->fd, (struct sockaddr *)&su, &alen) < 0) {
         bye("getsockname failed: %s", socket_strerror(socket_errno()));
     }
+#ifdef HAVE_SYS_UN_H
+    if (su.sockaddr.sa_family == AF_UNIX) {
+        /* say localhost to keep it backwards compatible, else su.un.sun_path */
+        setenv_portable("NCAT_LOCAL_ADDR", "localhost");
+        setenv_portable("NCAT_LOCAL_PORT", "");
+    } else
+#endif
     if (getnameinfo((struct sockaddr *)&su, alen, ip, sizeof(ip),
             port, sizeof(port), NI_NUMERICHOST | NI_NUMERICSERV) == 0) {
         setenv_portable("NCAT_LOCAL_ADDR", ip);


### PR DESCRIPTION
The call to getnameinfo() fails on OSX if the sockaddr actually means a
unix socket. Linux, apparently, just fills with "localhost", so do we,
if we detect a unix socket.

Simple test:

$ ncat -lUc 'echo $NCAT_REMOTE_ADDR:$NCAT_LOCAL_ADDR' test &
$ ncat -U test

This currently fails with:
Ncat: getnameinfo failed: Undefined error: 0 QUITTING.

With this fix we'll get "localhost:localhost" just like on Linux.