### PR TITLE
Created service probe for iperf3

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -14679,3 +14679,10 @@ ports 1194,443,500
 rarity 9
 match openvpn m|^@........\x01\0\0\0\0d\xc1x\x01\xb8\x9b\xcb\x8f\0\0\0\0$| p/OpenVPN/
 
+##############################NEXT PROBE##############################
+# Detects iperf3 servers by sending a string longer than the 37-byte test identifer or cookie
+# https://github.com/esnet/iperf/wiki/IperfProtocolStates#test-initiation
+Probe TCP iperf3 q|000000000000000000000000000000000000000|
+ports 5201
+match iperf3 m|\t$|
+


### PR DESCRIPTION
# iperf3 Service Probe
## Background

A remote code execution vulnerability was recently identified in iperf3, a benchmark tool widely used to test network throughput performance. The[ write-up from Cisco's Talos](https://www.talosintel.com/reports/TALOS-2016-0164/) contains details and a Proof of Concept. iperf3 is maintained by ESNet on GitHub at https://github.com/esnet/iperf. The iperf3 Github Wiki contains [protocol documentation](https://github.com/esnet/iperf/wiki/IperfProtocolStates).

## Service Scan -sV using Nmap SVN Version
An Nmap scan using the latest version from master resulted in an incorrect match against nmap-services:

```bash
$ ./nmap -sV localhost -p 5201

Starting Nmap 7.12SVN ( https://nmap.org ) at 2016-06-11 17:57 EDT
Got nsock WRITE error #104 (Connection reset by peer)
Nmap scan report for localhost (127.0.0.1)
Host is up (0.00018s latency).
PORT     STATE SERVICE          VERSION
5201/tcp open  targus-getdata1?

Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
Nmap done: 1 IP address (1 host up) scanned in 13.11 seconds
```

Several client errors are observed from the server due to incorrect service-probes and the rpc-grind NSE script.

```bash
$ iperf3 -s 
-----------------------------------------------------------
Server listening on 5201
-----------------------------------------------------------
iperf3: error - unable to receive cookie at server: Connection reset by peer

-----------------------------------------------------------
Server listening on 5201
-----------------------------------------------------------
iperf3: error - unable to receive parameters from client: Connection reset by peer

-----------------------------------------------------------
Server listening on 5201
-----------------------------------------------------------
iperf3: error - unable to receive parameters from client: Connection reset by peer

-----------------------------------------------------------
Server listening on 5201
-----------------------------------------------------------
```

## Service Scan with Proposed Change
Here is the result of the same scan but using the proposed service-probe:

```bash
$ ./nmap -sV localhost -p 5201

Starting Nmap 7.12SVN ( https://nmap.org ) at 2016-06-11 18:02 EDT
Nmap scan report for localhost (127.0.0.1)
Host is up (0.00018s latency).
PORT     STATE SERVICE VERSION
5201/tcp open  iperf3

Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
Nmap done: 1 IP address (1 host up) scanned in 8.13 seconds
```
The new scan results in two errors on the server, one for the TCP GenericLines probe and another for the proposed iperf3 probe:

```bash
$ iperf3 -s 
-----------------------------------------------------------
Server listening on 5201
-----------------------------------------------------------
iperf3: error - unable to receive cookie at server: Connection reset by peer

-----------------------------------------------------------
Server listening on 5201
-----------------------------------------------------------
iperf3: error - unable to receive parameters from client: Connection reset by peer

-----------------------------------------------------------
Server listening on 5201
-----------------------------------------------------------
```

I tried to use a match for the GenericLines probe but the timeout occurred before the server response. So far I have been unable to create a probe that does not result in a server error. The protocol does not appear to divulge information about the iperf3 version or hostname.

I would like to eventually create an NSE script or a cleaner service probe, any advice on reversing the protocol would be greatly appreciated.