### PR TITLE
option to remove stdout output

### DIFF
--- a/nmap.cc
+++ b/nmap.cc
@@ -1422,6 +1422,9 @@ void parse_options(int argc, char **argv) {
     case 'v':
       if (optarg && isdigit(optarg[0])) {
         o.verbose = atoi(optarg);
+        if(o.verbose == 0) {
+          o.nmap_stdout = fopen(DEVNULL, "w");
+        }
       } else {
         const char *p;
         o.verbose++;


### PR DESCRIPTION
A simple patch. resolves #236.
It use option '-v0' a suggestion of @cldrn.