### PR TITLE
Teradici PCoIP versioning and proposed SSL client auth support

### DIFF
--- a/nse_nsock.cc
+++ b/nse_nsock.cc
@@ -56,6 +56,9 @@ typedef struct nse_nsock_udata
 
   void *ssl_session;
 
+  char *ssl_x509;
+  char *ssl_key;
+
   struct sockaddr_storage source_addr;
   size_t source_addrlen;
 
@@ -523,6 +526,16 @@ static int l_connect (lua_State *L)
       fatal("nsock_iod_set_hostname(\"%s\" failed in %s()", targetname, __func__);
   }
 
+#ifdef HAVE_OPENSSL
+  if (nu->ssl_x509 != NULL && nu->ssl_key != NULL) {
+    if (nsock_iod_set_ssl_client_cert(nu->nsiod, nu->ssl_x509, nu->ssl_key) == -1)
+      fatal("nsock_iod_set_ssl_client_cert failed in %s()", __func__);
+  } else {
+    if (nsock_iod_set_ssl_client_cert(nu->nsiod, NULL, NULL) == -1)
+      fatal("nsock_iod_set_ssl_client_cert failed in %s()", __func__);
+  }
+#endif
+
   nu->af = dest->ai_addr->sa_family;
   nu->thread = L;
   nu->action = "PRECONNECT";
@@ -869,6 +882,8 @@ static void initialize (lua_State *L, int idx, nse_nsock_udata *nu,
   nu->proto = proto;
   nu->af = af;
   nu->ssl_session = NULL;
+  nu->ssl_x509 = NULL;
+  nu->ssl_key = NULL;
   nu->source_addr.ss_family = AF_UNSPEC;
   nu->source_addrlen = sizeof(nu->source_addr);
   nu->timeout = DEFAULT_TIMEOUT;
@@ -933,6 +948,53 @@ static int nsock_gc (lua_State *L)
   return 0;
 }
 
+/* SSL client cert/key */
+
+static int l_set_ssl_client_cert(lua_State *L)
+{
+  nse_nsock_udata *nu = check_nsock_udata(L, 1, true);
+  size_t size;
+  const char *string = lua_tolstring(L, 2, &size);
+
+  if (nu->ssl_x509) {
+    free(nu->ssl_x509);
+    nu->ssl_x509 = NULL;
+  }
+
+  if (string != NULL) {
+    size = sizeof(char)*(strlen(string)+1);
+    nu->ssl_x509 = (char*)malloc(size);
+    if (nu->ssl_x509 == NULL) {
+      return nseU_safeerror(L, "memory allocation error");
+    }
+    strncpy(nu->ssl_x509, string, size);
+  }
+
+  return nseU_success(L);
+}
+
+static int l_set_ssl_client_key(lua_State *L)
+{
+  nse_nsock_udata *nu = check_nsock_udata(L, 1, true);
+  size_t size;
+  const char *string = lua_tolstring(L, 2, &size);
+
+  if (nu->ssl_key) {
+    free(nu->ssl_key);
+    nu->ssl_key = NULL;
+  }
+
+  if (string != NULL) {
+    size = sizeof(char)*(strlen(string)+1);
+    nu->ssl_key = (char*)malloc(size);
+    if (nu->ssl_key == NULL) {
+      return nseU_safeerror(L, "memory allocation error");
+    }
+    strncpy(nu->ssl_key, string, size);
+  }
+
+  return nseU_success(L);
+}
 
 /****************** PCAP_SOCKET ***********************************************/
 
@@ -1070,6 +1132,8 @@ LUALIB_API int luaopen_nsock (lua_State *L)
     {"receive_bytes", l_receive_bytes},
     {"receive_lines", l_receive_lines},
     {"reconnect_ssl", l_reconnect_ssl},
+    {"set_ssl_client_cert", l_set_ssl_client_cert},
+    {"set_ssl_client_key", l_set_ssl_client_key},
     {"set_timeout", l_set_timeout},
     {NULL, NULL}
   };

--- a/nselib/comm.lua
+++ b/nselib/comm.lua
@@ -64,6 +64,14 @@ local setup_connect = function(host, port, opts)
 
   sock:set_timeout(connect_timeout)
 
+  if opts and opts.ssl_client_x509 and opts.ssl_client_key then
+    sock:set_ssl_client_cert(opts.ssl_client_x509)
+    sock:set_ssl_client_key(opts.ssl_client_key)
+  elseif opts then
+    sock:set_ssl_client_cert(nil)
+    sock:set_ssl_client_key(nil)
+  end
+
   local status, err = sock:connect(host, port, opts.proto)
 
   if not status then

--- a/nselib/http.lua
+++ b/nselib/http.lua
@@ -273,6 +273,16 @@ local function validate_options(options)
         stdnse.debug1('http: options.timeout contains a non-numeric value')
         bad = true
       end
