### PR TITLE
Detect DROWN with NSE script sslv2-drown

### DIFF
--- a/scripts/sslv2-drown.nse
+++ b/scripts/sslv2-drown.nse
@@ -14,7 +14,7 @@ CVE-2015-3197, CVE-2016-0703 and CVE-2016-0800 (DROWN)
 author = "Bertrand Bonnefoy-Claudet <bertrand@cryptosense.com>"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 dependencies = {"sslv2"}
-categories = {"default", "safe"}
+categories = {"intrusive", "vuln"}
 
 ---
 -- @output

--- a/scripts/sslv2-drown.nse
+++ b/scripts/sslv2-drown.nse
@@ -8,15 +8,18 @@ local sslcert = require "sslcert"
 local vulns = require "vulns"
 
 description = [[
-Determines whether the server supports obsolete and less secure SSLv2, and discovers which ciphers it
-supports.
+Determines whether the server supports SSLv2, what ciphers it supports and tests for
+CVE-2015-3197, CVE-2016-0703 and CVE-2016-0800 (DROWN)
 ]]
+author = "Bertrand Bonnefoy-Claudet <bertrand@cryptosense.com>"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+dependencies = {"sslv2"}
+categories = {"default", "safe"}
 
 ---
---@output
--- 443/tcp open   https   syn-ack
--- | sslv2:
--- |   SSLv2 supported
+-- @output
+-- 443/tcp open  https
+-- | sslv2-drown:
 -- |   ciphers:
 -- |     SSL2_DES_192_EDE3_CBC_WITH_MD5
 -- |     SSL2_IDEA_128_CBC_WITH_MD5
@@ -24,24 +27,127 @@ supports.
 -- |     SSL2_RC4_128_WITH_MD5
 -- |     SSL2_DES_64_CBC_WITH_MD5
 -- |     SSL2_RC2_128_CBC_EXPORT40_WITH_MD5
