### PR TITLE
introduces short syntax for script's argument

### DIFF
--- a/NmapOps.h
+++ b/NmapOps.h
@@ -386,6 +386,7 @@ class NmapOps {
   int script;
   char *scriptargs;
   char *scriptargsfile;
+  char *script_expression;
   int scriptversion;
   int scripttrace;
   int scriptupdatedb;

--- a/nmap.cc
+++ b/nmap.cc
@@ -709,6 +709,7 @@ void parse_options(int argc, char **argv) {
       if (strcmp(long_options[option_index].name, "script") == 0) {
         o.script = 1;
         o.chooseScripts(optarg);
+        o.script_expression = strdup(optarg);
       } else if (optcmp(long_options[option_index].name, "script-args") == 0) {
         o.scriptargs = strdup(optarg);
       } else if (optcmp(long_options[option_index].name, "script-args-file") == 0) {

--- a/nse_main.cc
+++ b/nse_main.cc
@@ -384,6 +384,7 @@ static void open_cnse (lua_State *L)
   nseU_setsfield(L, -1, "script_dbpath", SCRIPT_ENGINE_DATABASE);
   nseU_setsfield(L, -1, "scriptargs", o.scriptargs);
   nseU_setsfield(L, -1, "scriptargsfile", o.scriptargsfile);
+  nseU_setsfield(L, -1, "script_expression", o.script_expression);
   nseU_setsfield(L, -1, "NMAP_URL", NMAP_URL);
 
 }

--- a/nse_main.lua
+++ b/nse_main.lua
@@ -661,6 +661,71 @@ do
   Script.__index = Script;
 end
 
+local function generate_args(tbl)
+  local o={}
+  local name=""
+  for _, val in pairs(tbl) do
+    if type(val) == "string" then
+      name=val
+    end
+    if type(val) == "table" then
+      table.insert(o,name.."."..val[1].."="..val[2])
+    end
+  end
+  return o
+end
+
+local function get_script_name(tbl)
+  local o={}
+  for _, val in pairs(tbl) do
+    if type(val) == "string" then
+      table.insert(o,val)
+    end
+  end
+  return o
+end
+
+local function make_parser()
+  local script_file_name = C( (1-S'\\/=?%*:|\"<>.,')^1 )
+  local parameter = C( (1-S"=")^1 )
+  local nested_table =  C{"{" * ((1 - lpeg.S"{}") + lpeg.V(1))^0 * "}"}
+  local value=C((1-S"=,}")^1)
+  local values = nested_table + value
+  local argument = Ct(parameter * P"=" * values)
+  local arguments = argument * ( P"," * argument)^0
+  local without_argument = P","^0
+  local with_argument = P"={" * arguments * P"}" * P","^0
+  local parser = script_file_name * (with_argument + without_argument) * ( script_file_name * (with_argument + without_argument) )^0
+  parser=assert(Ct(parser))
+  return parser
+end
+
+local function apply_short_syntax(script_args)
+ 
+  local parser = make_parser()
+  local output = parser:match(cnse.script_expression)
+  local args = generate_args(output)
+
+  for _, arg in pairs(args) do
+    if #script_args == 0 then
+      script_args = script_args..arg
+    else
+      script_args = script_args..","..arg
+    end
+  end
+
+  --empty the rules table
+  for k in pairs (rules) do
+      rules[k] = nil
+  end
+
+  local scripts = get_script_name(output)
+  for index, val in pairs(scripts) do
+    rules[index] = val
+  end
+
+  return script_args
+end
 -- check_rules(rules)
 -- Adds the "default" category if no rules were specified.
 -- Adds other implicitly specified rules (e.g. "version")
@@ -702,6 +767,7 @@ local function get_chosen_scripts (rules)
     end
   end
 
+
   for i, rule in ipairs(rules) do
     rule = match(rule, "^%s*(.-)%s*$"); -- strip surrounding whitespace
     local original_rule = rule;
@@ -712,6 +778,7 @@ local function get_chosen_scripts (rules)
     rule = gsub(rule, "\\([^\\])", "\\\\%1");
     rules[i] = rule;
   end
+--  os.exit()
 
   -- Checks if a given script, script_entry, should be loaded. A script_entry
   -- should be in the form: { filename = "name.nse", categories = { ... } }
@@ -1160,7 +1227,6 @@ end
 nmap.registry.args = {};
 do
   local args = {};
-
   if cnse.scriptargsfile then
     local t, path = cnse.fetchfile_absolute(cnse.scriptargsfile)
     assert(t == 'file', format("%s is not a file", path))
@@ -1174,6 +1240,8 @@ do
   end
 
   args = concat(args, ",");
+  args = apply_short_syntax(args)
+
   if #args > 0 then
     print_debug(1, "Arguments parsed: %s", args);
     local function set (t, a, b)


### PR DESCRIPTION
As asked in [#233](https://github.com/nmap/nmap/issues/233), I have tried to implement it. Please test it for different kind of input and let me know if there are problems. Many things are yet to be done in this like using locale so that it can be used worldwide, as I am new to lpeg please suggest any changes if you see in the parser. I have added few new data-structures to ensure that current input specification remain as it is.

USAGE ( Please notice the inverted comma `'` after script since that's necessary in this implementation) - 

` nmap --script 'http-form-fuzzer={targets={1={path=/owncloud/index.php}}},http-form-brute={path="/owncloud/index.php"}' <target>`