### PR TITLE
Add tls.servername script-arg for TLS SNI without DNS

### DIFF
--- a/nselib/tls.lua
+++ b/nselib/tls.lua
@@ -1460,4 +1460,32 @@ function record_buffer(sock, buffer, i)
   return true, buffer
 end
 
+-- Get a server_name for use with the TLS Server Name Indication extension.
+--
+-- This returns the value of the script argument "tls.servername" if given.  Otherwise, it
+-- returns the target name of the host parameter.
+--
+-- @param host Host table as received by the action function
+-- @return String of the selected host name
+function servername(host)
+    local script_arg = stdnse.get_script_args("tls.servername")
+    if script_arg then
+        return script_arg
+    elseif type(host) == "table" then
+        return host.targetname
+    end
+end
+
+-- Get data for the TLS Server Name Indication extension.
+--
+-- If the argument is nil, this returns nil.
+--
+-- @param server_name String to use as server name for the extension, or nil
+-- @return Data for the extension or nil
+function servername_extension(server_name)
+  if server_name then
+    return EXTENSION_HELPERS["server_name"](server_name)
+  end
+end
+
 return _ENV;

--- a/scripts/ssl-cert.nse
+++ b/scripts/ssl-cert.nse
@@ -3,6 +3,7 @@ local shortport = require "shortport"
 local sslcert = require "sslcert"
 local stdnse = require "stdnse"
 local string = require "string"