+    elseif(key == 'ssl_client_x509') then
+      if(value ~= nil and type(value) ~= 'string') then
+        stdnse.debug1("http: ssl_client_x509 should be a string")
+        bad = true
+      end
+    elseif(key == 'ssl_client_key') then
+      if(value ~= nil and type(value) ~= 'string') then
+        stdnse.debug1("http: ssl_client_key should be a string")
+        bad = true
+      end
     elseif(key == 'header') then
       if(type(value) ~= 'table') then
         stdnse.debug1("http: options.header should be a table")
@@ -1202,7 +1212,7 @@ local function request(host, port, data, options)
     host = addrs[1] or host
   end
 
-  local socket, partial, opts = comm.tryssl(host, port, data, { timeout = options.timeout })
+  local socket, partial, opts = comm.tryssl(host, port, data, { timeout = options.timeout, ssl_client_x509 = options.ssl_client_x509, ssl_client_key = options.ssl_client_key })
 
   if not socket then
     stdnse.debug1("http.request socket error: %s", partial)

--- a/nselib/teradici.lua
+++ b/nselib/teradici.lua
@@ -1,0 +1,99 @@
+--
+-- this library implements management requests for Teradici PCoIP devices
+-- uses key from software downloaded from their website
+--
+
+local http = require 'http'
+local stdnse = require 'stdnse'
+local nmap = require 'nmap'
+local slaxml = require 'slaxml'
+local string = require 'string'
+
+_ENV = stdnse.module('teradici', stdnse.seeall)
+
+local crt = [[
+-----BEGIN CERTIFICATE-----
+MIIDJDCCAgygAwIBAgIJAMW4gkQr3113MA0GCSqGSIb3DQEBBQUAMC0xEzARBgNV
+BAoTClBDb0lQIFJvb3QxFjAUBgNVBAMTDVBDb0lQIFJvb3QgQ0EwHhcNMDYwODIx
+MTYxODU0WhcNMjYwODE2MTYxODU0WjA9MRIwEAYDVQQKEwlQQ29JUCBDTVMxGTAX
+BgNVBAsTEHRlcmEgQ01TIHRlc3RiZWQxDDAKBgNVBAMTA2NtczCBnzANBgkqhkiG
+9w0BAQEFAAOBjQAwgYkCgYEA5F9K9KAPiP1Xj2wnSb56qfYXjN8rEMAbAVGvmN9W
+C88lnyqBuEsPC47pege7UMAi1EqmkE+qk1Ul8HRKsj+2GxG2uMYQQTDeo53zdwf2
+WD1uXUfcRwBMxxJ6K5OWCHAuhZSwRUGNGBvauIXvOFrMzanuEVf17kCeREKCIX5p
+WoECAwEAAaOBujCBtzAJBgNVHRMEAjAAMCwGCWCGSAGG+EIBDQQfFh1PcGVuU1NM
+IEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQULkg8b8gWSn1sPxXBT56a
+tBc9IM8wXQYDVR0jBFYwVIAUpEuDdUPn5OBO9a2zv5tUOfrEbv+hMaQvMC0xEzAR
+BgNVBAoTClBDb0lQIFJvb3QxFjAUBgNVBAMTDVBDb0lQIFJvb3QgQ0GCCQC2oRrW
+SCjrdDANBgkqhkiG9w0BAQUFAAOCAQEA5CjLoF5WLEe4oJYSGPynbIjw+Zeefqn7
+6vnMv0lKJ+xxOh6l+wI0GYEV6HcZHwmjK/+d+6TqhU+bvVPC/ESkaBcywgs4DRvP
+Y+gh8Onw06F1x3SdgFTG9WBEWp2Z3wuFVRA58r8S6BCtpTRP7hVHImKTX97tcioT
+vB3GMvRS0MHALfNGLltLTcqgeLzxCjXPwddmiZkjLZNYrlhhIO8cdPgeFLr/btcp
+/H2EgrxiJ1Y4glboM39C7Y/kYWKln7/UAgga6JHAabxRZUpZqe/85OX/7oNfqM4z
+FVRM9qEI98HgccX2v/GvGPf2i7RP6rmubemfU8DiT0BmQ6AR65imsQ==
+-----END CERTIFICATE-----
+]]
+
+local key = [[
+-----BEGIN RSA PRIVATE KEY-----
+MIICXgIBAAKBgQDkX0r0oA+I/VePbCdJvnqp9heM3ysQwBsBUa+Y31YLzyWfKoG4
+Sw8Ljul6B7tQwCLUSqaQT6qTVSXwdEqyP7YbEba4xhBBMN6jnfN3B/ZYPW5dR9xH
+AEzHEnork5YIcC6FlLBFQY0YG9q4he84WszNqe4RV/XuQJ5EQoIhfmlagQIDAQAB
+AoGAB4tSWZR0Du13mAhVn+0H9ldn3cJ9lLcT7U46g81U9VzpfEGWOXVZUONuuRZK
+TNecDvFMYVYQZ3+XmkLtOMg8BsbmQnUawb36slrJ2kZrsGfPo1woZT07pyOAJM6V
+txQ0M4tApvQjNTu85M3JvpaAyg8kfOkjbE+kjL6un+8AQ/ECQQD/WURXRPerZrmx
+AOk5N2i/DS79KrrnRWEjoin8J+XlG1Mwss2XcqLkZPPj3uidDnNZcKetUV9aEhzg
+0YSmUGAtAkEA5PRpRlQ7mYSlDLsW8HMpQZi8U/IP3c0PPcxDfGieABqtEzSp0zvC
+UZO8/Bn2jiogJWJUEmwaL2cY7aXl2G3EJQJBAMVmVRbCElVHDLZxZdr9otRPdMvy
+hJrVX8sUSjDNB0SeYyl6kMVLsfGuuXynjlwcF8BE/ttV1Mjkx75lOo74A+ECQQDg
+yJF/Kf3lyFQfPqPT6MytiV4E8NfhBI2dN6leQHw3T/lyrLa7G6W5X9ogjQEDLJqo
++XPfLmE6/vZ7g/A4X/Q9AkEA21n1SvGVAgbNTNpZHU3XsOxBd/ii2w1QtYSfb8ys
+6ukWc0+gQSdEa99dSsxIn5gAZlYZUW8v1waBIzcGBatONQ==
+-----END RSA PRIVATE KEY-----
+]]
+
+local req = [[
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope" xmlns:SOAP-ENC="http://www.w3.org/2003/05/soap-encoding" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:pcoip="http://www.pcoip.org/2006/XMLSchema" xmlns:SOAP-RPC="http://www.w3.org/2003/05/soap-rpc"><SOAP-ENV:Body><pcoip:getPROPERTY SOAP-ENV:encodingStyle="http://www.w3.org/2003/05/soap-encoding"></pcoip:getPROPERTY></SOAP-ENV:Body></SOAP-ENV:Envelope>
+]]
+
+function get_property(host, port, property)
+  if not nmap.have_ssl() then
+    return nil
+  end
+
+  local thisReq = string.gsub(req, 'PROPERTY', property)
+
+  local headers = {}
+  headers['Content-Length'] = string.len(thisReq)
+
+  rsp = http.post(host, port, '/', { ssl_client_x509 = crt, ssl_client_key = key, header = headers }, nil, thisReq.."\n\n")
+
+  if rsp.status ~= 200 or rsp.body == nil then
+    return nil
+  end
+
+  local to_return = {}
+  local current_tag = nil
+
+  local callbacks = {
+    startElement = function(name, nsURI, nsPrefix)
+      current_tag = name
+    end,
+
+    closeElement = function(name, nsURI)
+      current_tag = nil
+    end,
+
+    text = function(text)
+      if current_tag ~= nil then
+        to_return[current_tag]=text
+      end
+    end
+  }
+
+  slaxml.parser:new(callbacks):parseSAX(rsp.body)
+
+  return to_return
+end
+
+return _ENV

