### PR TITLE
[NSE] smb-os-discovery - Augment version detection of SMB related services

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # Nmap Changelog ($Id$); -*-text-*-
 
+
+o [NSE] Update to enable smb-os-discovery to augment version detection
+  for certain SMB related services using data that the script discovers.
+  [Tom Sellers]
+
 o Improved version detection and descriptions for Microsoft and Samba
   SMB services. Also addresses certain issues with OS identification. 
   [Tom Sellers]

--- a/nselib/smb.lua
+++ b/nselib/smb.lua
@@ -3279,6 +3279,7 @@ end
 -- * <code>date</code>: <code>"2012-09-08 09:24:30"</code>
 -- * <code>timezone</code>: <code>-7</code>
 -- * <code>timezone_str</code>: <code>UTC-7</code>
+-- * <code>port</code>: <code>445</code>
 -- The table may also contain these additional keys:
 -- * <code>fqdn</code>: <code>"Sql2008.lab.test.local"</code>
 -- * <code>domain_dns</code>: <code>"lab.test.local"</code>
@@ -3312,6 +3313,7 @@ function get_os(host)
   response['time']         = smbstate['time']
   response['timezone_str'] = smbstate['timezone_str']
   response['timezone']     = smbstate['timezone']
+  response['port']         = smbstate['port']
 
   -- Kill SMB
   stop(smbstate)


### PR DESCRIPTION
The attached changes allow smb-os-discovery.nse to augment nmap's standard version detection with data that it has discovered.  It will only update the version information for the port that was used by smb-os-discovery.nse.

The change requires that smb.lua be modified to return the port in the response table that smb.get_os returns.  This should be non-disruptive for other scripts.

The changes have been tested against multiple versions of Windows and Samba. The intent is to improve the ability to audit the environment as a result of pre-release of information about the 'Badlock' branded vulnerability. In addition to providing more accurate version information for Samba, it also makes extracting this data via the greppable and XML outputs easier.

Examples of changes to results:

**Linux + Samba Before**

```
PORT    STATE SERVICE     REASON              VERSION
139/tcp open  netbios-ssn syn-ack ttl 64      Samba smbd 3.X - 4.X (workgroup: WORKGROUP)
445/tcp open  netbios-ssn syn-ack ttl 64      Samba smbd 3.X - 4.X (workgroup: WORKGROUP)
```


**Linux + Samba After**
```
PORT    STATE SERVICE     REASON              VERSION
139/tcp open  netbios-ssn syn-ack ttl 64      Samba smbd 3.X - 4.X (workgroup: WORKGROUP)
445/tcp open  netbios-ssn syn-ack ttl 64      Samba smbd 4.1.6-Ubuntu (workgroup: WORKGROUP)
```





**Windows Before**

```
PORT    STATE SERVICE      REASON               VERSION
139/tcp open  netbios-ssn  syn-ack ttl 127      Microsoft Windows netbios-ssn
445/tcp open  microsoft-ds syn-ack ttl 127      Microsoft Windows Server 2008 R2 - 2012 microsoft-ds
```

**Windows After**

```
PORT    STATE SERVICE      REASON               VERSION
139/tcp open  netbios-ssn  syn-ack ttl 127      Microsoft Windows netbios-ssn
445/tcp open  microsoft-ds syn-ack ttl 127      Windows Server 2008 R2 Enterprise 7601 Service Pack 1 microsoft-ds
```

**A couple more 'After' examples**

```
139/tcp open  netbios-ssn syn-ack ttl 61      Samba smbd 3.X - 4.X (workgroup: MINE)
445/tcp open  netbios-ssn syn-ack ttl 61      Samba smbd 3.6.07 (workgroup: MINE)
```

```
PORT    STATE SERVICE     REASON              VERSION
139/tcp open  netbios-ssn syn-ack ttl 63      Samba smbd 3.X - 4.X (workgroup: MINE)
445/tcp open  netbios-ssn syn-ack ttl 63      Samba smbd 3.0.26a-apple (workgroup: MINE)
```

