### PR TITLE
[NSE] [nfs-ls & nfs-statfs] Fix false assumption: port.version.version is set

### DIFF
--- a/scripts/nfs-ls.nse
+++ b/scripts/nfs-ls.nse
@@ -168,7 +168,7 @@ hostrule = function(host)
     if mountport and nfsport then break end
   end
   if nfsport == nil then return false end
-  if host.registry.nfs.nfsver == nil then
+  if host.registry.nfs.nfsver == nil and nfsport.version.version then
     local low, high = string.match(nfsport.version.version, "(%d)%-(%d)")
     if high == nil then
       high = tonumber(nfsport.version.version)
@@ -186,7 +186,7 @@ hostrule = function(host)
     end
   end
   if mountport == nil then return false end
-  if host.registry.nfs.mountver == nil then
+  if host.registry.nfs.mountver == nil and mountport.version.version then
     local low, high = string.match(mountport.version.version, "(%d)%-(%d)")
     if high == nil then
       host.registry.nfs.mountver = tonumber(mountport.version.version)

--- a/scripts/nfs-statfs.nse
+++ b/scripts/nfs-statfs.nse
@@ -69,7 +69,7 @@ hostrule = function(host)
     if mountport and nfsport then break end
   end
   if nfsport == nil then return false end
-  if host.registry.nfs.nfsver == nil then
+  if host.registry.nfs.nfsver == nil and nfsport.version.version then
     local low, high = string.match(nfsport.version.version, "(%d)%-(%d)")
     if high == nil then
       high = tonumber(nfsport.version.version)
@@ -87,7 +87,7 @@ hostrule = function(host)
     end
   end
   if mountport == nil then return false end
-  if host.registry.nfs.mountver == nil then
+  if host.registry.nfs.mountver == nil and mountport.version.version then
     local low, high = string.match(mountport.version.version, "(%d)%-(%d)")
     if high == nil then
       host.registry.nfs.mountver = tonumber(mountport.version.version)


### PR DESCRIPTION
This should prevent nfs-ls.nse and nfs-statfs.nse from failing because they pass a nil
value to string.match when version detection wasn't performed.

    # nmap --script nfs-ls nfs-statfs 192.168.1.76
    ....
    NSE: nfs-statfs M:340e3c8 against 192.168.1.76 threw an error!
    /usr/local/bin/../share/nmap/scripts/nfs-statfs.nse:73: bad argument #1 to 'match' (string expected, got nil)
    stack traceback:
            [C]: in function 'string.match'
            /usr/local/bin/../share/nmap/scripts/nfs-statfs.nse:73: in global '?'
            /usr/local/bin/../share/nmap/nse_main.lua:458: in function </usr/local/bin/../share/nmap/nse_main.lua:453>

    NSE: Starting nfs-statfs M:342c708 against 192.168.1.76:111.
    ....
    NSE: nfs-ls against 192.168.1.76 threw an error!
    /usr/local/bin/../share/nmap/scripts/nfs-ls.nse:172: bad argument #1 to 'match' (string expected, got nil)
    stack traceback:
            [C]: in function 'string.match'
            /usr/local/bin/../share/nmap/scripts/nfs-ls.nse:172: in global '?'
            /usr/local/bin/../share/nmap/nse_main.lua:458: in function </usr/local/bin/../share/nmap/nse_main.lua:453>

    NSE: Starting nfs-ls against 192.168.1.76:111.

