### PR TITLE
Add handling of fragmented TLS records to the TLS library

### DIFF
--- a/nselib/tls.lua
+++ b/nselib/tls.lua
@@ -1107,12 +1107,14 @@ end
 
 ---
 -- Read a SSL/TLS record
--- @param buffer The read buffer
--- @param i      The position in the buffer to start reading
+-- @param buffer   The read buffer
+-- @param i        The position in the buffer to start reading
+-- @param fragment Message fragment left over from previous record (nil if none)
 -- @return The current position in the buffer
 -- @return The record that was read, as a table
-function record_read(buffer, i)
+function record_read(buffer, i, fragment)
   local b, h, len
+  local add = 0
 
   ------------
   -- Header --
@@ -1147,6 +1149,14 @@ function record_read(buffer, i)
     return i, nil
   end
 
+  -- Adjust buffer and length to account for message fragment left over
+  -- from last record.
+  if fragment then
+    add = #fragment
+    len = len + add
+    buffer = buffer:sub(1, j - 1) .. fragment .. buffer:sub(j, -1)
+  end
+
   -- Convert to human-readable form.
 
   ----------
@@ -1154,12 +1164,11 @@ function record_read(buffer, i)
   ----------
 
   h["body"] = {}
-  while j < len do
+
+  while j <= len do
     -- RFC 2246, 6.2.1 "multiple client messages of the same ContentType may
     -- be coalesced into a single TLSPlaintext record"
-    -- TODO: implement reading of fragmented records
     b = {}
-    table.insert(h["body"], b)
     if h["type"] == "alert" then
       -- Parse body.
       j, b["level"] = bin.unpack("C", buffer, j)
@@ -1168,15 +1177,30 @@ function record_read(buffer, i)
       -- Convert to human-readable form.
       b["level"] = find_key(TLS_ALERT_LEVELS, b["level"])
       b["description"] = find_key(TLS_ALERT_REGISTRY, b["description"])
+
+      table.insert(h["body"], b)
     elseif h["type"] == "handshake" then
+
+			-- Check for message fragmentation.
+			if len - j < 3 then
+				h.fragment = buffer:sub(j, len)
+				return len + 1 - add, h
+			end
+
       -- Parse body.
       j, b["type"] = bin.unpack("C", buffer, j)
       local msg_end
       j, msg_end = unpack_3byte(buffer, j)
       msg_end = msg_end + j
 
-      -- Convert to human-readable form.
+			-- Convert to human-readable form.
       b["type"] = find_key(TLS_HANDSHAKETYPE_REGISTRY, b["type"])
+
+      -- Check for message fragmentation.
+      if msg_end > len + 1 then
+        h.fragment = buffer:sub(j - 4, len)
+        return len + 1 - add, h
+      end
 
       if b["type"] == "server_hello" then
         -- Parse body.
@@ -1225,18 +1249,21 @@ function record_read(buffer, i)
         stdnse.debug2("Unknown handshake message type: %s", b["type"])
         j, b["data"] = bin.unpack("A" .. msg_end - j, buffer, j)
       end
+
+      table.insert(h["body"], b)
     elseif h["type"] == "heartbeat" then
       j, b["type"], b["payload_length"] = bin.unpack("C>S", buffer, j)
       j, b["payload"], b["padding"] = bin.unpack("PP", buffer, j)
+      table.insert(h["body"], b)
     else
       stdnse.debug1("Unknown message type: %s", h["type"])
     end
   end
 
   -- Ignore unparsed bytes.
-  j = len+1
+  j = len + 1
 
-  return j, h
+  return j - add, h
 end
 
 ---

--- a/scripts/ssl-enum-ciphers.nse
+++ b/scripts/ssl-enum-ciphers.nse
@@ -149,20 +149,22 @@ end
 local function get_record_iter(sock)
   local buffer = ""
   local i = 1
+  local fragment
   return function ()
     local record
-    i, record = tls.record_read(buffer, i)
+    i, record = tls.record_read(buffer, i, fragment)
     if record == nil then
       local status, err
       status, buffer, err = tls.record_buffer(sock, buffer, i)
       if not status then
         return nil, err
       end
-      i, record = tls.record_read(buffer, i)
+      i, record = tls.record_read(buffer, i, fragment)
       if record == nil then
         return nil, "done"
       end
     end
+    fragment = record.fragment
     return record
   end
 end


### PR DESCRIPTION
Implement handling of messages fragmented across multiple TLSPlaintext records.  As described in RFC 2246 (Section 6.2.1), client message boundaries are not preserved across TLSPlaintext records, which have a size limit of 16KB.  As a result, handshake messages can straddle multiple TLSPlaintext records, for example, when a server sends a Certificate message with a long certificate chain.  Currently, the TLS library's behavior in this case is to ignore the incomplete message fragment in the first TLSPlaintext record, and causes a crash when trying to parse the incomplete message fragment at the beginning of the second TLSPlaintext record.

This patch implements support for message fragmentation by adding a 'fragment' parameter to the record_read() function in the TLS library.  This parameter is used to pass a fragment from a previously read TLSPlaintext record and prepend it to the next TLSPlaintext record to be read.

When a TLSPlaintext record that ends with an incomplete message fragment is read by record_read(), the fragment will be returned in the 'fragment' member of the record table, and can be passed to the next invocation of the record_read() function.  This usage is illustrated in the get_record_iter() function of the modified ssl-enum-ciphers script included in this patch.

Scripts that have not been modified to take advantage of this fragmentation support (i.e. they ignore the 'fragment' parameter when invoking the record_read() function in tls.lua) will continue to function exactly the same as before.