### PR TITLE
wrongfully reading version

### DIFF
--- a/nselib/mysql.lua
+++ b/nselib/mysql.lua
@@ -130,7 +130,7 @@ function receiveGreeting( socket )
   end
 
   pos, response.proto = bin.unpack( "C", data, pos )
-  pos, response.version = bin.unpack( "z", data, pos )
+  pos, response.version = bin.unpack( "z", data, pos-1 )
   pos, response.threadid = bin.unpack( "I", data, pos )
   pos, response.salt, _ = bin.unpack( "A8C", data, pos )
   pos, response.capabilities = bin.unpack( "S", data, pos )


### PR DESCRIPTION
when nmap extracts the version, it apparently skips a byte

```
$ sudo nmap -sV -p 3306 x.x.x.x --script mysql-info

Starting Nmap 7.12 ( https://nmap.org ) at 2016-08-25 10:33 WEST
Nmap scan report for ... (x.x.x.x)
Host is up (0.018s latency).
PORT     STATE SERVICE VERSION
3306/tcp open  mysql   MySQL 5.5.50-cll
| mysql-info:
|   Protocol: 53
|   Version: .5.50-cll
|   Thread ID: 14395236
|   Capabilities flags: 63487
|   Some Capabilities: SupportsCompression, Support41Auth,
SupportsLoadDataLocal, InteractiveClient, ConnectWithDatabase,
LongColumnFlag, SupportsTransactions, ODBCClient, FoundRows,
DontAllowDatabaseTableColumn, IgnoreSigpipes, Speaks41ProtocolNew,
IgnoreSpaceBeforeParenthesis, LongPassword, Speaks41ProtocolOld
|   Status: Autocommit
|_  Salt: /@2y,ma}sHO1IZj&xOax

Service detection performed. Please report any incorrect results at
https://nmap.org/submit/ .
Nmap done: 1 IP address (1 host up) scanned in 1.14 seconds
```

Might be due to the lack of padding or something, this fix allows the
version to be extracted adequately

```
$ sudo nmap -sV -p 3306 x-x-x-x --script mysql-info

Starting Nmap 7.12 ( https://nmap.org ) at 2016-08-25 10:36 WEST
Nmap scan report for ... (x.x.x.x)
Host is up (0.017s latency).
PORT     STATE SERVICE VERSION
3306/tcp open  mysql   MySQL 5.5.50-cll
| mysql-info:
|   Protocol: 53
|   Version: 5.5.50-cll
|   Thread ID: 14396483
|   Capabilities flags: 63487
|   Some Capabilities: LongPassword, ODBCClient, Support41Auth,
SupportsTransactions, SupportsLoadDataLocal, IgnoreSigpipes,
Speaks41ProtocolOld, SupportsCompression, InteractiveClient,
Speaks41ProtocolNew, FoundRows, LongColumnFlag,
IgnoreSpaceBeforeParenthesis, DontAllowDatabaseTableColumn,
ConnectWithDatabase
|   Status: Autocommit
|_  Salt: !4~Ailb(<7?vU)gN2Nqn

Service detection performed. Please report any incorrect results at
https://nmap.org/submit/ .
Nmap done: 1 IP address (1 host up) scanned in 1.09 seconds
```