### PR TITLE
NSE: Add STARTTLS Support to SSLv2.nse

### DIFF
--- a/scripts/sslv2.nse
+++ b/scripts/sslv2.nse
@@ -4,6 +4,7 @@ local string = require "string"
 local table = require "table"
 local bin = require "bin"
 local stdnse = require "stdnse"
+local sslcert = require "sslcert"
 
 description = [[
 Determines whether the server supports obsolete and less secure SSLv2, and discovers which ciphers it
@@ -42,7 +43,9 @@ license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 categories = {"default", "safe"}
 
 
-portrule = shortport.ssl
+portrule = function(host, port)
+  return shortport.ssl(host, port) or sslcert.getPrepareTLSWithoutReconnect(port)
+end
 
 local ssl_ciphers = {
   -- (cut down) table of codes with their corresponding ciphers.
@@ -80,8 +83,28 @@ local ciphers = function(cipher_list)
 end
 
 action = function(host, port)
+  local timeout = stdnse.get_timeout(host, 10000, 5000)
 
-  local socket = nmap.new_socket();
+  -- Create socket.
+  local status, sock, err
+  local starttls = sslcert.getPrepareTLSWithoutReconnect(port)
+  if starttls then
+    status, socket = starttls(host, port)
+    if not status then
+      stdnse.debug(1, "Can't connect using STARTTLS: %s", socket)
+      return nil
+    end
+  else
+    socket = nmap.new_socket()
+    socket:set_timeout(timeout)
+    status, err = socket:connect(host, port)
+    if not status then
+      stdnse.debug(1, "Can't connect: %s", err)
+      return nil
+    end
+  end
+
+  socket:set_timeout(timeout)
 
   -- build client hello packet (contents inspired by
   -- http://mail.nessus.org/pipermail/plugins-writers/2004-October/msg00041.html )
@@ -101,7 +124,6 @@ action = function(host, port)
   .. "\x02\x00\x80" -- SSL2_RC4_128_EXPORT40_WITH_MD5
   .. "\xe4\xbd\x00\x00\xa4\x41\xb6\x74\x71\x2b\x27\x95\x44\xc0\x3d\xc0" -- challenge
 
-  socket:connect(host, port);
   socket:send(ssl_v2_hello);
 
   local status, server_hello = socket:receive_bytes(2);


### PR DESCRIPTION
The script sslv2.nse doesn't support STARTTLS.  The result is that script misses SSLv2 on certain ports such as SMTP, POP3, etc.  These changes add support for STARTTLS.  This script has been verified by scanning a host on 443, verifying that the script returns results and then checking the same host on port 25.