### PR TITLE
Use FQDN_LEN instead of MAXHOSTNAMELEN for DNS name buffers

### DIFF
--- a/Target.cc
+++ b/Target.cc
@@ -134,10 +134,8 @@
 #include "nbase.h"
 #include "NmapOps.h"
 #include "utils.h"
+#include "nmap.h"
 #include "nmap_error.h"
-
-#define FQDN_LEN 255
-
 extern NmapOps o;
 
 Target::Target() {
@@ -431,8 +429,10 @@ const char *Target::NameIP(char *buf, size_t buflen) const {
 
 /* This next version returns a static buffer -- so no concurrency */
 const char *Target::NameIP() const {
-  if (!nameIPBuf) nameIPBuf = (char *) safe_malloc(FQDN_LEN + INET6_ADDRSTRLEN);
-  return NameIP(nameIPBuf, FQDN_LEN + INET6_ADDRSTRLEN);
+  /* Add 3 characters for the hostname and IP string, hence we allocate 
+      (FQDN_LEN + INET6_ADDRSTRLEN + 3) octets */
+  if (!nameIPBuf) nameIPBuf = (char *) safe_malloc(FQDN_LEN + INET6_ADDRSTRLEN + 3);
+  return NameIP(nameIPBuf, FQDN_LEN + INET6_ADDRSTRLEN + 3);
 }
 
   /* Returns the next hop for sending packets to this host.  Returns true if

--- a/Target.cc
+++ b/Target.cc
@@ -136,6 +136,8 @@
 #include "utils.h"
 #include "nmap_error.h"
 
+#define FQDN_LEN 255
+
 extern NmapOps o;
 
 Target::Target() {
@@ -429,8 +431,8 @@ const char *Target::NameIP(char *buf, size_t buflen) const {
 
 /* This next version returns a static buffer -- so no concurrency */
 const char *Target::NameIP() const {
-  if (!nameIPBuf) nameIPBuf = (char *) safe_malloc(MAXHOSTNAMELEN + INET6_ADDRSTRLEN);
-  return NameIP(nameIPBuf, MAXHOSTNAMELEN + INET6_ADDRSTRLEN);
+  if (!nameIPBuf) nameIPBuf = (char *) safe_malloc(FQDN_LEN + INET6_ADDRSTRLEN);
+  return NameIP(nameIPBuf, FQDN_LEN + INET6_ADDRSTRLEN);
 }
 
   /* Returns the next hop for sending packets to this host.  Returns true if

--- a/Target.cc
+++ b/Target.cc
@@ -430,9 +430,9 @@ const char *Target::NameIP(char *buf, size_t buflen) const {
 /* This next version returns a static buffer -- so no concurrency */
 const char *Target::NameIP() const {
   /* Add 3 characters for the hostname and IP string, hence we allocate 
-      (FQDN_LEN + INET6_ADDRSTRLEN + 3) octets */
-  if (!nameIPBuf) nameIPBuf = (char *) safe_malloc(FQDN_LEN + INET6_ADDRSTRLEN + 3);
-  return NameIP(nameIPBuf, FQDN_LEN + INET6_ADDRSTRLEN + 3);
+      (FQDN_LEN + INET6_ADDRSTRLEN + 4) octets, with octet for the null terminator */
+  if (!nameIPBuf) nameIPBuf = (char *) safe_malloc(FQDN_LEN + INET6_ADDRSTRLEN + 4);
+  return NameIP(nameIPBuf, FQDN_LEN + INET6_ADDRSTRLEN + 4);
 }
 
   /* Returns the next hop for sending packets to this host.  Returns true if

--- a/idle_scan.cc
+++ b/idle_scan.cc
@@ -535,7 +535,6 @@ static void ipv6_force_fragmentation(struct idle_proxy_info *proxy, Target *targ
    proxy is determined to be unsuitable, the function whines and exits
    the program */
 #define NUM_IPID_PROBES 6
-#define FQDN_LEN 255
 static void initialize_idleproxy(struct idle_proxy_info *proxy, char *proxyName,
                                  Target *target, const struct scan_lists *ports) {
   unsigned int probes_sent = 0, probes_returned = 0;

--- a/idle_scan.cc
+++ b/idle_scan.cc
@@ -547,7 +547,7 @@ static void initialize_idleproxy(struct idle_proxy_info *proxy, char *proxyName,
   int newipid;
   unsigned int i;
   char filter[512]; /* Libpcap filter string */
-  char name[FQDN_LEN];
+  char name[FQDN_LEN + 1];
   struct sockaddr_storage ss;
   size_t sslen;
   u32 sequence_base;

--- a/idle_scan.cc
+++ b/idle_scan.cc
@@ -535,6 +535,7 @@ static void ipv6_force_fragmentation(struct idle_proxy_info *proxy, Target *targ
    proxy is determined to be unsuitable, the function whines and exits
    the program */
 #define NUM_IPID_PROBES 6
+#define FQDN_LEN 255
 static void initialize_idleproxy(struct idle_proxy_info *proxy, char *proxyName,
                                  Target *target, const struct scan_lists *ports) {
   unsigned int probes_sent = 0, probes_returned = 0;
@@ -547,7 +548,7 @@ static void initialize_idleproxy(struct idle_proxy_info *proxy, char *proxyName,
   int newipid;
   unsigned int i;
   char filter[512]; /* Libpcap filter string */
-  char name[MAXHOSTNAMELEN + 1];
+  char name[FQDN_LEN];
   struct sockaddr_storage ss;
   size_t sslen;
   u32 sequence_base;
@@ -1399,7 +1400,7 @@ static int idle_treescan(struct idle_proxy_info *proxy, Target *target,
 void idle_scan(Target *target, u16 *portarray, int numports,
                char *proxyName, const struct scan_lists *ports) {
 
-  static char lastproxy[MAXHOSTNAMELEN + 1] = ""; /* The proxy used in any previous call */
+  static char lastproxy[FQDN_LEN] = ""; /* The proxy used in any previous call */
   static struct idle_proxy_info proxy;
   int groupsz;
   int portidx = 0; /* Used for splitting the port array into chunks */

--- a/idle_scan.cc
+++ b/idle_scan.cc
@@ -1399,7 +1399,7 @@ static int idle_treescan(struct idle_proxy_info *proxy, Target *target,
 void idle_scan(Target *target, u16 *portarray, int numports,
                char *proxyName, const struct scan_lists *ports) {
 
-  static char lastproxy[FQDN_LEN] = ""; /* The proxy used in any previous call */
+  static char lastproxy[FQDN_LEN + 1] = ""; /* The proxy used in any previous call */
   static struct idle_proxy_info proxy;
   int groupsz;
   int portidx = 0; /* Used for splitting the port array into chunks */

--- a/nmap.cc
+++ b/nmap.cc
@@ -1745,11 +1745,11 @@ int nmap_main(int argc, char *argv[]) {
 #endif
   unsigned int ideal_scan_group_sz = 0;
   Target *currenths;
-  char myname[MAXHOSTNAMELEN + 1];
+  char myname[FQDN_LEN + 1];
   int sourceaddrwarning = 0; /* Have we warned them yet about unguessable
                                 source addresses? */
   unsigned int targetno;
-  char hostname[MAXHOSTNAMELEN + 1] = "";
+  char hostname[FQDN_LEN + 1] = "";
   struct sockaddr_storage ss;
   size_t sslen;
 
@@ -2035,7 +2035,7 @@ int nmap_main(int argc, char *argv[]) {
           if (o.SourceSockAddr(&ss, &sslen) == 0) {
             currenths->setSourceSockAddr(&ss, sslen);
           } else {
-            if (gethostname(myname, MAXHOSTNAMELEN) ||
+            if (gethostname(myname, FQDN_LEN) ||
                 resolve(myname, 0, &ss, &sslen, o.af()) != 0)
               fatal("Cannot get hostname!  Try using -S <my_IP_address> or -e <interface to scan through>\n");
 

--- a/nmap.cc
+++ b/nmap.cc
@@ -180,6 +180,8 @@
 #endif
 #define DNET_VERSION VERSION
 
+#define FQDN_LEN 255
+
 #include <string>
 #include <sstream>
 #include <vector>
@@ -965,8 +967,8 @@ void parse_options(int argc, char **argv) {
         } else if (strcmp(long_options[option_index].name, "sI") == 0) {
           o.idlescan = 1;
           o.idleProxy = strdup(optarg);
-          if (strlen(o.idleProxy) > MAXHOSTNAMELEN) {
-            fatal("ERROR: -sI argument must be less than %d characters", MAXHOSTNAMELEN);
+          if (strlen(o.idleProxy) > FQDN_LEN) {
+            fatal("ERROR: -sI argument must be less than %d characters", FQDN_LEN);
           }
         } else if (strcmp(long_options[option_index].name, "vv") == 0) {
           /* Compatibility hack ... ugly */

--- a/nmap.cc
+++ b/nmap.cc
@@ -180,8 +180,6 @@
 #endif
 #define DNET_VERSION VERSION
 
-#define FQDN_LEN 255
-
 #include <string>
 #include <sstream>
 #include <vector>

--- a/nmap.h
+++ b/nmap.h
@@ -323,6 +323,8 @@
 #define MAXHOSTNAMELEN 64
 #endif
 
+#define FQDN_LEN 254
+
 /* Max payload: Worst case is IPv4 with 40bytes of options and TCP with 20
  * bytes of options. */
 #define MAX_PAYLOAD_ALLOWED 65535-60-40

--- a/nmap_dns.cc
+++ b/nmap_dns.cc
@@ -1206,7 +1206,7 @@ static void nmap_mass_rdns_core(Target **targets, int num_targets) {
     for(i=0, reqI = deferred_reqs.begin(); reqI != deferred_reqs.end(); reqI++, i++) {
       struct sockaddr_storage ss;
       size_t sslen;
-      char hostname[MAXHOSTNAMELEN + 1] = "";
+      char hostname[FQDN_LEN + 1] = "";
 
       if (keyWasPressed())
         SPM->printStats((double) i / deferred_reqs.size(), NULL);
@@ -1240,7 +1240,7 @@ static void nmap_system_rdns_core(Target **targets, int num_targets) {
   Target *currenths;
   struct sockaddr_storage ss;
   size_t sslen;
-  char hostname[MAXHOSTNAMELEN + 1] = "";
+  char hostname[FQDN_LEN + 1] = "";
   char spmobuf[1024];
   int i;
 

--- a/nmap_ftp.cc
+++ b/nmap_ftp.cc
@@ -168,9 +168,9 @@ int parse_bounce_argument(struct ftpinfo *ftp, char *url) {
     ftp->port = atoi(s);
   }
 
-  strncpy(ftp->server_name, q, FQDN_LEN);
+  strncpy(ftp->server_name, q, FQDN_LEN+1);
 
-  ftp->user[63] = ftp->pass[255] = ftp->server_name[FQDN_LEN] = 0;
+  ftp->user[63] = ftp->pass[255] = ftp->server_name[FQDN_LEN+1] = 0;
 
   return 1;
 }

--- a/nmap_ftp.cc
+++ b/nmap_ftp.cc
@@ -170,7 +170,7 @@ int parse_bounce_argument(struct ftpinfo *ftp, char *url) {
 
   strncpy(ftp->server_name, q, FQDN_LEN+1);
 
-  ftp->user[63] = ftp->pass[255] = ftp->server_name[FQDN_LEN+1] = 0;
+  ftp->user[63] = ftp->pass[255] = ftp->server_name[FQDN_LEN] = 0;
 
   return 1;
 }

--- a/nmap_ftp.cc
+++ b/nmap_ftp.cc
@@ -121,6 +121,7 @@
  ***************************************************************************/
 
 /* $Id$ */
+#include "nmap.h"
 #include "nmap_ftp.h"
 #include "output.h"
 #include "NmapOps.h"
@@ -128,7 +129,6 @@
 #include "tcpip.h"
 #include "Target.h"
 #include "nmap_tty.h"
-#define FQDN_LEN 255
 extern NmapOps o;
 
 struct ftpinfo get_default_ftpinfo(void) {

--- a/nmap_ftp.cc
+++ b/nmap_ftp.cc
@@ -128,6 +128,7 @@
 #include "tcpip.h"
 #include "Target.h"
 #include "nmap_tty.h"
+#define FQDN_LEN 255
 extern NmapOps o;
 
 struct ftpinfo get_default_ftpinfo(void) {
@@ -167,9 +168,9 @@ int parse_bounce_argument(struct ftpinfo *ftp, char *url) {
     ftp->port = atoi(s);
   }
 
-  strncpy(ftp->server_name, q, MAXHOSTNAMELEN);
+  strncpy(ftp->server_name, q, FQDN_LEN);
 
-  ftp->user[63] = ftp->pass[255] = ftp->server_name[MAXHOSTNAMELEN] = 0;
+  ftp->user[63] = ftp->pass[255] = ftp->server_name[FQDN_LEN] = 0;
 
   return 1;
 }

--- a/nmap_ftp.h
+++ b/nmap_ftp.h
@@ -137,7 +137,7 @@ class Target;
 struct ftpinfo {
   char user[64];
   char pass[256]; /* methinks you're paranoid if you need this much space */
-  char server_name[MAXHOSTNAMELEN + 1];
+  char server_name[FQDN_LEN + 1];
   struct in_addr server;
   u16 port;
   int sd; /* socket descriptor */

--- a/nping/NpingTarget.cc
+++ b/nping/NpingTarget.cc
@@ -761,8 +761,8 @@ const char *NpingTarget::getNameAndIP(char *buf, size_t buflen) {
 /** This next version returns a static buffer -- so no concurrency */
 const char *NpingTarget::getNameAndIP() {
   if(!nameIPBuf)
-    nameIPBuf = (char *)safe_malloc(MAXHOSTNAMELEN + INET6_ADDRSTRLEN);
-  return getNameAndIP(nameIPBuf, MAXHOSTNAMELEN + INET6_ADDRSTRLEN);
+    nameIPBuf = (char *)safe_malloc(FQDN_LEN + INET6_ADDRSTRLEN + 4);
+  return getNameAndIP(nameIPBuf, FQDN_LEN + INET6_ADDRSTRLEN + 4);
 } /* End of getNameAndIP() */
 
 

--- a/nping/NpingTarget.cc
+++ b/nping/NpingTarget.cc
@@ -130,7 +130,7 @@
 
 #include "NpingTarget.h"
 #include <dnet.h>
-#include "nmap.h"
+#include "../nmap.h"
 #include "nbase.h"
 #include "nping.h"
 #include "output.h"

--- a/nping/NpingTarget.cc
+++ b/nping/NpingTarget.cc
@@ -130,6 +130,7 @@
 
 #include "NpingTarget.h"
 #include <dnet.h>
+#include "nmap.h"
 #include "nbase.h"
 #include "nping.h"
 #include "output.h"

--- a/nping/NpingTarget.cc
+++ b/nping/NpingTarget.cc
@@ -123,14 +123,16 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #ifdef WIN32
 #include "nping_winconfig.h"
 #endif
 
+#ifndef FQDN_LEN
+#define FQDN_LEN 254
+#endif
+
 #include "NpingTarget.h"
 #include <dnet.h>
-#include "../nmap.h"
 #include "nbase.h"
 #include "nping.h"
 #include "output.h"

--- a/output.cc
+++ b/output.cc
@@ -2095,7 +2095,7 @@ void printserviceinfooutput(Target *currenths) {
   Port port;
   struct serviceDeductions sd;
   int i, numhostnames = 0, numostypes = 0, numdevicetypes = 0, numcpes = 0;
-  char hostname_tbl[MAX_SERVICE_INFO_FIELDS][MAXHOSTNAMELEN];
+  char hostname_tbl[MAX_SERVICE_INFO_FIELDS][FQDN_LEN+1];
   char ostype_tbl[MAX_SERVICE_INFO_FIELDS][64];
   char devicetype_tbl[MAX_SERVICE_INFO_FIELDS][64];
   char cpe_tbl[MAX_SERVICE_INFO_FIELDS][80];


### PR DESCRIPTION
FQDN_LEN is defined as 255 octets.
This aims to fix issue #140, waiting for feedback.