### PR TITLE
[Mac] New zenmap_auth_wrapper in Objective-C

### DIFF
--- a/zenmap/install_scripts/macosx/make-bundle.sh
+++ b/zenmap/install_scripts/macosx/make-bundle.sh
@@ -62,8 +62,8 @@ mv $BASE/MacOS/$APP_NAME $BASE/MacOS/zenmap.bin
 rm $BASE/MacOS/$APP_NAME-bin
 
 echo "Compiling and installing authorization wrapper."
-echo $CC $CPPFLAGS $CFLAGS $LDFLAGS -framework Security -o "$BASE/MacOS/$APP_NAME" "$SCRIPT_DIR/zenmap_auth.c"
-$CC $CPPFLAGS $CFLAGS $LDFLAGS -framework Security -o "$BASE/MacOS/$APP_NAME" "$SCRIPT_DIR/zenmap_auth.c"
+echo clang $CPPFLAGS $CFLAGS $LDFLAGS -v "$SCRIPT_DIR/zenmap_auth.m" -lobjc -framework Foundation -o "$BASE/MacOS/$APP_NAME"
+clang $CPPFLAGS $CFLAGS $LDFLAGS -v "$SCRIPT_DIR/zenmap_auth.m" -lobjc -framework Foundation -o "$BASE/MacOS/$APP_NAME"
 
 echo "Filling out Info.plist"
 python - "$SCRIPT_DIR/Info.plist" >"$BASE/Info.plist" <<'EOF'

--- a/zenmap/install_scripts/macosx/zenmap_auth.m
+++ b/zenmap/install_scripts/macosx/zenmap_auth.m
@@ -1,0 +1,47 @@
+//
+//  zenmap_auth.m
+//  Objective-C
+//
+//  This program attempts to run an applescript script which asks for root
+//  privileges. If the authorization fails or is canceled, Zenmap is run 
+//  without privileges using applescript.
+//  
+//  This program is the first link in the chain:
+//      zenmap_auth -> zenmap_wrapper.py -> zenmap.bin
+//  
+
+#import <Foundation/Foundation.h>
+#import <libgen.h>
+#define EXECUTABLE_NAME "zenmap.bin"
+
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+        NSString *executable_path;
+        NSString *cwd;
+        size_t len_cwd;
+        
+        cwd = [[NSBundle mainBundle] bundlePath];
+        len_cwd = [cwd length];
+        executable_path = cwd;
+        executable_path = [NSString stringWithFormat:@"%@/Contents/MacOS/%s", executable_path, EXECUTABLE_NAME];
+        NSLog(@"%@",executable_path);
+        
+        NSDictionary *error = [NSDictionary new];
+        NSString *script = [NSString stringWithFormat:@"do shell script \"%@ %s\" with administrator privileges", executable_path, (char*)argv];
+        NSAppleScript *appleScript = [[NSAppleScript alloc] initWithSource:script];
+        if ([appleScript executeAndReturnError:&error]) {
+            NSLog(@"success!");
+        } else {
+            NSLog(@"failure!");
+            NSDictionary *error = [NSDictionary new];
+            NSString *script = [NSString stringWithFormat:@"do shell script \"%@ %s\"", executable_path, (char*)argv];
+            NSAppleScript *appleScript = [[NSAppleScript alloc] initWithSource:script];
+            if ([appleScript executeAndReturnError:&error]) {
+                NSLog(@"success!");
+            } else {
+                NSLog(@"total failure!");
+            }
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
The Objective-C **zenmap_auth.m** file replaces **zenmap_auth.c**.
Its main purpose is to call applescript scripts to launch Zenmap with a "helper tool" (an authorisation wrapper), that will launch Zenmap with/without administrator privileges.

Waiting for your comments!
Cheers,
VincentD