### PR TITLE
NSE: http.identify_404 - change to not follow redirects

### DIFF
--- a/nselib/http.lua
+++ b/nselib/http.lua
@@ -118,6 +118,7 @@ local table = require "table"
 local url = require "url"
 local smbauth = require "smbauth"
 local unicode = require "unicode"
+
 _ENV = stdnse.module("http", stdnse.seeall)
 
 ---Use ssl if we have it
@@ -2462,8 +2463,7 @@ function identify_404(host, port)
   local URL_404_2 = '/NmapUpperCheck' .. os.time(os.date('*t'))
   local URL_404_3 = '/Nmap/folder/check' .. os.time(os.date('*t'))
 
-  data = get(host, port, URL_404_1)
-
+  data = get(host, port, URL_404_1,{redirect_ok=false})
   if(data == nil) then
     stdnse.debug1("HTTP: Failed while testing for 404 status code")
     return false, "Failed while testing for 404 error message"

--- a/scripts/http-avaya-ipoffice-users.nse
+++ b/scripts/http-avaya-ipoffice-users.nse
@@ -39,10 +39,11 @@ local table = require "table"
 portrule = shortport.http
 
 action = function(host, port)
-  local _, http_status, _ = http.identify_404(host,port)
-  if ( http_status == 200 ) then
+  -- Identify servers that answer 200 to invalid HTTP requests and exit as these would invalidate the tests
+  local status_404, result_404, _ = http.identify_404(host,port)
+  if ( status_404 and result_404 == 200 ) then
     stdnse.debug1("Exiting due to ambiguous response from web server on %s:%s. All URIs return status 200.", host.ip, port.number)
-    return
+    return nil
   end
   local output = stdnse.output_table()
   local vuln_report = vulns.Report:new(SCRIPT_NAME, host, port)

--- a/scripts/http-default-accounts.nse
+++ b/scripts/http-default-accounts.nse
@@ -230,9 +230,9 @@ action = function(host, port)
   local output_lns = {}
 
   -- Identify servers that answer 200 to invalid HTTP requests and exit as these would invalidate the tests
-  local _, http_status, _ = http.identify_404(host,port)
-  if ( http_status == 200 ) then
-    stdnse.debug(1, "Exiting due to ambiguous response from web server on %s:%s. All URIs return status 200.", host.ip, port.number)
+  local status_404, result_404, known_404 = http.identify_404(host,port)
+  if ( status_404 and result_404 == 200 ) then
+    stdnse.debug1("Exiting due to ambiguous response from web server on %s:%s. All URIs return status 200.", host.ip, port.number)
     return nil
   end
 
@@ -260,12 +260,6 @@ action = function(host, port)
   if results == nil then
     return stdnse.format_output(false,
       "HTTP request table is empty. This should not happen since we at least made one request.")
-  end
-
-  -- Record 404 response, later it will be used to determine if page exists
-  local result, result_404, known_404 = http.identify_404(host, port)
-  if(result == false) then
-    return stdnse.format_output(false, result_404)
   end
 
   -- Iterate through responses to find a candidate for login routine

--- a/scripts/http-enum.nse
+++ b/scripts/http-enum.nse
@@ -366,10 +366,11 @@ action = function(host, port)
   end
   stdnse.debug1("Loaded %d fingerprints", #fingerprints)
 
-  -- Check what response we get for a 404
-  local result, result_404, known_404 = http.identify_404(host, port)
-  if(result == false) then
-    return stdnse.format_output(false, result_404)
+  -- Identify servers that answer 200 to invalid HTTP requests and exit as these would invalidate the tests
+  local status_404, result_404, known_404 = http.identify_404(host,port)
+  if ( status_404 and result_404 == 200 ) then
+    stdnse.debug1("Exiting due to ambiguous response from web server on %s:%s. All URIs return status 200.", host.ip, port.number)
+    return nil
   end
 
   -- Queue up the checks

--- a/scripts/http-huawei-hg5xx-vuln.nse
+++ b/scripts/http-huawei-hg5xx-vuln.nse
@@ -84,10 +84,10 @@ including PPPoE credentials, firmware version, model, gateway, dns servers and a
   }
 
   -- Identify servers that answer 200 to invalid HTTP requests and exit as these would invalidate the tests
-  local _, http_status, _ = http.identify_404(host,port)
-  if ( http_status == 200 ) then
+  local status_404, result_404, _ = http.identify_404(host,port)
+  if ( status_404 and result_404 == 200 ) then
     stdnse.debug1("Exiting due to ambiguous response from web server on %s:%s. All URIs return status 200.", host.ip, port.number)
-    return false
+    return nil
   end
 
   local vuln_report = vulns.Report:new(SCRIPT_NAME, host, port)

