### PR TITLE
Update mysql-cis.audit

### DIFF
--- a/nselib/data/mysql-cis.audit
+++ b/nselib/data/mysql-cis.audit
@@ -1,4 +1,6 @@
-require("tab")
+tab=require("tab")
+stdnse=require("stdnse")
+
 
 TEMPLATE_NAME="CIS MySQL Benchmarks v1.0.2"
 


### PR DESCRIPTION
The following two variables make this file to properly run with nmap 7.21. With the original file, syntax error was thrown due to stones and tab variable not declared

> tab=require("tab")
> stdnse=require("stdnse")