### PR TITLE
New Nmap script dns-server with supporting changes and some tidying up of nselib dns

### DIFF
--- a/nselib/dns.lua
+++ b/nselib/dns.lua
@@ -1,3 +1,5 @@
+-- -*- mode: lua; lua-indent-level: 2; -*-
+
 ---
 -- Simple DNS library supporting packet creation, encoding, decoding,
 -- and querying.
@@ -73,6 +75,31 @@ CLASS = {
   ANY = 255
 }
 
+--- Opcodes, rfc 1035, rfc 1996, rfc 2136.
+opcodes = {
+   query = 0,
+   status = 2,
+   notify = 4,
+   update = 5,
+}
+
+
+--- Rcodes, rfc 1035, rfc 6895.
+rcodes = {
+  noerror = 0,
+  formerr = 1,
+  servfail = 2,
+  nxdomain = 3,
+  notimp = 4,
+  refused = 5,
+  yxdomain = 6,
+  yxrrset = 7,
+  nxrrset = 8,
+  notauth = 9,
+  notzone = 10,
+  badvers = 16
+}
+
 
 ---
 -- Repeatedly sends UDP packets to host, waiting for an answer.
@@ -83,7 +110,7 @@ CLASS = {
 -- @param cnt Number of tries.
 -- @param multiple If true, keep reading multiple responses until timeout.
 -- @return Status (true or false).
--- @return Response (if status is true).
+-- @return Responses or error.
 local function sendPacketsUDP(data, host, port, timeout, cnt, multiple)
   local socket = nmap.new_socket("udp")
   local responses = {}
@@ -129,7 +156,7 @@ local function sendPacketsUDP(data, host, port, timeout, cnt, multiple)
     end
   end
   socket:close()
-  return false
+  return false, "No Answers"
 end
 
 ---
@@ -139,15 +166,15 @@ end
 -- @param port Port to connect to.
 -- @param timeout Number of ms to wait for a response.
 -- @return Status (true or false).
--- @return Response (if status is true).
+-- @return Responses or error.
 local function sendPacketsTCP(data, host, port, timeout)
   local socket = nmap.new_socket()
   local response
   local responses = {}
   socket:set_timeout(timeout)
   socket:connect(host, port)
-  -- add payload size we are assuming a minimum size here of 256?
-  local send_data = '\000' .. string.char(#data) .. data
+  -- prefix message length (rfc 1035 section 4.2.2)
+  local send_data = bin.pack('>P', data)
   socket:send(send_data)
   local response = ''
   local got_response = false
@@ -160,10 +187,10 @@ local function sendPacketsTCP(data, host, port, timeout)
   local status, _, _, ip, _ = socket:get_info()
   socket:close()
   if not got_response then
-    return false
+    return false, "No Answers"
   end
-  -- remove payload size
-  table.insert(responses, { data = string.sub(response,3), peer = ip } )
+  -- strip message length (rfc 1035 section 4.2.2)
+  table.insert(responses, { data = response:sub(3), peer = ip } )
   return true, responses
 end
 
@@ -176,7 +203,8 @@ end
 -- @param cnt Number of tries.
 -- @param multiple If true, keep reading multiple responses until timeout.
 -- @return Status (true or false).
-local function sendPackets(data, host, port, timeout, cnt, multiple, proto)
+-- @return Responses or error.
+function sendPackets(data, host, port, timeout, cnt, multiple, proto)
   if proto == nil or proto == 'udp' then
     return sendPacketsUDP(data, host, port, timeout, cnt, multiple)
   else
@@ -212,7 +240,7 @@ local function gotAnswer(rPkt)
       return true
     end
     -- no such name is the answer
-  elseif rPkt.flags.RC3 and rPkt.flags.RC4 then
+  elseif rPkt.rcode == rcodes.nxdomain then
     return true
     -- really no answer
   else
@@ -349,6 +377,7 @@ function query(dname, options)
   end
 
   local pkt = newPacket()
+  pkt.opcode = opcodes.query
   addQuestion(pkt, dname, dtype, class)
   if options.norecurse then pkt.flags.RD = false end
 
@@ -376,7 +405,7 @@ function query(dname, options)
   local status, response = sendPackets(data, host, port, options.timeout, options.sendCount, options.multiple, proto)
 
 
-  -- if working with know nameservers, try the others
+  -- if working with known nameservers, try the others
   while((not status) and srv and srvI < #srv) do
     srvI = srvI + 1
     host = srv[srvI]
@@ -399,7 +428,7 @@ function query(dname, options)
     end
   else
     stdnse.debug1("dns.query() got zero responses attempting to resolve query%s%s", dname and ": " or ".", dname or "")
-    return false, "No Answers"
+    return false, response
   end
 end
 
@@ -657,7 +686,7 @@ function findNiceAnswer(dtype, dec, retAll)
       stdnse.debug1("dns.findNiceAnswer() does not have an answerFetcher for dtype %s", tostring(dtype))
       return false, "Unable to handle response"
     end
-  elseif (dec.flags.RC3 and dec.flags.RC4) then
+  elseif dec.rcode == rcodes.nxdomain then
     return false, "No Such Name"
   else
     stdnse.debug1("dns.findNiceAnswer() found zero answers in a response, but got an unexpected flags.replycode")
@@ -789,7 +818,7 @@ function findNiceAdditional(dtype, dec, retAll)
       (type(dtype) == 'string' and dtype) or type(dtype) or "nil")
       return false, "Unable to handle response"
     end
-  elseif (dec.flags.RC3 and dec.flags.RC4) then
+  elseif dec.rcode == rcodes.nxdomain then
     return false, "No Such Name"
   else
     stdnse.debug1("dns.findNiceAdditional() found zero answers in a response, but got an unexpected flags.replycode")
@@ -797,18 +826,24 @@ function findNiceAdditional(dtype, dec, retAll)
   end
 end
 
---
--- Encodes a FQDN
--- @param fqdn containing the fully qualified domain name
--- @return encQ containing the encoded value
+---
+-- Encode an FQDN.
+-- @param fqdn Fully qualified domain name or nil, may be supplied
+-- with terminal dot, nil will be coded as the dns root.
+-- @return Encoded value.
 local function encodeFQDN(fqdn)
-  if ( not(fqdn) or #fqdn == 0 ) then return "\0" end
+  if not fqdn or fqdn == '' or fqdn == '.' then return '\0' end
 
-  local encQ = {}
-  for part in string.gmatch(fqdn, "[^%.]+") do
-    encQ[#encQ+1] = bin.pack("p", part)
+  assert(not fqdn:match('^%.') and not fqdn:match('%.%.'),
+         ("Illegal name: %s, contains empty label."):format(fqdn))
+
+  local encQ, label = {}, nil
+  for label in string.gmatch(fqdn, '[^%.]+') do
+    assert(#label <= 63,
+           ("Illegal name, label: %s exceeds 63 octets."):format(label))
+    encQ[#encQ + 1] = bin.pack('p', label)
   end
-  encQ[#encQ+1] = "\0"
+  encQ[#encQ + 1] = '\0'
   return table.concat(encQ)
 end
 
@@ -860,28 +895,43 @@ local function encodeAdditional(additional)
 end
 
 ---
--- Encodes DNS flags to a binary digit string.
--- @param flags Flag table, each entry representing a flag (QR, OCx, AA, TC, RD,
--- RA, RCx).
--- @return Binary digit string representing flags.
-local function encodeFlags(flags)
+-- Encode DNS codes and flags to a binary digit string.
+-- @param opcode Opcode as integer, overrides OCx in flags unless nil.
+-- @param rcode Rcode as integer, overrides RCx in flags unless nil.
+-- @param flags Flag table, each entry representing a flag (QR, OCx,
+-- AA, TC, RD, RA, Z, AD, CD, RCx).
+-- @return Binary digit string representing flags and codes.
+local function encodeCodesFlags(opcode, rcode, flags)
   if type(flags) == "string" then return flags end
   if type(flags) ~= "table" then return nil end
+  local pos, opc, rc
   local fb = ""
   if flags.QR then fb = fb .. "1" else fb = fb .. "0" end
-  if flags.OC1 then fb = fb .. "1" else fb = fb .. "0" end
-  if flags.OC2 then fb = fb .. "1" else fb = fb .. "0" end
-  if flags.OC3 then fb = fb .. "1" else fb = fb .. "0" end
-  if flags.OC4 then fb = fb .. "1" else fb = fb .. "0" end
+  if opcode ~= nil then
+     pos, opc = bin.unpack('B', bin.pack('C', opcode))
+     fb = fb .. opc:sub(-4)
+  else
+     if flags.OC1 then fb = fb .. "1" else fb = fb .. "0" end
+     if flags.OC2 then fb = fb .. "1" else fb = fb .. "0" end
+     if flags.OC3 then fb = fb .. "1" else fb = fb .. "0" end
+     if flags.OC4 then fb = fb .. "1" else fb = fb .. "0" end
+  end
   if flags.AA then fb = fb .. "1" else fb = fb .. "0" end
   if flags.TC then fb = fb .. "1" else fb = fb .. "0" end
   if flags.RD then fb = fb .. "1" else fb = fb .. "0" end
   if flags.RA then fb = fb .. "1" else fb = fb .. "0" end
-  fb = fb .. "000"
-  if flags.RC1 then fb = fb .. "1" else fb = fb .. "0" end
-  if flags.RC2 then fb = fb .. "1" else fb = fb .. "0" end
-  if flags.RC3 then fb = fb .. "1" else fb = fb .. "0" end
-  if flags.RC4 then fb = fb .. "1" else fb = fb .. "0" end
+  if flags.Z then fb = fb .. "1" else fb = fb .. "0" end
+  if flags.AD then fb = fb .. "1" else fb = fb .. "0" end
+  if flags.CD then fb = fb .. "1" else fb = fb .. "0" end
+  if rcode ~= nil then
+     pos, rc = bin.unpack('B', bin.pack('C', rcode))
+     fb = fb .. rc:sub(-4)
+  else
+     if flags.RC1 then fb = fb .. "1" else fb = fb .. "0" end
+     if flags.RC2 then fb = fb .. "1" else fb = fb .. "0" end
+     if flags.RC3 then fb = fb .. "1" else fb = fb .. "0" end
+     if flags.RC4 then fb = fb .. "1" else fb = fb .. "0" end
+  end
   return fb
 end
 
@@ -894,7 +944,7 @@ end
 -- @return Encoded DNS packet.
 function encode(pkt)
   if type(pkt) ~= "table" then return nil end
-  local encFlags = encodeFlags(pkt.flags)
+  local encFlags = encodeCodesFlags(pkt.opcode, pkt.rcode, pkt.flags)
   local additional = encodeAdditional(pkt.additional)
   local aorplen = #pkt.answers
   local data, qorzlen, aorulen
@@ -1032,7 +1082,6 @@ end
 -- @param data Complete encoded DNS packet.
 -- @param pos Position in packet after RR.
 decoder[types.SOA] = function(entry, data, pos)
-
   local np = pos - #entry.data
 
   entry.SOA = {}
@@ -1172,7 +1221,7 @@ decoder[types.NS] = decDomain
 decoder[types.PTR] = decDomain
 
 -- Decodes TXT records.
--- Puts result in <code>entry.domain</code>.
+-- Puts results in table <code>entry.TXT.text</code>.
 -- @name decoder[types.TXT]
 -- @class function
 -- @param entry RR in packet.
@@ -1180,32 +1229,26 @@ decoder[types.PTR] = decDomain
 -- @param pos Position in packet after RR.
 decoder[types.TXT] =
 function (entry, data, pos)
-
-  local len = entry.data:len()
   local np = pos - #entry.data
-  local txt_len
   local txt
 
-  if len > 0 then
+  if np < pos then
     entry.TXT = {}
     entry.TXT.text = {}
   end
 
-  while len > 0 do
-    np, txt_len = bin.unpack("C", data, np)
-    np, txt = bin.unpack("A" .. txt_len, data, np )
-    len = len - txt_len - 1
-    table.insert( entry.TXT.text, txt )
+  while np < pos do
+    np, txt = bin.unpack("p", data, np)
+    table.insert(entry.TXT.text, txt)
   end
-
 end
 
 ---
 -- Decodes OPT record, puts it in <code>entry.OPT</code>.
 --
--- <code>entry.OPT</code> has the fields <code>mname</code>, <code>rname</code>,
--- <code>serial</code>, <code>refresh</code>, <code>retry</code>,
--- <code>expire</code>, and <code>minimum</code>.
+-- <code>entry.OPT</code> has the fields <code>bufsize</code>,
+-- <code>rcode</code>, <code>version</code>, <code>zflags</code>,
+-- <code>rdlen</code>, and <code>data</code>.
 -- @param entry RR in packet.
 -- @param data Complete encoded DNS packet.
 -- @param pos Position in packet after RR.
@@ -1213,8 +1256,8 @@ decoder[types.OPT] =
 function(entry, data, pos)
   local np = pos - #entry.data - 6
   local opt = { bufsize = entry.class }
-  np, opt.rcode, opt.version, opt.zflags, opt.rdlen = bin.unpack(">CCSS", data, np)
-  np, opt.data = bin.unpack("A" .. opt.rdlen, data, np)
+  np, opt.rcode, opt.version, opt.zflags, opt.data = bin.unpack(">CCSP", data, np)
+  opt.rdlen = #opt.data
   entry.OPT = opt
 end
 
@@ -1246,9 +1289,8 @@ end
 decoder[types.SRV] =
 function(entry, data, pos)
   local np = pos - #entry.data
-  local _
   entry.SRV = {}
-  np, entry.SRV.prio, entry.SRV.weight, entry.SRV.port = bin.unpack(">S>S>S", data, np)
+  np, entry.SRV.prio, entry.SRV.weight, entry.SRV.port = bin.unpack(">SSS", data, np)
   np, entry.SRV.target = decStr(data, np)
 end
 
@@ -1259,15 +1301,12 @@ end
 -- @return Table of RRs.
 local function decodeRR(data, count, pos)
   local ans = {}
-  for i = 1, count do
+  local ii
+  for ii = 1, count do
     local currRR = {}
     pos, currRR.dname = decStr(data, pos)
-    pos, currRR.dtype, currRR.class, currRR.ttl = bin.unpack(">SSI", data, pos)
-
-    local reslen
-    pos, reslen = bin.unpack(">S", data, pos)
-
-    pos, currRR.data = bin.unpack("A" .. reslen, data, pos)
+    pos, currRR.dtype, currRR.class, currRR.ttl, currRR.data = bin.unpack(
+      ">SSIP", data, pos)
 
     -- try to be smart: decode per type
     if decoder[currRR.dtype] then
@@ -1307,6 +1346,9 @@ local function decodeFlags(flgStr)
   if flgTbl[7] == '1' then flags.TC = true end
   if flgTbl[8] == '1' then flags.RD = true end
   if flgTbl[9] == '1' then flags.RA = true end
+  if flgTbl[10] == '1' then flags.Z = true end
+  if flgTbl[11] == '1' then flags.AD = true end
+  if flgTbl[12] == '1' then flags.CD = true end
   if flgTbl[13] == '1' then flags.RC1 = true end
   if flgTbl[14] == '1' then flags.RC2 = true end
   if flgTbl[15] == '1' then flags.RC3 = true end
@@ -1324,16 +1366,13 @@ function decode(data)
   local encFlags
   local cnt = {}
   pos, pkt.id, encFlags, cnt.q, cnt.a, cnt.auth, cnt.add = bin.unpack(">SB2S4", data)
-  -- for now, don't decode the flags
   pkt.flags = decodeFlags(encFlags)
+  local half_char_max = bit.lshift(1, 4) - 1
+  pkt.opcode = bit.band(bit.rshift(data:byte(3), 3), half_char_max)
+  pkt.rcode = bit.band(data:byte(4), half_char_max)
 
-  --
-  -- check whether this is an update response or not
-  -- a quick fix to allow decoding of non updates and not break for updates
-  -- the flags are enough for the current code to determine whether an update was successful or not
-  --
-  local strflags=encodeFlags(pkt.flags)
-  if ( strflags:sub(1,4) == "1010" ) then
+  -- Check whether this is an update response or not.
+  if pkt.flags.QR and pkt.opcode == opcodes.update then
     return pkt
   else
     pos, pkt.questions = decodeQuestions(data, cnt.q, pos)
@@ -1353,6 +1392,8 @@ function newPacket()
   pkt.id = 1
   pkt.flags = {}
   pkt.flags.RD = true
+  -- pkt.opcode not set.
+  -- pkt.rcode not set.
   pkt.questions = {}
   pkt.zones = {}
   pkt.updates = {}
@@ -1512,7 +1553,6 @@ end
 function update(dname, options)
   local options = options or {}
   local pkt = newPacket()
-  local flags = pkt.flags
   local host, port = options.host, options.port
   local timeout = ( type(options.timeout) == "number" ) and options.timeout or get_default_timeout()
   local sendcount = options.sendCount or 2
@@ -1531,8 +1571,8 @@ function update(dname, options)
     return false, "hostname needs to be supplied as FQDN"
   end
 
-  flags.RD = false
-  flags.OC1, flags.OC2, flags.OC3, flags.OC4 = false, true, false, true
+  pkt.flags.RD = false
+  pkt.opcode = opcodes.update
 
   -- If ttl is zero and updata is string and zero length or nil, assume delete record
   if ( ttl == 0 and ( ( type(updata) == "string" and #updata == 0 ) or not(updata) ) ) then
@@ -1573,8 +1613,7 @@ function update(dname, options)
 
   if ( status ) then
     local decoded = decode(response[1].data)
-    local flags=encodeFlags(decoded.flags)
-    if (flags:sub(-4) == "0000") then
+    if decoded.rcode == rcodes.noerror then
       return true
     end
   end
@@ -1585,8 +1624,70 @@ if not unittest.testing() then
   return _ENV
 end
 
--- Self test
-test_suite = unittest.TestSuite:new()
+-- Self tests
 
-test_suite:add_test(unittest.equal(encodeFQDN("test.me.com"), "\x04test\x02me\x03com\0"), "encodeFQDN")
+--; Test tables for equality or string match, 1 level deep
+-- @param aa The first table to test
+-- @param bb The second table to test
+-- @return bool True if #aa == #bb and aa[i] match bb[i] or aa[i] ==
+-- bb[i] (depending on type of bb[i]) for every i<#bb, false
+-- otherwise.
+local function table_equal_or_match(aa, bb)
+  return function(suite)
+    if #aa ~= #bb then
+      return false, "Length not equal"
+    end
+    local ii, pattern
+    for ii, pattern in ipairs(bb) do
+      if type(pattern) == 'string' then
+        if not aa[ii]:match(pattern) then
+          return false, string.format("'%s' does not match '%s' at position %d", aa[ii], pattern, ii)
+        end
+      elseif pattern ~= aa[ii] then
+        return false, string.format("%s ~= %s at position %d", pattern, aa[ii], ii)
+      end
+    end
+    return true
+  end
+end
+
+test_suite = unittest.TestSuite:new()
+test_suite:add_test(unittest.equal(encodeFQDN('x.x.x.x.x.x.x.x.x.x.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.-.x.x.x.x.x.x.x.x.x.x.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.-.x.x.x.x.x.x.x.x.x.x.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.-.x.x.x.x.x.x.x.x.x.x.x.a.b.c.d.e.'), '\1x\1x\1x\1x\1x\1x\1x\1x\1x\1x\1a\1b\1c\1d\1e\1f\1g\1h\1i\1j\1k\1l\1m\1n\1o\1p\1q\1r\1s\1t\1u\1v\1w\1x\1y\1z\1-\1x\1x\1x\1x\1x\1x\1x\1x\1x\1x\1a\1b\1c\1d\1e\1f\1g\1h\1i\1j\1k\1l\1m\1n\1o\1p\1q\1r\1s\1t\1u\1v\1w\1x\1y\1z\1-\1x\1x\1x\1x\1x\1x\1x\1x\1x\1x\1a\1b\1c\1d\1e\1f\1g\1h\1i\1j\1k\1l\1m\1n\1o\1p\1q\1r\1s\1t\1u\1v\1w\1x\1y\1z\1-\1x\1x\1x\1x\1x\1x\1x\1x\1x\1x\1x\1a\1b\1c\1d\1e\0'), 'encodeFQDN long name')
+test_suite:add_test(unittest.equal(encodeFQDN('scanme.nmap.org.'),
+                                   '\x06scanme\x04nmap\x03org\0'),
+                    'encodeFQDN scanme.nmap.org.')
+test_suite:add_test(unittest.equal(encodeFQDN('scanme.nmap.org'),
+                                   '\x06scanme\x04nmap\x03org\0'),
+                    'encodeFQDN scanme.nmap.org')
+test_suite:add_test(unittest.equal(encodeFQDN('nmap.org.'),
+                                   '\x04nmap\x03org\0'),
+                    'encodeFQDN nmap.org.')
+test_suite:add_test(unittest.equal(encodeFQDN('nmap.org'),
+                                   '\x04nmap\x03org\0'),
+                    'encodeFQDN nmap.org')
+test_suite:add_test(unittest.equal(encodeFQDN('net.'),
+                                   '\x03net\0'),
+                    'encodeFQDN net.')
+test_suite:add_test(unittest.equal(encodeFQDN('net'),
+                                   '\x03net\0'),
+                    'encodeFQDN net')
+test_suite:add_test(unittest.equal(encodeFQDN('.'),
+                                   '\0'),
+                    'encodeFQDN .')
+test_suite:add_test(unittest.equal(encodeFQDN(''),
+                                   '\0'),
+                    'encodeFQDN empty string')
+test_suite:add_test(unittest.equal(encodeFQDN(nil),
+                                   '\0'),
+                    'encodeFQDN nil')
+test_suite:add_test(table_equal_or_match({ pcall(encodeFQDN, '0123456789abcdefghijklmnopqrstuvwxyz-0123456789abcdefghijklmnopq.net.') },
+                      { false, 'Illegal name, label: 0123456789abcdefghijklmnopqrstuvwxyz%-0123456789abcdefghijklmnopq exceeds 63 octets%.$' }),
+                    'encodeFQDN long label')
+test_suite:add_test(table_equal_or_match({ pcall(encodeFQDN,  '.nmap.org') },
+                      { false, 'Illegal name: %.nmap%.org, contains empty label%.$' }),
+                    'encodeFQDN empty label')
+test_suite:add_test(table_equal_or_match({ pcall(encodeFQDN,  '..') },
+                      { false, 'Illegal name: %.%., contains empty label%.$' }),
+                    'encodeFQDN empty label')
+
 return _ENV;

--- a/scripts/dns-server.nse
+++ b/scripts/dns-server.nse
@@ -1,0 +1,523 @@
+-- -*- mode: lua; lua-indent-level: 2; ispell-local-dictionary: "british" -*-
+
+local dns = require "dns"
+local bin = require "bin"
+local bit = require "bit"
+local nmap = require "nmap"
+local math = require "math"
+local stdnse = require "stdnse"
+local shortport = require "shortport"
+
+
+description = [[
+Show responses to dns query, optionally limited to responses matching
+certain conditions, see the report arg.
+]]
+
+
+---
+-- @usage
+-- nmap -sUS -p53 --script=dns-server -- <target>
+--
+-- @args
+-- dns-server.name string naming domain to look up, default: nmap.org.
+--
+-- dns-server.type string naming type to look up, default: a.
+--
+-- dns-server.class string naming class to look up, default: in.
+--
+-- dns-server.clear-do boolean requesting that no dnssec ok (do) flag
+-- should be sent in an opt pseudo rr, default false.
+--
+-- dns-server.clear-opt boolean requesting that no opt pseudo rr
+-- should be included int the query, implies clear-do, default false.
+--
+-- dns-server.report string naming conditions that should cause non
+-- nil report, colon separated list of one or more of these: 'ra' to
+-- report answers with ra flag (recursion), 'upref' to report answers
+-- over udp with upward referral, 'amp>n' to report answers over udp
+-- with bandwidth amplification factor greater than n (an integer).
+--
+-- @output
+-- PORT   STATE SERVICE
+-- 53/tcp open  domain
+-- | dns-server:
+-- |   status: noerror (0)
+-- |   id: 31530
+-- |   flags: qr rd ra
+-- |   rr counts: query: 1, answer: 1, authority: 0, additional: 1
+-- |   opt pseudosection:
+-- |     edns: version: 0, flags: do, udp: 4096
+-- |   question section:
+-- |     nmap.org.                    IN      A
+-- |   answer section:
+-- |_    nmap.org.            3562    IN      A       45.33.49.119
+-- 53/udp open  domain
+-- | dns-server:
+-- |   payload amplification: 53/37=1.4
+-- |   status: noerror (0)
+-- |   id: 63004
+-- |   flags: qr rd ra
+-- |   rr counts: query: 1, answer: 1, authority: 0, additional: 1
+-- |   opt pseudosection:
+-- |     edns: version: 0, flags: do, udp: 4096
+-- |   question section:
+-- |     nmap.org.                    IN      A
+-- |   answer section:
+-- |_    nmap.org.            3562    IN      A       45.33.49.119
+--
+-- @xmloutput
+-- <ports>
+--   <port protocol="tcp" portid="53">
+--     <state state="open" reason="syn-ack" reason_ttl="62"/>
+--     <service name="domain" method="table" conf="3"/>
+--     <script id="dns-server" output="See @output.">
+--       <elem key="status">noerror (0)</elem>
+--       <elem key="id">31530</elem>
+--       <elem key="flags">qr rd ra</elem>
+--       <elem key="rr counts">query: 1, answer: 1, authority: 0, additional: 1</elem>
+--       <table key="opt pseudosection">
+--         <elem>edns: version: 0, flags: do, udp: 4096</elem>
+--       </table>
+--       <table key="question section">
+--         <elem>nmap.org.                    IN      A</elem>
+--       </table>
+--       <table key="answer section">
+--         <elem>nmap.org.            3562    IN      A       45.33.49.119</elem>
+--       </table>
+--     </script>
+--   </port>
+--   <port protocol="udp" portid="53">
+--     <state state="open" reason="udp-response" reason_ttl="62"/>
+--     <service name="domain" method="table" conf="3"/>
+--     <script id="dns-server" output="See @output.">
+--       <elem key="payload amplification">53/37=1.4</elem>
+--       <elem key="status">noerror (0)</elem>
+--       <elem key="id">63004</elem>
+--       <elem key="flags">qr rd ra</elem>
+--       <elem key="rr counts">query: 1, answer: 1, authority: 0, additional: 1</elem>
+--       <table key="opt pseudosection">
+--         <elem>edns: version: 0, flags: do, udp: 4096</elem>
+--       </table>
+--       <table key="question section">
+--         <elem>nmap.org.                    IN      A</elem>
+--       </table>
+--       <table key="answer section">
+--         <elem>nmap.org.            3562    IN      A       45.33.49.119</elem>
+--       </table>
+--     </script>
+--   </port>
+-- </ports>
+
+
+categories = { "default", "discovery", "safe" }
+author = "Ulrik Haugen"
+license = "Same as Nmap--See http://nmap.org/book/man-legal.html"
+
+-- https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml
+
+portrule = shortport.service('domain', { 'udp', 'tcp' })
+
+
+--- Like assert but put /message/ in the ERROR key in /results_table/ to
+-- better suit collate_results and pass 0 as level to error to ensure
+-- the error message will not be prefixed with file and line number.
+-- /results_table/ may be left out.
+local function assert_w_table(condition, message, results_table)
+  if condition then
+    return condition
+  else
+    results_table = results_table or {}
+    results_table.ERROR = message
+    error(results_table, 0)
+  end
+end
+
+
+--- Return sorted keys of /tab/.
+local function sorted_keys(tab)
+  local keys = {}
+  for key in pairs(tab) do
+    keys.insert(key)
+  end
+  table.sort(keys)
+  return keys
+end
+
+
+--- Computed tables.
+local class_by_id = {}
+local type_by_id = {}
+local rcode_by_id = {}
+
+
+--- Constants.
+local short_max = bit.lshift(1, 16) - 1
+
+
+--- Return string listing flags set in /flags/ ordered as in
+-- /flags_order/ and lower cased.
+local function list_flags(flags, flags_order)
+  local flags_list = ''
+  for idx, flag in pairs(flags_order) do
+    if flags[flag] then
+      flags_list = flags_list .. flag:lower() .. ' '
+    end
+  end
+  return flags_list:sub(1, -2)
+end
+
+
+--- Translate /rcode/ to status string.
+local function status_for_rcode(rcode)
+  return ("%s (%u)"):format(rcode_by_id[rcode], rcode)
+end
+
+
+--- Formatter for cname, ns and ptr rr.
+local function domain_formatter(rr)
+  return ("%s."):format(rr.domain)
+end
+
+
+--- Formatter for soa rr.
+local function soa_formatter(rr)
+  return ("%s. %s. %u %u %u %u %u"):format(
+    rr.SOA.mname, rr.SOA.rname, rr.SOA.serial, rr.SOA.refresh,
+    rr.SOA.retry, rr.SOA.expire, rr.SOA.minimum)
+end
+
+
+--- Formatters for an rr indexed by rr type value.
+local formatter_by_dtype = {
+  [ dns.types.A ] = function(rr) return rr.ip end,
+  [ dns.types.AAAA ] = function(rr) return rr.ipv6 end,
+  [ dns.types.SSHFP ] = function(rr) return ("%u %s"):format(
+      rr.SSHFP.fptype, rr.SSHFP.fingerprint) end,
+  [ dns.types.SOA ] = soa_formatter,
+  [ dns.types.NSEC ] = function(rr) return ("%s. %s. %s"):format(
+      rr.NSEC.dname, rr.NSEC.next_dname,
+      sorted_keys(rr.NSEC.types)) end,
+  [ dns.types.NSEC3 ] = function(rr) return ("%s. %u %s %s"):format(
+      rr.NSEC3.dname, rr.NSEC3.hash.alg,
+      rr.NSEC3.hash.base32, rr.NSEC3.salt.hex) end,
+  [ dns.types.CNAME ] = domain_formatter,
+  [ dns.types.NS ] = domain_formatter,
+  [ dns.types.PTR ] = domain_formatter,
+  [ dns.types.TXT ] = function(rr) return ('"%s"'):format(
+      table.concat(rr.TXT.text, '" "')) end,
+  [ dns.types.MX ] = function(rr) return ("%u %s."):format(
+      rr.MX.pref, rr.MX.server) end,
+  [ dns.types.SRV ] = function(rr) return ("%u %u %u %s."):format(
+      rr.SRV.prio, rr.SRV.weight, rr.SRV.port,
+      rr.SRV.target) end,
+}
+
+
+--- Return /rr/ as string of dname, ttl, class and type and rrdata.
+--
+-- Formatted according to formatter_by_dtype or just type number,
+-- rdata length and rdata in hex.
+local function answer_by_dtype(rr)
+  if formatter_by_dtype[rr.dtype] then
+    return ("%-20s %-7d %-7s %-7s %s"):format(
+      rr.dname .. '.', rr.ttl,
+      class_by_id[rr.class],
+      type_by_id[rr.dtype],
+      formatter_by_dtype[rr.dtype](rr))
+  else
+    local len, unpacked_data = bin.unpack("A" .. rr.data:len(), rr.data)
+    return ("%-20s %-7d %-7s unparsed_type(%u, %u, %s)"):format(
+      rr.dname .. '.', rr.ttl,
+      class_by_id[rr.class],
+      rr.dtype,
+      len,
+      stdnse.tohex(unpacked_data))
+  end
+end
+
+
+--- Decode opt pseudo rr, rfc 6891.
+local function decode_opt(rr)
+  local do_bit = bit.lshift(1, 15)
+  local opt = { ext_rcode = rr.OPT.rcode,
+                version = rr.OPT.version,
+                flags = { DO = bit.band(rr.OPT.zflags, do_bit) ~= 0, },
+                zflags = bit.band(rr.OPT.zflags, bit.bnot(do_bit)),
+                max_udp_pl = rr.OPT.bufsize,
+                rdlen = rr.OPT.rdlen,
+                rdata = rr.OPT.data, }
+  return opt
+end
+
+
+--- Check /response/ for ra flag and nonempty answer section. Return a
+-- boolean.
+local function has_ra_flag_and_answers(_, port, response)
+  return response.flags.RA and #response.answers > 0
+end
+
+
+--- Check udp /response/ for upward referrals. Return a boolean.
+--
+-- https://www.dns-oarc.net/oarc/articles/upward-referrals-considered-harmful
+local function has_upref(_, port, response)
+  if port.protocol ~= 'udp' then
+    return false
+  end
+  local root_server_name_pattern = '%.root%-servers%.net$'
+  local idx, rr
+  for idx, rr in ipairs(response.auth) do
+    if (rr.dtype == dns.types.NS
+        and rr.domain:lower():match(root_server_name_pattern)) then
+      return true
+    end
+  end
+  for idx, rr in ipairs(response.add) do
+    if ((rr.dtype == dns.types.A or rr.dtype == dns.types.AAAA)
+      and rr.dname:lower():match(root_server_name_pattern)) then
+      return true
+    end
+  end
+  return false
+end
+
+--- Check udp /response/ for amplification factor greater than
+-- /limit/. Return a boolean.
+local function has_amp_gt(limit, port, response)
+  if port.protocol ~= 'udp' then
+    return false
+  end
+  assert_w_table(limit > 0, ("Invalid limit for report.amp>: %s"):format(limit))
+  return response.response_pl_len / response.query_pl_len > limit
+end
+
+
+--- Parse /report_arg/ and return an object to help with testing
+-- port/response.
+local function parse_report_arg(report_arg)
+  local report_response = {
+    __conds = {},
+    __order = {},
+    __enabled = {},
+    --- Define /condition/ with /reason/ and /test/.
+    define = function(ct, condition, reason, test)
+      ct.__conds[condition] = { reason = reason, test = test, }
+      table.insert(ct.__order, condition)
+    end,
+    --- Enable /condition/.
+    enable = function(ct, condition, limit)
+      ct.__enabled[condition] = true
+      ct.__conds[condition].limit = limit
+      return ct.__conds[condition] ~= nil
+    end,
+    --- Return true if no conditions are enabled, false otherwise.
+    empty = function(ct)
+      return next(ct.__enabled) == nil
+    end,
+    --- Iterate over enabled conditions in the order they were
+    --- defined, yield reason and test for each condition.
+    enabled_conditions = function(ct)
+      return coroutine.wrap(
+        function()
+          local idx, condition
+          for idx, condition in ipairs(ct.__order) do
+            if ct.__enabled[condition] then
+              coroutine.yield(ct.__conds[condition])
+            end
+          end
+        end)
+    end,
+  }
+  -- Define conditions in decreasing order of severity.
+  report_response:define('amp>', "amplification", has_amp_gt)
+  report_response:define('ra', "recursion", has_ra_flag_and_answers)
+  report_response:define('upref', "upwards referral", has_upref)
+
+  if report_arg then
+    local label, limit
+    for label, limit in report_arg:gmatch('(%w+[>]?)(%d*)') do
+      assert_w_table(report_response:enable(label, tonumber(limit)),
+                     "Unrecognised condition: " .. label)
+    end
+  end
+
+  return report_response
+end
+
+
+--- Query dns-server on /host/, /port/ for /qname/, /qclass_raw/,
+-- /qtype_raw/, limiting responses according to /report_raw/. Returns
+-- an output_table.
+local function query_server(host, port,
+                            qname, qclass_raw, qtype_raw,
+                            clear_do, clear_opt,
+                            report_raw)
+  local qclass = dns.CLASS[qclass_raw:upper()]
+  assert_w_table(qclass, "Invalid class: " .. qclass_raw)
+  local qtype = dns.types[qtype_raw:upper()]
+  assert_w_table(qtype, "Invalid type: " .. qtype_raw)
+  local report_response = parse_report_arg(report_raw)
+
+  local query_table = dns.newPacket()
+  query_table.opcode = dns.opcodes.query
+  dns.addQuestion(query_table, qname, qtype, qclass)
+  if not clear_opt then
+    dns.addOPT(query_table, { DO = not clear_do, })
+  end
+  query_table.id = math.random(0, short_max)
+  local query_pl = dns.encode(query_table)
+  local status, response_or_error = dns.sendPackets(
+    query_pl, host.ip, port.number,
+    dns.get_default_timeout(),
+    2,     -- maximum send count for udp
+    false, -- don't expect multiple responses
+    port.protocol)
+  assert_w_table(status, response_or_error)
+  nmap.set_port_state(host, port, 'open')
+  local response_info = stdnse.output_table()
+
+  assert_w_table(#response_or_error == 1, "unexpected response count")
+  response_table = dns.decode(response_or_error[1].data)
+  response_table.query_pl_len = query_pl:len()
+  response_table.response_pl_len = response_or_error[1].data:len()
+
+  if not report_response:empty() then
+    local condition
+    for condition in report_response:enabled_conditions() do
+      if condition.test(condition.limit, port, response_table) then
+        response_info["reported for"] = condition.reason
+        break
+      end
+    end
+    assert_w_table(response_info["reported for"],
+                   "Response matches no conditions in "
+                     .. SCRIPT_NAME .. ".report: "
+                     .. report_raw:gsub(':', ', '),
+                   response_info)
+  end
+
+  if port.protocol == 'udp' then
+    response_info['payload amplification'] = ("%u/%u=%.1f"):format(
+      response_table.response_pl_len, response_table.query_pl_len,
+      response_table.response_pl_len / response_table.query_pl_len)
+  end
+
+  response_info.status = ''
+  response_info.id = response_table.id
+
+  local rcode = response_table.rcode
+  local idx, question, answer, section
+  response_info.flags = list_flags(response_table.flags,
+                                   { 'QR', 'AA', 'TC', 'RD', 'RA',
+                                     'Z', 'AD', 'CD', })
+  response_info['rr counts'] = (
+    "query: %u, answer: %u, authority: %u, additional: %u"):format(
+    #response_table.questions, #response_table.answers,
+    #response_table.auth, #response_table.add)
+  response_info['opt pseudosection'] = {}
+
+  response_info["question section"] = {}
+  for idx, question in pairs(response_table.questions) do
+    table.insert(response_info["question section"],
+                 ("%-28s %-7s %s"):format(
+                   question.dname .. '.', class_by_id[question.class],
+                   type_by_id[question.dtype]))
+  end
+
+  local opt = nil
+  for idx, section in pairs({
+      { key = 'answers', label = "answer section" },
+      { key = 'auth', label = "authority section" },
+      { key = 'add', label = "additional section" }, }) do
+    for idx, rr in pairs(response_table[section.key]) do
+      if idx == 1 then
+        response_info[section.label] = {}
+      end
+      if section.key == 'add' and rr.dtype == dns.types.OPT then
+        opt = decode_opt(rr)
+      else
+        table.insert(response_info[section.label], answer_by_dtype(rr))
+      end
+    end
+  end
+
+  if opt then
+    rcode = bit.lshift(opt.ext_rcode, 4) + rcode
+    table.insert(response_info['opt pseudosection'],
+                 ("edns: version: %u, flags: %s, udp: %u"):format(
+                   opt.version, list_flags(opt.flags, { 'DO', }),
+                   opt.max_udp_pl))
+    if opt.zflags ~= 0 then
+      table.insert(response_info['opt pseudosection'],
+                   ("undecoded z flags: %x"):format(opt.zflags))
+    end
+    if opt.rdlen > 0 then
+      -- rudimentary presentation
+      table.insert(response_info['opt pseudosection'],
+                   ("rdlen: %u, rdata: %s"):format(opt.rdlen, opt.rdata))
+    end
+  else
+    response_info['opt pseudosection'] = nil
+  end
+  response_info.status = status_for_rcode(rcode)
+
+  -- Remove empty sections.
+  if (response_info['additional section'] ~= nil
+      and next(response_info['additional section'])) == nil then
+    response_info['additional section'] = nil
+  end
+
+  return response_info
+end
+
+
+--- Return /results_table/ unless contraindicated by /status/ and
+-- debugging being false.
+local function collate_results(status, results_table)
+  if not status and nmap.debugging() < 1 then
+    return nil
+  end
+  return results_table
+end
+
+
+--- Nmap entry point.
+function action(host, port)
+  -- Define global computed tables.
+  local class, dtype, id
+  for class, id in pairs(dns.CLASS) do
+    class_by_id[id] = class
+  end
+  for dtype, id in pairs(dns.types) do
+    type_by_id[id] = dtype
+  end
+  for rcode, id in pairs(dns.rcodes) do
+    rcode_by_id[id] = rcode
+  end
+
+  -- Get script args.
+
+  -- nmap.org selected as default name for two reasons:
+  -- * it should be registered for the service life of this script
+  -- * whoever scans the nmap.org datacenter for open resolvers should
+  --   be the last to have trouble with supplying script args
+  local qname = stdnse.get_script_args(
+    SCRIPT_NAME .. ".name") or 'nmap.org'
+  local qtype = stdnse.get_script_args(
+    SCRIPT_NAME .. ".type") or 'a'
+  local qclass = stdnse.get_script_args(
+    SCRIPT_NAME .. ".class") or 'in'
+  local clear_do = stdnse.get_script_args(
+    SCRIPT_NAME .. ".clear-do")
+  local clear_opt = stdnse.get_script_args(
+    SCRIPT_NAME .. ".clear-opt")
+  local report = stdnse.get_script_args(
+    SCRIPT_NAME .. ".report")
+
+  -- Dispatch.
+  return collate_results(pcall(query_server, host, port,
+                               qname, qclass, qtype,
+                               clear_do, clear_opt,
+                               report))
+end

--- a/scripts/rmi-dumpregistry.nse
+++ b/scripts/rmi-dumpregistry.nse
@@ -6,7 +6,8 @@ local string = require "string"
 local table = require "table"
 
 description = [[
-Connects to a remote RMI registry and attempts to dump all of its objects.
+Connects to a remote RMI registry and attempts to dump all of its
+objects.
 
 First it tries to determine the names of all objects bound in the
 registry, and then it tries to determine information about the
@@ -19,7 +20,8 @@ on it.
 It also gives information about where the objects are located, (marked
 with @<ip>:port in the output).
 
-Some apps give away the classpath, which this scripts catches in so-called "Custom data".
+Some apps give away the classpath, which this scripts catches in
+so-called "Custom data".
 ]]
 
 ---
@@ -181,7 +183,7 @@ end
 -- @return title, data
 function customDataFormatter(className, customData)
   if customData == nil then return nil end
-  if #customData ==0 then return nil end
+  if #customData == 0 then return nil end
 
   local retData = {}
   for k,v in ipairs(customData) do
@@ -200,18 +202,17 @@ end
 
 
 function action(host,port, args)
-
-  local registry= rmi.Registry:new( host, port )
-
+  local registry = rmi.Registry:new( host, port )
 
   local status, j_array = registry:list()
   local output = {}
   if not status then
-    return false, ("Registry listing failed (%s)"):format(tostring(j_array))
+    table.insert(output, ("Registry listing failed (%s)"):format(tostring(j_array)))
+    return stdnse.format_output(false, output)
   end
   -- It's definitely RMI!
-  port.version.name ='java-rmi'
-  port.version.product='Java RMI Registry'
+  port.version.name = 'java-rmi'
+  port.version.product = 'Java RMI Registry'
   nmap.set_port_version(host,port)
 
   -- Monkey patch the java-class in rmi, to set our own custom data formatter
@@ -224,13 +225,12 @@ function action(host,port, args)
     --print(data)
     table.insert(output, name)
     dbg("Querying object %s", name)
-    local status, j_object= registry:lookup(name)
+    local status, j_object = registry:lookup(name)
 
     if status then
       table.insert(output, j_object:toTable())
     end
-
-
   end
+
   return stdnse.format_output(true, output)
 end


### PR DESCRIPTION
I have created an Nmap script to scan for dns servers optionally limited to one or more of recursive servers over tcp and udp, servers with upwards referrals over udp or amplifiers over udp, see example below.

Probes can be extensively configured to whatever provokes your targets.

Responses received are clearly presented.

At work we are running an earlier version of this script with good results.

The changes to dns.lua enable working with rcodes and opcodes directly rather than bitwise through the flags, make sendPackets available externally so that the amplification ratio can be determined, encodes and decodes more flags. The rest is mainly tidying up and some changes to encodeFQDN as the version I started with did not work on names with terminal dot and I wanted to be able to supply the root as a script argument.

I look forward to getting your feedback. ~~In particular if anyone has suggestions for making both the plain and xml formatted output look good.~~ [ I have replaced the tabs with formatting field widths so it looks a lot more presentable. ]

Example run with report argument:

    # nmap -sUS -p53 --script dns-server --script-args 'dns-server.report=ra:upref:amp>30,dns-server.name=a,dns-server.type=ns,dns-server.clear-opt' server-a.example.net server-b.example.net server-c.example.net server-d.example.net
    
    Starting Nmap 6.47 ( http://nmap.org ) at 2015-08-14 20:40 CEST
    Nmap scan report for server-a.example.net (192.168.21.9)
    Host is up (0.00032s latency).
    rDNS record for 192.168.21.9: ns.example.net
    PORT   STATE SERVICE
    53/tcp open  domain
    | dns-server: 
    |   reported for: recursion
    |   status: nxdomain (3)
    |   id: 8234
    |   flags: qr rd ra
    |   rr counts: query: 1, answer: 0, authority: 1, additional: 0
    |   question section: 
    |     a.                IN      NS
    |   authority section: 
    |_    . 10271   IN      SOA     a.root-servers.net. nstld.verisign-grs.com. 2015081401 1800 900 604800 86400
    53/udp open  domain
    | dns-server: 
    |   reported for: recursion
    |   payload amplification: 94/19=4.9
    |   status: nxdomain (3)
    |   id: 24639
    |   flags: qr rd ra
    |   rr counts: query: 1, answer: 0, authority: 1, additional: 0
    |   question section: 
    |     a.                IN      NS
    |   authority section: 
    |_    . 10271   IN      SOA     a.root-servers.net. nstld.verisign-grs.com. 2015081401 1800 900 604800 86400
    
    Nmap scan report for server-b.example.net (192.168.26.52)
    Host is up (0.00057s latency).
    PORT   STATE SERVICE
    53/tcp open  domain
    53/udp open  domain
    
    Nmap scan report for server-c.example.net (192.168.23.21)
    Host is up (0.00034s latency).
    PORT   STATE SERVICE
    53/tcp open  domain
    53/udp open  domain
    
    Nmap scan report for server-d.example.net (192.168.249.154)
    Host is up (0.0018s latency).
    PORT   STATE SERVICE
    53/tcp open  domain
    53/udp open  domain
    | dns-server: 
    |   reported for: upwards referral
    |   payload amplification: 498/19=26.2
    |   status: noerror (0)
    |   id: 6456
    |   flags: qr rd
    |   rr counts: query: 1, answer: 0, authority: 13, additional: 4
    |   question section: 
    |     a.                IN      NS
    |   authority section: 
    |     . 3600    IN      NS      d.root-servers.net.
    |     . 3600    IN      NS      c.root-servers.net.
    |     . 3600    IN      NS      b.root-servers.net.
    |     . 3600    IN      NS      a.root-servers.net.
    |     . 3600    IN      NS      m.root-servers.net.
    |     . 3600    IN      NS      l.root-servers.net.
    |     . 3600    IN      NS      k.root-servers.net.
    |     . 3600    IN      NS      j.root-servers.net.
    |     . 3600    IN      NS      i.root-servers.net.
    |     . 3600    IN      NS      h.root-servers.net.
    |     . 3600    IN      NS      g.root-servers.net.
    |     . 3600    IN      NS      f.root-servers.net.
    |     . 3600    IN      NS      e.root-servers.net.
    |   additional section: 
    |     d.root-servers.net.       3600    IN      A       128.8.10.90
    |     c.root-servers.net.       3600    IN      A       192.33.4.12
    |     b.root-servers.net.       3600    IN      A       192.228.79.201
    |_    a.root-servers.net.       3600    IN      A       198.41.0.4
    
    Nmap done: 4 IP addresses (4 hosts up) scanned in 4.92 seconds