### PR TITLE
Adds support for decoys in IPv6

### DIFF
--- a/FPEngine.cc
+++ b/FPEngine.cc
@@ -475,7 +475,7 @@ void FPNetworkControl::probe_transmission_handler(nsock_pool nsp, nsock_event ns
         /* We don't need to change address if decoys aren't specified */
         if (o.numdecoys > 1)
           /* Decoys have to be sent only if changeSourceAddress worked */
-          assert(myprobe->changeSourceAddress(&((struct sockaddr_in6 *)&o.decoys[decoy])->sin6_addr) == OP_SUCCESS)
+          assert(myprobe->changeSourceAddress(&((struct sockaddr_in6 *)&o.decoys[decoy])->sin6_addr) == OP_SUCCESS);
         assert(myprobe->host != NULL);
         buf = myprobe->getPacketBuffer(&len);
         if (send_ip_packet(this->rawsd, myprobe->getEthernet(), myprobe->host->getTargetAddress(), buf, len) == -1) {

--- a/FPEngine.cc
+++ b/FPEngine.cc
@@ -140,7 +140,6 @@ extern "C" int g_has_npcap_loopback;
 
 #include <math.h>
 #include <sstream>
-#include <iostream>
 
 /******************************************************************************
  * Globals.                                                                   *
@@ -457,7 +456,7 @@ int FPNetworkControl::scheduleProbe(FPProbe *pkt, int in_msecs_time) {
 
 /* This is the handler for packet transmission. It is called by nsock whenever a timer expires,
  * which means that a new packet needs to be transmitted. Note that this method is not
- * called directly by Nsiock but by the wrapper function probe_transmission_handler_wrapper().
+ * called directly by Nsock but by the wrapper function probe_transmission_handler_wrapper().
  * The reason for that is because C++ does not allow to use class methods as callback
  * functions, so this is a small hack to make that happen. */
 void FPNetworkControl::probe_transmission_handler(nsock_pool nsp, nsock_event nse, void *arg) {
@@ -499,8 +498,6 @@ void FPNetworkControl::probe_transmission_handler(nsock_pool nsp, nsock_event ns
         for (int decoy = 0; decoy < o.numdecoys; decoy++) {
           if (decoy == o.decoyturn)
             continue;
-          char str[INET6_ADDRSTRLEN];
-          inet_ntop(AF_INET6,(struct sockaddr_in6 *) myprobe->host->getTargetAddress(), str, INET6_ADDRSTRLEN);
           it = decoy_probes.find(get_unique_id(myprobe->getProbeID(), decoy, (const char *)((struct sockaddr_in6 *)myprobe->host->getTargetAddress())->sin6_addr.s6_addr));
           if (it != decoy_probes.end()) {
             /* First we should free up the previously allocated buffer */

--- a/FPEngine.cc
+++ b/FPEngine.cc
@@ -491,7 +491,7 @@ void FPNetworkControl::probe_transmission_handler(nsock_pool nsp, nsock_event ns
         gh_perror("Unable to send packet in %s", __func__);
       }
       /* If Packet was sent successfully and Decoys are present */
-      else if (o.numdecoys) {  
+      else if (o.numdecoys > 1) {  
         FPPacket *temp = new FPPacket();
         std::map<std::string, IPv6Header*>::iterator it;
         char addr[INET6_ADDRSTRLEN];
@@ -1806,6 +1806,8 @@ int FPHost6::build_probe_list() {
     this->total_probes++;
 
     for (decoy = 0; decoy < o.numdecoys; decoy++) {
+      if (decoy == o.decoyturn)
+        continue;
       ip6 = make_tcp((struct sockaddr_in6 *) &o.decoys[decoy],
       (struct sockaddr_in6 *) this->target_host->TargetSockAddr(),
       OSDETECT_FLOW_LABEL, TCP_DESCS[i].win, this->tcpSeqBase + i, get_random_u32(),
@@ -1854,6 +1856,8 @@ int FPHost6::build_probe_list() {
   this->total_probes++;
 
   for (decoy = 0; decoy < o.numdecoys; decoy++) {
+    if (decoy == o.decoyturn)
+      continue;
     ip6 = new IPv6Header();
     icmp6 = new ICMPv6Header();
     hopbyhop1 = new HopByHopHeader();
@@ -1917,6 +1921,8 @@ int FPHost6::build_probe_list() {
   this->total_probes++;
 
   for (decoy = 0; decoy < o.numdecoys; decoy++) {
+    if (decoy == o.decoyturn)
+      continue;
     ip6 = new IPv6Header();
     hopbyhop1 = new HopByHopHeader();
     dstopts = new DestOptsHeader();
@@ -1977,6 +1983,8 @@ int FPHost6::build_probe_list() {
     this->total_probes++;
 
     for (decoy = 0; decoy < o.numdecoys; decoy++) {
+      if (decoy == o.decoyturn)
+        continue;
       ip6 = new IPv6Header();
       icmp6 = new ICMPv6Header();
       sockaddr_in6 *s = (struct sockaddr_in6 *)&o.decoys[decoy];
@@ -2025,6 +2033,8 @@ int FPHost6::build_probe_list() {
   this->total_probes++;
 
   for (decoy = 0; decoy < o.numdecoys; decoy++) {
+    if (decoy == o.decoyturn)
+      continue;
     ip6 = new IPv6Header();
     udp = new UDPHeader();
     payload = new RawData();
@@ -2064,6 +2074,8 @@ int FPHost6::build_probe_list() {
     this->total_probes++;
 
     for (decoy = 0; decoy < o.numdecoys; decoy++) {
+      if (decoy == o.decoyturn)
+        continue;
       ip6 = make_tcp((struct sockaddr_in6 *)&o.decoys[decoy],
       (struct sockaddr_in6 *) this->target_host->TargetSockAddr(),
       OSDETECT_FLOW_LABEL, TCP_DESCS[i].win, this->tcpSeqBase + i, 0,
@@ -2099,6 +2111,8 @@ int FPHost6::build_probe_list() {
     this->total_probes++;
 
     for (decoy = 0; decoy < o.numdecoys; decoy++) {
+      if (decoy == o.decoyturn)
+        continue;
       ip6 = make_tcp((struct sockaddr_in6 *)&o.decoys[decoy],
         (struct sockaddr_in6 *) this->target_host->TargetSockAddr(),
         OSDETECT_FLOW_LABEL, TCP_DESCS[i].win, this->tcpSeqBase + i, get_random_u32(),

--- a/FPEngine.cc
+++ b/FPEngine.cc
@@ -456,6 +456,7 @@ void FPNetworkControl::probe_transmission_handler(nsock_pool nsp, nsock_event ns
   FPProbe *myprobe = (FPProbe *)arg;
   u8 *buf;
   size_t len;
+  int result = true;
 
   if (status == NSE_STATUS_SUCCESS) {
     switch(type) {
@@ -473,24 +474,28 @@ void FPNetworkControl::probe_transmission_handler(nsock_pool nsp, nsock_event ns
       /* Send the packet*/
       for (int decoy = 0; decoy < o.numdecoys; decoy++) {
         /* We don't need to change address if decoys aren't specified */
-        if (o.numdecoys > 1)
-          /* Decoys have to be sent only if changeSourceAddress worked */
-          assert(myprobe->changeSourceAddress(&((struct sockaddr_in6 *)&o.decoys[decoy])->sin6_addr) == OP_SUCCESS);
-        assert(myprobe->host != NULL);
-        buf = myprobe->getPacketBuffer(&len);
-        if (send_ip_packet(this->rawsd, myprobe->getEthernet(), myprobe->host->getTargetAddress(), buf, len) == -1) {
-          if (decoy == o.decoyturn) {
-            myprobe->setFailed();
-            this->cc_report_final_timeout();
-            myprobe->host->fail_one_probe();
-            gh_perror("Unable to send packet in %s", __func__);
-          }
+        if (o.numdecoys > 1) {
+          result = myprobe->changeSourceAddress(&((struct sockaddr_in6 *)&o.decoys[decoy])->sin6_addr) == OP_SUCCESS;
         }
-        free(buf);
+        /* Decoys have to be sent only if changeSourceAddress worked */
+        if (result) {
+          assert(myprobe->host != NULL);
+          buf = myprobe->getPacketBuffer(&len);
+          if (send_ip_packet(this->rawsd, myprobe->getEthernet(), myprobe->host->getTargetAddress(), buf, len) == -1) {
+            if (decoy == o.decoyturn) {
+              myprobe->setFailed();
+              this->cc_report_final_timeout();
+              myprobe->host->fail_one_probe();
+              gh_perror("Unable to send packet in %s", __func__);
+            }
+          }
+          free(buf);
+        }
       }
       /* Reset the address to the original one if decoys were present and original Address wasn't last one */
       if ( o.numdecoys != o.decoyturn+1 )
-        assert(myprobe->changeSourceAddress(&((struct sockaddr_in6 *)&o.decoys[o.decoyturn])->sin6_addr) == OP_SUCCESS);
+        result = myprobe->changeSourceAddress(&((struct sockaddr_in6 *)&o.decoys[o.decoyturn])->sin6_addr) == OP_SUCCESS;
+      assert(result == true);
 
       myprobe->setTimeSent();
       break;

--- a/FPEngine.h
+++ b/FPEngine.h
@@ -353,6 +353,7 @@ class FPProbe : public FPPacket {
   int setFailed();
   bool isTimed() const;
   int setTimed();
+  int changeSourceAddress(struct in6_addr *addr);
 
 };
 

--- a/NmapOps.cc
+++ b/NmapOps.cc
@@ -570,8 +570,8 @@ dialog where you can start NPF if you have administrator privileges.";
     fatal("--min-rate=%g must be less than or equal to --max-rate=%g", min_packet_send_rate, max_packet_send_rate);
   }
 
-  if (af() == AF_INET6 && (generate_random_ips|numdecoys|bouncescan|fragscan)) {
-    fatal("Random targets, decoys, FTP bounce scan, and fragmentation are not supported with IPv6.");
+  if (af() == AF_INET6 && (generate_random_ips|bouncescan|fragscan)) {
+    fatal("Random targets, FTP bounce scan, and fragmentation are not supported with IPv6.");
   }
 
   if(ipoptions && osscan)

--- a/NmapOps.h
+++ b/NmapOps.h
@@ -313,7 +313,7 @@ class NmapOps {
   int override_excludeports;
   int version_intensity;
 
-  struct in_addr decoys[MAX_DECOYS];
+  struct sockaddr_storage decoys[MAX_DECOYS];
   int osscan_limit; /* Skip OS Scan if no open or no closed TCP ports */
   int osscan_guess;   /* Be more aggressive in guessing OS type */
   int numdecoys;

--- a/Target.cc
+++ b/Target.cc
@@ -352,12 +352,13 @@ void Target::setSourceSockAddr(const struct sockaddr_storage *ss, size_t ss_len)
 }
 
 // Returns IPv4 host address or {0} if unavailable.
-struct in_addr Target::v4source() const {
-  const struct in_addr *addy = v4sourceip();
+struct sockaddr_storage Target::source() const {
+  return sourcesock;
+  /*const struct in_addr *addy = v4sourceip();
   struct in_addr in;
   if (addy) return *addy;
   in.s_addr = 0;
-  return in;
+  return in;*/
 }
 
 // Returns IPv4 host address or NULL if unavailable.

--- a/Target.h
+++ b/Target.h
@@ -205,7 +205,7 @@ class Target {
   /* Note that it is OK to pass in a sockaddr_in or sockaddr_in6 casted
      to sockaddr_storage */
   void setSourceSockAddr(const struct sockaddr_storage *ss, size_t ss_len);
-  struct in_addr v4source() const;
+  struct sockaddr_storage source() const;
   const struct in_addr *v4sourceip() const;
   const struct in6_addr *v6sourceip() const;
   /* The IPv4 or IPv6 literal string for the target host */

--- a/nmap.cc
+++ b/nmap.cc
@@ -503,6 +503,7 @@ public:
     this->pre_host_timeout      = -1;
     this->iflist                = false;
     this->af                    = AF_UNSPEC;
+    this->decoys                = false;
   }
 
   // Pre-specified timing parameters.
@@ -514,9 +515,9 @@ public:
   int   pre_max_retries;
   long  pre_host_timeout;
   char  *machinefilename, *kiddiefilename, *normalfilename, *xmlfilename;
-  bool  iflist;
+  bool  iflist, decoys;
   char  *exclude_spec, *exclude_file;
-  char  *spoofSource;
+  char  *spoofSource, *decoy_arguments;
   const char *spoofmac;
   int af;
   std::vector<std::string> verbose_out;
@@ -542,7 +543,7 @@ static void test_file_name(const char *filename, const char *option) {
 }
 
 void parse_options(int argc, char **argv) {
-  char *p, *q;
+  char *p;
   int arg;
   long l;
   double d;
@@ -1067,59 +1068,7 @@ void parse_options(int argc, char **argv) {
       }
       break;
     case 'D':
-      p = optarg;
-      do {
-        q = strchr(p, ',');
-        if (q)
-          *q = '\0';
-        if (!strcasecmp(p, "me")) {
-          if (o.decoyturn != -1)
-            fatal("Can only use 'ME' as a decoy once.\n");
-          o.decoyturn = o.numdecoys++;
-        } else if (!strcasecmp(p, "rnd") || !strncasecmp(p, "rnd:", 4)) {
-          if (delayed_options.af == AF_INET6)
-            fatal("Random decoys can only be used with IPv4");
-          int i = 1;
-
-          /* 'rnd:' is allowed and just gives them one */
-          if (strlen(p) > 4)
-            i = atoi(&p[4]);
-
-          if (i < 1)
-            fatal("Bad 'rnd' decoy \"%s\"", p);
-
-          if (o.numdecoys + i >= MAX_DECOYS - 1)
-            fatal("You are only allowed %d decoys (if you need more redefine MAX_DECOYS in nmap.h)", MAX_DECOYS);
-
-          while (i--) {
-            do {
-              ((struct sockaddr_in *)&o.decoys[o.numdecoys])->sin_addr.s_addr = get_random_u32();
-            } while (ip_is_reserved(&((struct sockaddr_in *)&o.decoys[o.numdecoys])->sin_addr));
-            o.numdecoys++;
-          }
-        } else {
-          if (o.numdecoys >= MAX_DECOYS - 1)
-            fatal("You are only allowed %d decoys (if you need more redefine MAX_DECOYS in nmap.h)", MAX_DECOYS);
-
-          /* Try to resolve it */
-          struct sockaddr_storage decoytemp;
-          size_t decoytemplen = sizeof(struct sockaddr_storage);
-          int rc;
-          if (delayed_options.af == AF_INET6){
-            rc = resolve(p, 0, (sockaddr_storage*)&decoytemp, &decoytemplen, AF_INET6);
-          }
-          else
-            rc = resolve(p, 0, (sockaddr_storage*)&decoytemp, &decoytemplen, AF_INET);
-          if (rc != 0)
-            fatal("Failed to resolve decoy host \"%s\": %s", p, gai_strerror(rc));
-          o.decoys[o.numdecoys] = decoytemp;
-          o.numdecoys++;
-        }
-        if (q) {
-          *q = ',';
-          p = q + 1;
-        }
-      } while (q);
+      delayed_options.decoy_arguments = optarg;
       break;
     case 'd':
       if (optarg && isdigit(optarg[0])) {
@@ -1734,6 +1683,61 @@ void  apply_delayed_options() {
   }
   o.exclude_spec = delayed_options.exclude_spec;
 
+  if (delayed_options.decoy_arguments) {
+    char *p = delayed_options.decoy_arguments, *q;
+    do {
+      q = strchr(p, ',');
+      if (q)
+        *q = '\0';
+      if (!strcasecmp(p, "me")) {
+        if (o.decoyturn != -1)
+          fatal("Can only use 'ME' as a decoy once.\n");
+        o.decoyturn = o.numdecoys++;
+      } else if (!strcasecmp(p, "rnd") || !strncasecmp(p, "rnd:", 4)) {
+        if (delayed_options.af == AF_INET6)
+          fatal("Random decoys can only be used with IPv4");
+        int i = 1;
+
+        /* 'rnd:' is allowed and just gives them one */
+        if (strlen(p) > 4)
+          i = atoi(&p[4]);
+
+        if (i < 1)
+          fatal("Bad 'rnd' decoy \"%s\"", p);
+
+        if (o.numdecoys + i >= MAX_DECOYS - 1)
+          fatal("You are only allowed %d decoys (if you need more redefine MAX_DECOYS in nmap.h)", MAX_DECOYS);
+
+        while (i--) {
+          do {
+            ((struct sockaddr_in *)&o.decoys[o.numdecoys])->sin_addr.s_addr = get_random_u32();
+          } while (ip_is_reserved(&((struct sockaddr_in *)&o.decoys[o.numdecoys])->sin_addr));
+          o.numdecoys++;
+        }
+      } else {
+        if (o.numdecoys >= MAX_DECOYS - 1)
+          fatal("You are only allowed %d decoys (if you need more redefine MAX_DECOYS in nmap.h)", MAX_DECOYS);
+
+        /* Try to resolve it */
+        struct sockaddr_storage decoytemp;
+        size_t decoytemplen = sizeof(struct sockaddr_storage);
+        int rc;
+        if (delayed_options.af == AF_INET6){
+          rc = resolve(p, 0, (sockaddr_storage*)&decoytemp, &decoytemplen, AF_INET6);
+        }
+        else
+          rc = resolve(p, 0, (sockaddr_storage*)&decoytemp, &decoytemplen, AF_INET);
+        if (rc != 0)
+          fatal("Failed to resolve decoy host \"%s\": %s", p, gai_strerror(rc));
+        o.decoys[o.numdecoys] = decoytemp;
+        o.numdecoys++;
+      }
+      if (q) {
+        *q = ',';
+        p = q + 1;
+      }
+    } while (q);
+  }
 }
 
 int nmap_main(int argc, char *argv[]) {

--- a/nmap.cc
+++ b/nmap.cc
@@ -1081,7 +1081,7 @@ void parse_options(int argc, char **argv) {
             fatal("Random decoys can only be used with IPv4");
           int i = 1;
 
-          /// * 'rnd:' is allowed and just gives them one * /
+          /* 'rnd:' is allowed and just gives them one */
           if (strlen(p) > 4)
             i = atoi(&p[4]);
 
@@ -2080,9 +2080,9 @@ int nmap_main(int argc, char *argv[]) {
 
     // Our source must be set in decoy list because nexthost() call can
     // change it (that issue really should be fixed when possible)
-    if (o.RawScan()){
+    if (o.RawScan())
         o.decoys[o.decoyturn] = Targets[0]->source();
-    }
+
     /* I now have the group for scanning in the Targets vector */
 
     if (!o.noportscan) {

--- a/nmap.cc
+++ b/nmap.cc
@@ -1648,14 +1648,6 @@ void  apply_delayed_options() {
     error("WARNING: a IP Protocol ping scan was requested, but after excluding requested protocols, none remain. Skipping this scan type.");
 
 
-  /* Set up our array of decoys! */
-  if (o.decoyturn == -1) {
-    o.decoyturn = (o.numdecoys == 0) ?  0 : get_random_uint() % o.numdecoys;
-    o.numdecoys++;
-    for (i = o.numdecoys - 1; i > o.decoyturn; i--)
-      o.decoys[i] = o.decoys[i - 1];
-  }
-
   /* We need to find what interface to route through if:
    * --None have been specified AND
    * --We are root and doing tcp ping OR
@@ -1737,6 +1729,13 @@ void  apply_delayed_options() {
         p = q + 1;
       }
     } while (q);
+  }
+  /* Set up host address also in array of decoys! */
+  if (o.decoyturn == -1) {
+    o.decoyturn = (o.numdecoys == 0) ?  0 : get_random_uint() % o.numdecoys;
+    o.numdecoys++;
+    for (i = o.numdecoys - 1; i > o.decoyturn; i--)
+      o.decoys[i] = o.decoys[i - 1];
   }
 }
 

--- a/scan_engine_raw.cc
+++ b/scan_engine_raw.cc
@@ -1346,7 +1346,7 @@ UltraProbe *sendIPScanProbe(UltraScanInfo *USI, HostScanStats *hss,
         free(packet);
       }
     }
-   } else if (pspec->type == PS_UDP) {
+  } else if (pspec->type == PS_UDP) {
     const char *payload;
     size_t payload_length;
 

--- a/targets.cc
+++ b/targets.cc
@@ -571,7 +571,7 @@ static Target *setup_target(const HostGroupState *hs,
 #endif
     t->setSourceSockAddr(&rnfo.srcaddr, sizeof(rnfo.srcaddr));
     if (hs->current_batch_sz == 0) /* Because later ones can have different src addy and be cut off group */
-      o.decoys[o.decoyturn] = t->v4source();
+      o.decoys[o.decoyturn] = t->source();
     t->setDeviceNames(rnfo.ii.devname, rnfo.ii.devfullname);
     t->setMTU(rnfo.ii.mtu);
     // printf("Target %s %s directly connected, goes through local iface %s, which %s ethernet\n", t->NameIP(), t->directlyConnected()? "IS" : "IS NOT", t->deviceName(), (t->ifType() == devt_ethernet)? "IS" : "IS NOT");
@@ -660,7 +660,7 @@ static void refresh_hostbatch(HostGroupState *hs, const addrset *exclude_group,
         break;
     }
 
-    o.decoys[o.decoyturn] = t->v4source();
+    o.decoys[o.decoyturn] = t->source();
     hs->hostbatch[hs->current_batch_sz++] = t;
   }
 

--- a/tcpip.cc
+++ b/tcpip.cc
@@ -839,7 +839,7 @@ int send_tcp_raw_decoys(int sd, const struct eth_nfo *eth,
 
   for (decoy = 0; decoy < o.numdecoys; decoy++)
     if (send_tcp_raw(sd, eth,
-                     &o.decoys[decoy], victim,
+                     &((struct sockaddr_in *)&o.decoys[decoy])->sin_addr, victim,
                      ttl, df,
                      ipopt, ipoptlen,
                      sport, dport,
@@ -956,7 +956,7 @@ int send_udp_raw_decoys(int sd, const struct eth_nfo *eth,
   int decoy;
 
   for (decoy = 0; decoy < o.numdecoys; decoy++)
-    if (send_udp_raw(sd, eth, &o.decoys[decoy], victim,
+    if (send_udp_raw(sd, eth, &((struct sockaddr_in *)&o.decoys[decoy])->sin_addr, victim,
                      ttl, ipid, ipops, ipoptlen,
                      sport, dport, data, datalen) == -1)
       return -1;

--- a/traceroute.cc
+++ b/traceroute.cc
@@ -673,16 +673,7 @@ void Probe::send(int rawsd, eth_t *ethsd, struct timeval *now) {
       host->target->SourceSockAddr(&source, &source_len);
       sent_time = get_now(now);
     } else {
-      if (o.af() == AF_INET) {
-        struct sockaddr_in *sin;
-
-        sin = (struct sockaddr_in *) &source;
-        sin->sin_family = AF_INET;
-        sin->sin_addr = ((struct sockaddr_in *)&o.decoys[decoy])->sin_addr;
-      } else {
-        /* Decoys are IPv4-only. */
-        continue;
-      }
+      source = o.decoys[decoy];
     }
 
     packet = this->build_packet(&source, &packetlen);

--- a/traceroute.cc
+++ b/traceroute.cc
@@ -678,7 +678,7 @@ void Probe::send(int rawsd, eth_t *ethsd, struct timeval *now) {
 
         sin = (struct sockaddr_in *) &source;
         sin->sin_family = AF_INET;
-        sin->sin_addr = o.decoys[decoy];
+        sin->sin_addr = ((struct sockaddr_in *)&o.decoys[decoy])->sin_addr;
       } else {
         /* Decoys are IPv4-only. */
         continue;


### PR DESCRIPTION
This is a very basic change I've made till now, I think few modules needs to be changed to ensure that it works as good as for IPv4. More specific queries I've made along with code. I have tested it with my VM where I allocated IPv6 address to both my machine and VM and then scanned using decoys, it worked well but I am not sure whether it is working flawless I have just checked by seeing the output of tcpdump on my target VM.