### PR TITLE
Update LPeg to v1.0.0. Closes #432

### DIFF
--- a/lpeg.c
+++ b/lpeg.c
@@ -1,7 +1,7 @@
 /*
-** $Id: lptypes.h,v 1.8 2013/04/12 16:26:38 roberto Exp $
+** $Id: lptypes.h,v 1.14 2015/09/28 17:17:41 roberto Exp $
 ** LPeg - PEG pattern matching for Lua
-** Copyright 2007, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
+** Copyright 2007-2015, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
 ** written by Roberto Ierusalimschy
 */
 
@@ -19,7 +19,7 @@
 #include "lua.h"
 
 
-#define VERSION         "0.12"
+#define VERSION         "1.0.0"
 
 
 #define PATTERN_T	"lpeg-pattern"
@@ -27,36 +27,38 @@
 
 
 /*
-** compatibility with Lua 5.2
+** compatibility with Lua 5.1
 */
-#if (LUA_VERSION_NUM == 502)
+#if (LUA_VERSION_NUM == 501)
 
-#undef lua_equal
-#define lua_equal(L,idx1,idx2)  lua_compare(L,(idx1),(idx2),LUA_OPEQ)
+#define lp_equal	lua_equal
 
-#undef lua_getfenv
-#define lua_getfenv	lua_getuservalue
-#undef lua_setfenv
-#define lua_setfenv	lua_setuservalue
+#define lua_getuservalue	lua_getfenv
+#define lua_setuservalue	lua_setfenv
 
-#undef lua_objlen
-#define lua_objlen	lua_rawlen
+#define lua_rawlen		lua_objlen
 
-#undef luaL_register
-#define luaL_register(L,n,f) \
-	{ if ((n) == NULL) luaL_setfuncs(L,f,0); else luaL_newlib(L,f); }
+#define luaL_setfuncs(L,f,n)	luaL_register(L,NULL,f)
+#define luaL_newlib(L,f)	luaL_register(L,"lpeg",f)
 
+#endif
+
+
+#if !defined(lp_equal)
+#define lp_equal(L,idx1,idx2)  lua_compare(L,(idx1),(idx2),LUA_OPEQ)
 #endif
 
 
 /* default maximum size for call/backtrack stack */
 #if !defined(MAXBACK)
-#define MAXBACK         100
+#define MAXBACK         400
 #endif
 
 
 /* maximum number of rules in a grammar */
-#define MAXRULES        200
+#if !defined(MAXRULES)
+#define MAXRULES        1000
+#endif
 
 
 
