### PR TITLE
TCP options interface for nping

### DIFF
--- a/nping/ArgParser.cc
+++ b/nping/ArgParser.cc
@@ -197,6 +197,10 @@ int ArgParser::parseArguments(int argc, char *argv[]) {
   {"ack", required_argument, 0, 0},
   {"win", required_argument, 0, 0},
   {"badsum", no_argument, 0, 0},
+  {"tcp-options", no_argument, 0, 0},
+  {"tcp-ts", no_argument, 0, 0},
+  {"ts-increment", no_argument, 0, 0},
+  {"tcp-options-raw", required_argument, 0, 0},
 
   /* ICMP */ 
   {"icmp-type", required_argument, 0, 0},
@@ -536,6 +540,21 @@ int ArgParser::parseArguments(int argc, char *argv[]) {
     /* Set a bad TCP checksum */
     } else if (optcmp(long_options[option_index].name, "badsum") == 0) {
         o.enableBadsum();
+    /* use TCP Options */
+    } else if (optcmp(long_options[option_index].name, "tcp-options") == 0) {
+        o.setGenericTCPOptions(true);
+    } else if (optcmp(long_options[option_index].name, "tcp-ts") == 0) {
+        o.setTCPOptTSUse(true);
+    } else if (optcmp(long_options[option_index].name, "ts-increment") == 0) {
+        o.setTCPOptTSIncrement(true);
+    } else if (optcmp(long_options[option_index].name, "tcp-options-raw") == 0) {
+        u8 *tempbuff=NULL;
+        size_t len=0;
+        if( (tempbuff=parseBufferSpec(optarg, &len))==NULL) 
+            nping_fatal(QT_3,"Invalid hex string specification for raw tcp options\n");
+        else{
+            o.setRawTCPOptions(tempbuff, len);
+        }
 
 /* ICMP OPTIONS **************************************************************/
     /* ICMP Type */
@@ -1220,6 +1239,10 @@ void ArgParser::printUsage(void){
 "   --ack <acknumber>               : Set ACK number.\n"
 "   --win <size>                    : Set window size.\n"
 "   --badsum                        : Use a random invalid checksum. \n"
+"   --tcp-options                   : Include hardcoded TCP Options in packet\n"
+"   --tcp-options-raw <hexstring>   : Use the given hex string as the TCP Options\n"
+"   --tcp-ts                        : Include a timestamp value in the TCP Options\n"
+"   --ts-increment                  : Increment the timestamp value in the TCP Options\n"
 "UDP PROBE MODE:\n"
 "   -g, --source-port <portnumber>  : Set source port.\n"
 "   -p, --dest-port <port spec>     : Set destination port(s).\n"

--- a/nping/NpingOps.cc
+++ b/nping/NpingOps.cc
@@ -266,6 +266,13 @@ NpingOps::NpingOps() {
     tcpwin=0;
     tcpwin_set=false;
 
+    tcpopts=NULL;
+    tcpopts_set=false;
+    tcpopts_len=0;
+    tcpopts_use=false;
+    tcpopts_tsuse=false;
+    tcpopts_tsincrement=false;
+
     badsum=false;
     badsum_set=false;
 
@@ -376,6 +383,8 @@ NpingOps::~NpingOps() {
     free(ip_options);
  if ( target_ports!=NULL )
     free(target_ports);
+ if ( tcpopts!=NULL )
+    free(tcpopts);
  return;
 } /* End of ~NpingOps() */
 
@@ -1649,6 +1658,57 @@ bool NpingOps::issetTCPWindow(){
   return this->tcpwin_set;
 } /* End of issetTCPWindow() */
 
+/** Sets the use of TCP Options.  Which TCP options to use are hard-coded with this mode
+ */
+int NpingOps::setGenericTCPOptions(bool val) {
+  this->tcpopts_use = val;
+  return OP_SUCCESS;
+}
+
+bool NpingOps::issetGenericTCPOptions() {
+  return this->tcpopts_use;
+}
+
+int NpingOps::setTCPOptTSIncrement(bool val) {
+  this->tcpopts_tsincrement = val;
+  return OP_SUCCESS;
+}
+
+bool NpingOps::issetTCPOptTSIncrement() {
+  return this->tcpopts_tsincrement;
+}
+
+int NpingOps::setTCPOptTSUse(bool val) {
+  this->tcpopts_tsuse = val;
+  return OP_SUCCESS;
+}
+
+bool NpingOps::issetTCPOptTSUse() {
+  return this->tcpopts_tsuse;
+}
+
+// makes a copy of val
+int NpingOps::setRawTCPOptions(u8 *val, ssize_t len) {
+  this->tcpopts = (u8 *)safe_zalloc( len );
+  memcpy(this->tcpopts, val, len);
+  this->tcpopts_len = len;
+  this->tcpopts_set = true;
+  return OP_SUCCESS;
+}
+
+// val should point to an area at least len bytes long before calling
+int NpingOps::getRawTCPOptions(u8 *val, ssize_t *len) {
+  if(*len < this->tcpopts_len) {
+    nping_fatal(QT_3, "tcp options length buffer too small ");
+  }
+  memcpy(val, this->tcpopts, this->tcpopts_len);
+  *len = this->tcpopts_len;
+  return OP_SUCCESS;
+}
+
+bool NpingOps::issetRawTCPOptions() {
+  return this->tcpopts_set;
+}
 
 /** Sets attribute badsum to "true". (Generate invalid checksums in UDP / TCP
  *  packets)

--- a/nping/NpingOps.h
+++ b/nping/NpingOps.h
@@ -276,6 +276,12 @@ class NpingOps {
     bool tcpflags_set;
     u16 tcpwin;               /* TCP Window                            */
     bool tcpwin_set;
+    bool tcpopts_use;         /* use standard TCP options?             */
+    bool tcpopts_tsincrement; /* increment TS value?                   */
+    bool tcpopts_tsuse;       /* use TS in TCP options?                */
+    u8 *tcpopts;              /* raw TCP options                       */
+    ssize_t tcpopts_len;
+    bool tcpopts_set;
     bool badsum;              /* Generate invalid TCP/UDP checksums?   */
     bool badsum_set;
 
@@ -561,6 +567,16 @@ class NpingOps {
     int setTCPWindow(u16 val);
     u16 getTCPWindow();
     bool issetTCPWindow();
+
+    int setGenericTCPOptions(bool val);
+    bool issetGenericTCPOptions();
+    int setTCPOptTSIncrement(bool val);
+    bool issetTCPOptTSIncrement();
+    int setTCPOptTSUse(bool val);
+    bool issetTCPOptTSUse();
+    int setRawTCPOptions(u8 *val, ssize_t len);
+    int getRawTCPOptions(u8 *val, ssize_t *len);
+    bool issetRawTCPOptions();
 
     /* ICMP */
     int setICMPType(u8 type);


### PR DESCRIPTION
adds the following options to the TCP probe mode of nping:

```
--tcp-options                   : Include hardcoded TCP Options in packet
--tcp-options-raw <hexstring>   : Use the given hex string as the TCP Options
--tcp-ts                        : Include a timestamp value in the TCP Options
--ts-increment                  : Increment the timestamp value in the TCP Options
```
