### PR TITLE
Possible fix to issue #328

### DIFF
--- a/nbase/nbase_misc.c
+++ b/nbase/nbase_misc.c
@@ -227,9 +227,7 @@ const char *inet_ntop_ez(const struct sockaddr_storage *ss, size_t sslen) {
 
   const struct sockaddr_in *sin = (struct sockaddr_in *) ss;
   static char str[INET6_ADDRSTRLEN];
-#if HAVE_IPV6
   const struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *) ss;
-#endif
 
   str[0] = '\0';
 
@@ -238,13 +236,11 @@ const char *inet_ntop_ez(const struct sockaddr_storage *ss, size_t sslen) {
       return NULL;
     return inet_ntop(AF_INET, &sin->sin_addr, str, sizeof(str));
   }
-#if HAVE_IPV6
   else if(sin->sin_family == AF_INET6) {
     if (sslen < sizeof(struct sockaddr_in6))
       return NULL;
     return inet_ntop(AF_INET6, &sin6->sin6_addr, str, sizeof(str));
   }
-#endif
   //Some laptops report the ip and address family of disabled wifi cards as null
   //so yes, we will hit this sometimes.
   return NULL;


### PR DESCRIPTION
This fix is intended to prevent a segmentation fault.
Here is how I understood it:

In `TargetGroup.cc:621` : 
`result << inet_ntop_ez((struct sockaddr_storage *) &this->addr, sizeof(this->addr)) << "/" << bits;`
Here, `inet_ntop_ez` return `NULL` because IPV6 is disabled by default. The calling function (or parent) `NetBlockIPv6Netmask::str()` return `result.str()` which produces a segmentation fault.

With this fix, `inet_ntop_ez` do not check if IPv6 is disabled, so it will return the address even if it's disabled, so the check will be made by the parent calling function `TargetGroup::get_next_host` (targets.cc:392). Before, `this->netblock->str().c_str()` was causing the crash, so now the error handles it normally, telling you to add `-6` option if you didn't, and if you do nmap.cc will yell at you at line 1045 because you don't have IPv6 enabled.

Waiting for feedback,
Cheers