### PR TITLE
Modify make debug command to make debugging possible on Mac

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -15,6 +15,7 @@ srcdir = @srcdir@
 nmapdatadir = @datadir@/nmap
 deskdir = $(prefix)/share/applications
 NMAPDEVDIR=~/nmap-private-dev
+UNAME := $(shell uname)
 
 export NBASEDIR=@NBASEDIR@
 export NSOCKDIR=@NSOCKDIR@
@@ -164,7 +165,11 @@ static:
 	$(MAKE) STATIC=-static
 
 debug:
+ifeq ($(UNAME),Darwin)
+	$(MAKE) DBGFLAGS="-O0 -g -pg -ftest-coverage"
+else
 	$(MAKE) DBGFLAGS="-O0 -g -pg -ftest-coverage -fprofile-arcs"
+endif
 
 # CALL THIS FROM ONE COMPUTER AND CHECK IN RESULTS BEFORE DOING ANYONE
 # DOES A MAKE RELEASE


### PR DESCRIPTION
I just added a check to verify if the user is using Mac OS. I removed the -fprofile-arcs option for Mac because the compiler was unable to find llvm libraries, which I only succeeded linking into Xcode (not with command-line — its called code coverage and its compicated to use on gcc/g++ compiled sources), so it was easier to simply remove this option.