### PR TITLE
remove bug from http-form-brute

### DIFF
--- a/scripts/http-form-brute.nse
+++ b/scripts/http-form-brute.nse
@@ -422,8 +422,13 @@ Driver = {
         opts.cookies = nil
         return response, true
       end
-      -- set cookies
-      update_cookies(opts.cookies, response.cookies)
+      if response.cookies then
+        -- set cookies
+        update_cookies(opts.cookies, response.cookies)
+      else
+        stdnse.debug1("Failed to get new session cookies, reason: %s", response['status-line'] or "Unknown")
+        return nil, false
+      end
       if self.options.is_failure and self.options.is_failure(response) then
         return response, false
       end


### PR DESCRIPTION
This happens when there is an error in creating socket, which lets the request return an unexpected response one example is [here](https://github.com/nmap/nmap/blob/master/nselib/http.lua#L1209), indirectly there is no cookies field in the http response which comes [here](https://github.com/nmap/nmap/blob/master/scripts/http-form-brute.nse#L426) then passes a nil rather than cookie and hence script stops at this point itself and therefore not all combination from dictionary are tried on the host's website.