### PR TITLE
Initial submission of MQTT-related code to the Nmap project.

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -14640,3 +14640,11 @@ ports 1194,443,500
 rarity 9
 match openvpn m|^@........\x01\0\0\0\0d\xc1x\x01\xb8\x9b\xcb\x8f\0\0\0\0$| p/OpenVPN/
 
+
+##############################NEXT PROBE##############################
+# MQTT v3.1.1 CONNECT
+Probe TCP mqtt q|\x10\x10\x00\x04MQTT\x04\x02\x00\x1e\x00\x04nmap|
+rarity 9
+ports 1883
+sslports 8883
+match mqtt m|^\x20\x02\x00.$|

--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -12066,7 +12066,7 @@ softmatch ftp m|^220[\s-].*ftp[^\r]*\r\n214[\s-]|i
 # TLSv1-only servers, based on a failed handshake alert.
 Probe TCP SSLSessionReq q|\x16\x03\0\0S\x01\0\0O\x03\0?G\xd7\xf7\xba,\xee\xea\xb2`~\xf3\0\xfd\x82{\xb9\xd5\x96\xc8w\x9b\xe6\xc4\xdb<=\xdbo\xef\x10n\0\0(\0\x16\0\x13\0\x0a\0f\0\x05\0\x04\0e\0d\0c\0b\0a\0`\0\x15\0\x12\0\x09\0\x14\0\x11\0\x08\0\x06\0\x03\x01\0|
 rarity 1
-ports 443,444,465,548,636,989,990,992,993,994,995,1241,1311,1443,2000,2252,2443,3443,4433,4443,4444,5061,5443,5550,6443,7210,7272,7443,8009,8181,8194,8443,9001,9443,10443,14443,44443,60443
+ports 443,444,465,548,636,989,990,992,993,994,995,1241,1311,1443,2000,2252,2443,3443,4433,4443,4444,5061,5443,5550,6443,7210,7272,7443,8009,8181,8194,8443,8883,9001,9443,10443,14443,44443,60443
 fallback GetRequest
 
 match adabas m|^,\0,\0\x03\x02\0\0G\xd7\xf7\xbaO\x03\0\?\x05\0\0\0\0\x02\x18\0\xfd\x0b\0\0<=\xdbo\xef\x10n \xd5\x96\xc8w\x9b\xe6\xc4\xdb$| p/ADABAS database/
@@ -12245,7 +12245,7 @@ match xamarin m|^ERROR: Another instance is running\n| p/Xamarin MonoTouch/
 # in the match lines)
 Probe TCP TLSSessionReq q|\x16\x03\0\0\x69\x01\0\0\x65\x03\x03U\x1c\xa7\xe4random1random2random3random4\0\0\x0c\0/\0\x0a\0\x13\x009\0\x04\0\xff\x01\0\0\x30\0\x0d\0,\0*\0\x01\0\x03\0\x02\x06\x01\x06\x03\x06\x02\x02\x01\x02\x03\x02\x02\x03\x01\x03\x03\x03\x02\x04\x01\x04\x03\x04\x02\x01\x01\x01\x03\x01\x02\x05\x01\x05\x03\x05\x02|
 rarity 1
-ports 443,444,465,636,989,990,992,993,994,995,1241,1311,2252,3389,4433,4444,5061,6679,6697,8443,9001
+ports 443,444,465,636,989,990,992,993,994,995,1241,1311,2252,3389,4433,4444,5061,6679,6697,8443,8883,9001
 fallback GetRequest
 
 # SSLv3 - TLSv1.2 ServerHello

--- a/nmap-services
+++ b/nmap-services
@@ -2628,6 +2628,7 @@ canocentral0	1871/udp	0.000330	# Cano Central 0
 fjmpjps	1873/udp	0.000330	# Fjmpjps
 westell-stats	1875/tcp	0.000152	# westell stats
 westell-stats	1875/udp	0.000330	# westell stats
+mqtt	1883/tcp	0.000330
 ibm-mqisdp	1883/udp	0.000330	# IBM MQSeries SCADA
 idmaps	1884/udp	0.000661	# Internet Distance Map Svc
 vrtstrapserver	1885/udp	0.003304	# Veritas Trap Server
@@ -5590,6 +5591,7 @@ unknown	8878/tcp	0.000076
 unknown	8879/tcp	0.000076
 cddbp-alt	8880/tcp	0.000076	# CDDBP
 unknown	8882/tcp	0.000076
+mqtt-tls	8883/tcp	0.000076
 unknown	8885/udp	0.000330
 unknown	8886/udp	0.000330
 unknown	8887/tcp	0.000076

--- a/nmap-services
+++ b/nmap-services
@@ -5591,7 +5591,7 @@ unknown	8878/tcp	0.000076
 unknown	8879/tcp	0.000076
 cddbp-alt	8880/tcp	0.000076	# CDDBP
 unknown	8882/tcp	0.000076
-mqtt-tls	8883/tcp	0.000076
+secure-mqtt	8883/tcp	0.000076
 unknown	8885/udp	0.000330
 unknown	8886/udp	0.000330
 unknown	8887/tcp	0.000076

--- a/nmap-services
+++ b/nmap-services
@@ -2628,7 +2628,7 @@ canocentral0	1871/udp	0.000330	# Cano Central 0
 fjmpjps	1873/udp	0.000330	# Fjmpjps
 westell-stats	1875/tcp	0.000152	# westell stats
 westell-stats	1875/udp	0.000330	# westell stats
-mqtt	1883/tcp	0.000330
+mqtt	1883/tcp	0.000330	# Message Queuing Telemetry Transport Protocol
 ibm-mqisdp	1883/udp	0.000330	# IBM MQSeries SCADA
 idmaps	1884/udp	0.000661	# Internet Distance Map Svc
 vrtstrapserver	1885/udp	0.003304	# Veritas Trap Server
@@ -5591,7 +5591,7 @@ unknown	8878/tcp	0.000076
 unknown	8879/tcp	0.000076
 cddbp-alt	8880/tcp	0.000076	# CDDBP
 unknown	8882/tcp	0.000076
-secure-mqtt	8883/tcp	0.000076
+secure-mqtt	8883/tcp	0.000076	# Secure MQTT
 unknown	8885/udp	0.000330
 unknown	8886/udp	0.000330
 unknown	8887/tcp	0.000076

--- a/nselib/mqtt.lua
+++ b/nselib/mqtt.lua
@@ -122,9 +122,6 @@ MQTT = {
       parse = nil,
     },
   },
