### PR TITLE
Support for reap flag

### DIFF
--- a/nse_main.lua
+++ b/nse_main.lua
@@ -473,7 +473,6 @@ do
       script = self,
       type = script_type,
       worker = false,
-      reap = false, --reap flag is used to indicate whether child threads should be killed or not
     };
     thread.parent = thread;
     setmetatable(thread, Thread)
@@ -490,7 +489,7 @@ do
       info = format("%s W:%s", self.id, match(tostring(co), "^thread: 0?[xX]?(.*)"));
       parent = self,
       worker = true,
-      reap = false, --reap flag is used to indicate whether child threads should be killed or not
+      reap = false, --reap flag is used to indicate whether to wait for child threads or not
     };
     setmetatable(thread, Worker)
     local function info ()


### PR DESCRIPTION
So as discussed in [#407](https://github.com/nmap/nmap/issues/407), I have added reap flag here. Just one problem I got to see and that was how to return this flag by reference so instead, I passed the whole thread to the script and yes as predicted it works super fast in killing the worker threads created from inside of a script ( I tested it for http-slowloris ). But one more problem is there and that is how to return this flag for those worker threads which are getting created in `action()`