### PR TITLE
Hide first makefile attempt to include makefile.dep

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -478,7 +478,7 @@ lua-format:
 
 makefile.dep:
 	$(CXX) -MM $(CPPFLAGS) $(SRCS) > $@
-include makefile.dep
+-include makefile.dep
 
 # These the old names of scripts that have been renamed or deleted. Any
 # scripts with these names will be deleted from the installation

--- a/libnetutil/Makefile.in
+++ b/libnetutil/Makefile.in
@@ -38,4 +38,4 @@ Makefile: Makefile.in
 
 makefile.dep:
 	$(CXX) -MM $(CPPFLAGS) $(SRCS) > $@
-include makefile.dep
+-include makefile.dep

--- a/ncat/Makefile.in
+++ b/ncat/Makefile.in
@@ -209,5 +209,5 @@ check: $(TARGET) $(TEST_PROGS)
 
 makefile.dep:
 	$(CC) -MM $(CPPFLAGS) $(SRCS) > $@
-include makefile.dep
+-include makefile.dep
 

--- a/nmap-update/Makefile.in
+++ b/nmap-update/Makefile.in
@@ -59,6 +59,6 @@ Makefile: Makefile.in
 
 makefile.dep:
 	$(CC) -MM $(CPPFLAGS) $(C_FILES) > $@
-include makefile.dep
+-include makefile.dep
 
 .PHONY: all clean

--- a/nping/Makefile.in
+++ b/nping/Makefile.in
@@ -164,4 +164,4 @@ config.status: configure
 
 makefile.dep:
 	$(CXX) -MM $(CPPFLAGS) $(SRCS) > $@
-include makefile.dep
+-include makefile.dep

--- a/nsock/src/Makefile.in
+++ b/nsock/src/Makefile.in
@@ -61,7 +61,7 @@ clean-test:
 	cd $(NSOCKTESTDIR) && $(MAKE) clean
 
 clean: clean-test
-	rm -f $(OBJS) $(TARGET)
+	rm -f $(OBJS) $(TARGET-)
 
 distclean: clean
 	rm -f Makefile makefile.dep config.log config.status ../include/nsock_config.h $(NSOCKTESTDIR)/Makefile
@@ -94,4 +94,4 @@ config.status: configure
 
 makefile.dep:
 	$(CC) -MM $(CPPFLAGS) $(SRCS) > $@
-include makefile.dep
+-include makefile.dep


### PR DESCRIPTION
This is to avoid having a warning saying that there is no makefile.dep file, which will be generated right after the warning and then included in the Makefile.