+local tls = require "tls"
 local unicode = require "unicode"
 
 description = [[
@@ -255,6 +256,7 @@ local function output_str(cert)
 end
 
 action = function(host, port)
+  host.targetname = tls.servername(host)
   local status, cert = sslcert.getCertificate(host, port)
   if ( not(status) ) then
     stdnse.debug1("getCertificate error: %s", cert or "unknown")

--- a/scripts/ssl-dh-params.nse
+++ b/scripts/ssl-dh-params.nse
@@ -607,11 +607,9 @@ local function get_dhe_params(host, port, protocol, ciphers)
   local t = {}
   local pos = 1
   t.protocol = protocol
-  t.extensions = {}
-
-  if host.targetname then
-    t.extensions.server_name = tls.EXTENSION_HELPERS.server_name(host.targetname)
-  end
+  t.extensions = {
+    server_name = tls.servername_extension(tls.servername(host)),
+  }
 
   -- Keep ClientHello record size below 255 bytes and the number of ciphersuites
   -- to 64 or less in order to avoid implementation issues with some TLS servers

--- a/scripts/ssl-enum-ciphers.nse
+++ b/scripts/ssl-enum-ciphers.nse
@@ -499,26 +499,16 @@ local function remove_high_byte_ciphers(t)
   return output
 end
 
--- Claim to support every elliptic curve and EC point format
-local base_extensions = {
-  -- Claim to support every elliptic curve
-  ["elliptic_curves"] = tls.EXTENSION_HELPERS["elliptic_curves"](sorted_keys(tls.ELLIPTIC_CURVES)),
-  -- Claim to support every EC point format
-  ["ec_point_formats"] = tls.EXTENSION_HELPERS["ec_point_formats"](sorted_keys(tls.EC_POINT_FORMATS)),
-}
-
--- Recursively copy a table.
--- Only recurs when a value is a table, other values are copied by assignment.
-local function tcopy (t)
-  local tc = {};
-  for k,v in pairs(t) do
-    if type(v) == "table" then
-      tc[k] = tcopy(v);
-    else
-      tc[k] = v;
-    end
-  end
-  return tc;
+-- Get TLS extensions
+local function base_extensions(host)
+  return {
+    -- Claim to support every elliptic curve
+    ["elliptic_curves"] = tls.EXTENSION_HELPERS["elliptic_curves"](sorted_keys(tls.ELLIPTIC_CURVES)),
+    -- Claim to support every EC point format
+    ["ec_point_formats"] = tls.EXTENSION_HELPERS["ec_point_formats"](sorted_keys(tls.EC_POINT_FORMATS)),
+    -- Enable SNI if a server name is available
+    ["server_name"] = tls.servername_extension(tls.servername(host)),
+  }
 end
 
 -- Get a message body from a record which has the specified property set to value
@@ -587,11 +577,8 @@ local function find_ciphers_group(host, port, protocol, group, scores)
   local results = {}
   local t = {
     ["protocol"] = protocol,
-    ["extensions"] = tcopy(base_extensions),
+    ["extensions"] = base_extensions(host),
   }
-  if host.targetname then
-    t["extensions"]["server_name"] = tls.EXTENSION_HELPERS["server_name"](host.targetname)
-  end
 
   -- This is a hacky sort of tristate variable. There are three conditions:
   -- 1. false = either ciphers or protocol is bad. Keep trying with new ciphers
@@ -775,11 +762,8 @@ local function get_chunk_size(host, protocol)
   local len_t = {
     protocol = protocol,
     ciphers = {},
-    extensions = tcopy(base_extensions),
+    extensions = base_extensions(host),
   }
-  if host.targetname then
-    len_t.extensions.server_name = tls.EXTENSION_HELPERS.server_name(host.targetname)
-  end
   local cipher_len_remaining = 255 - #tls.client_hello(len_t)
   -- if we're over 255 anyway, just go for it.
   -- Each cipher adds 2 bytes
@@ -815,11 +799,8 @@ local function find_compressors(host, port, protocol, good_ciphers)
   local t = {
     ["protocol"] = protocol,
     ["ciphers"] = good_ciphers,
-    ["extensions"] = tcopy(base_extensions),
+    ["extensions"] = base_extensions(host),
   }
-  if host.targetname then
-    t["extensions"]["server_name"] = tls.EXTENSION_HELPERS["server_name"](host.targetname)
-  end
 
   local results = {}
 
@@ -896,11 +877,8 @@ local function compare_ciphers(host, port, protocol, cipher_a, cipher_b)
   local t = {
     ["protocol"] = protocol,
     ["ciphers"] = {cipher_a, cipher_b},
-    ["extensions"] = tcopy(base_extensions),
+    ["extensions"] = base_extensions(host),
   }
-  if host.targetname then
-    t["extensions"]["server_name"] = tls.EXTENSION_HELPERS["server_name"](host.targetname)
-  end
   local records = try_params(host, port, t)
   local server_hello = records.handshake and get_body(records.handshake, "type", "server_hello")
   if server_hello then

--- a/scripts/ssl-google-cert-catalog.nse
+++ b/scripts/ssl-google-cert-catalog.nse
@@ -6,6 +6,7 @@ local sslcert = require "sslcert"
 local stdnse = require "stdnse"
 local string = require "string"
 local table = require "table"
+local tls = require "tls"
 
 description = [[
 Queries Google's Certificate Catalog for the SSL certificates retrieved from
@@ -41,6 +42,7 @@ end
 portrule = shortport.ssl
 
 action = function(host, port)
+    host.targetname = tls.servername(host)
     local lines, sha1, query
     local status, cert = sslcert.getCertificate(host, port)
 

--- a/scripts/ssl-known-key.nse
+++ b/scripts/ssl-known-key.nse
@@ -108,6 +108,7 @@ portrule = shortport.ssl
 
 action = function(host, port)
   -- Get script arguments.
+  host.targetname = tls.servername(host)
   local path = stdnse.get_script_args("ssl-known-key.fingerprintfile") or FINGERPRINT_FILE
   local status, result = get_fingerprints(path)
   if not status then

--- a/scripts/ssl-poodle.nse
+++ b/scripts/ssl-poodle.nse
@@ -174,13 +174,16 @@ local function remove_high_byte_ciphers(t)
   return output
 end
 
--- Claim to support every elliptic curve and EC point format
-local base_extensions = {
-  -- Claim to support every elliptic curve
-  ["elliptic_curves"] = tls.EXTENSION_HELPERS["elliptic_curves"](sorted_keys(tls.ELLIPTIC_CURVES)),
-  -- Claim to support every EC point format
-  ["ec_point_formats"] = tls.EXTENSION_HELPERS["ec_point_formats"](sorted_keys(tls.EC_POINT_FORMATS)),
-}
+local function base_extensions(host)
+  return {
+    -- Claim to support every elliptic curve
+    ["elliptic_curves"] = tls.EXTENSION_HELPERS["elliptic_curves"](sorted_keys(tls.ELLIPTIC_CURVES)),
+    -- Claim to support every EC point format
+    ["ec_point_formats"] = tls.EXTENSION_HELPERS["ec_point_formats"](sorted_keys(tls.EC_POINT_FORMATS)),
+    -- Enable SNI if a server name is available
+    ["server_name"] = tls.servername_extension(tls.servername(host)),
+  }
+end
 
 -- Recursively copy a table.
 -- Only recurs when a value is a table, other values are copied by assignment.
@@ -202,11 +205,8 @@ local function find_ciphers_group(host, port, protocol, group)
   results = {}
   local t = {
     ["protocol"] = protocol,
-    ["extensions"] = tcopy(base_extensions),
+    ["extensions"] = base_extensions(host),
   }
-  if host.targetname then
-    t["extensions"]["server_name"] = tls.EXTENSION_HELPERS["server_name"](host.targetname)
-  end
 
   -- This is a hacky sort of tristate variable. There are three conditions:
   -- 1. false = either ciphers or protocol is bad. Keep trying with new ciphers
@@ -303,11 +303,8 @@ local function check_fallback_scsv(host, port, protocol, ciphers)
   local results = {}
   local t = {
     ["protocol"] = protocol,
-    ["extensions"] = tcopy(base_extensions),
+    ["extensions"] = base_extensions(host),
   }
-  if host.targetname then
-    t["extensions"]["server_name"] = tls.EXTENSION_HELPERS["server_name"](host.targetname)
-  end
 
   t["ciphers"] = tcopy(ciphers)
   t.ciphers[#t.ciphers+1] = "TLS_FALLBACK_SCSV"


### PR DESCRIPTION
As explained in http://seclists.org/nmap-dev/2016/q1/46, when the DNS cannot be used, or for testing purposes, it can be useful to force the TLS server name indicated by Nmap.  This pull request should thus address #276.

Examples of how this is achieved:

``` bash
nmap --script ssl-cert --script-args=tls.servername=example.net 192.0.2.1
nmap --script ssl-cert --script-args=tls.servername=example.net example.org
nmap --script ssl-enum-ciphers --script-args=tls.servername=example.net example.org
```

The script-arg has precedence over `host.targetname` and there is no support for supplying multiple servernames to be attempted.  It basically behaves the same as

``` bash
openssl s_client -servername <tls.servername> -connect example.net:<port> <host.targetname>
```

The script argument is supported by all scripts already benefiting from Nmap's existing TLS SNI support.  Those using the `tls.lua` library were easy to adapt because of the modularity of that library.  By the way, I think this reduced the complexity of `ssl-enum-ciphers.nse`. Those relying on `sslcert.getCertificate` were adapted with just:

``` lua
host.targetname = tls.servername(host)
```

The reason is that `sslcert.getCertificate` uses Nmap's nsock implementation of TLS with OpenSSL, which would have been trickier to modify.

My main use case is building a script that scans the right IP address of a host even if the DNS of that host rotates, which is a common way of performing load-balancing.  It is about to be used (merged into Nmap or not) by https://discovery.cryptosense.com.

I hope this is useful!