-
-  build_req = function(self, type, options)
-  end,
 }
 
 Comm = {

--- a/nselib/mqtt.lua
+++ b/nselib/mqtt.lua
@@ -404,7 +404,7 @@ Helper = {
     return self.comm:connect(options)
   end,
 
-    --- Sends a request to the MQTT broker.
+  --- Sends a request to the MQTT broker.
   --
   -- @name Helper.send
   --

--- a/nselib/mqtt.lua
+++ b/nselib/mqtt.lua
@@ -4,6 +4,7 @@ local comm = require "comm"
 local match = require "match"
 local nmap = require "nmap"
 local stdnse = require "stdnse"
+local table = require "table"
 
 _ENV = stdnse.module("mqtt", stdnse.seeall)
 

--- a/nselib/mqtt.lua
+++ b/nselib/mqtt.lua
@@ -3,7 +3,6 @@ local bit = require "bit"
 local comm = require "comm"
 local match = require "match"
 local nmap = require "nmap"
-local os = require "os"
 local stdnse = require "stdnse"
 
 _ENV = stdnse.module("mqtt", stdnse.seeall)
@@ -362,7 +361,7 @@ Helper = {
     assert(type(types) == "table")
     assert(type(timeout) == "number")
 
-    local start_time = os.time()
+    local end_time = nmap.clock_ms() + timeout * 1000
     while true do
       local status, result = self.comm:receive()
 
@@ -380,7 +379,7 @@ Helper = {
 
       -- Check timeout, but only if we care about it.
       if timeout > 0 then
-        if os.time() >= start_time + timeout then
+        if nmap.clock_ms() >= end_time then
           break
         end
       end

--- a/nselib/mqtt.lua
+++ b/nselib/mqtt.lua
@@ -1,0 +1,768 @@
+local bin = require "bin"
+local bit = require "bit"
+local comm = require "comm"
+local match = require "match"
+local nmap = require "nmap"
+local os = require "os"
+local stdnse = require "stdnse"
+
+_ENV = stdnse.module("mqtt", stdnse.seeall)
+
+---
+-- An implementation of MQTT 3.1.1
+-- https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html
+--
+-- This library does not currently implement the entire MQTT protocol,
+-- only those control packets which are necessary for existing scripts
+-- are included. Extending to accomodate additional control packets
+-- should not be difficult.
+--
+-- @author "Mak Kolybabi <mak@kolybabi.com>"
+-- @copyright Same as Nmap--See https://nmap.org/book/man-legal.html
+
+MQTT = {
+  -- Types of control packets
+  packet = {
+    ["CONNECT"] = {
+      number = 1,
+      options = {
+        "client_id",
+        "keep_alive_secs",
+        "password",
+        "username",
+        "will_message",
+        "will_topic",
+        "clean_session",
+        "will_qos",
+        "will_retain",
+        "protocol_level",
+        "protocol_name",
+      },
+      build = nil,
+      parse = nil,
+    },
+    ["CONNACK"] = {
+      number = 2,
+      options = {},
+      build = nil,
+      parse = nil,
+    },
+    ["PUBLISH"] = {
+      number = 3,
+      options = {},
+      build = nil,
+      parse = nil,
+    },
+    ["PUBACK"] = {
+      number = 4,
+      options = {},
+      build = nil,
+      parse = nil,
+    },
+    ["PUBREC"] = {
+      number = 5,
+      options = {},
+      build = nil,
+      parse = nil,
+    },
+    ["PUBREL"] = {
+      number = 6,
+      options = {},
+      build = nil,
+      parse = nil,
+    },
+    ["PUBCOMP"] = {
+      number = 7,
+      options = {},
+      build = nil,
+      parse = nil,
+    },
+    ["SUBSCRIBE"] = {
+      number = 8,
+      options = {
+        "filters",
+      },
+      build = nil,
+      parse = nil,
+    },
+    ["SUBACK"] = {
+      number = 9,
+      options = {},
+      build = nil,
+      parse = nil,
+    },
+    ["UNSUBSCRIBE"] = {
+      number = 10,
+      options = {},
+      build = nil,
+      parse = nil,
+    },
+    ["UNSUBACK"] = {
+      number = 11,
+      options = {},
+      build = nil,
+      parse = nil,
+    },
+    ["PINGREQ"] = {
+      number = 12,
+      options = {},
+      build = nil,
+      parse = nil,
+    },
+    ["PINGRESP"] = {
+      number = 13,
+      options = {},
+      build = nil,
+      parse = nil,
+    },
+    ["DISCONNECT"] = {
+      number = 14,
+      options = {},
+      build = nil,
+      parse = nil,
+    },
+  },
+
+  build_req = function(self, type, options)
+  end,
+}
+
+Comm = {
+  --- Creates a new Client instance.
+  --
+  -- @name Comm.new
+  --
+  -- @param host Table as received by the action method.
+  -- @param port Table as received by the action method.
+  -- @param options Table as received by the action method.
+  -- @return o Instance of Client.
+  new = function(self, host, port, options)
+    local o = {host = host, port = port, options = options or {}}
+    o["packet_id"] = 0
+    setmetatable(o, self)
+    self.__index = self
+    return o
+  end,
+
+  --- Connects to the MQTT broker.
+  --
+  -- @name Comm.connect
+  --
+  -- @return status true on success, false on failure.
+  -- @return err string containing the error message on failure.
+  connect = function(self)
+    -- XXX-MAK: This should be changed to support TLS.
+    self.socket = nmap.new_socket()
+    self.socket:set_timeout(self.options.timeout or 5000)
+    return self.socket:connect(self.host, self.port)
+  end,
+
+  --- Sends an MQTT control packet.
+  --
+  -- @name Comm.send
+  --
+  -- @param type Type of MQTT control packet to build and send.
+  -- @param options Table of options accepted by the requested type of
+  --        control packet.
+  -- @return status true on success, false on failure.
+  -- @return err string containing the error message on failure.
+  send = function(self, type, options)
+    -- Ensure the requested packet type is known.
+    local pkt = MQTT.packet[type]
+    assert(pkt, ("Control packet type '%s' is not known."):format(type))
+
+    -- Ensure the requested packet type is handled.
+    local fn = pkt.build
+    assert(fn, ("Control packet type '%s' has not been implemented."):format(type))
+
+    -- Validate the options.
+    options = options or {}
+    local o = {["packet_id"] = self:packet_identifier()}
+    for _, key in pairs(pkt.options) do
+      o[key] = false
+    end
+
+    for key, val in pairs(options) do
+      -- Reject unrecognized options.
+      assert(o[key] ~= nil, ("Control packet type '%s' does not have the option '%s'."):format(type, key))
+      o[key] = val
+    end
+
+    -- Build the packet as specified.
+    local status, req = fn(o)
+    if not status then
+      return status, req
+    end
+
+    -- Send the packet.
+    return self.socket:send(req)
+  end,
+
+  --- Receives an MQTT control packet.
+  --
+  -- @name Comm.receive
+  --
+  -- @return status True on success, false on failure.
+  -- @return response Table representing a control packet on success,
+  --         string containing the error message on failure.
+  receive = function(self)
+    -- Receive the type and flags of the response packet's fixed header.
+    local status, buf = self.socket:receive_buf(match.numbytes(1), true)
+    if not status then
+      return false, "Failed to receive response from server."
+    end
+
+    -- Extract the control packet type and fixed header flags of the packet.
+    local _, type_and_flags = bin.unpack("C", buf)
+
+    -- Retrieve the remaining length.
+    -- 2.2.3 Remaining Length
+    -- This only happens for large packets of size >= 128 bytes.
+    local multiplier = 1
+    local length = 0
+    repeat
+      status, buf = self.socket:receive_buf(match.numbytes(1), true)
+      if not status then
+        return false, "Failed to receive response from server."
+      end
+      local _, byte = bin.unpack("C", buf)
+      length = length + bit.band(byte, 0x7F) * multiplier
+      if (multiplier > 0x200000) then
+        return false, "Server response contained invalid packet length."
+      end
+      multiplier = bit.lshift(multiplier, 7)
+    until bit.band(byte, 0x80) == 0
+    assert(length >= 0)
+
+    -- Pull the rest of the packet off the wire.
+    status, buf = self.socket:receive_buf(match.numbytes(length), true)
+    if not status then
+      return status, buf
+    end
+    assert(buf:len() == length, ("Length of packet (%d) doesn't match expectation (%d)."):format(buf:len(), length))
+
+    -- Parse type and flags.
+    local type = bit.rshift(bit.band(type_and_flags, 0xF0), 4)
+    local fhflags = bit.band(type_and_flags, 0x0F)
+
+    -- Search for the definition of the packet type.
+    local pkt = nil
+    for key,val in pairs(MQTT.packet) do
+      if val.number == type then
+        type = key
+        pkt = val
+        break
+      end
+    end
+
+    -- Ensure the requested packet type is handled.
+    if not pkt then
+      return false, ("Control packet type '%d' is not known."):format(type)
+    end
+
+    -- Ensure the requested packet type is handled.
+    local fn = pkt.parse
+    if not fn then
+      return false, ("Control packet type '%s' is not implemented."):format(type)
+    end
+
+    return fn(fhflags, buf)
+  end,
+
+  --- Disconnects from the MQTT broker.
+  --
+  -- @name Comm.close
+  close = function(self)
+    return self.socket:close()
+  end,
+
+  --- Generates a packet identifier.
+  --
+  -- @name Comm.packet_identifier
+  --
+  -- See "2.3.1 Packet Identifier" section of the standard.
+  --
+  -- @return Unique identifier for a packet.
+  packet_identifier = function(self)
+    self.packet_id = self.packet_id + 1
+    local num = bin.pack(">S", self.packet_id)
+    return num
+  end,
+}
+
+Helper = {
+  --- Creates a new Helper instance.
+  --
+  -- @name Helper.create
+  --
+  -- @param host Table as received by the action method.
+  -- @param port Table as received by the action method.
+  -- @return o instance of Client
+  new = function(self, host, port, opt)
+    local o = { host = host, port = port, opt = opt or {} }
+    setmetatable(o, self)
+    self.__index = self
+    return o
+  end,
+
+  --- Connects to the MQTT broker.
+  --
+  -- @name Helper.connect
+  --
+  -- @param options Table of options for the CONNECT control packet.
+  -- @return status True on success, false on failure.
+  -- @return response Table representing a CONNACK control packet on
+  --         success, string containing the error message on failure.
+  connect = function(self, options)
+    self.comm = Comm:new(self.host, self.port, self.opt)
+
+    local result, status = self.comm:connect()
+    if not result then
+      return false, status
+    end
+
+    return self:request("CONNECT", options, "CONNACK")
+  end,
+
+  --- Sends a request to the MQTT broker, and receive a response.
+  --
+  -- @name Helper.request
+  --
+  -- @param req_type Type of control packet to build and send.
+  -- @param options Table of options for the CONNECT control packet.
+  -- @param res_type Type of control packet to receive and parse.
+  -- @return status True on success, false on failure.
+  -- @return response Table representing a <code>res_type</code>
+  --         control packet on success, string containing the error
+  --         message on failure.
+  request = function(self, req_type, options, res_type)
+    assert(type(req_type) == "string")
+
+    local status, result = self.comm:send(req_type, options)
+    if not status then
+       return false, result
+    end
+
+    return self.comm:receive({res_type})
+  end,
+
+  --- Listens for a response matching a list of types.
+  --
+  -- @name Helper.receive
+  --
+  -- @param types Type of control packet to build and send.
+  -- @param timeout Number of seconds to listen for matching response.
+  -- @param res_type Table of types of control packet to receive and
+  --        parse.
+  -- @return status True on success, false on failure.
+  -- @return response Table representing any <code>res_type</code>
+  --         control packet on success, string containing the error
+  --         message on failure.
+  receive = function(self, types, timeout)
+    assert(type(types) == "table")
+    assert(type(timeout) == "number")
+
+    local start_time = os.time()
+    while true do
+      local status, result = self.comm:receive()
+
+      -- Check for failures.
+      if not status then
+        return false, result
+      end
+
+      -- Check for messages matching our filters.
+      for _, type in pairs(types) do
+        if result.type == type then
+          return true, result
+        end
+      end
+
+      -- Check timeout, but only if we care about it.
+      if timeout > 0 then
+        if os.time() >= start_time + timeout then
+          break
+        end
+      end
+    end
+
+    return false, ("No messages received in %d seconds matching desired types."):format(timeout)
+  end,
+
+  -- Closes the socket with the server.
+  --
+  -- @name Helper.close
+  close = function(self)
+    self.comm:send("DISCONNECT")
+    return self.comm:close()
+  end,
+}
+
+--- Build an MQTT CONNECT control packet.
+--
+-- See "3.1 CONNECT – Client requests a connection to a Server"
+-- section of the standard.
+--
+-- @param options Table of options accepted by this type of control
+--        packet.
+-- @return A string representing a CONNECT control packet.
+MQTT.packet["CONNECT"].build = function(options)
+  assert(type(options) == "table")
+
+  local head = ""
+  local tail = ""
+
+  -- 3.1.2.1 Protocol Name
+  local protocol_name = options.protocol_name
+  if not protocol_name then
+    protocol_name = "MQTT"
+  end
+  assert(type(protocol_name) == "string")
+  head = head .. MQTT.utf8_build(protocol_name)
+
+  -- 3.1.2.2 Protocol Level
+  local protocol_level = options.protocol_level
+  if not protocol_level then
+    protocol_level = 4
+  end
+  assert(type(protocol_level) == "number")
+  head = head .. bin.pack("C", protocol_level)
+
+  -- 3.1.3.1 Client Identifier
+  local client_id = options.client_id
+  if not client_id then
+    -- We throw in randomness in case there are multiple scripts using this
+    -- library on a single port.
+    client_id = "nmap" .. stdnse.generate_random_string(16)
+  end
+  assert(type(client_id) == "string")
+  tail = tail .. MQTT.utf8_build(client_id)
+
+  -- 3.1.2.3 Connect Flags
+  local cflags = 0x00
+
+  -- 3.1.2.4 Clean Session
+  if options.clean_session then
+    cflags = bit.bor(cflags, 0x02)
+  end
+
+  -- 3.1.2.6 Will QoS
+  if not options.will_qos then
+    options.will_qos = 0
+  end
+  assert(options.will_qos >= 0)
+  assert(options.will_qos <= 2)
+  cflags = bit.bor(cflags, bit.lshift(options.will_qos, 3))
+
+  -- 3.1.2.7 Will Retain
+  if options.will_retain then
+    cflags = bit.bor(cflags, 0x20)
+  end
+
+  -- 3.1.2.5 Will Flag
+  if options.will_topic and options.will_message then
+    cflags = bit.bor(cflags, 0x04)
+    tail = tail .. MQTT.utf8_build(options.will_topic)
+    tail = tail .. MQTT.utf8_build(options.will_message)
+  end
+
+  -- 3.1.2.8 User Name Flag
+  if options.username then
+    cflags = bit.bor(cflags, 0x80)
+    tail = tail .. MQTT.utf8_build(options.username)
+  end
+
+  -- 3.1.2.9 Password Flag
+  if options.password then
+    cflags = bit.bor(cflags, 0x40)
+    tail = tail .. MQTT.utf8_build(options.password)
+  end
+
+  head = head .. bin.pack("C", cflags)
+
+  -- 3.1.2.10 Keep Alive
+  if not options.keep_alive_secs then
+    options.keep_alive_secs = 30
+  end
+  head = head .. bin.pack(">S", options.keep_alive_secs)
+
+  return true, MQTT.fixed_header(1, 0x0, head .. tail)
+end
+
+--- Parse an MQTT CONNACK control packet.
+--
+-- See "3.2 CONNACK – Acknowledge connection request" section of the
+-- standard.
+--
+-- @param fhflags The flags of the control packet.
+-- @param buf The string representing the control packet.
+-- @return status True on success, false on failure.
+-- @return response Table representing a CONNACK control packet on
+--         success, string containing the error message on failure.
+MQTT.packet["CONNACK"].parse = function(fhflags, buf)
+  assert(type(fhflags) == "number")
+  assert(type(buf) == "string")
+
+  -- 3.2.1 Fixed header
+  -- We expect that the packet structure is rigid. We allow variation, but we
+  -- warn about it just in case.
+  if fhflags ~= 0x00 then
+    stdnse.debug4("Fixed header flags in CONNACK packet were %d, should be 0.", fhflags)
+  end
+  if buf:len() ~= 2 then
+    stdnse.debug4("Fixed header remaining length in CONNACK packet was %d, should be 2.", buf:len())
+  end
+
+  -- 3.2.2.1 Connect Acknowledge Flags
+  local res = {["type"] = "CONNACK"}
+  local _, caflags, crcode = bin.unpack("CC", buf)
+
+  -- 3.2.2.2 Session Present
+  res.session_present = (bit.band(caflags, 0x01) == 1)
+
+  -- 3.2.2.3 Connect Return code
+  res.accepted = (crcode == 0x00)
+  if crcode == 0x01 then
+     res.reason = "Unacceptable Protocol Version"
+  elseif crcode == 0x02 then
+     res.reason = "Client Identifier Rejected"
+  elseif crcode == 0x03 then
+     res.reason = "Server Unavailable"
+  elseif crcode == 0x04 then
+     res.reason = "Bad User Name or Password"
+  elseif crcode == 0x05 then
+     res.reason = "Not Authorized"
+  else
+     res.reason = "Unrecognized Connect Return Code"
+  end
+
+  return true, res
+end
+
+--- Build an MQTT SUBSCRIBE control packet.
+--
+-- See "3.8 SUBSCRIBE - Subscribe to topics" section of the standard.
+--
+-- @param options Table of options accepted by this type of control
+--        packet.
+-- @return A string representing a SUBSCRIBE control packet.
+MQTT.packet["SUBSCRIBE"].build = function(options)
+  assert(type(options) == "table")
+
+  local pkt = ""
+
+  -- 3.8.2 Variable header
+  pkt = pkt .. options.packet_id
+
+  for key, val in pairs(options.filters) do
+    local name = val.filter
+    assert(type(name) == "string")
+
+    local qos = val.qos
+    if not qos then
+      qos = 0
+    end
+    assert(type(qos) == "number")
+    assert(qos >= 0)
+    assert(qos <= 2)
+
+    pkt = pkt .. MQTT.utf8_build(name)
+    pkt = pkt .. bin.pack("C", qos)
+  end
+
+  return true, MQTT.fixed_header(8, 0x2, pkt)
+end
+
+--- Parse an MQTT SUBACK control packet.
+--
+-- See "3.9 SUBACK – Subscribe acknowledgement" section of the
+-- standard.
+--
+-- @param fhflags The flags of the control packet.
+-- @param buf The string representing the control packet.
+-- @return status True on success, false on failure.
+-- @return response Table representing a SUBACK control packet on
+--         success, string containing the error message on failure.
+MQTT.packet["SUBACK"].parse = function(fhflags, buf)
+  assert(type(fhflags) == "number")
+  assert(type(buf) == "string")
+
+  -- 3.9.1 Fixed header
+  -- We expect that the packet structure is rigid. We allow variation, but we
+  -- warn about it just in case.
+  if fhflags ~= 0x00 then
+    stdnse.debug4("Fixed header flags in CONNACK packet were %d, should be 0.", fhflags)
+  end
+
+  local res = {["type"] = "SUBACK"}
+  local length = buf:len()
+
+  -- 3.9.2 Variable header
+  if length < 2 then
+    return false, ("Failed to parse SUBACK packet, too short.")
+  end
+  local pos, packet_id = bin.unpack(">S", buf)
+  res.packet_id = packet_id
+
+  -- 3.9.3 Payload
+  local code
+  local codes = {}
+  while pos <= length do
+    pos, code = bin.unpack("C", buf, pos)
+    if code == 0x00 then
+      table.insert(codes, {["success"] = true, ["max_qos"] = 0})
+    elseif code == 0x01 then
+      table.insert(codes, {["success"] = true, ["max_qos"] = 1})
+    elseif code == 0x02 then
+      table.insert(codes, {["success"] = true, ["max_qos"] = 2})
+    else
+      table.insert(codes, {["success"] = false})
+    end
+  end
+  res.filters = codes
+
+  return true, res
+end
+
+--- Parse an MQTT PUBLISH control packet.
+--
+-- See "3.3 PUBLISH – Publish message" section of the standard.
+--
+-- @param fhflags The flags of the control packet.
+-- @param buf The string representing the control packet.
+-- @return
+-- @return status True on success, false on failure.
+-- @return response Table representing a PUBLISH control packet on
+--         success, string containing the error message on failure.
+MQTT.packet["PUBLISH"].parse = function(fhflags, buf)
+  assert(type(fhflags) == "number")
+  assert(type(buf) == "string")
+
+  -- 3.9.1 Fixed header
+  local res = {["type"] = "PUBLISH"}
+
+  -- 3.3.1.1 DUP
+  local dup = (bit.band(fhflags, 0x8) == 0x8)
+  res.dup = dup
+
+  -- 3.3.1.2 QoS
+  local qos = bit.rshift(bit.band(fhflags, 0x6), 1)
+  res.qos = qos
+
+  -- 3.3.1.3 RETAIN
+  local ret = (bit.band(fhflags, 0x1) == 0x8)
+  res.retain = ret
+
+  -- 3.3.2.1 Topic Name
+  local pos, val = MQTT.utf8_parse(buf)
+  if not pos then
+    return false, val
+  end
+  res.topic = val
+
+  -- 3.3.2.2 Packet Identifier
+  if qos == 1 or qos == 2 then
+    pos, val = bin.unpack(">S", buf, pos)
+    if not pos then
+      return false, val
+    end
+    res.packet_id = val
+  end
+
+  -- 3.3.3 Payload
+  local length = buf:len()
+  res.payload = buf:sub(pos, length)
+
+  return true, res
+end
+
+--- Build an MQTT DISCONNECT control packet.
+--
+-- See "3.14 DISCONNECT – Disconnect notification" section of the
+-- standard.
+--
+-- @param options Table of options accepted by this type of control
+--        packet.
+-- @return A string representing a DISCONNECT control packet.
+MQTT.packet["DISCONNECT"].build = function(options)
+  assert(type(options) == "table")
+  return true, MQTT.fixed_header(14, 0x00, "")
+end
+
+--- Build a UTF-8 string in MQTT's length-prefixed format.
+--
+-- See section "1.5.3 UTF-8 encoded strings" of the standard.
+--
+-- @param str The string to convert.
+-- @return A length-prefixed string.
+MQTT.utf8_build = function(str)
+  assert(type(str) == "string")
+
+  return bin.pack(">P", str)
+end
+
+--- Parser a UTF-8 string in MQTT's length-prefixed format.
+--
+-- See section "1.5.3 UTF-8 encoded strings" of the standard.
+--
+-- @param buf The bytes to parse.
+-- @param pos The position from which to start parsing.
+-- @return status True on success, false on failure.
+-- @return response Parsed string on success, string containing the
+--         error message on failure.
+MQTT.utf8_parse = function(buf, pos)
+  assert(type(buf) == "string")
+
+  if not pos then
+    pos = 0
+  end
+  assert(type(pos) == "number")
+
+  local buf_length = buf:len()
+  if pos + 2 > buf_length then
+    return false, ("Buffer at position %d has no space for a UTF-8 length-prefixed string."):format(pos)
+  end
+
+  local _, str_length = bin.unpack(">S", buf, pos)
+  if pos + 2 + str_length > buf_length then
+    return false, ("Buffer at position %d has no space for a %d-byte UTF-8 string."):format(pos, str_length)
+  end
+
+  return bin.unpack(">P", buf, pos)
+end
+
+--- Prefix the body of an MQTT packet with a fixed header.
+--
+-- See section "2.2 Fixed header" of the standard.
+--
+-- @param num The type of the control packet.
+-- @param flags The flags of the control packet.
+-- @param pkt The string representing the control packet.
+-- @return A string representing a completed MQTT control packet.
+MQTT.fixed_header = function(num, flags, pkt)
+  assert(type(num) == "number")
+  assert(type(flags) == "number")
+  assert(type(pkt) == "string")
+
+  -- Build the fixed header.
+  -- 2.2.1 MQTT Control Packet type
+  -- 2.2.2 Flags
+  local hdr = bit.bor(bit.lshift(num, 4), flags)
+
+  -- Construct the remaining length.
+  -- 2.2.3 Remaining Length
+  local tlen = pkt:len()
+  local rlen = ""
+  repeat
+    local byte = bit.band(tlen, 0x7F)
+    tlen = bit.rshift(tlen, 7)
+    if tlen > 0 then
+      byte = bit.bor(byte, 0x80)
+    end
+    rlen = bin.pack("C", byte) .. rlen
+  until tlen == 0
+
+  return bin.pack("C", hdr) .. rlen .. pkt
+end
+
+return _ENV;

--- a/nselib/mqtt.lua
+++ b/nselib/mqtt.lua
@@ -743,7 +743,6 @@ end
 -- @return response Table representing a PUBLISH control packet on
 --         success, string containing the error message on failure.
 MQTT.packet["PUBLISH"].parse = function(fhflags, buf)
-  stdnse.debug1("PUB")
   assert(type(fhflags) == "number")
   assert(type(buf) == "string")
 

--- a/nselib/shortport.lua
+++ b/nselib/shortport.lua
@@ -162,7 +162,7 @@ Apache Tomcat HTTP server default ports: 8180 and 8000
 Litespeed webserver default ports: 8088 and 7080
 --]]
 LIKELY_HTTP_PORTS = {
-  80, 443, 631, 7080, 8080, 8443, 8088, 5800, 3872, 8180, 8000
+  80, 443, 631, 7080, 8080, 8443, 8088, 5800, 3872, 8180, 8000, 8883
 }
 
 LIKELY_HTTP_SERVICES = {

--- a/nselib/unittest.lua
+++ b/nselib/unittest.lua
@@ -75,6 +75,7 @@ local libs = {
 "membase",
 "mobileme",
 "mongodb",
+"mqtt",
 "msrpc",
 "msrpcperformance",
 "msrpctypes",

--- a/scripts/mqtt-subscribe.nse
+++ b/scripts/mqtt-subscribe.nse
@@ -4,9 +4,17 @@ local shortport = require "shortport"
 local stdnse = require "stdnse"
 
 description = [[
-Establishes a connection to an MQTT broker and subscribes to selected
-topics. The default topics are chosen to fetch system information and
-all client updates.
+Dumps message traffic from MQTT brokers.
+
+This script establishes a connection to an MQTT broker and subscribes
+to the requested topics. The default topics have been chosen to
+receive system information and all messages from other clients. This
+allows Nmap, to listen to all messages being published by clients to
+the MQTT broker.
+
+For additional information:
+* https://en.wikipedia.org/wiki/MQTT
+* https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html
 ]]
 
 ---

--- a/scripts/mqtt-subscribe.nse
+++ b/scripts/mqtt-subscribe.nse
@@ -140,7 +140,7 @@ author = "Mak Kolybabi <mak@kolybabi.com>"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 categories = {"safe", "discovery", "version"}
 
-portrule = shortport.version_port_or_service({1883, 8883}, {"mqtt", "mqtt-tls"}, "tcp")
+portrule = shortport.version_port_or_service({1883, 8883}, {"mqtt", "secure-mqtt"}, "tcp")
 
 local function parse_args()
   local args = {}

--- a/scripts/mqtt-subscribe.nse
+++ b/scripts/mqtt-subscribe.nse
@@ -2,6 +2,7 @@ local mqtt = require "mqtt"
 local nmap = require "nmap"
 local shortport = require "shortport"
 local stdnse = require "stdnse"
+local table = require "table"
 
 description = [[
 Dumps message traffic from MQTT brokers.

--- a/scripts/mqtt-subscribe.nse
+++ b/scripts/mqtt-subscribe.nse
@@ -1,0 +1,383 @@
+local mqtt = require "mqtt"
+local os = require "os"
+local shortport = require "shortport"
+local stdnse = require "stdnse"
+
+description = [[
+Establishes a connection to an MQTT broker and subscribes to selected
+topics. The default topics are chosen to fetch system information and
+all client updates.
+]]
+
+---
+-- @usage nmap -p 1883 --script mqtt-subscribe <target>
+--
+-- @output
+-- PORT     STATE SERVICE                 REASON
+-- 1883/tcp open  mosquitto version 1.4.8 syn-ack
+-- | mqtt-subscribe:
+-- |   Topics and their most recent payloads:
+-- |     $SYS/broker/load/publish/received/5min: 0.27
+-- |     $SYS/broker/publish/messages/received: 7
+-- |     $SYS/broker/heap/current: 39240
+-- |     $SYS/broker/load/messages/sent/15min: 21.54
+-- |     $SYS/broker/load/bytes/sent/5min: 647.13
+-- |     $SYS/broker/clients/disconnected: 40
+-- |     $SYS/broker/clients/connected: 1
+-- |     $SYS/broker/subscriptions/count: 40
+-- |     $SYS/broker/load/publish/received/15min: 0.46
+-- |     $SYS/broker/clients/inactive: 40
+-- |     $SYS/broker/messages/sent: 2318
+-- |     $SYS/broker/load/publish/sent/1min: 2.48
+-- |     $SYS/broker/load/sockets/1min: 0.09
+-- |     $SYS/broker/load/connections/15min: 0.41
+-- |     $SYS/broker/load/bytes/sent/15min: 822.79
+-- |     $SYS/broker/load/sockets/15min: 0.81
+-- |     $SYS/broker/version: mosquitto version 1.4.8
+-- |     $SYS/broker/load/messages/received/5min: 1.24
+-- |     $SYS/broker/load/publish/sent/15min: 20.39
+-- |     $SYS/broker/uptime: 225478 seconds
+-- |     $SYS/broker/load/publish/received/1min: 0.05
+-- |     $SYS/broker/publish/messages/dropped: 0
+-- |     $SYS/broker/retained messages/count: 47
+-- |     $SYS/broker/messages/received: 293
+-- |     $SYS/broker/load/connections/5min: 0.28
+-- |     $SYS/broker/load/messages/sent/1min: 2.78
+-- |     $SYS/broker/bytes/sent: 83026
+-- |     $SYS/broker/load/bytes/received/5min: 13.98
+-- |     $SYS/broker/load/messages/received/1min: 0.35
+-- |     $SYS/broker/messages/stored: 47
+-- |     $SYS/broker/publish/messages/sent: 2070
+-- |     $SYS/broker/load/sockets/5min: 0.53
+-- |     $SYS/broker/clients/active: 1
+-- |     $SYS/broker/timestamp: Sun, 14 Feb 2016 15:48:26 +0000
+-- |     $SYS/broker/load/bytes/received/15min: 17.83
+-- |     $SYS/broker/publish/bytes/received: 49
+-- |     $SYS/broker/load/publish/sent/5min: 16.03
+-- |     $SYS/broker/publish/bytes/sent: 9752
+-- |     $SYS/broker/load/bytes/sent/1min: 100.49
+-- |     $SYS/broker/load/bytes/received/1min: 2.72
+-- |     $SYS/broker/load/connections/1min: 0.06
+-- |     $SYS/broker/clients/expired: 0
+-- |     $SYS/broker/load/messages/received/15min: 1.49
+-- |     $SYS/broker/load/messages/sent/5min: 17.00
+-- |     $SYS/broker/bytes/received: 2520
+-- |     $SYS/broker/heap/maximum: 41992
+-- |_    $SYS/broker/clients/total: 41
+--
+-- @xmloutput
+-- <table key="Topics and their most recent payloads">
+--   <elem key="$SYS/broker/load/messages/sent/15min">23.48</elem>
+--   <elem key="$SYS/broker/bytes/received">2469</elem>
+--   <elem key="$SYS/broker/load/sockets/5min">0.63</elem>
+--   <elem key="$SYS/broker/messages/sent">2268</elem>
+--   <elem key="$SYS/broker/load/publish/sent/15min">22.25</elem>
+--   <elem key="$SYS/broker/load/publish/received/1min">0.05</elem>
+--   <elem key="$SYS/broker/load/bytes/sent/1min">626.45</elem>
+--   <elem key="$SYS/broker/publish/messages/received">7</elem>
+--   <elem key="$SYS/broker/load/connections/15min">0.39</elem>
+--   <elem key="$SYS/broker/heap/current">38864</elem>
+--   <elem key="$SYS/broker/load/sockets/1min">0.36</elem>
+--   <elem key="$SYS/broker/messages/stored">47</elem>
+--   <elem key="$SYS/broker/load/bytes/sent/15min">897.46</elem>
+--   <elem key="$SYS/broker/version">mosquitto version 1.4.8</elem>
+--   <elem key="$SYS/broker/clients/inactive">39</elem>
+--   <elem key="$SYS/broker/subscriptions/count">39</elem>
+--   <elem key="$SYS/broker/timestamp">Sun, 14 Feb 2016 15:48:26 +0000</elem>
+--   <elem key="$SYS/broker/uptime">225280 seconds</elem>
+--   <elem key="$SYS/broker/publish/bytes/sent">9520</elem>
+--   <elem key="$SYS/broker/publish/messages/sent">2023</elem>
+--   <elem key="$SYS/broker/load/bytes/received/1min">10.58</elem>
+--   <elem key="$SYS/broker/load/connections/5min">0.31</elem>
+--   <elem key="$SYS/broker/load/messages/received/15min">1.58</elem>
+--   <elem key="$SYS/broker/publish/messages/dropped">0</elem>
+--   <elem key="$SYS/broker/clients/connected">1</elem>
+--   <elem key="$SYS/broker/load/messages/received/5min">1.51</elem>
+--   <elem key="$SYS/broker/retained messages/count">47</elem>
+--   <elem key="$SYS/broker/load/bytes/received/15min">18.78</elem>
+--   <elem key="$SYS/broker/messages/received">289</elem>
+--   <elem key="$SYS/broker/clients/disconnected">39</elem>
+--   <elem key="$SYS/broker/load/publish/received/15min">0.46</elem>
+--   <elem key="$SYS/broker/load/sockets/15min">0.82</elem>
+--   <elem key="$SYS/broker/load/publish/sent/5min">21.44</elem>
+--   <elem key="$SYS/broker/bytes/sent">81121</elem>
+--   <elem key="$SYS/broker/publish/bytes/received">49</elem>
+--   <elem key="$SYS/broker/load/connections/1min">0.18</elem>
+--   <elem key="$SYS/broker/load/messages/received/1min">1.45</elem>
+--   <elem key="$SYS/broker/clients/expired">0</elem>
+--   <elem key="$SYS/broker/load/publish/received/5min">0.27</elem>
+--   <elem key="$SYS/broker/load/messages/sent/5min">22.63</elem>
+--   <elem key="$SYS/broker/load/bytes/received/5min">16.53</elem>
+--   <elem key="$SYS/broker/load/messages/sent/1min">16.80</elem>
+--   <elem key="$SYS/broker/clients/total">40</elem>
+--   <elem key="$SYS/broker/clients/active">1</elem>
+--   <elem key="$SYS/broker/load/publish/sent/1min">15.57</elem>
+--   <elem key="$SYS/broker/load/bytes/sent/5min">863.85</elem>
+--   <elem key="$SYS/broker/heap/maximum">41992</elem>
+-- </table>
+--
+-- @args mqtt-subscribe.client-id MQTT client identifier, defaults to
+--       <code>nmap</code> with a random suffix.
+-- @args mqtt-subscribe.listen-msgs Number of PUBLISH messages to
+--       receive, defaults to 100. A value of zero forces this script
+--       to stop only when listen-secs has passed.
+-- @args mqtt-subscribe.listen-secs Number of seconds to listen for
+--       PUBLISH messages, defaults to 5. A value of zero forces this
+--       script to stop only when listen-msgs PUBLISH messages have
+--       been received.
+-- @args mqtt-subscribe.password Password for MQTT brokers requiring
+--       authentication.
+-- @args mqtt-subscribe.protocol-level MQTT protocol level, defaults
+--       to 4.
+-- @args mqtt-subscribe.protocol-name MQTT protocol name, defaults to
+--       <code>MQTT</code>.
+-- @args mqtt-subscribe.topic Topic filters to indicate which PUBLISH
+--       messages we'd like to receive.
+-- @args mqtt-subscribe.username Username for MQTT brokers requiring
+--       authentication.
+
+author = "Mak Kolybabi <mak@kolybabi.com>"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"safe", "discovery", "version"}
+
+portrule = shortport.version_port_or_service({1883, 8883}, {"mqtt", "mqtt-tls"}, "tcp")
+
+local function parse_args()
+  local args = {}
+
+  local protocol_level = stdnse.get_script_args(SCRIPT_NAME .. '.protocol-level')
+  if protocol_level then
+    -- Sanity check the value from the user.
+    protocol_level = tonumber(protocol_level)
+    if type(protocol_level) ~= "number" then
+      return false, "protocol-level argument must be a number."
+    elseif protocol_level < 0 or protocol_level > 255 then
+      return false, "protocol-level argument must be in range between 0 and 255 inclusive."
+    end
+  else
+    -- Indicate to the library that it should choose this on its own.
+    protocol_level = false
+  end
+  args.protocol_level = protocol_level
+
+  local protocol_name = stdnse.get_script_args(SCRIPT_NAME .. '.protocol-name')
+  if protocol_name then
+    -- Sanity check the value from the user.
+    if type(protocol_name) ~= "string" then
+      return false, "protocol-name argument must be a string."
+    end
+  else
+    -- Indicate to the library that it can choose this on its own.
+    protocol_name = false
+  end
+  args.protocol_name = protocol_name
+
+  local client_id = stdnse.get_script_args(SCRIPT_NAME .. '.client-id')
+  if not client_id then
+    -- Indicate to the library that it should choose this on its own.
+    client_id = false
+  end
+  args.client_id = client_id
+
+  local max_msgs = stdnse.get_script_args(SCRIPT_NAME .. '.listen-msgs')
+  if max_msgs then
+    -- Sanity check the value from the user.
+    max_msgs = tonumber(max_msgs)
+    if type(max_msgs) ~= "number" then
+      return false, "listen-msgs argument must be a number."
+    elseif max_msgs < 0 then
+      return false, "listen-msgs argument must be non-negative."
+    end
+  else
+    -- Many brokers have ~50 $SYS/# messages, so we double that number
+    -- for how many messages we'll receive.
+    max_msgs = 100
+  end
+  args.max_msgs = max_msgs
+
+  local max_secs = stdnse.get_script_args(SCRIPT_NAME .. '.listen-secs')
+  if max_secs then
+    -- Sanity check the value from the user
+    max_secs = tonumber(max_secs)
+    if type(max_secs) ~= "number" then
+      return false, "listen-secs argument must be a number."
+    elseif max_secs < 0 then
+      return false, "listen-secs argument must be non-negative."
+    elseif args.max_msgs == 0 and max_secs == 0 then
+      return falsem "listen-secs and listen-msgs may not both be zero."
+    end
+  else
+    max_secs = 5
+  end
+  args.max_secs = max_secs
+
+  local username = stdnse.get_script_args(SCRIPT_NAME .. '.username')
+  if not username then
+    username = false
+  end
+  args.username = username
+
+  local password = stdnse.get_script_args(SCRIPT_NAME .. '.password')
+  if password then
+    -- Sanity check the value from the user.
+    if not username then
+      return false, "A password cannot be given without also giving a username."
+    end
+  else
+    password = false
+  end
+  args.password = password
+
+  local topic = stdnse.get_script_args(SCRIPT_NAME .. '.topic')
+  if topic then
+    -- Sanity check the value from the user.
+    if type(topic) ~= "table" then
+      topic = {topic}
+    end
+  else
+    -- These topic filters should receive most messages.
+    topic = {"$SYS/#", "#"}
+  end
+  args.topic = topic
+
+  return true, args
+end
+
+action = function(host, port)
+  local output = stdnse.output_table()
+
+  -- Parse and sanity check the command line arguments.
+  local status, options = parse_args()
+  if not status then
+    output.ERROR = options
+    return output, output.ERROR
+  end
+
+  -- Create an instance of the MQTT library's client object.
+  local helper = mqtt.Helper:new(host, port)
+
+  -- Connect to the MQTT broker.
+  local status, response = helper:connect({
+    ["protocol_level"] = options.protocol_level,
+    ["protocol_name"] = options.protocol_name,
+    ["client_id"] = options.client_id,
+    ["username"] = options.username,
+    ["password"] = options.password,
+  })
+  if not status then
+    output.ERROR = response
+    return output, output.ERROR
+  elseif response.type ~= "CONNACK" then
+    output.ERROR = ("Received control packet type '%s' instead of 'CONNACK'."):format(response.type)
+    return output, output.ERROR
+  elseif not response.accepted then
+    output.ERROR = ("Connection rejected: %s"):format(response.reason)
+    return output, output.ERROR
+  end
+
+  -- Build a list of topic filters.
+  local filters = {}
+  for _, filter in ipairs(options.topic) do
+    table.insert(filters, {["filter"] = filter})
+  end
+
+  -- Subscribe to receive PUBLISH messages that match our topic
+  -- filters.The MQTT standard allows sending PUBLISH messages before
+  -- the SUBACK message, so we explicitly ignore any non-CONNACK
+  -- messages at this point.
+  local status, response = helper:request("SUBSCRIBE", {["filters"] = filters}, "SUBACK")
+  if not status then
+    output.ERROR = response
+    return output, output.ERROR
+  end
+
+  -- For each topic to which we tried to subscribe, the MQTT broker
+  -- informs us whether we were successful. We will note if any
+  -- subscriptions fail, but continue so long as any succeeded.
+  local success = false
+  local results = response.filters
+  for i, result in ipairs(results) do
+    topic = options.topic[i]
+    if result.success then
+      stdnse.debug3("Topic filter '%s' was accepted with a maximum QoS of %d.", topic, result.max_qos)
+      success = true
+    else
+      stdnse.debug3("Topic filter '%s' was rejected.", topic)
+    end
+  end
+
+  if not success then
+    output.ERROR = "Every topic filter was rejected."
+    return output, output.ERROR
+  end
+
+  -- We are now in a position to receive PUBLISH messages for at least
+  -- one of our topic filters. We will record the topic of every
+  -- PUBLISH message, but only retain the most recent payload.
+  --
+  -- We will continue to listen for PUBLISH messages until one of two
+  -- conditions is met, whichever comes first:
+  --   1) We have listened for max_secs
+  --   2) We have received max_msgs
+  local end_time = os.time() + options.max_secs
+  local topics = {}
+  local keys = {}
+  local msgs = 0
+  while true do
+    -- Check for the first condition.
+    local time_left = end_time - os.time()
+    if time_left <= 0 then
+      break
+    end
+
+    status, response = helper:receive({"PUBLISH"}, time_left)
+    if not status then
+      break
+    end
+
+    local name = response.topic
+    if not topics[name] then
+      table.insert(keys, name)
+    end
+    topics[name] = response.payload
+
+    -- Check for the second condition.
+    msgs = msgs + 1
+    if options.max_msgs ~= 0 and msgs >= options.max_msgs then
+      break
+    end
+  end
+
+  -- Disconnect from the MQTT broker.
+  helper:close()
+
+  -- We're not going to error out if the last response was an error if
+  -- there were successful responses before it, but we will log it.
+  if not status then
+    if #keys > 0 then
+      stdnse.debug3("Received error while listening for PUBLISH messages: %s", response)
+    else
+      output.ERROR = response
+      return output, output.ERROR
+    end
+  end
+
+  -- Try and offer information on what software the MQTT broker is
+  -- running through the version identification interface. Sadly this
+  -- is often just a version number with no product name.
+  local ver = topics["$SYS/broker/version"]
+  if ver then
+    port.version.name = ver
+    nmap.set_port_version(host, port)
+  end
+
+  -- Format the topics and payloads we received.
+  table.sort(keys)
+  local topics_in_order = {}
+  for _, key in ipairs(keys) do
+    topics_in_order[key] = topics[key]
+  end
+
+  output["Topics and their most recent payloads"] = topics_in_order
+  return output, stdnse.format_output(true, output)
+end

--- a/scripts/mqtt-subscribe.nse
+++ b/scripts/mqtt-subscribe.nse
@@ -307,7 +307,7 @@ action = function(host, port)
   local success = false
   local results = response.filters
   for i, result in ipairs(results) do
-    topic = options.topic[i]
+    local topic = options.topic[i]
     if result.success then
       stdnse.debug3("Topic filter '%s' was accepted with a maximum QoS of %d.", topic, result.max_qos)
       success = true


### PR DESCRIPTION
I am submitting a new port definition, service probe, discovery script, and protocol library for MQTT, an Internet of Things publish-subscribe protocol. MQTT is standardized and has many implementations and public test servers.

The code in this branch has one deficiency that I suspect the reviewer(s) can help fix: it does not properly connect over TLS for either the service probe nor the discovery script.

The following command lines can be used to test multiple public test servers using multiple MQTT broker implementations both with and without user authentication.

Without user authentication and without TLS (working):
* `nmap -p 1883 --script mqtt-subscribe test.mosquitto.org`
* `nmap -p 1883 --script mqtt-subscribe broker.hivemq.com`
* `nmap -p 1883 --script mqtt-subscribe broker.mqttdashboard.com`

With user authentication and without TLS (working):
* `nmap -PN -sV --allports -p 11638 --script mqtt-subscribe --script-args=username=nmap,password=hunter2 m10.cloudmqtt.com`

Without user authentication and with TLS (not working):
* `nmap -p 8883 --script mqtt-subscribe test.mosquitto.org`

If you have any questions or guidance, I will do my best to respond promptly.