### PR TITLE
Added DTLS and ALPN client support.

### DIFF
--- a/ncat/ncat_connect.c
+++ b/ncat/ncat_connect.c
@@ -239,6 +239,25 @@ static void set_ssl_ctx_options(SSL_CTX *ctx)
         if ((o.sslcert == NULL) != (o.sslkey == NULL))
             bye("The --ssl-key and --ssl-cert options must be used together.");
     }
+
+    if (o.sslalpn) {
+        size_t alpn_len;
+        unsigned char *alpn = next_protos_parse(&alpn_len, o.sslalpn);
+
+        if (alpn == NULL)
+            bye("Could not parse ALPN string");
+
+        if (o.debug)
+            logdebug("Using ALPN String %s\n", o.sslalpn);
+
+        /* SSL_CTX_set_alpn_protos returns 0 on success */
+        if (SSL_CTX_set_alpn_protos(ctx, alpn, alpn_len) != 0){
+            free(alpn);
+            bye("SSL_CTX_set_alpn_protos: %s.", ERR_error_string(ERR_get_error(), NULL));
+        }
+
+        free(alpn);
+    }
 }
 #endif
 
@@ -891,7 +910,10 @@ int ncat_connect(void)
     nsock_pool_set_broadcast(mypool, 1);
 
 #ifdef HAVE_OPENSSL
-    set_ssl_ctx_options((SSL_CTX *) nsock_pool_ssl_init(mypool, 0));
+    if(o.proto == IPPROTO_UDP)
+        set_ssl_ctx_options((SSL_CTX *) nsock_pool_dtls_init(mypool, 0));
+    else
+        set_ssl_ctx_options((SSL_CTX *) nsock_pool_ssl_init(mypool, 0));
 #endif
 
     if (!o.proxytype) {
@@ -986,7 +1008,17 @@ int ncat_connect(void)
             }
         } else
 #endif
-        if (o.proto == IPPROTO_UDP) {
+
+#ifdef HAVE_OPENSSL
+        if (o.ssl && o.proto == IPPROTO_UDP) {
+            nsock_connect_ssl(mypool, cs.sock_nsi, connect_handler,
+                              o.conntimeout, NULL,
+                              &targetss.sockaddr, targetsslen,
+                              IPPROTO_UDP, inet_port(&targetss),
+                              NULL);
+        }
+#endif
+        else if (o.proto == IPPROTO_UDP) {
             nsock_connect_udp(mypool, cs.sock_nsi, connect_handler,
                               NULL, &targetss.sockaddr, targetsslen,
                               inet_port(&targetss));

--- a/ncat/ncat_connect.c
+++ b/ncat/ncat_connect.c
@@ -240,6 +240,8 @@ static void set_ssl_ctx_options(SSL_CTX *ctx)
             bye("The --ssl-key and --ssl-cert options must be used together.");
     }
 
+#if (OPENSSL_VERSION_NUMBER >= 0x10002000L)
+
     if (o.sslalpn) {
         size_t alpn_len;
         unsigned char *alpn = next_protos_parse(&alpn_len, o.sslalpn);
@@ -258,6 +260,9 @@ static void set_ssl_ctx_options(SSL_CTX *ctx)
 
         free(alpn);
     }
+
+#endif
+
 }
 #endif
 
@@ -910,9 +915,11 @@ int ncat_connect(void)
     nsock_pool_set_broadcast(mypool, 1);
 
 #ifdef HAVE_OPENSSL
+#if (OPENSSL_VERSION_NUMBER >= 0x10002000L)
     if(o.proto == IPPROTO_UDP)
         set_ssl_ctx_options((SSL_CTX *) nsock_pool_dtls_init(mypool, 0));
     else
+#endif
         set_ssl_ctx_options((SSL_CTX *) nsock_pool_ssl_init(mypool, 0));
 #endif
 
@@ -1009,7 +1016,7 @@ int ncat_connect(void)
         } else
 #endif
 
-#ifdef HAVE_OPENSSL
+#if (OPENSSL_VERSION_NUMBER >= 0x10002000L)
         if (o.ssl && o.proto == IPPROTO_UDP) {
             nsock_connect_ssl(mypool, cs.sock_nsi, connect_handler,
                               o.conntimeout, NULL,
@@ -1017,8 +1024,10 @@ int ncat_connect(void)
                               IPPROTO_UDP, inet_port(&targetss),
                               NULL);
         }