--- |_    SSL2_RC4_128_EXPORT40_WITH_MD5
---@xmloutput
---<elem>SSLv2 supported</elem>
---<table key="ciphers">
---  <elem>SSL2_DES_192_EDE3_CBC_WITH_MD5</elem>
---  <elem>SSL2_IDEA_128_CBC_WITH_MD5</elem>
---  <elem>SSL2_RC2_128_CBC_WITH_MD5</elem>
---  <elem>SSL2_RC4_128_WITH_MD5</elem>
---  <elem>SSL2_DES_64_CBC_WITH_MD5</elem>
---  <elem>SSL2_RC2_128_CBC_EXPORT40_WITH_MD5</elem>
---  <elem>SSL2_RC4_128_EXPORT40_WITH_MD5</elem>
---</table>
-
-
-author = "Matthew Boyle"
-license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
-dependencies = {"sslv2"}
-categories = {"default", "safe"}
+-- |     SSL2_RC4_128_EXPORT40_WITH_MD5
+-- |   forced_ciphers:
+-- |     SSL2_RC2_128_CBC_EXPORT40_WITH_MD5
+-- |     SSL2_DES_64_CBC_WITH_MD5
+-- |     SSL2_RC4_128_EXPORT40_WITH_MD5
+-- |     SSL2_IDEA_128_CBC_WITH_MD5
+-- |     SSL2_RC4_128_WITH_MD5
+-- |     SSL2_DES_192_EDE3_CBC_WITH_MD5
+-- |     SSL2_RC2_128_CBC_WITH_MD5
+-- |   vulns:
+-- |     CVE-2016-0800:
+-- |       title: OpenSSL: Cross-protocol attack on TLS using SSLv2 (DROWN)
+-- |       state: VULNERABLE
+-- |       ids:
+-- |         CVE:CVE-2016-0800
+-- |       description:
+-- |               The SSLv2 protocol, as used in OpenSSL before 1.0.1s and 1.0.2 before 1.0.2g and
+-- |       other products, requires a server to send a ServerVerify message before establishing
+-- |       that a client possesses certain plaintext RSA data, which makes it easier for remote
+-- |       attackers to decrypt TLS ciphertext data by leveraging a Bleichenbacher RSA padding
+-- |       oracle, aka a "DROWN" attack.
+-- |
+-- |       refs:
+-- |         https://www.openssl.org/news/secadv/20160301.txt
+-- |_        https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0800
+--
+-- @xmloutput
+-- <elem>SSLv2 supported</elem>
+-- <table key="ciphers">
+--   <elem>SSL2_DES_192_EDE3_CBC_WITH_MD5</elem>
+--   <elem>SSL2_IDEA_128_CBC_WITH_MD5</elem>
+--   <elem>SSL2_RC2_128_CBC_WITH_MD5</elem>
+--   <elem>SSL2_RC4_128_WITH_MD5</elem>
+--   <elem>SSL2_DES_64_CBC_WITH_MD5</elem>
+--   <elem>SSL2_RC2_128_CBC_EXPORT40_WITH_MD5</elem>
+--   <elem>SSL2_RC4_128_EXPORT40_WITH_MD5</elem>
+-- </table>
+-- @xmloutput
+-- <table key="ciphers">
+--   <table>
+--     <elem key="value">0700c0</elem>
+--     <elem key="name">SSL2_DES_192_EDE3_CBC_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">050080</elem>
+--     <elem key="name">SSL2_IDEA_128_CBC_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">030080</elem>
+--     <elem key="name">SSL2_RC2_128_CBC_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">010080</elem>
+--     <elem key="name">SSL2_RC4_128_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">060040</elem>
+--     <elem key="name">SSL2_DES_64_CBC_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">040080</elem>
+--     <elem key="name">SSL2_RC2_128_CBC_EXPORT40_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">020080</elem>
+--     <elem key="name">SSL2_RC4_128_EXPORT40_WITH_MD5</elem>
+--   </table>
+-- </table>
+-- <table key="forced_ciphers">
+--   <table>
+--     <elem key="value">050080</elem>
+--     <elem key="name">SSL2_IDEA_128_CBC_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">030080</elem>
+--     <elem key="name">SSL2_RC2_128_CBC_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">010080</elem>
+--     <elem key="name">SSL2_RC4_128_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">0700c0</elem>
+--     <elem key="name">SSL2_DES_192_EDE3_CBC_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">020080</elem>
+--     <elem key="name">SSL2_RC4_128_EXPORT40_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">060040</elem>
+--     <elem key="name">SSL2_DES_64_CBC_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">040080</elem>
+--     <elem key="name">SSL2_RC2_128_CBC_EXPORT40_WITH_MD5</elem>
+--   </table>
+-- </table>
+-- <table key="vulns">
+--   <table key="CVE-2016-0800">
+--     <elem key="title">OpenSSL: Cross-protocol attack on TLS using SSLv2 (DROWN)</elem>
+--     <elem key="state">VULNERABLE</elem>
+--     <table key="ids">
+--       <elem>CVE:CVE-2016-0800</elem>
+--     </table>
+--     <table key="description">
+--       <elem>
+--         The SSLv2 protocol, as used in OpenSSL before 1.0.1s and 1.0.2 before
+--         1.0.2g and other products, requires a server to send a ServerVerify
+--         message before establishing that a client possesses certain plaintext
+--         RSA data, which makes it easier for remote attackers to decrypt TLS
+--         ciphertext data by leveraging a Bleichenbacher RSA padding oracle, aka
+--         a "DROWN" attack.
+--       </elem>
+--     </table>
+--     <table key="refs">
+--       <elem>https://www.openssl.org/news/secadv/20160301.txt</elem>
+--       <elem>https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0800</elem>
+--     </table>
+--   </table>
+-- </table>
 
 local SSL_MT = {
   ERROR = 0,

--- a/scripts/sslv2-drown.nse
+++ b/scripts/sslv2-drown.nse
@@ -64,6 +64,7 @@ local SSL_CK = {
   DES_192_EDE3_CBC_WITH_MD5 = "\x07\x00\xC0",
 
   -- from OpenSSL
+  NULL_WITH_MD5 = "\x00\x00\x00",
   RC4_64_WITH_MD5 = "\x08\x00\x80",
 }
 
@@ -110,6 +111,11 @@ local CIPHER_INFO = {
     key_length = 24,
     encrypted_key_length = 24,
   },
+  ["\x00\x00\x00"] = {
+    str = "SSL2_NULL_WITH_MD5",
+    key_length = 0,
+    encrypted_key_length = 0,
+  },
   ["\x08\x00\x80"] = {
     str = "SSL2_RC4_64_WITH_MD5",
     key_length = 16,
@@ -120,7 +126,7 @@ local CIPHER_INFO = {
 local CLIENT_HELLO_EXAMPLE =
   "\x01" -- MSG-CLIENT-HELLO
   .. "\x00\x02" -- version: SSL 2.0
-  .. "\x00\x18" -- cipher spec length
+  .. "\x00\x1b" -- cipher spec length
   .. "\x00\x00" -- session ID length
   .. "\x00\x10" -- challenge length
   .. SSL_CK.DES_192_EDE3_CBC_WITH_MD5
@@ -131,6 +137,7 @@ local CLIENT_HELLO_EXAMPLE =
   .. SSL_CK.DES_64_CBC_WITH_MD5
   .. SSL_CK.RC2_128_CBC_EXPORT40_WITH_MD5
   .. SSL_CK.RC4_128_EXPORT40_WITH_MD5
+  .. SSL_CK.NULL_WITH_MD5
   .. "\xe4\xbd\x00\x00\xa4\x41\xb6\x74\x71\x2b\x27\x95\x44\xc0\x3d\xc0" -- challenge
 
 portrule = function(host, port)

--- a/scripts/sslv2.nse
+++ b/scripts/sslv2.nse
@@ -7,15 +7,16 @@ local stdnse = require "stdnse"
 local sslcert = require "sslcert"
 
 description = [[
-Determines whether the server supports obsolete and less secure SSLv2, and discovers which ciphers it
-supports.
+Determines whether the server supports SSLv2 and discovers which ciphers it supports.
 ]]
+author = "Matthew Boyle, Bertrand Bonnefoy-Claudet <bertrand@cryptosense.com>"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"default", "safe"}
 
----
---@output
--- 443/tcp open   https   syn-ack
+-- @output
+-- 443/tcp open  https
 -- | sslv2:
--- |   SSLv2 supported
+-- |   sslv2_supported: yes
 -- |   ciphers:
 -- |     SSL2_DES_192_EDE3_CBC_WITH_MD5
 -- |     SSL2_IDEA_128_CBC_WITH_MD5
@@ -24,23 +25,39 @@ supports.
 -- |     SSL2_DES_64_CBC_WITH_MD5
 -- |     SSL2_RC2_128_CBC_EXPORT40_WITH_MD5
 -- |_    SSL2_RC4_128_EXPORT40_WITH_MD5
---@xmloutput
---<elem>SSLv2 supported</elem>
---<table key="ciphers">
---  <elem>SSL2_DES_192_EDE3_CBC_WITH_MD5</elem>
---  <elem>SSL2_IDEA_128_CBC_WITH_MD5</elem>
---  <elem>SSL2_RC2_128_CBC_WITH_MD5</elem>
---  <elem>SSL2_RC4_128_WITH_MD5</elem>
---  <elem>SSL2_DES_64_CBC_WITH_MD5</elem>
---  <elem>SSL2_RC2_128_CBC_EXPORT40_WITH_MD5</elem>
---  <elem>SSL2_RC4_128_EXPORT40_WITH_MD5</elem>
---</table>
-
-
-author = "Matthew Boyle"
-license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
-
-categories = {"default", "safe"}
+--
+-- @xmloutput
+-- <elem key="sslv2_supported">yes</elem>
+-- <table key="ciphers">
+--   <table>
+--     <elem key="value">0700c0</elem>
+--     <elem key="name">SSL2_DES_192_EDE3_CBC_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">050080</elem>
+--     <elem key="name">SSL2_IDEA_128_CBC_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">030080</elem>
+--     <elem key="name">SSL2_RC2_128_CBC_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">010080</elem>
+--     <elem key="name">SSL2_RC4_128_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">060040</elem>
+--     <elem key="name">SSL2_DES_64_CBC_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">040080</elem>
+--     <elem key="name">SSL2_RC2_128_CBC_EXPORT40_WITH_MD5</elem>
+--   </table>
+--   <table>
+--     <elem key="value">020080</elem>
+--     <elem key="name">SSL2_RC4_128_EXPORT40_WITH_MD5</elem>
+--   </table>
+-- </table>
 
 local SSL_MT = {
   ERROR = 0,

--- a/scripts/sslv2.nse
+++ b/scripts/sslv2.nse
@@ -64,6 +64,7 @@ local SSL_CK = {
   DES_192_EDE3_CBC_WITH_MD5 = "\x07\x00\xC0",
 
   -- from OpenSSL
+  NULL_WITH_MD5 = "\x00\x00\x00",
   RC4_64_WITH_MD5 = "\x08\x00\x80",
 }
 
@@ -96,6 +97,9 @@ local CIPHER_INFO = {
   ["\x07\x00\xc0"] = {
     str = "SSL2_DES_192_EDE3_CBC_WITH_MD5",
   },
+  ["\x00\x00\x00"] = {
+    str = "SSL2_NULL_WITH_MD5",
+  },
   ["\x08\x00\x80"] = {
     str = "SSL2_RC4_64_WITH_MD5",
   },
@@ -104,7 +108,7 @@ local CIPHER_INFO = {
 local CLIENT_HELLO_EXAMPLE =
   "\x01" -- MSG-CLIENT-HELLO
   .. "\x00\x02" -- version: SSL 2.0
-  .. "\x00\x18" -- cipher spec length
+  .. "\x00\x1b" -- cipher spec length
   .. "\x00\x00" -- session ID length
   .. "\x00\x10" -- challenge length
   .. SSL_CK.DES_192_EDE3_CBC_WITH_MD5
@@ -115,6 +119,7 @@ local CLIENT_HELLO_EXAMPLE =
   .. SSL_CK.DES_64_CBC_WITH_MD5
   .. SSL_CK.RC2_128_CBC_EXPORT40_WITH_MD5
   .. SSL_CK.RC4_128_EXPORT40_WITH_MD5
+  .. SSL_CK.NULL_WITH_MD5
   .. "\xe4\xbd\x00\x00\xa4\x41\xb6\x74\x71\x2b\x27\x95\x44\xc0\x3d\xc0" -- challenge
 
 portrule = function(host, port)

--- a/scripts/sslv2.nse
+++ b/scripts/sslv2.nse
@@ -79,6 +79,14 @@ local ciphers = function(cipher_list)
     end
   end
 
+  if #available_ciphers == 0 then
+    setmetatable(available_ciphers, {
+        __tostring = function(t)
+          return "none"
+        end
+      })
+  end
+
   return available_ciphers
 end
 
@@ -174,7 +182,7 @@ action = function(host, port)
   local idx, connection_ID = bin.unpack("A" .. connection_ID_len, server_hello, idx)
 
   -- get a list of ciphers offered
-  local available_ciphers = ciphers_len > 0 and ciphers(cipher_list) or "none"
+  local available_ciphers = ciphers(cipher_list)
 
   -- actually run some tests:
   local o = stdnse.output_table()

--- a/scripts/sslv2.nse
+++ b/scripts/sslv2.nse
@@ -266,6 +266,13 @@ local function test_sslv2(host, port)
   return ssl_version == 2, ciphers
 end
 
+local function registry_set(host, port, offered_ciphers)
+  if not host.registry.sslv2 then
+    host.registry.sslv2 = {}
+  end
+  host.registry.sslv2[port.number] = offered_ciphers
+end
+
 local function format_ciphers(ciphers)
   local seen = {}
   local available_ciphers = {}
@@ -306,6 +313,7 @@ function action(host, port)
   else
     return
   end
+  registry_set(host, port, offered_ciphers)
   output.ciphers = format_ciphers(offered_ciphers)
 
   return output


### PR DESCRIPTION
This adds the detection of severe SSLv2 vulnerabilities in OpenSSL (CVE-2015-3197, CVE-2016-0703 and CVE-2016-0800, also known as [DROWN][1]).  The three CVEs are related and the result of the test should give an idea of how vulnerable the tested server is.  I've tested the script with real servers from https://test.drownattack.com/ and relevant versions of OpenSSL `s_server`).  Because they can be intrusive, those tests are only performed if the `sslv2.extended-test` script-arg is given.  The default behavior of the script is mostly the same as before.

To deal with more than SSLv2 hello packets, I've had to refine the decoding and encoding of packets and I followed the [draft spec][2] for that.  For instance, this should make record length computing a lot clearer.  The script should also be easier to extend in the future.

I've mentioned this work on the mailing-list some time ago: http://seclists.org/nmap-dev/2016/q1/259 and as said there, I'd be happy to get feedback on this new version.

[1]: https://drownattack.com/
[2]: https://tools.ietf.org/html/draft-hickman-netscape-ssl-00