### PR TITLE
tftp-enum is slow. Use coroutines to parallelize it. #116

### DIFF
--- a/scripts/tftp-enum.nse
+++ b/scripts/tftp-enum.nse
@@ -1,9 +1,10 @@
-local datafiles = require "datafiles"
 local nmap = require "nmap"
 local shortport = require "shortport"
 local stdnse = require "stdnse"
 local string = require "string"
 local table = require "table"
+local coroutine = require "coroutine"
+local io = require "io"
 
 description = [[
 Enumerates TFTP (trivial file transfer protocol) filenames by testing
@@ -45,50 +46,6 @@ local FILE_NOT_FOUND = 2
 
 portrule = shortport.portnumber(69, "udp")
 
--- return a new array containing the concatenation of all of its
--- parameters. Scaler parameters are included in place, and array
--- parameters have their values shallow-copied to the final array.
--- Note that userdata and function values are treated as scalar.
-local function array_concat(...)
-  local t = {}
-  for n = 1, select("#", ...) do
-    local arg = select(n, ...)
-    if type(arg) == "table" then
-      for _, v in ipairs(arg) do
-        t[#t + 1] = v
-      end
-    else
-      t[#t + 1] = arg
-    end
-  end
-  return t
-end
-
-local generate_cisco_address_confg = function(base_address)
-  local filenames = {}
-  local octets = stdnse.strsplit("%.", base_address)
-
-  for i = 0, 255 do
-    local address_confg = octets[1] .. "." .. octets[2] .. "." .. octets[3] .. "." .. i .. "-confg"
-    table.insert(filenames, address_confg)
-  end
-
-  return filenames
-end
-
-local generate_filenames = function(host)
-  local customlist = stdnse.get_script_args('tftp-enum.filelist')
-  local status, default_filenames = datafiles.parse_file(customlist or "nselib/data/tftplist.txt" , {})
-  if not status then
-    stdnse.debug1("Can not open file with tftp file names list")
-    return {}
-  end
-
-  local cisco_address_confg_filenames = generate_cisco_address_confg(host.ip)
-
-  return array_concat(default_filenames, cisco_address_confg_filenames)
-end
-
 
 local create_tftp_file_request = function(filename)
   return "\0\x01" .. filename .. "\0octet\0"
@@ -100,10 +57,9 @@ local check_file_present = function(host, port, filename)
   local file_request = create_tftp_file_request(filename)
 
 
-  local socket = nmap.new_socket()
-  socket:connect(host, port)
+  local socket = nmap.new_socket("udp")
+  socket:connect(host, port, "udp")
   local status, lhost, lport, rhost, rport = socket:get_info()
-
 
   if (not (status)) then
     stdnse.debug1("error %s", lhost)
@@ -111,41 +67,39 @@ local check_file_present = function(host, port, filename)
     return REQUEST_ERROR
   end
 
-
-  local bind_socket = nmap.new_socket("udp")
   stdnse.debug1("local port = %d", lport)
 
   socket:send(file_request)
   socket:close()
 
-  local bindOK, error = bind_socket:bind(nil, lport)
+  local bindOK, error = socket:bind(nil, lport)
 
 
   stdnse.debug1("starting listener")
 
   if (not (bindOK)) then
     stdnse.debug1("Error in bind %s", error)
-    bind_socket:close()
+    socket:close()
     return REQUEST_ERROR
   end
 
-
-  local recvOK, data = bind_socket:receive()
+  socket:set_timeout(1000)
+  local recvOK, data = socket:receive()
 
   if (not (recvOK)) then
     stdnse.debug1("Error in receive %s", data)
-    bind_socket:close()
+    socket:close()
     return REQUEST_ERROR
   end
 
   if (data:byte(1) == 0x00 and data:byte(2) == 0x03) then
-    bind_socket:close()
+    socket:close()
     return FILE_FOUND
   elseif (data:byte(1) == 0x00 and data:byte(2) == 0x05) then
-    bind_socket:close()
+    socket:close()
     return FILE_NOT_FOUND
   else
-    bind_socket:close()
+    socket:close()
     return REQUEST_ERROR
   end
 
@@ -162,8 +116,34 @@ local check_open_tftp = function(host, port)
   end
 end
 
-action = function(host, port)
+local filename_iterator = function(host)
+  return coroutine.wrap(function ()
 
+    local filename = stdnse.get_script_args('tftp-enum.filelist')
+    filename = filename or "nselib/data/tftplist.txt"
+
+    for line in io.lines(filename) do
+      if line:match('{[Mm][Aa][Cc]}') then
+        if not host.mac_addr then
+          goto next_filename
+        end
+        line = line:gsub('{MAC}', string.upper(stdnse.tohex(host.mac_addr)))
+        line = line:gsub('{mac}', stdnse.tohex(host.mac_addr))
+      end
+      coroutine.yield(line)
+      ::next_filename::
+    end
+
+    local octets = stdnse.strsplit("%.", host.ip)
+
+    for i = 0, 255 do
+      local address_confg = octets[1] .. "." .. octets[2] .. "." .. octets[3] .. "." .. i .. "-confg"
+      coroutine.yield(address_confg) 
+    end
+  end)
+end
+
+action = function(host, port)
   if (not (check_open_tftp(host, port))) then
     stdnse.debug1("tftp seems not active")
     return
@@ -175,21 +155,17 @@ action = function(host, port)
   nmap.set_port_state(host, port, "open")
 
   local results = {}
-  local filenames = generate_filenames(host)
 
-  for i, filename in ipairs(filenames) do
-    if filename:match('{[Mm][Aa][Cc]}') then
-      if not host.mac_addr then
-        goto next_filename
+  for filename in filename_iterator(host) do
+    local retries = 3
+    repeat
+      local request_status = check_file_present(host, port, filename)
+      if (request_status == FILE_FOUND) then
+        table.insert(results, filename)
+        break
       end
-      filename = filename:gsub('{MAC}', string.upper(stdnse.tohex(host.mac_addr)))
-      filename = filename:gsub('{mac}', stdnse.tohex(host.mac_addr))
-    end
-    local request_status = check_file_present(host, port, filename)
-    if (request_status == FILE_FOUND) then
-      table.insert(results, filename)
-    end
-    ::next_filename::
+      retries = retries - 1
+    until retries == 0
   end
 
   return stdnse.format_output(true, results)


### PR DESCRIPTION
Made the timeout shorter, added 3 retries and used coroutines to serve filenames
tftp-enum is slow. Use coroutines to parallelize it. #116