-#endif
         else if (o.proto == IPPROTO_UDP) {
+#else
+        if (o.proto == IPPROTO_UDP) {
+#endif
             nsock_connect_udp(mypool, cs.sock_nsi, connect_handler,
                               NULL, &targetss.sockaddr, targetsslen,
                               inet_port(&targetss));

--- a/ncat/ncat_core.c
+++ b/ncat/ncat_core.c
@@ -208,6 +208,7 @@ void options_init(void)
     o.sslverify = 0;
     o.ssltrustfile = NULL;
     o.sslciphers = NULL;
+    o.sslalpn = NULL;
 #endif
 }
 

--- a/ncat/ncat_core.h
+++ b/ncat/ncat_core.h
@@ -205,6 +205,7 @@ struct options {
     int sslverify;
     char *ssltrustfile;
     char *sslciphers;
+    char *sslalpn;
 };
 
 extern struct options o;

--- a/ncat/ncat_listen.c
+++ b/ncat/ncat_listen.c
@@ -257,6 +257,8 @@ static int ncat_listen_stream(int proto)
 
 #ifdef HAVE_OPENSSL
     if (o.ssl)
+        if (o.sslalpn)
+            bye("ALPN is not supported in listen mode\n");
         setup_ssl_listen();
 #endif
 
@@ -667,6 +669,11 @@ static int ncat_listen_dgram(int proto)
     struct timeval tv;
     struct timeval *tvp = NULL;
     unsigned int num_sockets;
+
+#ifdef HAVE_OPENSSL
+    if(o.ssl)
+        bye("DTLS is not supported in listen mode\n");
+#endif
 
     for (i = 0; i < NUM_LISTEN_ADDRS; i++) {
         sockfd[i].fd = -1;

--- a/ncat/ncat_main.c
+++ b/ncat/ncat_main.c
@@ -313,6 +313,7 @@ int main(int argc, char *argv[])
         {"ssl-verify",      no_argument,        NULL,         0},
         {"ssl-trustfile",   required_argument,  NULL,         0},
         {"ssl-ciphers",     required_argument,  NULL,         0},
+        {"ssl-alpn",        required_argument,  NULL,         0},
 #else
         {"ssl-cert",        optional_argument,  NULL,         0},
         {"ssl-key",         optional_argument,  NULL,         0},
@@ -526,6 +527,9 @@ int main(int argc, char *argv[])
             } else if (strcmp(long_options[option_index].name, "ssl-ciphers") == 0) {
                 o.ssl = 1;
                 o.sslciphers = Strdup(optarg);
+            } else if (strcmp(long_options[option_index].name, "ssl-alpn") == 0) {
+                o.ssl = 1;
+                o.sslalpn = Strdup(optarg);
             }
 #else
             else if (strcmp(long_options[option_index].name, "ssl-cert") == 0) {
@@ -538,6 +542,8 @@ int main(int argc, char *argv[])
                 bye("OpenSSL isn't compiled in. The --ssl-trustfile option cannot be chosen.");
             } else if (strcmp(long_options[option_index].name, "ssl-ciphers") == 0) {
                 bye("OpenSSL isn't compiled in. The --ssl-ciphers option cannot be chosen.");
+            } else if (strcmp(long_options[option_index].name, "ssl-alpn") == 0) {
+                bye("OpenSSL isn't compiled in. The --ssl-alpn option cannot be chosen.");
             }
 #endif
 #ifdef HAVE_LUA
@@ -626,6 +632,7 @@ int main(int argc, char *argv[])
 "      --ssl-verify           Verify trust and domain name of certificates\n"
 "      --ssl-trustfile        PEM file containing trusted SSL certificates\n"
 "      --ssl-ciphers          Cipherlist containing SSL ciphers to use\n"
+"      --ssl-alpn             ALPN protocol list to use.\n"
 #endif
 "      --version              Display Ncat's version information and exit\n"
 "\n"
@@ -872,9 +879,6 @@ int main(int argc, char *argv[])
     }
 
     if (o.proto == IPPROTO_UDP) {
-        /* Don't allow a false sense of security if someone tries SSL over UDP. */
-        if (o.ssl)
-            bye("UDP mode does not support SSL.");
         if (o.keepopen && o.cmdexec == NULL)
             bye("UDP mode does not support the -k or --keep-open options, except with --exec or --sh-exec.");
         if (o.broker)

--- a/ncat/util.c
+++ b/ncat/util.c
@@ -743,3 +743,39 @@ int fix_line_endings(char *src, int *len, char **dst, int *state)
 
     return 1;
 }
+
+/*-
+ * next_protos_parse parses a comma separated list of strings into a string
+ * in a format suitable for passing to SSL_CTX_set_next_protos_advertised.
+ *   outlen: (output) set to the length of the resulting buffer on success.
+ *   err: NULL on failure
+ *   in: a NULL terminated string like "abc,def,ghi"
+ *
+ *   returns: a malloc'd buffer or NULL on failure.
+ */
+unsigned char *next_protos_parse(size_t *outlen, const char *in)
+{
+    size_t len;
+    unsigned char *out;
+    size_t i, start = 0;
+
+    len = strlen(in);
+    if (len >= 65535)
+        return NULL;
+
+    out = safe_malloc(strlen(in) + 1);
+    for (i = 0; i <= len; ++i) {
+        if (i == len || in[i] == ',') {
+            if (i - start > 255) {
+                free(out);
+                return NULL;
+            }
+            out[start] = i - start;
+            start = i + 1;
+        } else
+            out[i + 1] = in[i];
+    }
+
+    *outlen = len + 1;
+    return out;
+}

