### PR TITLE
Bugfix for non-HTTP ports (xmlrpc-methods.nse)

### DIFF
--- a/scripts/xmlrpc-methods.nse
+++ b/scripts/xmlrpc-methods.nse
@@ -108,7 +108,7 @@ action = function(host, port)
       setmetatable(output["Supported Methods"], under_80)
     end
     return output
-  elseif response.body:find("<name>faultCode</name>", nil, true) then
+  elseif response and response.body and response.body:find("<name>faultCode</name>", nil, true) then
     output.error = "XMLRPC instance doesn't support introspection."
     return output, output.error
   end


### PR DESCRIPTION
Whenever the script runs on a non HTTP port (like a sshd running on
TCP/443), this script returns an ERROR because it references
response.body which is not set in such a case.