### PR TITLE
Fix some inefficiencies in ip-geolocation-maxmind

### DIFF
--- a/scripts/ip-geolocation-maxmind.nse
+++ b/scripts/ip-geolocation-maxmind.nse
@@ -6,6 +6,9 @@ local nmap = require "nmap"
 local stdnse = require "stdnse"
 local table = require "table"
 
+-- TODO: Support IPv6. Database format supports it, but we need to be able to
+-- do equivalent of bit operations on 128-bit integers to make it work.
+
 description = [[
 Tries to identify the physical location of an IP address using a
 Geolocation Maxmind database file (available from
@@ -31,8 +34,26 @@ author = "Gorjan Petrovski"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 categories = {"discovery","external","safe"}
 
+local db_file
+local function get_db_file()
+  if db_file == nil then
+    db_file = stdnse.get_script_args(SCRIPT_NAME .. ".maxmind_db")
+    if db_file == nil then
+      db_file = nmap.fetchfile("nselib/data/GeoLiteCity.dat")
+      if db_file == nil then
+        stdnse.verbose1("You must specify a Maxmind database file with the maxmind_db argument.")
+      end
+    end
+  end
+  return db_file or false
+end
 
 hostrule = function(host)
+  if nmap.address_family() ~= "inet" then
+    stdnse.verbose1("Only IPv4 is currently supported.")
+    return false
+  end
+  if not get_db_file() then return false end
   local is_private, err = ipOps.isPrivate( host.ip )
   if is_private == nil then
     stdnse.debug1("Error in Hostrule: %s.", err )
@@ -389,13 +410,25 @@ local MaxmindDef = {
   }
 }
 
-local ip2long=function(ip_str)
-  local ip = stdnse.strsplit('%.',ip_str)
-  local ip_num = (tonumber(ip[1])*16777216 + tonumber(ip[2])*65536
-  + tonumber(ip[3])*256 + tonumber(ip[4]))
-  return ip_num
-end
+local record_metatable = {
+  __tostring = function(loc)
+    local output = {
+    "coordinates (lat,lon): ", loc.latitude, ",", loc.longitude, "\n"
+    }
 
+    if loc.city then
+      output[#output+1] = "city: "..loc.city
+    end
+    if loc.metro_code then
+      output[#output+1] = ", "..loc.metro_code
+    end
+    if loc.country_name then
+      output[#output+1] = ", "..loc.country_name
+    end
+    output[#output+1] = "\n"
+    return table.concat(output)
+  end
+}
 local GeoIP = {
   new = function(self, filename)
     local o = {}
@@ -461,28 +494,12 @@ local GeoIP = {
   output_record_by_addr = function(self,addr)
     local loc = self:record_by_addr(addr)
     if not loc then return nil end
-
-    local output = {}
-    --output.name = "Maxmind database"
-    table.insert(output, "coordinates (lat,lon): " .. loc.latitude .. "," .. loc.longitude)
-
-    local str = ""
-    if loc.city then
-      str = str.."city: "..loc.city
-    end
-    if loc.metro_code then
-      str = str .. ", "..loc.metro_code
-    end
-    if loc.country_name then
-      str = str .. ", "..loc.country_name
-    end
-    table.insert(output,str)
-
-    return output
+    setmetatable(loc, record_metatable)
+    return loc
   end,
 
   record_by_addr=function(self,addr)
-    local ipnum = ip2long(addr)
+    local ipnum = ipOps.todword(addr)
     return self:_get_record(ipnum)
   end,
 
@@ -584,28 +601,25 @@ local GeoIP = {
   end,
 }
 
-action = function(host,port)
-  local f_maxmind = stdnse.get_script_args(SCRIPT_NAME .. ".maxmind_db")
-
-  local output = {}
-
+local geoip
+local function get_geoip_instance()
+  if geoip then return geoip end
   --if f_maxmind is a string, it should specify the filename of the database
+  local f_maxmind = get_db_file()
   if f_maxmind then
-    local gi = assert( GeoIP:new(f_maxmind), "Wrong file specified for a Maxmind database")
-    local out = gi:output_record_by_addr(host.ip)
-    output = out
+    geoip = assert( GeoIP:new(f_maxmind), "Wrong file specified for a Maxmind database")
   else
-    local gi = assert( GeoIP:new(nmap.fetchfile("nselib/data/GeoLiteCity.dat")), "Cannot read Maxmind database file in 'nselib/data/'.")
-    local out = gi:output_record_by_addr(host.ip)
-    output = out
+    return nil
+  end
+  return geoip
+end
+
+action = function(host,port)
+
+  local gi = get_geoip_instance()
+  if not gi then
+    return stdnse.format_output(false, "No Maxmind database found")
   end
 
-  if(#output~=0) then
-    output.name = host.ip
-    if host.targetname then
-      output.name = output.name.." ("..host.targetname..")"
-    end
-  end
-
-  return stdnse.format_output(true,output)
+  return gi:output_record_by_addr(host.ip)
 end


### PR DESCRIPTION
Now, the hostrule makes sure that script args are in order and the
database exists. Previously, the action function was responsible for
these checks.

The GeoIP object representing the parsed database is cached.

The output has been changed to structured output. IP address removed,
since Nmap reports that already.

ip2long function replaced by ipOps.todword. This would have to change if
we move to support IPv6 either way.