--- a/ncat/util.h
+++ b/ncat/util.h
@@ -223,4 +223,6 @@ struct fdinfo *get_fdinfo(const fd_list_t *, int);
 
 int fix_line_endings(char *src, int *len, char **dst, int *state);
 
+unsigned char *next_protos_parse(size_t *outlen, const char *in);
+
 #endif

--- a/nsock/include/nsock.h
+++ b/nsock/include/nsock.h
@@ -248,6 +248,13 @@ void nsock_pool_set_device(nsock_pool nsp, const char *device);
 #define NSOCK_SSL_MAX_SPEED (1 << 0)
 nsock_ssl_ctx nsock_pool_ssl_init(nsock_pool ms_pool, int flags);
 
+/* Initializes an Nsock pool to create a DTLS connect. This sets and internal
+ * SSL_CTX, which is like a template that sets options for all connections that
+ * are made from it. Returns the SSL_CTX so tyou can set your own options.
+ *
+ * Functionally similar to nsock_pool_ssl_init, just for the DTLS */
+nsock_ssl_ctx nsock_pool_dtls_init(nsock_pool ms_pool, int flags);
+
 /* Enforce use of a given IO engine.
  * The engine parameter is a zero-terminated string that will be
  * strup()'ed by the library. No validity check is performed by this function,

--- a/nsock/src/nsock_connect.c
+++ b/nsock/src/nsock_connect.c
@@ -184,8 +184,8 @@ int nsock_setup_udp(nsock_pool nsp, nsock_iod ms_iod, int af) {
   return nsi->sd;
 }
 
-/* This does the actual logistics of requesting a TCP connection.  It is shared
- * by nsock_connect_tcp and nsock_connect_ssl */
+/* This does the actual logistics of requesting a connection.  It is shared
+ * by nsock_connect_tcp and nsock_connect_ssl, among others */
 void nsock_connect_internal(struct npool *ms, struct nevent *nse, int type, int proto, struct sockaddr_storage *ss, size_t sslen,
                             unsigned short port) {
 
@@ -376,7 +376,7 @@ nsock_event_id nsock_connect_sctp(nsock_pool nsp, nsock_iod ms_iod, nsock_ev_han
   return nse->id;
 }
 
-/* Request an SSL over TCP/SCTP connection to another system (by IP address).
+/* Request an SSL over TCP/SCTP/UDP connection to another system (by IP address).
  * The in_addr is normal network byte order, but the port number should be given
  * in HOST BYTE ORDER.  This function will call back only after it has made the
  * connection AND done the initial SSL negotiation.  From that point on, you use
@@ -396,7 +396,9 @@ nsock_event_id nsock_connect_ssl(nsock_pool nsp, nsock_iod nsiod, nsock_ev_handl
   struct npool *ms = (struct npool *)nsp;
   struct nevent *nse;
 
-  if (!ms->sslctx)
+  if (!ms->sslctx && proto == IPPROTO_UDP)
+    nsock_pool_dtls_init(ms, 0);
+  else if (!ms->sslctx)
     nsock_pool_ssl_init(ms, 0);
 
   assert(nsi->state == NSIOD_STATE_INITIAL || nsi->state == NSIOD_STATE_UNKNOWN);
@@ -407,12 +409,21 @@ nsock_event_id nsock_connect_ssl(nsock_pool nsp, nsock_iod nsiod, nsock_ev_handl
   /* Set our SSL_SESSION so we can benefit from session-id reuse. */
   nsi_set_ssl_session(nsi, (SSL_SESSION *)ssl_session);
 
-  nsock_log_info("SSL connection requested to %s:%hu/%s (IOD #%li) EID %li",
+  if (proto == IPPROTO_UDP)
+    nsock_log_info("DTLS connection requested to %s:%hu/udp (IOD #%li) EID %li",
+
+                 inet_ntop_ez(ss, sslen), port, nsi->id, nse->id);
+  else
+    nsock_log_info("SSL connection requested to %s:%hu/%s (IOD #%li) EID %li",
                  inet_ntop_ez(ss, sslen), port, (proto == IPPROTO_TCP ? "tcp" : "sctp"),
                  nsi->id, nse->id);
 
   /* Do the actual connect() */
-  nsock_connect_internal(ms, nse, SOCK_STREAM, proto, ss, sslen, port);
+  if (proto == IPPROTO_UDP)
+    nsock_connect_internal(ms, nse, SOCK_DGRAM, proto, ss, sslen, port);
+  else
+    nsock_connect_internal(ms, nse, SOCK_STREAM, proto, ss, sslen, port);
+
   nsock_pool_add_event(ms, nse);
 
   return nse->id;


### PR DESCRIPTION
This change adds support Datagram Transport Layer Security (DTLS) when creating UDP connections with ncat. Application-Layer Protocol Negotiation (ALPN) support has also been added, allowing the user to specify an ALPN string when connecting the SSL services. For example, connecting to an HTTP2 compatible web server and supplying the 'h2' ALPN string.