--- a/scripts/http-userdir-enum.nse
+++ b/scripts/http-userdir-enum.nse
@@ -55,10 +55,11 @@ action = function(host, port)
     return fail("Didn't find any users to test (should be in nselib/data/usernames.lst)")
   end
 
-  -- Check what response we get for a 404
-  local result, result_404, known_404 = http.identify_404(host, port)
-  if(result == false) then
-    return fail(result_404)
+  -- Identify servers that answer 200 to invalid HTTP requests and exit as these would invalidate the tests
+  local status_404, result_404, known_404 = http.identify_404(host,port)
+  if ( status_404 and result_404 == 200 ) then
+    stdnse.debug1("Exiting due to ambiguous response from web server on %s:%s. All URIs return status 200.", host.ip, port.number)
+    return nil
   end
 
   -- Check if we can use HEAD requests

--- a/scripts/http-vuln-cve2010-0738.nse
+++ b/scripts/http-vuln-cve2010-0738.nse
@@ -46,10 +46,10 @@ action = function(host, port)
   end
 
   -- Identify servers that answer 200 to invalid HTTP requests and exit as these would invalidate the tests
-  local _, http_status, _ = http.identify_404(host,port)
-  if ( http_status == 200 ) then
+  local status_404, result_404, _ = http.identify_404(host,port)
+  if ( status_404 and result_404 == 200 ) then
     stdnse.debug1("Exiting due to ambiguous response from web server on %s:%s. All URIs return status 200.", host.ip, port.number)
-    return false
+    return nil
   end
 
   -- fallback to jmx-console

--- a/scripts/membase-http-info.nse
+++ b/scripts/membase-http-info.nse
@@ -122,10 +122,10 @@ end
 action = function(host, port)
 
   -- Identify servers that answer 200 to invalid HTTP requests and exit as these would invalidate the tests
-  local _, http_status, _ = http.identify_404(host,port)
-  if ( http_status == 200 ) then
+  local status_404, result_404, _ = http.identify_404(host,port)
+  if ( status_404 and result_404 == 200 ) then
     stdnse.debug1("Exiting due to ambiguous response from web server on %s:%s. All URIs return status 200.", host.ip, port.number)
-    return false
+    return nil
   end
 
   local urls = { "/pools/default/buckets", "/pools" }

--- a/scripts/riak-http-info.nse
+++ b/scripts/riak-http-info.nse
@@ -114,10 +114,10 @@ action = function(host, port)
   end
 
   -- Identify servers that answer 200 to invalid HTTP requests and exit as these would invalidate the tests
-  local _, http_status, _ = http.identify_404(host,port)
-  if ( http_status == 200 ) then
+  local status_404, result_404, _ = http.identify_404(host,port)
+  if ( status_404 and result_404 == 200 ) then
     stdnse.debug1("Exiting due to ambiguous response from web server on %s:%s. All URIs return status 200.", host.ip, port.number)
-    return false
+    return nil
   end
 
   -- Silently abort if the server responds as anything different than


### PR DESCRIPTION
This PR changes http.identify_404 so that it no longer follows HTTP redirects which caused false positives and other unexpected behavior.  The PR also changes calls to this function in certain scripts to be more standardized and return nil instead of false.


Context:

References:
  https://nmap.org/nsedoc/lib/http.html#identify_404
  https://svn.nmap.org/nmap/nselib/http.lua
  http://seclists.org/nmap-dev/2015/q4/186

http.identify_404 is a function that can be used to determine how an HTTP server responds to unknown pages. It can be used, for example, to detect when an HTTP server responds 200 OK to everything which can break a script if it is merely checking the status code when requesting something like  /MyAppsSpecialPage.


http.identify_404 follows HTTP redirects which may result in unexpected behavior.  I noticed this while testing some changes to a script against a ethernet switch that generates a 302 redirect
response for any request to /.    http.identify_404 follows the redirect and then the 'data' variable contains the results for the new location instead of the specific URL that the script was asking for.  The identify_404 function has code to deal with redirects and other errors but this won't be triggered if the call to http.get follows it first.


Relevant code is at line 2476 in nselib/http.lua


    function identify_404(host, port)
      local data
      local bad_responses = { 301, 302, 400, 401, 403, 499, 501, 503 }

      -- The URLs used to check 404s
      local URL_404_1 = '/nmaplowercheck' .. os.time(os.date('*t'))
      local URL_404_2 = '/NmapUpperCheck' .. os.time(os.date('*t'))
      local URL_404_3 = '/Nmap/folder/check' .. os.time(os.date('*t'))

      data = get(host, port, URL_404_1)

The key change is in the last line:

    data = get(host, port, URL_404_1,{redirect_ok=false})

A review of the scripts where identify_404 is being used did not find any place where it looked like following redirects would be desirable.
