### PR TITLE
Use the AppleLocale prefs directly

### DIFF
--- a/zenmap/install_scripts/macosx/launcher.sh
+++ b/zenmap/install_scripts/macosx/launcher.sh
@@ -35,13 +35,10 @@ export PYTHONPATH
 
 # We need a UTF-8 locale.
 if [ -z ${lang+x} ]; then 
-  # lang is unset 
-  lang=`defaults read /Library/Preferences/.GlobalPreferences AppleLanguages 2>/dev/null | awk '{ print $1 }' | head -n2 | tail -n1 | sed 's/\,/ /'`
-  if [ -z ${lang+x} ]; then
-    # lang is still unset 
-    lang=`defaults read .GlobalPreferences AppleLocale 2>/dev/null`
-  fi
-  export LANG="`grep \"\`echo $lang\`_\" /usr/share/locale/locale.alias |  tail -n1 | sed 's/\./ /' | awk '{print $2}'`.UTF-8"
+  # lang is unset, we are thus using the Apple locale because it's set to the currently used language,
+  # which is already in the good format
+  lang=`defaults read /Library/Preferences/.GlobalPreferences AppleLocale 2>/dev/null`
+  export LANG="`echo $lang`.UTF-8"
 fi
 
 if test -f "$bundle_lib/charset.alias"; then


### PR DESCRIPTION
This is really easier and much more portable (Mac OS 10.5 and later) than the other solution proposed. The problem with the actual code happens when I set English as my main language with a French localisation and keyboard. Sometimes, the AppleLanguages configuration file contains names like "English" instead of "en", "EN" or "en_EN". Moreover, there can be more than one language defined here. Instead, I suggest with this PR to use AppleLocale directly, which is in the "en_EN" format (or whatever language) and is set to the current language used by the machine. This would allow users to just launch Zenmap and have the software launched in the desired language without having to use the terminal (they can still change their machine language in the System Preferences or via the Terminal, but it would be easier to use). 