### PR TITLE
Add checks for $lang variable

### DIFF
--- a/zenmap/install_scripts/macosx/launcher.sh
+++ b/zenmap/install_scripts/macosx/launcher.sh
@@ -34,15 +34,14 @@ PYTHONPATH="$bundle_res/lib/zenmap"
 export PYTHONPATH
 
 # We need a UTF-8 locale.
-if test "x$LANG" == "x"; then
-lang=`defaults read .GlobalPreferences AppleLocale 2>/dev/null`
-if test "$?" != "0"; then
-  lang=`defaults read .GlobalPreferences AppleCollationOrder 2>/dev/null | sed 's/_.*//'`
-fi
-if test "$?" == "0"; then
-    export LANG="`grep \"\`echo $lang\`_\" /usr/share/locale/locale.alias | \
-  tail -n1 | sed 's/\./ /' | awk '{print $2}'`.UTF-8"
-fi
+if [ -z ${lang+x} ]; then 
+  # lang is unset 
+  lang=`defaults read /Library/Preferences/.GlobalPreferences AppleLanguages 2>/dev/null | awk '{ print $1 }' | head -n2 | tail -n1 | sed 's/\,/ /'`
+  if [ -z ${lang+x} ]; then
+    # lang is still unset 
+    lang=`defaults read .GlobalPreferences AppleLocale 2>/dev/null`
+  fi
+  export LANG="`grep \"\`echo $lang\`_\" /usr/share/locale/locale.alias |  tail -n1 | sed 's/\./ /' | awk '{print $2}'`.UTF-8"
 fi
 
 if test -f "$bundle_lib/charset.alias"; then


### PR DESCRIPTION
This PR propose using AppleLanguages first instead of AppleLocale, resulting in a good output for a locale language.