### PR TITLE
refguide.xml: document ip6 cidr support.

### DIFF
--- a/docs/refguide.xml
+++ b/docs/refguide.xml
@@ -207,9 +207,9 @@ addresses ending in 13.37.  This sort of broad sampling can be useful
 for Internet surveys and research.</para>
 
 <indexterm><primary>IPv6</primary></indexterm>
-<para>IPv6 addresses can only be specified by their fully qualified IPv6
-address or hostname.  CIDR and octet ranges aren't yet supported for
-IPv6.</para>
+<para>IPv6 addresses can be specified by their fully qualified IPv6
+address or hostname or with CIDR notation for subnets.  Octet ranges
+aren't yet supported for IPv6.</para>
 
 <indexterm><primary>link-local IPv6 address</primary><see>IPv6 address, link-local</see></indexterm>
 <indexterm><primary>IPv6 address</primary><secondary>link-local</secondary></indexterm>


### PR DESCRIPTION
Target specification: note support of cidr notation for subnets when
using ip6 as advertised on: https://nmap.org/7/#changes-ipv6