--- a/nsock/include/nsock.h
+++ b/nsock/include/nsock.h
@@ -443,6 +443,9 @@ int nsock_iod_set_localaddr(nsock_iod iod, struct sockaddr_storage *ss, size_t s
  * destroyed */
 int nsock_iod_set_ipoptions(nsock_iod iod, void *ipopts, size_t ipoptslen);
 
+/* sets an SSL client certificate and key before connect() */
+int nsock_iod_set_ssl_client_cert(nsock_iod iod, const char *x509, const char *key);
+
 /* Returns that host/port/protocol information for the last communication (or
  * comm. attempt) this nsi has been involved with.  By "involved" with I mean
  * interactions like establishing (or trying to) a connection or sending a UDP

--- a/nsock/src/nsock_core.c
+++ b/nsock/src/nsock_core.c
@@ -397,6 +397,17 @@ void handle_connect_result(struct npool *ms, struct nevent *nse, enum nse_status
       }
 #endif
 
+      /* set client certificate and key, if applicable */
+      if (iod->client_x509 && iod->client_key) {
+        if (SSL_use_certificate(iod->ssl, iod->client_x509) != 1) {
+          fatal("SSL_use_certificate failed: %s", ERR_error_string(ERR_get_error(), NULL));
+        }
+
+        if (SSL_use_PrivateKey(iod->ssl, iod->client_key) != 1) {
+          fatal("SSL_use_PrivateKey failed: %s", ERR_error_string(ERR_get_error(), NULL));
+        }
+      }
+
       /* Associate our new SSL with the connected socket.  It will inherit the
        * non-blocking nature of the sd */
       if (SSL_set_fd(iod->ssl, iod->sd) != 1)

--- a/nsock/src/nsock_internal.h
+++ b/nsock/src/nsock_internal.h
@@ -276,6 +276,10 @@ struct niod {
   SSL *ssl;
   /* SSL SESSION ID (or NULL if none) */
   SSL_SESSION *ssl_session;
+
+  /* optional client certificate and key */
+  X509 *client_x509;
+  EVP_PKEY *client_key;
 #else
   /* Because there are many if (nsi->ssl) cases in the code */
   char *ssl;

--- a/scripts/script.db
+++ b/scripts/script.db
@@ -503,6 +503,8 @@ Entry { filename = "teamspeak2-version.nse", categories = { "version", } }
 Entry { filename = "telnet-brute.nse", categories = { "brute", "intrusive", } }
 Entry { filename = "telnet-encryption.nse", categories = { "discovery", "safe", } }
 Entry { filename = "telnet-ntlm-info.nse", categories = { "default", "discovery", "safe", } }
+Entry { filename = "teradici-storedcreds.nse", categories = { "auth", "intrusive", } }
+Entry { filename = "teradici-version.nse", categories = { "version", } }
 Entry { filename = "tftp-enum.nse", categories = { "discovery", "intrusive", } }
 Entry { filename = "tls-nextprotoneg.nse", categories = { "default", "discovery", "safe", } }
 Entry { filename = "tor-consensus-checker.nse", categories = { "external", "safe", } }

--- a/scripts/teradici-storedcreds.nse
+++ b/scripts/teradici-storedcreds.nse
@@ -1,0 +1,37 @@
+local nmap = require 'nmap'
+local shortport = require 'shortport'
+local stdnse = require 'stdnse'
+local teradici = require 'teradici'
+
+description = [[
+Prints stored auto-login or kiosk creds on Teradici PCoIP devices.
+]]
+
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {'auth','intrusive'}
+
+dependencies = {'teradici-version'}
+
+portrule = shortport.service('pcoipmgmt')
+
+action = function(host, port)
+  local output = stdnse.output_table()
+
+  local kiosk = teradici.get_property(host, port, 'VdmKioskMode')
+
+  if kiosk ~= nil then
+    output['kiosk mode username']=kiosk['vdmKioskModeCustomUsername']
+    output['kiosk mode password']=kiosk['vdmKioskModePassword']
+  end
+
+  local logon = teradici.get_property(host, port, 'VdmLogon')
+
+  if logon ~= nil then
+    output['auto logon domain']=logon['vdmLogonDomainName']
+    output['auto logon username']=logon['vdmLogonUsername']
+    output['auto logon password']=logon['vdmLogonPassword']
+  end
+
+  return output
+end
+

--- a/scripts/teradici-version.nse
+++ b/scripts/teradici-version.nse
@@ -1,0 +1,44 @@
+local nmap = require 'nmap'
+local shortport = require 'shortport'
+local stdnse = require 'stdnse'
+local teradici = require 'teradici'
+
+description = [[
+Prints basic version information for Teradici PCoIP devices using the management port 50000.
+]]
+
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"version"}
+
+dependencies = {'ssl-cert'}
+
+portrule = shortport.version_port_or_service(50000)
+
+action = function(host, port)
+  local output = teradici.get_property(host, port, 'ProvisionedId')
+
+  if output ~= nil then
+    local firmware = output['firmwareVersion']
+    local processor = output['pcoipProcessorRev']
+    local hardware = output['version']
+
+    if firmware ~= nil then
+      port.version.name = "pcoipmgmt"
+      port.version.name_confidence = 10
+      port.version.product = "Teradici PCoIP management interface " .. firmware
+      port.version.service_tunnel = "ssl"
+
+      if processor ~= nil and hardware ~= nil then
+        port.version.extrainfo = "processor '" .. processor .. "' hardware '" .. hardware .. "'"
+      elseif processor ~= nil then
+        port.version.extrainfo = "processor '" .. processor .. "'"
+      elseif hardware ~= nil then
+        port.version.extrainfo = "hardware '" .. hardware .. "'"
+      end
+
+      nmap.set_port_version(host, port)
+    end
+  end
+
+end
+


### PR DESCRIPTION
five commits, four of which focus on adding rudimentary SSL client auth support to nsock and NSE, and the last of which uses this added support to version and pull down other data from Teradici PCoIP devices

considering that these commits touch several important files, I've attempted to test these modifications against several SSL and non-SSL services in my environment. if I've made a mistake somewhere, or if developers would prefer that SSL client auth be implemented in a different way or elsewhere in the codebase, feel free to mention

cheers