### PR TITLE
Fix SYN scan under FreeBSD 10.0 and later.

### DIFF
--- a/libnetutil/netutil.cc
+++ b/libnetutil/netutil.cc
@@ -3604,7 +3604,7 @@ int send_ip_packet_sd(int sd, const struct sockaddr_in *dst,
      must deal with it here rather than when building the packet,
      because they should be in NBO when I'm sending over raw
      ethernet */
-#if FREEBSD || BSDI || NETBSD || DEC || MACOSX
+#if (defined(FREEBSD) && (__FreeBSD_version < 1000022)) || BSDI || NETBSD || DEC || MACOSX
   ip->ip_len = ntohs(ip->ip_len);
   ip->ip_off = ntohs(ip->ip_off);
 #endif
@@ -3614,7 +3614,7 @@ int send_ip_packet_sd(int sd, const struct sockaddr_in *dst,
                (int) sizeof(struct sockaddr_in));
 
   /* Undo the byte order switching. */
-#if FREEBSD || BSDI || NETBSD || DEC || MACOSX
+#if (defined(FREEBSD) && (__FreeBSD_version < 1000022)) || BSDI || NETBSD || DEC || MACOSX
   ip->ip_len = htons(ip->ip_len);
   ip->ip_off = htons(ip->ip_off);
 #endif


### PR DESCRIPTION
The byte order of some IP header fields has changed, see:

https://www.freebsd.org/doc/en_US.ISO8859-1/books/porters-handbook/versions.html

This fixes problem that manifested like this:

sendto in send_ip_packet_sd: sendto(5, packet, 44, 0, 127.0.0.1, 16) => Invalid argument
Offending packet: TCP 127.0.0.1:62353 > 127.0.0.1:995 S ttl=40 id=64012 iplen=11264  seq=1481935911 win=1024 <mss 1460>