@@ -146,6 +148,105 @@ typedef struct Charset {
 #endif
 
 /*
+** $Id: lpcap.h,v 1.2 2015/02/27 17:13:17 roberto Exp $
+*/
+
+#if !defined(lpcap_h)
+#define lpcap_h
+
+
+
+
+/* kinds of captures */
+typedef enum CapKind {
+  Cclose, Cposition, Cconst, Cbackref, Carg, Csimple, Ctable, Cfunction,
+  Cquery, Cstring, Cnum, Csubst, Cfold, Cruntime, Cgroup
+} CapKind;
+
+
+typedef struct Capture {
+  const char *s;  /* subject position */
+  unsigned short idx;  /* extra info (group name, arg index, etc.) */
+  byte kind;  /* kind of capture */
+  byte siz;  /* size of full capture + 1 (0 = not a full capture) */
+} Capture;
+
+
+typedef struct CapState {
+  Capture *cap;  /* current capture */
+  Capture *ocap;  /* (original) capture list */
+  lua_State *L;
+  int ptop;  /* index of last argument to 'match' */
+  const char *s;  /* original string */
+  int valuecached;  /* value stored in cache slot */
+} CapState;
+
+
+int runtimecap (CapState *cs, Capture *close, const char *s, int *rem);
+int getcaptures (lua_State *L, const char *s, const char *r, int ptop);
+int finddyncap (Capture *cap, Capture *last);
+
+#endif
+
+
+/*
+** $Id: lpvm.h,v 1.3 2014/02/21 13:06:41 roberto Exp $
+*/
+
+#if !defined(lpvm_h)
+#define lpvm_h
+
+
+
+/* Virtual Machine's instructions */
+typedef enum Opcode {
+  IAny, /* if no char, fail */
+  IChar,  /* if char != aux, fail */
+  ISet,  /* if char not in buff, fail */
+  ITestAny,  /* in no char, jump to 'offset' */
+  ITestChar,  /* if char != aux, jump to 'offset' */
+  ITestSet,  /* if char not in buff, jump to 'offset' */
+  ISpan,  /* read a span of chars in buff */
+  IBehind,  /* walk back 'aux' characters (fail if not possible) */
+  IRet,  /* return from a rule */
+  IEnd,  /* end of pattern */
+  IChoice,  /* stack a choice; next fail will jump to 'offset' */
+  IJmp,  /* jump to 'offset' */
+  ICall,  /* call rule at 'offset' */
+  IOpenCall,  /* call rule number 'key' (must be closed to a ICall) */
+  ICommit,  /* pop choice and jump to 'offset' */
+  IPartialCommit,  /* update top choice to current position and jump */
+  IBackCommit,  /* "fails" but jump to its own 'offset' */
+  IFailTwice,  /* pop one choice and then fail */
+  IFail,  /* go back to saved state on choice and jump to saved offset */
+  IGiveup,  /* internal use */
+  IFullCapture,  /* complete capture of last 'off' chars */
+  IOpenCapture,  /* start a capture */
+  ICloseCapture,
+  ICloseRunTime
+} Opcode;
+
+
+
+typedef union Instruction {
+  struct Inst {
+    byte code;
+    byte aux;
+    short key;
+  } i;
+  int offset;
+  byte buff[1];
+} Instruction;
+
+
+void printpatt (Instruction *p, int n);
+const char *match (lua_State *L, const char *o, const char *s, const char *e,
+                   Instruction *op, Capture *capture, int ptop);
+
+
+#endif
+
+/*  
 ** $Id: lptree.h,v 1.2 2013/03/24 13:51:12 roberto Exp $
 */
 
@@ -222,111 +323,7 @@ extern const byte numsiblings[];
 #endif
 
 /*
-** $Id: lpcap.h,v 1.1 2013/03/21 20:25:12 roberto Exp $
-*/
-
-#if !defined(lpcap_h)
-#define lpcap_h
-
-
-
-
-/* kinds of captures */
-typedef enum CapKind {
-  Cclose, Cposition, Cconst, Cbackref, Carg, Csimple, Ctable, Cfunction,
-  Cquery, Cstring, Cnum, Csubst, Cfold, Cruntime, Cgroup
-} CapKind;
-
-
-typedef struct Capture {
-  const char *s;  /* subject position */
-  short idx;  /* extra info about capture (group name, arg index, etc.) */
-  byte kind;  /* kind of capture */
-  byte siz;  /* size of full capture + 1 (0 = not a full capture) */
-} Capture;
-
-
-typedef struct CapState {
-  Capture *cap;  /* current capture */
-  Capture *ocap;  /* (original) capture list */
-  lua_State *L;
-  int ptop;  /* index of last argument to 'match' */
-  const char *s;  /* original string */
-  int valuecached;  /* value stored in cache slot */
-} CapState;
-
-
-int runtimecap (CapState *cs, Capture *close, const char *s, int *rem);
-int getcaptures (lua_State *L, const char *s, const char *r, int ptop);
-int finddyncap (Capture *cap, Capture *last);
-
-#endif
-
-
-/*
-** $Id: lpvm.h,v 1.2 2013/04/03 20:37:18 roberto Exp $
-*/
-
-#if !defined(lpvm_h)
-#define lpvm_h
-
-
-
-/* Virtual Machine's instructions */
-typedef enum Opcode {
-  IAny, /* if no char, fail */
-  IChar,  /* if char != aux, fail */
-  ISet,  /* if char not in buff, fail */
-  ITestAny,  /* in no char, jump to 'offset' */
-  ITestChar,  /* if char != aux, jump to 'offset' */
-  ITestSet,  /* if char not in buff, jump to 'offset' */
-  ISpan,  /* read a span of chars in buff */
-  IBehind,  /* walk back 'aux' characters (fail if not possible) */
-  IRet,  /* return from a rule */
-  IEnd,  /* end of pattern */
-  IChoice,  /* stack a choice; next fail will jump to 'offset' */
-  IJmp,  /* jump to 'offset' */
-  ICall,  /* call rule at 'offset' */
-  IOpenCall,  /* call rule number 'key' (must be closed to a ICall) */
-  ICommit,  /* pop choice and jump to 'offset' */
-  IPartialCommit,  /* update top choice to current position and jump */
-  IBackCommit,  /* "fails" but jump to its own 'offset' */
-  IFailTwice,  /* pop one choice and then fail */
-  IFail,  /* go back to saved state on choice and jump to saved offset */
-  IGiveup,  /* internal use */
-  IFullCapture,  /* complete capture of last 'off' chars */
-  IOpenCapture,  /* start a capture */
-  ICloseCapture,
-  ICloseRunTime
-} Opcode;
-
-
-
-typedef union Instruction {
-  struct Inst {
-    byte code;
-    byte aux;
-    short key;
-  } i;
-  int offset;
-  byte buff[1];
-} Instruction;
-
-
-int getposition (lua_State *L, int t, int i);
-void printpatt (Instruction *p, int n);
-const char *match (lua_State *L, const char *o, const char *s, const char *e,
-                   Instruction *op, Capture *capture, int ptop);
-int verify (lua_State *L, Instruction *op, const Instruction *p,
-            Instruction *e, int postable, int rule);
-void checkrule (lua_State *L, Instruction *op, int from, int to,
-                int postable, int rule);
-
-
-#endif
-
-/*
-** $Id: lpcode.h,v 1.5 2013/04/04 21:24:45 roberto Exp $
+** $Id: lpcode.h,v 1.7 2015/06/12 18:24:45 roberto Exp $
 */
 
 #if !defined(lpcode_h)
@@ -341,14 +338,22 @@ int fixedlenx (TTree *tree, int count, int len);
 int hascaptures (TTree *tree);
 int lp_gc (lua_State *L);
 Instruction *compile (lua_State *L, Pattern *p);
-void reallocprog (lua_State *L, Pattern *p, int nsize);
+void realloccode (lua_State *L, Pattern *p, int nsize);
 int sizei (const Instruction *i);
 
 
 #define PEnullable      0
 #define PEnofail        1
 
+/*
+** nofail(t) implies that 't' cannot fail with any input
+*/
 #define nofail(t)	checkaux(t, PEnofail)
+
+/*
+** (not nullable(t)) implies 't' cannot match without consuming
+** something
+*/
 #define nullable(t)	checkaux(t, PEnullable)
 
 #define fixedlen(t)     fixedlenx(t, 0, 0)
@@ -357,7 +362,7 @@ int sizei (const Instruction *i);
 
 #endif
 /*
-** $Id: lpprint.h,v 1.1 2013/03/21 20:25:12 roberto Exp $
+** $Id: lpprint.h,v 1.2 2015/06/12 18:18:08 roberto Exp $
 */
 
 
@@ -374,6 +379,7 @@ void printtree (TTree *tree, int ident);
 void printktable (lua_State *L, int idx);
 void printcharset (const byte *st);
 void printcaplist (Capture *cap, Capture *limit);
+void printinst (const Instruction *op, const Instruction *p);
 
 #else
 
@@ -390,7 +396,7 @@ void printcaplist (Capture *cap, Capture *limit);
 #endif
 
 /*
-** $Id: lpcap.c,v 1.4 2013/03/21 20:25:12 roberto Exp $
+** $Id: lpcap.c,v 1.6 2015/06/15 16:09:57 roberto Exp $
 ** Copyright 2007, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
 */
 
@@ -515,7 +521,7 @@ static Capture *findback (CapState *cs, Capture *cap) {
       continue; /* opening an enclosing capture: skip and get previous */
     if (captype(cap) == Cgroup) {
       getfromktable(cs, cap->idx);  /* get group name */
-      if (lua_equal(L, -2, -1)) {  /* right group? */
+      if (lp_equal(L, -2, -1)) {  /* right group? */
         lua_pop(L, 2);  /* remove reference name and group name */
         return cap;
       }
@@ -851,7 +857,7 @@ static int pushcapture (CapState *cs) {
     case Carg: {
       int arg = (cs->cap++)->idx;
       if (arg + FIXEDARGS > cs->ptop)
-        return luaL_error(L, "reference to absent argument #%d", arg);
+        return luaL_error(L, "reference to absent extra argument #%d", arg);
       lua_pushvalue(L, arg + FIXEDARGS);
       return 1;
     }
@@ -900,7 +906,7 @@ static int pushcapture (CapState *cs) {
 /*
 ** Prepare a CapState structure and traverse the entire list of
 ** captures in the stack pushing its results. 's' is the subject
-** string, 'r' is the final position of the match, and 'ptop'
+** string, 'r' is the final position of the match, and 'ptop' 
 ** the index in the stack where some useful values were pushed.
 ** Returns the number of results pushed. (If the list produces no
 ** results, push the final position of the match.)
@@ -925,7 +931,7 @@ int getcaptures (lua_State *L, const char *s, const char *r, int ptop) {
 
 
 /*
-** $Id: lpcode.c,v 1.18 2013/04/12 16:30:33 roberto Exp $
+** $Id: lpcode.c,v 1.23 2015/06/12 18:36:47 roberto Exp $
 ** Copyright 2007, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
 */
 
@@ -957,26 +963,30 @@ static const Charset *fullset = &fullset_;
 */
 
 /*
-** Check whether a charset is empty (IFail), singleton (IChar),
-** full (IAny), or none of those (ISet).
+** Check whether a charset is empty (returns IFail), singleton (IChar),
+** full (IAny), or none of those (ISet). When singleton, '*c' returns
+** which character it is. (When generic set, the set was the input,
+** so there is no need to return it.)
 */
 static Opcode charsettype (const byte *cs, int *c) {
-  int count = 0;
+  int count = 0;  /* number of characters in the set */
   int i;
-  int candidate = -1;  /* candidate position for a char */
-  for (i = 0; i < CHARSETSIZE; i++) {
+  int candidate = -1;  /* candidate position for the singleton char */
+  for (i = 0; i < CHARSETSIZE; i++) {  /* for each byte */
     int b = cs[i];
-    if (b == 0) {
-      if (count > 1) return ISet;  /* else set is still empty */
+    if (b == 0) {  /* is byte empty? */
+      if (count > 1)  /* was set neither empty nor singleton? */
+        return ISet;  /* neither full nor empty nor singleton */
+      /* else set is still empty or singleton */
     }
-    else if (b == 0xFF) {
-      if (count < (i * BITSPERCHAR))
-        return ISet;
+    else if (b == 0xFF) {  /* is byte full? */
+      if (count < (i * BITSPERCHAR))  /* was set not full? */
+        return ISet;  /* neither full nor empty nor singleton */
       else count += BITSPERCHAR;  /* set is still full */
     }
-    else if ((b & (b - 1)) == 0) {  /* byte has only one bit? */
-      if (count > 0)
-        return ISet;  /* set is neither full nor empty */
+    else if ((b & (b - 1)) == 0) {  /* has byte only one bit? */
+      if (count > 0)  /* was set not empty? */
+        return ISet;  /* neither full nor empty nor singleton */
       else {  /* set has only one char till now; track it */
         count++;
         candidate = i;
@@ -1001,6 +1011,7 @@ static Opcode charsettype (const byte *cs, int *c) {
   }
 }
 
+
 /*
 ** A few basic operations on Charsets
 */
@@ -1008,16 +1019,11 @@ static void cs_complement (Charset *cs) {
   loopset(i, cs->cs[i] = ~cs->cs[i]);
 }
 
-
 static int cs_equal (const byte *cs1, const byte *cs2) {
   loopset(i, if (cs1[i] != cs2[i]) return 0);
   return 1;
 }
 
-
-/*
-** computes whether sets cs1 and cs2 are disjoint
-*/
 static int cs_disjoint (const Charset *cs1, const Charset *cs2) {
   loopset(i, if ((cs1->cs[i] & cs2->cs[i]) != 0) return 0;)
   return 1;
@@ -1025,7 +1031,8 @@ static int cs_disjoint (const Charset *cs1, const Charset *cs2) {
 
 
 /*
-** Convert a 'char' pattern (TSet, TChar, TAny) to a charset
+** If 'tree' is a 'char' pattern (TSet, TChar, TAny), convert it into a
+** charset and return 1; else return 0.
 */
 int tocharset (TTree *tree, Charset *cs) {
   switch (tree->tag) {
@@ -1040,7 +1047,7 @@ int tocharset (TTree *tree, Charset *cs) {
       return 1;
     }
     case TAny: {
-      loopset(i, cs->cs[i] = 0xFF);  /* add all to the set */
+      loopset(i, cs->cs[i] = 0xFF);  /* add all characters to the set */
       return 1;
     }
     default: return 0;
@@ -1049,13 +1056,16 @@ int tocharset (TTree *tree, Charset *cs) {
 
 
 /*
-** Checks whether a pattern has captures
+** Check whether a pattern tree has captures
 */
 int hascaptures (TTree *tree) {
  tailcall:
   switch (tree->tag) {
     case TCapture: case TRunTime:
       return 1;
+    case TCall:
+      tree = sib2(tree); goto tailcall;  /* return hascaptures(sib2(tree)); */
+    case TOpenCall: assert(0);
     default: {
       switch (numsiblings[tree->tag]) {
         case 1:  /* return hascaptures(sib1(tree)); */
@@ -1085,7 +1095,7 @@ int hascaptures (TTree *tree) {
 **    p is nullable => nullable(p)
 **    nofail(p) => p cannot fail
 ** The function assumes that TOpenCall is not nullable;
-** this will be checked again when the grammar is fixed.)
+** this will be checked again when the grammar is fixed.
 ** Run-time captures can do whatever they want, so the result
 ** is conservative.
 */
@@ -1122,7 +1132,7 @@ int checkaux (TTree *tree, int pred) {
     case TCall:  /* return checkaux(sib2(tree), pred); */
       tree = sib2(tree); goto tailcall;
     default: assert(0); return 0;
-  };
+  }
 }
 
 
@@ -1169,16 +1179,20 @@ int fixedlenx (TTree *tree, int count, int len) {
 /*
 ** Computes the 'first set' of a pattern.
 ** The result is a conservative aproximation:
-**   match p ax -> x' for some x ==> a in first(p).
+**   match p ax -> x (for some x) ==> a belongs to first(p)
+** or
+**   a not in first(p) ==> match p ax -> fail (for all x)
+**
 ** The set 'follow' is the first set of what follows the
 ** pattern (full set if nothing follows it).
-** The function returns 0 when this set can be used for
-** tests that avoid the pattern altogether.
+**
+** The function returns 0 when this resulting set can be used for
+** test instructions that avoid the pattern altogether.
 ** A non-zero return can happen for two reasons:
-** 1) match p '' -> ''            ==> returns 1.
-** (tests cannot be used because they always fail for an empty input)
-** 2) there is a match-time capture ==> returns 2.
-** (match-time captures should not be avoided by optimizations)
+** 1) match p '' -> ''            ==> return has bit 1 set
+** (tests cannot be used because they would always fail for an empty input);
+** 2) there is a match-time capture ==> return has bit 2 set
+** (optimizations should not bypass match-time captures).
 */
 static int getfirst (TTree *tree, const Charset *follow, Charset *firstset) {
  tailcall:
@@ -1189,7 +1203,7 @@ static int getfirst (TTree *tree, const Charset *follow, Charset *firstset) {
     }
     case TTrue: {
       loopset(i, firstset->cs[i] = follow->cs[i]);
-      return 1;
+      return 1;  /* accepts the empty string */
     }
     case TFalse: {
       loopset(i, firstset->cs[i] = 0);
@@ -1204,7 +1218,8 @@ static int getfirst (TTree *tree, const Charset *follow, Charset *firstset) {
     }
     case TSeq: {
       if (!nullable(sib1(tree))) {
-        /* return getfirst(sib1(tree), fullset, firstset); */
+        /* when p1 is not nullable, p2 has nothing to contribute;
+           return getfirst(sib1(tree), fullset, firstset); */
         tree = sib1(tree); follow = fullset; goto tailcall;
       }
       else {  /* FIRST(p1 p2, fl) = FIRST(p1, FIRST(p2, fl)) */
@@ -1248,7 +1263,7 @@ static int getfirst (TTree *tree, const Charset *follow, Charset *firstset) {
       /* else go through */
     }
     case TBehind: {  /* instruction gives no new information */
-      /* call 'getfirst' to check for math-time captures */
+      /* call 'getfirst' only to check for math-time captures */
       int e = getfirst(sib1(tree), follow, firstset);
       loopset(i, firstset->cs[i] = follow->cs[i]);  /* uses follow */
       return e | 1;  /* always can accept the empty string */
@@ -1259,8 +1274,8 @@ static int getfirst (TTree *tree, const Charset *follow, Charset *firstset) {
 
 
 /*
-** If it returns true, then pattern can fail only depending on the next
-** character of the subject
+** If 'headfail(tree)' true, then 'tree' can fail only depending on the
+** next character of the subject.
 */
 static int headfail (TTree *tree) {
  tailcall:
@@ -1306,7 +1321,7 @@ static int needfollow (TTree *tree) {
     case TSeq:
       tree = sib2(tree); goto tailcall;
     default: assert(0); return 0;
-  }
+  } 
 }
 
 /* }====================================================== */
@@ -1327,9 +1342,9 @@ int sizei (const Instruction *i) {
   switch((Opcode)i->i.code) {
     case ISet: case ISpan: return CHARSETINSTSIZE;
     case ITestSet: return CHARSETINSTSIZE + 1;
-    case ITestChar: case ITestAny: case IChoice: case IJmp:
-    case ICall: case IOpenCall: case ICommit: case IPartialCommit:
-    case IBackCommit: return 2;
+    case ITestChar: case ITestAny: case IChoice: case IJmp: case ICall:
+    case IOpenCall: case ICommit: case IPartialCommit: case IBackCommit:
+      return 2;
     default: return 1;
   }
 }
@@ -1346,16 +1361,17 @@ typedef struct CompileState {
 
 
 /*
-** code generation is recursive; 'opt' indicates that the code is
-** being generated under a 'IChoice' operator jumping to its end.
-** 'tt' points to a previous test protecting this code. 'fl' is
-** the follow set of the pattern.
+** code generation is recursive; 'opt' indicates that the code is being
+** generated as the last thing inside an optional pattern (so, if that
+** code is optional too, it can reuse the 'IChoice' already in place for
+** the outer pattern). 'tt' points to a previous test protecting this
+** code (or NOINST). 'fl' is the follow set of the pattern.
 */
 static void codegen (CompileState *compst, TTree *tree, int opt, int tt,
                      const Charset *fl);
 
 
-void reallocprog (lua_State *L, Pattern *p, int nsize) {
+void realloccode (lua_State *L, Pattern *p, int nsize) {
   void *ud;
   lua_Alloc f = lua_getallocf(L, &ud);
   void *newblock = f(ud, p->code, p->codesize * sizeof(Instruction),
@@ -1370,7 +1386,7 @@ void reallocprog (lua_State *L, Pattern *p, int nsize) {
 static int nextinstruction (CompileState *compst) {
   int size = compst->p->codesize;
   if (compst->ncode >= size)
-    reallocprog(compst->L, compst->p, size * 2);
+    realloccode(compst->L, compst->p, size * 2);
   return compst->ncode++;
 }
 
@@ -1386,6 +1402,9 @@ static int addinstruction (CompileState *compst, Opcode op, int aux) {
 }
 
 
+/*
+** Add an instruction followed by space for an offset (to be set later)
+*/
 static int addoffsetinst (CompileState *compst, Opcode op) {
   int i = addinstruction(compst, op, 0);  /* instruction */
   addinstruction(compst, (Opcode)0, 0);  /* open space for offset */
@@ -1394,6 +1413,9 @@ static int addoffsetinst (CompileState *compst, Opcode op) {
 }
 
 
+/*
+** Set the offset of an instruction
+*/
 static void setoffset (CompileState *compst, int instruction, int offset) {
   getinstr(compst, instruction + 1).offset = offset;
 }
@@ -1402,7 +1424,7 @@ static void setoffset (CompileState *compst, int instruction, int offset) {
 /*
 ** Add a capture instruction:
 ** 'op' is the capture instruction; 'cap' the capture kind;
-** 'key' the key into ktable; 'aux' is optional offset
+** 'key' the key into ktable; 'aux' is the optional capture offset
 **
 */
 static int addinstcap (CompileState *compst, Opcode op, int cap, int key,
@@ -1418,12 +1440,18 @@ static int addinstcap (CompileState *compst, Opcode op, int cap, int key,
 #define target(code,i)		((i) + code[i + 1].offset)
 
 
+/*
+** Patch 'instruction' to jump to 'target'
+*/
 static void jumptothere (CompileState *compst, int instruction, int target) {
   if (instruction >= 0)
     setoffset(compst, instruction, target - instruction);
 }
 
 
+/*
+** Patch 'instruction' to jump to current position
+*/
 static void jumptohere (CompileState *compst, int instruction) {
   jumptothere(compst, instruction, gethere(compst));
 }
@@ -1540,13 +1568,13 @@ static void codebehind (CompileState *compst, TTree *tree) {
 
 /*
 ** Choice; optimizations:
-** - when p1 is headfail
-** - when first(p1) and first(p2) are disjoint; than
+** - when p1 is headfail or
+** when first(p1) and first(p2) are disjoint, than
 ** a character not in first(p1) cannot go to p1, and a character
 ** in first(p1) cannot go to p2 (at it is not in first(p2)).
 ** (The optimization is not valid if p1 accepts the empty string,
 ** as then there is no character at all...)
-** - when p2 is empty and opt is true; a IPartialCommit can resuse
+** - when p2 is empty and opt is true; a IPartialCommit can reuse
 ** the Choice already active in the stack.
 */
 static void codechoice (CompileState *compst, TTree *p1, TTree *p2, int opt,
@@ -1561,7 +1589,7 @@ static void codechoice (CompileState *compst, TTree *p1, TTree *p2, int opt,
     int jmp = NOINST;
     codegen(compst, p1, 0, test, fl);
     if (!emptyp2)
-      jmp = addoffsetinst(compst, IJmp);
+      jmp = addoffsetinst(compst, IJmp); 
     jumptohere(compst, test);
     codegen(compst, p2, opt, NOINST, fl);
     jumptohere(compst, jmp);
@@ -1572,8 +1600,8 @@ static void codechoice (CompileState *compst, TTree *p1, TTree *p2, int opt,
     codegen(compst, p1, 1, NOINST, fullset);
   }
   else {
-    /* <p1 / p2> ==
-        test(fail(p1)) -> L1; choice L1; <p1>; commit L2; L1: <p2>; L2: */
+    /* <p1 / p2> == 
+        test(first(p1)) -> L1; choice L1; <p1>; commit L2; L1: <p2>; L2: */
     int pcommit;
     int test = codetestset(compst, &cs1, e1);
     int pchoice = addoffsetinst(compst, IChoice);
@@ -1661,7 +1689,7 @@ static void coderep (CompileState *compst, TTree *tree, int opt,
       /* L1: test (fail(p1)) -> L2; <p>; jmp L1; L2: */
       int jmp;
       int test = codetestset(compst, &st, 0);
-      codegen(compst, tree, opt, test, fullset);
+      codegen(compst, tree, 0, test, fullset);
       jmp = addoffsetinst(compst, IJmp);
       jumptohere(compst, test);
       jumptothere(compst, jmp, test);
@@ -1787,7 +1815,8 @@ static int codeseq1 (CompileState *compst, TTree *p1, TTree *p2,
 
 /*
 ** Main code-generation function: dispatch to auxiliar functions
-** according to kind of tree
+** according to kind of tree. ('needfollow' should return true
+** only for consructions that use 'fl'.)
 */
 static void codegen (CompileState *compst, TTree *tree, int opt, int tt,
                      const Charset *fl) {
@@ -1830,6 +1859,7 @@ static void peephole (CompileState *compst) {
   Instruction *code = compst->p->code;
   int i;
   for (i = 0; i < compst->ncode; i += sizei(&code[i])) {
+   redo:
     switch (code[i].i.code) {
       case IChoice: case ICall: case ICommit: case IPartialCommit:
       case IBackCommit: case ITestChar: case ITestSet:
@@ -1851,8 +1881,7 @@ static void peephole (CompileState *compst) {
             int fft = finallabel(code, ft);
             code[i] = code[ft];  /* jump becomes that instruction... */
             jumptothere(compst, i, fft);  /* but must correct its offset */
-            i--;  /* reoptimize its label */
-            break;
+            goto redo;  /* reoptimize its label */
           }
           default: {
             jumptothere(compst, i, ft);  /* optimize label */
@@ -1874,10 +1903,10 @@ static void peephole (CompileState *compst) {
 Instruction *compile (lua_State *L, Pattern *p) {
   CompileState compst;
   compst.p = p;  compst.ncode = 0;  compst.L = L;
-  reallocprog(L, p, 2);  /* minimum initial size */
+  realloccode(L, p, 2);  /* minimum initial size */
   codegen(&compst, p->tree, 0, NOINST, fullset);
   addinstruction(&compst, IEnd, 0);
-  reallocprog(L, p, compst.ncode);  /* set final size */
+  realloccode(L, p, compst.ncode);  /* set final size */
   peephole(&compst);
   return p->code;
 }
@@ -1886,7 +1915,7 @@ Instruction *compile (lua_State *L, Pattern *p) {
 /* }====================================================== */
 
 /*
-** $Id: lpprint.c,v 1.7 2013/04/12 16:29:49 roberto Exp $
+** $Id: lpprint.c,v 1.9 2015/06/15 16:09:57 roberto Exp $
 ** Copyright 2007, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
 */
 
@@ -1936,7 +1965,7 @@ static void printjmp (const Instruction *op, const Instruction *p) {
 }
 
 
-static void printinst (const Instruction *op, const Instruction *p) {
+void printinst (const Instruction *op, const Instruction *p) {
   const char *const names[] = {
     "any", "char", "set",
     "testany", "testchar", "testset",
@@ -2105,10 +2134,10 @@ void printtree (TTree *tree, int ident) {
 
 void printktable (lua_State *L, int idx) {
   int n, i;
-  lua_getfenv(L, idx);
+  lua_getuservalue(L, idx);
   if (lua_isnil(L, -1))  /* no ktable? */
     return;
-  n = lua_objlen(L, -1);
+  n = lua_rawlen(L, -1);
   printf("[");
   for (i = 1; i <= n; i++) {
     printf("%d = ", i);
@@ -2127,7 +2156,7 @@ void printktable (lua_State *L, int idx) {
 
 #endif
 /*
-** $Id: lptree.c,v 1.10 2013/04/12 16:30:33 roberto Exp $
+** $Id: lptree.c,v 1.21 2015/09/28 17:01:25 roberto Exp $
 ** Copyright 2013, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
 */
 
@@ -2144,7 +2173,7 @@ void printktable (lua_State *L, int idx) {
 /* number of siblings for each tree */
 const byte numsiblings[] = {
   0, 0, 0,	/* char, set, any */
-  0, 0,		/* true, false */
+  0, 0,		/* true, false */	
   1,		/* rep */
   2, 2,		/* seq, choice */
   1, 1,		/* not, and */
@@ -2249,6 +2278,189 @@ static void finalfix (lua_State *L, int postable, TTree *g, TTree *t) {
 }
 
 
+
+/*
+** {===================================================================
+** KTable manipulation
+**
+** - The ktable of a pattern 'p' can be shared by other patterns that
+** contain 'p' and no other constants. Because of this sharing, we
+** should not add elements to a 'ktable' unless it was freshly created
+** for the new pattern.
+**
+** - The maximum index in a ktable is USHRT_MAX, because trees and
+** patterns use unsigned shorts to store those indices.
+** ====================================================================
+*/
+
+/*
+** Create a new 'ktable' to the pattern at the top of the stack.
+*/
+static void newktable (lua_State *L, int n) {
+  lua_createtable(L, n, 0);  /* create a fresh table */
+  lua_setuservalue(L, -2);  /* set it as 'ktable' for pattern */
+}
+
+
+/*
+** Add element 'idx' to 'ktable' of pattern at the top of the stack;
+** Return index of new element.
+** If new element is nil, does not add it to table (as it would be
+** useless) and returns 0, as ktable[0] is always nil.
+*/
+static int addtoktable (lua_State *L, int idx) {
+  if (lua_isnil(L, idx))  /* nil value? */
+    return 0;
+  else {
+    int n;
+    lua_getuservalue(L, -1);  /* get ktable from pattern */
+    n = lua_rawlen(L, -1);
+    if (n >= USHRT_MAX)
+      luaL_error(L, "too many Lua values in pattern");
+    lua_pushvalue(L, idx);  /* element to be added */
+    lua_rawseti(L, -2, ++n);
+    lua_pop(L, 1);  /* remove 'ktable' */
+    return n;
+  }
+}
+
+
+/*
+** Return the number of elements in the ktable at 'idx'.
+** In Lua 5.2/5.3, default "environment" for patterns is nil, not
+** a table. Treat it as an empty table. In Lua 5.1, assumes that
+** the environment has no numeric indices (len == 0)
+*/
+static int ktablelen (lua_State *L, int idx) {
+  if (!lua_istable(L, idx)) return 0;
+  else return lua_rawlen(L, idx);
+}
+
+
+/*
+** Concatentate the contents of table 'idx1' into table 'idx2'.
+** (Assume that both indices are negative.)
+** Return the original length of table 'idx2' (or 0, if no
+** element was added, as there is no need to correct any index).
+*/
+static int concattable (lua_State *L, int idx1, int idx2) {
+  int i;
+  int n1 = ktablelen(L, idx1);
+  int n2 = ktablelen(L, idx2);
+  if (n1 + n2 > USHRT_MAX)
+    luaL_error(L, "too many Lua values in pattern");
+  if (n1 == 0) return 0;  /* nothing to correct */
+  for (i = 1; i <= n1; i++) {
+    lua_rawgeti(L, idx1, i);
+    lua_rawseti(L, idx2 - 1, n2 + i);  /* correct 'idx2' */
+  }
+  return n2;
+}
+
+
+/*
+** When joining 'ktables', constants from one of the subpatterns must
+** be renumbered; 'correctkeys' corrects their indices (adding 'n'
+** to each of them)
+*/
+static void correctkeys (TTree *tree, int n) {
+  if (n == 0) return;  /* no correction? */
+ tailcall:
+  switch (tree->tag) {
+    case TOpenCall: case TCall: case TRunTime: case TRule: {
+      if (tree->key > 0)
+        tree->key += n;
+      break;
+    }
+    case TCapture: {
+      if (tree->key > 0 && tree->cap != Carg && tree->cap != Cnum)
+        tree->key += n;
+      break;
+    }
+    default: break;
+  }
+  switch (numsiblings[tree->tag]) {
+    case 1:  /* correctkeys(sib1(tree), n); */
+      tree = sib1(tree); goto tailcall;
+    case 2:
+      correctkeys(sib1(tree), n);
+      tree = sib2(tree); goto tailcall;  /* correctkeys(sib2(tree), n); */
+    default: assert(numsiblings[tree->tag] == 0); break;
+  }
+}
+
+
+/*
+** Join the ktables from p1 and p2 the ktable for the new pattern at the
+** top of the stack, reusing them when possible.
+*/
+static void joinktables (lua_State *L, int p1, TTree *t2, int p2) {
+  int n1, n2;
+  lua_getuservalue(L, p1);  /* get ktables */
+  lua_getuservalue(L, p2);
+  n1 = ktablelen(L, -2);
+  n2 = ktablelen(L, -1);
+  if (n1 == 0 && n2 == 0)  /* are both tables empty? */
+    lua_pop(L, 2);  /* nothing to be done; pop tables */
+  else if (n2 == 0 || lp_equal(L, -2, -1)) {  /* 2nd table empty or equal? */
+    lua_pop(L, 1);  /* pop 2nd table */
+    lua_setuservalue(L, -2);  /* set 1st ktable into new pattern */
+  }
+  else if (n1 == 0) {  /* first table is empty? */
+    lua_setuservalue(L, -3);  /* set 2nd table into new pattern */
+    lua_pop(L, 1);  /* pop 1st table */
+  }
+  else {
+    lua_createtable(L, n1 + n2, 0);  /* create ktable for new pattern */
+    /* stack: new p; ktable p1; ktable p2; new ktable */
+    concattable(L, -3, -1);  /* from p1 into new ktable */
+    concattable(L, -2, -1);  /* from p2 into new ktable */
+    lua_setuservalue(L, -4);  /* new ktable becomes 'p' environment */
+    lua_pop(L, 2);  /* pop other ktables */
+    correctkeys(t2, n1);  /* correction for indices from p2 */
+  }
+}
+
+
+/*
+** copy 'ktable' of element 'idx' to new tree (on top of stack)
+*/
+static void copyktable (lua_State *L, int idx) {
+  lua_getuservalue(L, idx);
+  lua_setuservalue(L, -2);
+}
+
+
+/*
+** merge 'ktable' from 'stree' at stack index 'idx' into 'ktable'
+** from tree at the top of the stack, and correct corresponding
+** tree.
+*/
+static void mergektable (lua_State *L, int idx, TTree *stree) {
+  int n;
+  lua_getuservalue(L, -1);  /* get ktables */
+  lua_getuservalue(L, idx);
+  n = concattable(L, -1, -2);
+  lua_pop(L, 2);  /* remove both ktables */
+  correctkeys(stree, n);
+}
+
+
+/*
+** Create a new 'ktable' to the pattern at the top of the stack, adding
+** all elements from pattern 'p' (if not 0) plus element 'idx' to it.
+** Return index of new element.
+*/
+static int addtonewktable (lua_State *L, int p, int idx) {
+  newktable(L, 1);
+  if (p)
+    mergektable(L, p, NULL);
+  return addtoktable(L, idx);
+}
+
+/* }====================================================== */
+
+
 /*
 ** {======================================================
 ** Tree generation
@@ -2278,7 +2490,7 @@ static Pattern *getpattern (lua_State *L, int idx) {
 
 
 static int getsize (lua_State *L, int idx) {
-  return (lua_objlen(L, idx) - sizeof(Pattern)) / sizeof(TTree) + 1;
+  return (lua_rawlen(L, idx) - sizeof(Pattern)) / sizeof(TTree) + 1;
 }
 
 
@@ -2291,12 +2503,16 @@ static TTree *gettree (lua_State *L, int idx, int *len) {
 
 
 /*
-** create a pattern
+** create a pattern. Set its uservalue (the 'ktable') equal to its
+** metatable. (It could be any empty sequence; the metatable is at
+** hand here, so we use it.)
 */
 static TTree *newtree (lua_State *L, int len) {
   size_t size = (len - 1) * sizeof(TTree) + sizeof(Pattern);
   Pattern *p = (Pattern *)lua_newuserdata(L, size);
   luaL_getmetatable(L, PATTERN_T);
+  lua_pushvalue(L, -1);
+  lua_setuservalue(L, -3);
   lua_setmetatable(L, -2);
   p->code = NULL;  p->codesize = 0;
   return p->tree;
@@ -2326,29 +2542,6 @@ static TTree *seqaux (TTree *tree, TTree *sib, int sibsize) {
   tree->tag = TSeq; tree->u.ps = sibsize + 1;
   memcpy(sib1(tree), sib, sibsize * sizeof(TTree));
   return sib2(tree);
-}
-
-
-/*
-** Add element 'idx' to 'ktable' of pattern at the top of the stack;
-** create new 'ktable' if necessary. Return index of new element.
-*/
-static int addtoktable (lua_State *L, int idx) {
-  if (idx == 0 || lua_isnil(L, idx))  /* no actual value to insert? */
-    return 0;
-  else {
-    int n;
-    lua_getfenv(L, -1);  /* get ktable from pattern */
-    n = lua_objlen(L, -1);
-    if (n == 0) {  /* is it empty/non-existent? */
-      lua_pop(L, 1);  /* remove it */
-      lua_createtable(L, 1, 0);  /* create a fresh table */
-    }
-    lua_pushvalue(L, idx);  /* element to be added */
-    lua_rawseti(L, -2, n + 1);
-    lua_setfenv(L, -2);  /* set it as ktable for pattern */
-    return n + 1;
-  }
 }
 
 
@@ -2427,7 +2620,7 @@ static TTree *getpatt (lua_State *L, int idx, int *len) {
     case LUA_TFUNCTION: {
       tree = newtree(L, 2);
       tree->tag = TRunTime;
-      tree->key = addtoktable(L, idx);
+      tree->key = addtonewktable(L, 0, idx);
       sib1(tree)->tag = TTrue;
       break;
     }
@@ -2439,123 +2632,6 @@ static TTree *getpatt (lua_State *L, int idx, int *len) {
   if (len)
     *len = getsize(L, idx);
   return tree;
-}
-
-
-/*
-** Return the number of elements in the ktable of pattern at 'idx'.
-** In Lua 5.2, default "environment" for patterns is nil, not
-** a table. Treat it as an empty table. In Lua 5.1, assumes that
-** the environment has no numeric indices (len == 0)
-*/
-static int ktablelen (lua_State *L, int idx) {
-  if (!lua_istable(L, idx)) return 0;
-  else return lua_objlen(L, idx);
-}
-
-
-/*
-** Concatentate the contents of table 'idx1' into table 'idx2'.
-** (Assume that both indices are negative.)
-** Return the original length of table 'idx2'
-*/
-static int concattable (lua_State *L, int idx1, int idx2) {
-  int i;
-  int n1 = ktablelen(L, idx1);
-  int n2 = ktablelen(L, idx2);
-  if (n1 == 0) return 0;  /* nothing to correct */
-  for (i = 1; i <= n1; i++) {
-    lua_rawgeti(L, idx1, i);
-    lua_rawseti(L, idx2 - 1, n2 + i);  /* correct 'idx2' */
-  }
-  return n2;
-}
-
-
-/*
-** Make a merge of ktables from p1 and p2 the ktable for the new
-** pattern at the top of the stack.
-*/
-static int joinktables (lua_State *L, int p1, int p2) {
-  int n1, n2;
-  lua_getfenv(L, p1);  /* get ktables */
-  lua_getfenv(L, p2);
-  n1 = ktablelen(L, -2);
-  n2 = ktablelen(L, -1);
-  if (n1 == 0 && n2 == 0) {  /* are both tables empty? */
-    lua_pop(L, 2);  /* nothing to be done; pop tables */
-    return 0;  /* nothing to correct */
-  }
-  if (n2 == 0 || lua_equal(L, -2, -1)) {  /* second table is empty or equal? */
-    lua_pop(L, 1);  /* pop 2nd table */
-    lua_setfenv(L, -2);  /* set 1st ktable into new pattern */
-    return 0;  /* nothing to correct */
-  }
-  if (n1 == 0) {  /* first table is empty? */
-    lua_setfenv(L, -3);  /* set 2nd table into new pattern */
-    lua_pop(L, 1);  /* pop 1st table */
-    return 0;  /* nothing to correct */
-  }
-  else {
-    lua_createtable(L, n1 + n2, 0);  /* create ktable for new pattern */
-    /* stack: new p; ktable p1; ktable p2; new ktable */
-    concattable(L, -3, -1);  /* from p1 into new ktable */
-    concattable(L, -2, -1);  /* from p2 into new ktable */
-    lua_setfenv(L, -4);  /* new ktable becomes p env */
-    lua_pop(L, 2);  /* pop other ktables */
-    return n1;  /* correction for indices from p2 */
-  }
-}
-
-
-static void correctkeys (TTree *tree, int n) {
-  if (n == 0) return;  /* no correction? */
- tailcall:
-  switch (tree->tag) {
-    case TOpenCall: case TCall: case TRunTime: case TRule: {
-      if (tree->key > 0)
-        tree->key += n;
-      break;
-    }
-    case TCapture: {
-      if (tree->key > 0 && tree->cap != Carg && tree->cap != Cnum)
-        tree->key += n;
-      break;
-    }
-    default: break;
-  }
-  switch (numsiblings[tree->tag]) {
-    case 1:  /* correctkeys(sib1(tree), n); */
-      tree = sib1(tree); goto tailcall;
-    case 2:
-      correctkeys(sib1(tree), n);
-      tree = sib2(tree); goto tailcall;  /* correctkeys(sib2(tree), n); */
-    default: assert(numsiblings[tree->tag] == 0); break;
-  }
-}
-
-
-/*
-** copy 'ktable' of element 'idx' to new tree (on top of stack)
-*/
-static void copyktable (lua_State *L, int idx) {
-  lua_getfenv(L, idx);
-  lua_setfenv(L, -2);
-}
-
-
-/*
-** merge 'ktable' from rule at stack index 'idx' into 'ktable'
-** from tree at the top of the stack, and correct corresponding
-** tree.
-*/
-static void mergektable (lua_State *L, int idx, TTree *rule) {
-  int n;
-  lua_getfenv(L, -1);  /* get ktables */
-  lua_getfenv(L, idx);
-  n = concattable(L, -1, -2);
-  lua_pop(L, 2);  /* remove both ktables */
-  correctkeys(rule, n);
 }
 
 
@@ -2587,7 +2663,7 @@ static TTree *newroot2sib (lua_State *L, int tag) {
   tree->u.ps =  1 + s1;
   memcpy(sib1(tree), tree1, s1 * sizeof(TTree));
   memcpy(sib2(tree), tree2, s2 * sizeof(TTree));
-  correctkeys(sib2(tree), joinktables(L, 1, 2));
+  joinktables(L, 1, sib2(tree), 2);
   return tree;
 }
 
@@ -2647,8 +2723,8 @@ static int lp_choice (lua_State *L) {
 */
 static int lp_star (lua_State *L) {
   int size1;
-  int n = luaL_checkint(L, 2);
-  TTree *tree1 = gettree(L, 1, &size1);
+  int n = (int)luaL_checkinteger(L, 2);
+  TTree *tree1 = getpatt(L, 1, &size1);
   if (n >= 0) {  /* seq tree1 (seq tree1 ... (seq tree1 (rep tree1))) */
     TTree *tree = newtree(L, (n + 1) * (size1 + 1));
     if (nullable(tree1))
@@ -2716,7 +2792,7 @@ static int lp_sub (lua_State *L) {
     sib1(tree)->tag = TNot;  /* ...not... */
     memcpy(sib1(sib1(tree)), t2, s2 * sizeof(TTree));  /* ...t2 */
     memcpy(sib2(tree), t1, s1 * sizeof(TTree));  /* ... and t1 */
-    correctkeys(sib1(tree), joinktables(L, 1, 2));
+    joinktables(L, 1, sib1(tree), 2);
   }
   return 1;
 }
@@ -2757,8 +2833,8 @@ static int lp_behind (lua_State *L) {
   TTree *tree;
   TTree *tree1 = getpatt(L, 1, NULL);
   int n = fixedlen(tree1);
+  luaL_argcheck(L, n >= 0, 1, "pattern may not have fixed length");
   luaL_argcheck(L, !hascaptures(tree1), 1, "pattern have captures");
-  luaL_argcheck(L, n > 0, 1, "pattern may not have fixed length");
   luaL_argcheck(L, n <= MAXBEHIND, 1, "pattern too long to look behind");
   tree = newroot1sib(L, TBehind);
   tree->u.n = n;
@@ -2772,7 +2848,7 @@ static int lp_behind (lua_State *L) {
 static int lp_V (lua_State *L) {
   TTree *tree = newleaf(L, TOpenCall);
   luaL_argcheck(L, !lua_isnoneornil(L, 1), 1, "non-nil value expected");
-  tree->key = addtoktable(L, 1);
+  tree->key = addtonewktable(L, 0, 1);
   return 1;
 }
 
@@ -2785,7 +2861,7 @@ static int lp_V (lua_State *L) {
 static int capture_aux (lua_State *L, int cap, int labelidx) {
   TTree *tree = newroot1sib(L, TCapture);
   tree->cap = cap;
-  tree->key = addtoktable(L, labelidx);
+  tree->key = (labelidx == 0) ? 0 : addtonewktable(L, 1, labelidx);
   return 1;
 }
 
@@ -2793,10 +2869,9 @@ static int capture_aux (lua_State *L, int cap, int labelidx) {
 /*
 ** Fill a tree with an empty capture, using an empty (TTrue) sibling.
 */
-static TTree *auxemptycap (lua_State *L, TTree *tree, int cap, int idx) {
+static TTree *auxemptycap (TTree *tree, int cap) {
   tree->tag = TCapture;
   tree->cap = cap;
-  tree->key = addtoktable(L, idx);
   sib1(tree)->tag = TTrue;
   return tree;
 }
@@ -2805,8 +2880,18 @@ static TTree *auxemptycap (lua_State *L, TTree *tree, int cap, int idx) {
 /*
 ** Create a tree for an empty capture
 */
-static TTree *newemptycap (lua_State *L, int cap, int idx) {
-  return auxemptycap(L, newtree(L, 2), cap, idx);
+static TTree *newemptycap (lua_State *L, int cap) {
+  return auxemptycap(newtree(L, 2), cap);
+}
+
+
+/*
+** Create a tree for an empty capture with an associated Lua value
+*/
+static TTree *newemptycapkey (lua_State *L, int cap, int idx) {
+  TTree *tree = auxemptycap(newtree(L, 2), cap);
+  tree->key = addtonewktable(L, 0, idx);
+  return tree;
 }
 
 
@@ -2845,10 +2930,8 @@ static int lp_tablecapture (lua_State *L) {
 static int lp_groupcapture (lua_State *L) {
   if (lua_isnoneornil(L, 2))
     return capture_aux(L, Cgroup, 0);
-  else {
-    luaL_checkstring(L, 2);
+  else
     return capture_aux(L, Cgroup, 2);
-  }
 }
 
 
@@ -2864,14 +2947,14 @@ static int lp_simplecapture (lua_State *L) {
 
 
 static int lp_poscapture (lua_State *L) {
-  newemptycap(L, Cposition, 0);
+  newemptycap(L, Cposition);
   return 1;
 }
 
 
 static int lp_argcapture (lua_State *L) {
-  int n = luaL_checkint(L, 1);
-  TTree *tree = newemptycap(L, Carg, 0);
+  int n = (int)luaL_checkinteger(L, 1);
+  TTree *tree = newemptycap(L, Carg);
   tree->key = n;
   luaL_argcheck(L, 0 < n && n <= SHRT_MAX, 1, "invalid argument index");
   return 1;
@@ -2879,8 +2962,8 @@ static int lp_argcapture (lua_State *L) {
 
 
 static int lp_backref (lua_State *L) {
-  luaL_checkstring(L, 1);
-  newemptycap(L, Cbackref, 1);
+  luaL_checkany(L, 1);
+  newemptycapkey(L, Cbackref, 1);
   return 1;
 }
 
@@ -2894,9 +2977,10 @@ static int lp_constcapture (lua_State *L) {
   if (n == 0)  /* no values? */
     newleaf(L, TTrue);  /* no capture */
   else if (n == 1)
-    newemptycap(L, Cconst, 1);  /* single constant capture */
+    newemptycapkey(L, Cconst, 1);  /* single constant capture */
   else {  /* create a group capture with all values */
     TTree *tree = newtree(L, 1 + 3 * (n - 1) + 2);
+    newktable(L, n);  /* create a 'ktable' for new tree */
     tree->tag = TCapture;
     tree->cap = Cgroup;
     tree->key = 0;
@@ -2904,10 +2988,12 @@ static int lp_constcapture (lua_State *L) {
     for (i = 1; i <= n - 1; i++) {
       tree->tag = TSeq;
       tree->u.ps = 3;  /* skip TCapture and its sibling */
-      auxemptycap(L, sib1(tree), Cconst, i);
+      auxemptycap(sib1(tree), Cconst);
+      sib1(tree)->key = addtoktable(L, i);
       tree = sib2(tree);
     }
-    auxemptycap(L, tree, Cconst, i);
+    auxemptycap(tree, Cconst);
+    tree->key = addtoktable(L, i);
   }
   return 1;
 }
@@ -2917,7 +3003,7 @@ static int lp_matchtime (lua_State *L) {
   TTree *tree;
   luaL_checktype(L, 2, LUA_TFUNCTION);
   tree = newroot1sib(L, TRunTime);
-  tree->key = addtoktable(L, 2);
+  tree->key = addtonewktable(L, 1, 2);
   return 1;
 }
 
@@ -2974,7 +3060,7 @@ static int collectrules (lua_State *L, int arg, int *totalsize) {
   lua_pushnil(L);  /* prepare to traverse grammar table */
   while (lua_next(L, arg) != 0) {
     if (lua_tonumber(L, -2) == 1 ||
-        lua_equal(L, -2, postab + 1)) {  /* initial rule? */
+        lp_equal(L, -2, postab + 1)) {  /* initial rule? */
       lua_pop(L, 1);  /* remove value (keep key for lua_next) */
       continue;
     }
@@ -3051,36 +3137,40 @@ static int verifyerror (lua_State *L, int *passed, int npassed) {
 
 /*
 ** Check whether a rule can be left recursive; raise an error in that
-** case; otherwise return 1 iff pattern is nullable. Assume ktable at
-** the top of the stack.
+** case; otherwise return 1 iff pattern is nullable.
+** The return value is used to check sequences, where the second pattern
+** is only relevant if the first is nullable.
+** Parameter 'nb' works as an accumulator, to allow tail calls in
+** choices. ('nb' true makes function returns true.)
+** Assume ktable at the top of the stack.
 */
 static int verifyrule (lua_State *L, TTree *tree, int *passed, int npassed,
-                       int nullable) {
+                       int nb) {
  tailcall:
   switch (tree->tag) {
     case TChar: case TSet: case TAny:
     case TFalse:
-      return nullable;  /* cannot pass from here */
+      return nb;  /* cannot pass from here */
     case TTrue:
     case TBehind:  /* look-behind cannot have calls */
       return 1;
     case TNot: case TAnd: case TRep:
       /* return verifyrule(L, sib1(tree), passed, npassed, 1); */
-      tree = sib1(tree); nullable = 1; goto tailcall;
+      tree = sib1(tree); nb = 1; goto tailcall;
     case TCapture: case TRunTime:
-      /* return verifyrule(L, sib1(tree), passed, npassed); */
+      /* return verifyrule(L, sib1(tree), passed, npassed, nb); */
       tree = sib1(tree); goto tailcall;
     case TCall:
-      /* return verifyrule(L, sib2(tree), passed, npassed); */
+      /* return verifyrule(L, sib2(tree), passed, npassed, nb); */
       tree = sib2(tree); goto tailcall;
-    case TSeq:  /* only check 2nd child if first is nullable */
+    case TSeq:  /* only check 2nd child if first is nb */
       if (!verifyrule(L, sib1(tree), passed, npassed, 0))
-        return nullable;
-      /* else return verifyrule(L, sib2(tree), passed, npassed); */
+        return nb;
+      /* else return verifyrule(L, sib2(tree), passed, npassed, nb); */
       tree = sib2(tree); goto tailcall;
     case TChoice:  /* must check both children */
-      nullable = verifyrule(L, sib1(tree), passed, npassed, nullable);
-      /* return verifyrule(L, sib2(tree), passed, npassed, nullable); */
+      nb = verifyrule(L, sib1(tree), passed, npassed, nb);
+      /* return verifyrule(L, sib2(tree), passed, npassed, nb); */
       tree = sib2(tree); goto tailcall;
     case TRule:
       if (npassed >= MAXRULES)
@@ -3123,7 +3213,7 @@ static void verifygrammar (lua_State *L, TTree *grammar) {
 */
 static void initialrulename (lua_State *L, TTree *grammar, int frule) {
   if (sib1(grammar)->key == 0) {  /* initial rule is not referenced? */
-    int n = lua_objlen(L, -1) + 1;  /* index for name */
+    int n = lua_rawlen(L, -1) + 1;  /* index for name */
     lua_pushvalue(L, frule);  /* rule's name */
     lua_rawseti(L, -2, n);  /* ktable was on the top of the stack */
     sib1(grammar)->key = n;
@@ -3139,9 +3229,9 @@ static TTree *newgrammar (lua_State *L, int arg) {
   luaL_argcheck(L, n <= MAXRULES, arg, "grammar has too many rules");
   g->tag = TGrammar;  g->u.n = n;
   lua_newtable(L);  /* create 'ktable' */
-  lua_setfenv(L, -2);
+  lua_setuservalue(L, -2);
   buildgrammar(L, g, frule, n);
-  lua_getfenv(L, -1);  /* get 'ktable' for new tree */
+  lua_getuservalue(L, -1);  /* get 'ktable' for new tree */
   finalfix(L, frule - 1, g, sib1(g));
   initialrulename(L, g, frule);
   verifygrammar(L, g);
@@ -3155,7 +3245,7 @@ static TTree *newgrammar (lua_State *L, int arg) {
 
 
 static Instruction *prepcompile (lua_State *L, Pattern *p, int idx) {
-  lua_getfenv(L, idx);  /* push 'ktable' (may be used by 'finalfix') */
+  lua_getuservalue(L, idx);  /* push 'ktable' (may be used by 'finalfix') */
   finalfix(L, 0, NULL, p->tree);
   lua_pop(L, 1);  /* remove 'ktable' */
   return compile(L, p);
@@ -3166,7 +3256,7 @@ static int lp_printtree (lua_State *L) {
   TTree *tree = getpatt(L, 1, NULL);
   int c = lua_toboolean(L, 2);
   if (c) {
-    lua_getfenv(L, 1);  /* push 'ktable' (may be used by 'finalfix') */
+    lua_getuservalue(L, 1);  /* push 'ktable' (may be used by 'finalfix') */
     finalfix(L, 0, NULL, tree);
     lua_pop(L, 1);  /* remove 'ktable' */
   }
@@ -3219,7 +3309,7 @@ static int lp_match (lua_State *L) {
   int ptop = lua_gettop(L);
   lua_pushnil(L);  /* initialize subscache */
   lua_pushlightuserdata(L, capture);  /* initialize caplistidx */
-  lua_getfenv(L, 1);  /* initialize penvidx */
+  lua_getuservalue(L, 1);  /* initialize penvidx */
   r = match(L, s, s + i, s + l, code, capture, ptop);
   if (r == NULL) {
     lua_pushnil(L);
@@ -3236,8 +3326,12 @@ static int lp_match (lua_State *L) {
 ** =======================================================
 */
 
+/* maximum limit for stack size */
+#define MAXLIM		(INT_MAX / 100)
+
 static int lp_setmax (lua_State *L) {
-  luaL_optinteger(L, 1, -1);
+  lua_Integer lim = luaL_checkinteger(L, 1);
+  luaL_argcheck(L, 0 < lim && lim <= MAXLIM, 1, "out of range");
   lua_settop(L, 1);
   lua_setfield(L, LUA_REGISTRYINDEX, MAXSTACKIDX);
   return 0;
@@ -3261,8 +3355,7 @@ static int lp_type (lua_State *L) {
 
 int lp_gc (lua_State *L) {
   Pattern *p = getpattern(L, 1);
-  if (p->codesize > 0)
-    reallocprog(L, p, 0);
+  realloccode(L, p, 0);  /* delete code block */
   return 0;
 }
 
@@ -3345,8 +3438,8 @@ LUALIB_API int luaopen_lpeg (lua_State *L) {
   luaL_newmetatable(L, PATTERN_T);
   lua_pushnumber(L, MAXBACK);  /* initialize maximum backtracking */
   lua_setfield(L, LUA_REGISTRYINDEX, MAXSTACKIDX);
-  luaL_register(L, NULL, metareg);
-  luaL_register(L, "lpeg", pattreg);
+  luaL_setfuncs(L, metareg, 0);
+  luaL_newlib(L, pattreg);
   lua_pushvalue(L, -1);
   lua_setfield(L, -3, "__index");
   return 1;
@@ -3354,7 +3447,7 @@ LUALIB_API int luaopen_lpeg (lua_State *L) {
 
 /* }====================================================== */
 /*
-** $Id: lpvm.c,v 1.5 2013/04/12 16:29:49 roberto Exp $
+** $Id: lpvm.c,v 1.6 2015/09/28 17:01:25 roberto Exp $
 ** Copyright 2007, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
 */
 
@@ -3369,7 +3462,7 @@ LUALIB_API int luaopen_lpeg (lua_State *L) {
 
 /* initial size for call/backtrack stack */
 #if !defined(INITBACK)
-#define INITBACK	100
+#define INITBACK	MAXBACK
 #endif
 
 
@@ -3421,7 +3514,7 @@ static Stack *doublestack (lua_State *L, Stack **stacklimit, int ptop) {
   max = lua_tointeger(L, -1);  /* maximum allowed size */
   lua_pop(L, 1);
   if (n >= max)  /* already at maximum size? */
-    luaL_error(L, "too many pending calls/choices");
+    luaL_error(L, "backtrack stack overflow (current limit is %d)", max);
   newn = 2 * n;  /* new size */
   if (newn > max) newn = max;
   newstack = (Stack *)lua_newuserdata(L, newn * sizeof(Stack));
@@ -3657,7 +3750,7 @@ const char *match (lua_State *L, const char *o, const char *s, const char *e,
             capsize = 2 * captop;
           }
           /* add new captures to 'capture' list */
-          adddyncaptures(s, capture + captop - n - 2, n, fr);
+          adddyncaptures(s, capture + captop - n - 2, n, fr); 
         }
         p++;
         continue;

--- a/lpeg.c
+++ b/lpeg.c
@@ -1065,6 +1065,8 @@ int hascaptures (TTree *tree) {
       return 1;
     case TCall:
       tree = sib2(tree); goto tailcall;  /* return hascaptures(sib2(tree)); */
+    case TRule:
+      tree = sib1(tree); goto tailcall;  /* return hascaptures(sib1(tree)); */
     case TOpenCall: assert(0);
     default: {
       switch (numsiblings[tree->tag]) {


### PR DESCRIPTION
This update closes #432.

I used Devin's amalgamation script to create `lpeg.c` file from LPeg v1.0.0 distribution files
https://svn.nmap.org/nmap-private-dev/misc-scripts/amalgamate.py
http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.0.0.tar.gz

Tested `banner.nse` and `ntp-info.nse` scripts, which indirectly use `lpeg` library through `lpeg-utility` library. 

An indication that the LPeg v1.0.0 is fully backward compatible with v0.12 is that `re.lua` module which is distributed with LPeg source code did not have any changes since v0.12. Nmap includes `re.lua` as one of the libraries.
