### PR TITLE
Address false positive in hnap-info

### DIFF
--- a/scripts/hnap-info.nse
+++ b/scripts/hnap-info.nse
@@ -87,6 +87,14 @@ function get_text_callback(store, name)
 end
 
 function action (host, port)
+
+  -- Identify servers that answer 200 to invalid HTTP requests and exit as these would invalidate the tests
+  local _, http_status, _ = http.identify_404(host,port)
+  if ( http_status == 200 ) then
+    stdnse.debug1("Exiting due to ambiguous response from web server on %s:%s. All URIs return status 200.", host.ip, port.number)
+    return false
+  end
+
   local output = stdnse.output_table()
   local response = http.get(host, port, '/HNAP1')
   if response.status and response.status == 200 then


### PR DESCRIPTION
Currently hnap-info is generating false positives because it is treating HTTP 200 responses to requests for /HNAP1 as valid HNAP services.  There are multiple services that respond to every request with a HTTP 200 response.  Against these services hnap-info is often, but not consistently,  overwriting the version detection result with hnap.   I've added the standard code that will detect services that always responds 200 and then exit if found.  This should not break the normal functionality of the script unless hnap services behave this way to.  In that case the script needs to parse the response and validate the result prior to changing/updating the version detection result.

I have *NOT* tested this with an actual HNAP service.

CC @h4ck3rk3y