### PR TITLE
Convert float in rpc.lua to integer, as expected by bin.pack.

### DIFF
--- a/nselib/rpc.lua
+++ b/nselib/rpc.lua
@@ -339,7 +339,7 @@ Comm = {
     elseif auth.type == Portmap.AuthType.UNIX then
       packet = packet .. Util.marshall_int32(auth.type)
       local blob = (
-        Util.marshall_int32(nmap.clock()) --time
+        Util.marshall_int32(math.floor(nmap.clock())) --time
         .. Util.marshall_vopaque(auth.hostname or 'localhost')
         .. Util.marshall_int32(auth.uid or 0)
         .. Util.marshall_int32(auth.gid or 0)


### PR DESCRIPTION
The conversion of args from the deprecated bin.pack to the new Lua 5.3
string.pack fails because the tointeger(float) returns nil.

Fixes #494.