### PR TITLE
Zenmap Mac OS X set proper locale/language settings for all users

### DIFF
--- a/zenmap/install_scripts/macosx/launcher.sh
+++ b/zenmap/install_scripts/macosx/launcher.sh
@@ -34,16 +34,8 @@ PYTHONPATH="$bundle_res/lib/zenmap"
 export PYTHONPATH
 
 # We need a UTF-8 locale.
-if test "x$LANG" == "x"; then
-lang=`defaults read .GlobalPreferences AppleLocale 2>/dev/null`
-if test "$?" != "0"; then
-  lang=`defaults read .GlobalPreferences AppleCollationOrder 2>/dev/null | sed 's/_.*//'`
-fi
-if test "$?" == "0"; then
-    export LANG="`grep \"\`echo $lang\`_\" /usr/share/locale/locale.alias | \
-  tail -n1 | sed 's/\./ /' | awk '{print $2}'`.UTF-8"
-fi
-fi
+lang=`defaults read /Library/Preferences/.GlobalPreferences AppleLanguages 2>/dev/null | awk '{ print $1 }' | head -n2 | tail -n1 | sed 's/\,/ /'`
+export LANG="`grep \"\`echo $lang\`_\" /usr/share/locale/locale.alias |  tail -n1 | sed 's/\./ /' | awk '{print $2}'`.UTF-8"
 
 if test -f "$bundle_lib/charset.alias"; then
     export CHARSETALIASDIR="$bundle_lib"

--- a/zenmap/install_scripts/macosx/launcher.sh
+++ b/zenmap/install_scripts/macosx/launcher.sh
@@ -34,8 +34,14 @@ PYTHONPATH="$bundle_res/lib/zenmap"
 export PYTHONPATH
 
 # We need a UTF-8 locale.
-lang=`defaults read /Library/Preferences/.GlobalPreferences AppleLanguages 2>/dev/null | awk '{ print $1 }' | head -n2 | tail -n1 | sed 's/\,/ /'`
-export LANG="`grep \"\`echo $lang\`_\" /usr/share/locale/locale.alias |  tail -n1 | sed 's/\./ /' | awk '{print $2}'`.UTF-8"
+if [ -z ${LANG+x} ]; then 
+  # LANG is unset 
+  lang=`defaults read /Library/Preferences/.GlobalPreferences AppleLanguages 2>/dev/null | awk '{ print $1 }' | head -n2 | tail -n1 | sed 's/\,/ /'`
+  if test "x$lang" == "x"; then
+    lang=`defaults read .GlobalPreferences AppleLocale 2>/dev/null`
+  fi
+  export LANG="`grep \"\`echo $lang\`_\" /usr/share/locale/locale.alias |  tail -n1 | sed 's/\./ /' | awk '{print $2}'`.UTF-8"
+fi
 
 if test -f "$bundle_lib/charset.alias"; then
     export CHARSETALIASDIR="$bundle_lib"


### PR DESCRIPTION
Actually, `fr_FR.UTF-8` is the content of **my $LANG**, on my computer. I just forgot to to escape it while writing the commit message into the Terminal. I am going to send another pull request for clarity.