### PR TITLE
Changed use of unsafe str* and *printf functions

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -204,8 +204,8 @@ int main(int argc, char *argv[]) {
     }
     /* copy rest of command-line arguments */
     for (i = 1; i < argc && strlen(command) + strlen(argv[i]) + 1 < sizeof(command); i++) {
-      strcat(command, " ");
-      strcat(command, argv[i]);
+      strncat(command, " ", sizeof(command) - strlen(command) - 1);
+      strncat(command, argv[i], sizeof(command) - strlen(command) - 1);
     }
     myargc = arg_parse(command, &myargv);
     if (myargc < 1) {

--- a/nmap_dns.cc
+++ b/nmap_dns.cc
@@ -1338,7 +1338,7 @@ bool DNS::Factory::ipToPtr(const sockaddr_storage &ip, std::string &ptr)
       for (short i=15; i>=0; --i)
       {
         char tmp[3];
-        sprintf(tmp, "%02x", ipv6[i]);
+        Snprintf(tmp, sizeof(tmp), "%02x", ipv6[i]);
         ptr += '.';
         ptr += tmp[1];
         ptr += '.';

--- a/nping/NpingTarget.cc
+++ b/nping/NpingTarget.cc
@@ -713,7 +713,7 @@ const char *NpingTarget::getNextHopIPStr(){
 const char *NpingTarget::getMACStr(u8 *mac){
   static char buffer[256];
   assert(mac!=NULL);
-  sprintf(buffer, "%02x:%02x:%02x:%02x:%02x:%02x", (u8)mac[0],(u8)mac[1],
+  Snprintf(buffer, sizeof(buffer), "%02x:%02x:%02x:%02x:%02x:%02x", (u8)mac[0],(u8)mac[1],
           (u8)mac[2], (u8)mac[4],(u8)mac[4],(u8)mac[5]);
   return buffer;
 }

--- a/nping/ProbeMode.cc
+++ b/nping/ProbeMode.cc
@@ -1342,7 +1342,7 @@ char *ProbeMode::getBPFFilterString(){
  /* For the server in Echo mode we need a special filter */
  if( o.getRole()==ROLE_SERVER ){
     /* Capture all IP packets but the ones that belong to the side-channel */
-    sprintf(filterstring, "ip and ( not (tcp and (dst port %d or src port %d) ) )", o.getEchoPort(), o.getEchoPort() );
+    Snprintf(filterstring, sizeof(filterstring), "ip and ( not (tcp and (dst port %d or src port %d) ) )", o.getEchoPort(), o.getEchoPort() );
     nping_print(DBG_1, "BPF-filter: %s", filterstring);
     return filterstring;
  }
@@ -1387,7 +1387,7 @@ char *ProbeMode::getBPFFilterString(){
     inet_ntop(AF_INET, &s4->sin_addr, ipstring, sizeof(ipstring));
  }else{
     nping_warning(QT_2, "Warning: Wrong address family (%d) in getBPFFilterString(). Please report a bug", srcss.ss_family);
-    sprintf(ipstring,"127.0.0.1");
+    sprintf(ipstring, "127.0.0.1");
  }
 
  /* Tell the filter that we only want incoming packets, destined to our source IP */

--- a/nping/utils.cc
+++ b/nping/utils.cc
@@ -383,7 +383,7 @@ void luis_hdump(char *cp, unsigned int length) {
     current_char=cp[i];
     if( hex==HEX_START+24) hex++; /* Insert space every 8 bytes */
     /* First print the hex number */
-    sprintf(printbyte,"%02x", current_char);    
+    Snprintf(printbyte, sizeof(printbyte), "%02x", current_char);    
     line2print[hex++]=printbyte[0];
     line2print[hex++]=printbyte[1];
     line2print[hex++]=' ';

--- a/nping/utils_net.cc
+++ b/nping/utils_net.cc
@@ -868,7 +868,7 @@ int parseMAC(const char *txt, u8 *targetbuff){
 char *MACtoa(u8 *mac){
   static char macinfo[24];
   memset(macinfo, 0, 24);
-  sprintf(macinfo,"%02X:%02X:%02X:%02X:%02X:%02X",
+  Snprintf(macinfo, sizeof(macinfo), "%02X:%02X:%02X:%02X:%02X:%02X",
           mac[0],mac[1],mac[2],mac[3],mac[4],mac[5]);
   return macinfo;
 } /* End of MACtoa() */
@@ -898,21 +898,21 @@ const char *arppackethdrinfo(const u8 *packet, u32 len, int detail){
   u32 *tIP = (u32 *)(packet+24);
 
   if( ntohs(*op) == 1 ){ /* ARP Request */
-    sprintf(protoinfo, "ARP who has %s? ", IPtoa(*tIP));
-    sprintf(protoinfo+strlen(protoinfo),"Tell %s", IPtoa(*sIP) );
+    Snprintf(protoinfo, sizeof(protoinfo), "ARP who has %s? ", IPtoa(*tIP));
+    Snprintf(protoinfo + strlen(protoinfo), sizeof(protoinfo) - strlen(protoinfo), "Tell %s", IPtoa(*sIP));
   }
   else if( ntohs(*op) == 2 ){ /* ARP Reply */
-    sprintf(protoinfo, "ARP reply %s ", IPtoa(*sIP));
-    sprintf(protoinfo+strlen(protoinfo),"is at %s", MACtoa(sMAC) );
+    Snprintf(protoinfo, sizeof(protoinfo), "ARP reply %s ", IPtoa(*sIP));
+    Snprintf(protoinfo + strlen(protoinfo), sizeof(protoinfo) - strlen(protoinfo), "is at %s", MACtoa(sMAC));
   }
   else if( ntohs(*op) == 3 ){ /* RARP Request */
-    sprintf(protoinfo, "RARP who is %s? Tell %s", MACtoa(tMAC), MACtoa(sMAC) );
+    Snprintf(protoinfo, sizeof(protoinfo), "RARP who is %s? Tell %s", MACtoa(tMAC), MACtoa(sMAC));
   }
   else if( ntohs(*op) ==4 ){ /* RARP Reply */
-    sprintf(protoinfo, "RARP reply: %s is at %s", MACtoa(tMAC), IPtoa(*tIP) );
+    Snprintf(protoinfo, sizeof(protoinfo), "RARP reply: %s is at %s", MACtoa(tMAC), IPtoa(*tIP));
   }
   else{
-    sprintf(protoinfo, "HTYPE:%04X PTYPE:%04X HLEN:%d PLEN:%d OP:%04X SMAC:%s SIP:%s DMAC:%s DIP:%s",
+    Snprintf(protoinfo, sizeof(protoinfo), "HTYPE:%04X PTYPE:%04X HLEN:%d PLEN:%d OP:%04X SMAC:%s SIP:%s DMAC:%s DIP:%s",
             *htype, *ptype, *hlen, *plen, *op, MACtoa(sMAC), IPtoa(*sIP), MACtoa(tMAC), IPtoa(*tIP));
   }
  return protoinfo;
@@ -980,10 +980,10 @@ int tcppackethdrinfo(const u8 *packet, size_t len, u8 *dstbuff, size_t dstlen,
     else if( s6->sin6_family==AF_INET6){
         inet_ntop(AF_INET6, &s6->sin6_addr, srcipstring, sizeof(srcipstring));
     }else{
-        sprintf(dstipstring, "unknown_addr_family");
+        Snprintf(dstipstring, sizeof(dstipstring), "unknown_addr_family");
     }
   }else{
-    sprintf(srcipstring, "this_host");
+    Snprintf(srcipstring, sizeof(srcipstring), "this_host");
   }
 
   /* Determine source IP address */
@@ -994,10 +994,10 @@ int tcppackethdrinfo(const u8 *packet, size_t len, u8 *dstbuff, size_t dstlen,
     else if( d6->sin6_family==AF_INET6){
         inet_ntop(AF_INET6, &d6->sin6_addr, dstipstring, sizeof(dstipstring));
     }else{
-        sprintf(dstipstring, "unknown_addr_family");
+        Snprintf(dstipstring, sizeof(dstipstring), "unknown_addr_family");
     }
   }else{
-    sprintf(dstipstring, "unknown_host");
+    Snprintf(dstipstring, sizeof(dstipstring), "unknown_host");
   }
 
   /* TCP Flags */
@@ -1095,10 +1095,10 @@ int udppackethdrinfo(const u8 *packet, size_t len, u8 *dstbuff, size_t dstlen,
     else if( s6->sin6_family==AF_INET6){
         inet_ntop(AF_INET6, &s6->sin6_addr, srcipstring, sizeof(srcipstring));
     }else{
-        sprintf(dstipstring, "unknown_addr_family");
+        Snprintf(dstipstring, sizeof(dstipstring), "unknown_addr_family");
     }
   }else{
-    sprintf(srcipstring, "this_host");
+    Snprintf(srcipstring, sizeof(srcipstring), "this_host");
   }
 
   /* Determine source IP address */
@@ -1109,10 +1109,10 @@ int udppackethdrinfo(const u8 *packet, size_t len, u8 *dstbuff, size_t dstlen,
     else if( d6->sin6_family==AF_INET6){
         inet_ntop(AF_INET6, &d6->sin6_addr, dstipstring, sizeof(dstipstring));
     }else{
-        sprintf(dstipstring, "unknown_addr_family");
+        Snprintf(dstipstring, sizeof(dstipstring), "unknown_addr_family");
     }
   }else{
-    sprintf(dstipstring, "unknown_host");
+    Snprintf(dstipstring, sizeof(dstipstring), "unknown_host");
   }
 
   if( detail == LOW_DETAIL ){

--- a/nse_fs.cc
+++ b/nse_fs.cc
@@ -241,7 +241,7 @@ static int dir_iter_factory (lua_State *L) {
   if (strlen(path) > MAX_PATH-2)
     luaL_error (L, "path too long: %s", path);
   else
-    sprintf (d->pattern, "%s/*", path);
+    Snprintf (d->pattern, sizeof(d->pattern), "%s/*", path);
 #else
   d->dir = opendir (path);
   if (d->dir == NULL)

--- a/nsock/src/netutils.c
+++ b/nsock/src/netutils.c
@@ -171,12 +171,12 @@ static char *get_addr_string(const struct sockaddr_storage *ss, size_t sslen) {
 
 #if HAVE_SYS_UN_H
   if (ss->ss_family == AF_UNIX) {
-    sprintf(buffer, "%s", get_unixsock_path(ss));
+    Snprintf(buffer, sizeof(buffer), "%s", get_unixsock_path(ss));
     return buffer;
   }
 #endif
 
-  sprintf(buffer, "%s:%d", inet_ntop_ez(ss, sslen), get_port(ss));
+  Snprintf(buffer, sizeof(buffer), "%s:%d", inet_ntop_ez(ss, sslen), get_port(ss));
   return buffer;
 }
 

--- a/osscan.cc
+++ b/osscan.cc
@@ -985,7 +985,7 @@ const char *mergeFPs(FingerPrint *FPs[], int numFPs, bool isGoodFP,
 
     while (*p && end-p1 >= 3) {
       len = 0;
-      strcpy(p1, "OS:"); p1 += 3; len +=3;
+      Strncpy(p1, "OS:", sizeof(p1)); p1 += 3; len +=3;
       while (*p && len <= FP_RESULT_WRAP_LINE_LEN && end-p1 > 0) {
         *p1++ = *p++;
         len++;

--- a/osscan2.cc
+++ b/osscan2.cc
@@ -3403,7 +3403,7 @@ bool HostOsScan::get_tcpopt_string(struct tcp_hdr *tcp, int mss, char *result, i
       memcpy(&tmpshort, q, 2);
       /*  if (ntohs(tmpshort) == mss) */
       /*    *p++ = 'E'; */
-      sprintf(p, "%hX", ntohs(tmpshort));
+      Snprintf(p, sizeof(p), "%hX", ntohs(tmpshort));
       p += strlen(p); /* max movement of p is 4 (0xFFFF) */
       q += 2;
       length -= 4;

--- a/output.cc
+++ b/output.cc
@@ -760,7 +760,7 @@ void printportoutput(Target *currenths, PortList *plist) {
           log_write(LOG_MACHINE, ", ");
         else
           first = 0;
-        strcpy(protocol, IPPROTO2STR(current->proto));
+        Strncpy(protocol, IPPROTO2STR(current->proto), sizeof(protocol));
         Snprintf(portinfo, sizeof(portinfo), "%d/%s", current->portno, protocol);
         state = statenum2str(current->state);
         plist->getServiceDeductions(current->portno, current->proto, &sd);
@@ -1598,7 +1598,7 @@ static void printosclassificationoutput(const struct
                 sizeof(familygenerations[familyno]))
               fatal("buffer 0verfl0w of familygenerations");
             if (*familygenerations[familyno])
-              strcat(familygenerations[familyno], "|");
+              strncat(familygenerations[familyno], "|", sizeof(familygenerations[familyno]) - flen - 1);
             strncat(familygenerations[familyno],
                     OSR->OSC[classno]->OS_Generation,
                     sizeof(familygenerations[familyno]) - flen - 1);
@@ -2021,7 +2021,7 @@ void printosscanoutput(Target *currenths) {
         fatal("STRANGE ERROR #3877 -- please report to fyodor@nmap.org\n");
       if (p != numlst)
         *p++ = ',';
-      sprintf(p, "%X", currenths->seq.seqs[i]);
+      Snprintf(p, sizeof(p), "%X", currenths->seq.seqs[i]);
       while (*p)
         p++;
     }
@@ -2045,7 +2045,7 @@ void printosscanoutput(Target *currenths) {
         fatal("STRANGE ERROR #3876 -- please report to fyodor@nmap.org\n");
       if (p != numlst)
         *p++ = ',';
-      sprintf(p, "%hX", currenths->seq.ipids[i]);
+      Snprintf(p, sizeof(p), "%hX", currenths->seq.ipids[i]);
       while (*p)
         p++;
     }
@@ -2066,7 +2066,7 @@ void printosscanoutput(Target *currenths) {
         fatal("STRANGE ERROR #3878 -- please report to fyodor@nmap.org\n");
       if (p != numlst)
         *p++ = ',';
-      sprintf(p, "%X", currenths->seq.timestamps[i]);
+      Snprintf(p, sizeof(p), "%X", currenths->seq.timestamps[i]);
       while (*p)
         p++;
     }

--- a/protocols.cc
+++ b/protocols.cc
@@ -150,7 +150,7 @@ static int nmap_protocols_init() {
 
   if (nmap_fetchfile(filename, sizeof(filename), "nmap-protocols") != 1) {
     error("Unable to find nmap-protocols!  Resorting to /etc/protocols");
-    strcpy(filename, "/etc/protocols");
+    Strncpy(filename, "/etc/protocols", sizeof(filename));
   }
 
   fp = fopen(filename, "r");

--- a/services.cc
+++ b/services.cc
@@ -196,7 +196,7 @@ static int nmap_services_init() {
   if (nmap_fetchfile(filename, sizeof(filename), "nmap-services") != 1) {
 #ifndef WIN32
     error("Unable to find nmap-services!  Resorting to /etc/services");
-    strcpy(filename, "/etc/services");
+    Strncpy(filename, "/etc/services", sizeof(filename));
 #else
         int len, wnt = GetVersion() < 0x80000000;
     error("Unable to find nmap-services!  Resorting to /etc/services");
@@ -210,9 +210,9 @@ static int nmap_services_init() {
         else
         {
                 if(wnt)
-                        strcpy(filename + len, "\\drivers\\etc\\services");
+                        Strncpy(filename + len, "\\drivers\\etc\\services", sizeof(filename) - len);
                 else
-                        strcpy(filename + len, "\\services");
+                        Strncpy(filename + len, "\\services", sizeof(filename) - len);
         }
 #endif
   }

--- a/utils.cc
+++ b/utils.cc
@@ -187,7 +187,7 @@ void nmap_hexdump(unsigned char *cp, unsigned int length) {
 #ifndef HAVE_STRERROR
 char *strerror(int errnum) {
   static char buf[1024];
-  sprintf(buf, "your system is too old for strerror of errno %d\n", errnum);
+  Snprintf(buf, sizeof(buf), "your system is too old for strerror of errno %d\n", errnum);
   return buf;
 }
 #endif


### PR DESCRIPTION
Changed strcat, strcpy and sprintf;
except some sprintf used with no variables in format string.
Issue #278 by @dmiller-nmap 