### PR TITLE
Fix XML output overwrite when reporting multiple vulnerabilities from one script

### DIFF
--- a/nselib/vulns.lua
+++ b/nselib/vulns.lua
@@ -2246,9 +2246,8 @@ Report = {
       for i, vuln_table in ipairs(self.entries.vulns) do
         local vuln_out, out_t = format_vuln_base(vuln_table)
         if type(out_t) == "table" then
-          for i, v, k in pairs(out_t) do
-            output_t2[i]=v
-          end
+          local ID = vuln_table.IDS.CVE or vuln_table.IDS[next(vuln_table.IDS)]
+          output_t2[ID] = out_t
         end
         if vuln_out then
           output_table.report = concat(vuln_out, "\n")
@@ -2269,9 +2268,8 @@ Report = {
       for i, vuln_table in ipairs(self.entries.not_vulns) do
         local vuln_out, out_t = format_vuln_base(vuln_table, SHOW_ALL)
         if type(out_t) == "table" then
-          for i, v, k in pairs(out_t) do
-            output_t2[i]=v
-          end
+          local ID = vuln_table.IDS.CVE or vuln_table.IDS[next(vuln_table.IDS)]
+          output_t2[ID] = out_t
         end
         if vuln_out then
           output_table.report = concat(vuln_out, "\n")


### PR DESCRIPTION
The vulns.lua library currently overwrites the XML output array whenever multiple vulnerabilities are reported from one script.  This patch modifies the vulns library to insert the XML output entries as keyed table members (with key = vulnerability ID) rather than indexed array members to prevent overwriting any previous entries.