### PR TITLE
Modify #if/ifdef's to be compatible with libressl

### DIFF
--- a/nping/Crypto.cc
+++ b/nping/Crypto.cc
@@ -178,7 +178,7 @@ int Crypto::aes128_cbc_encrypt(u8 *inbuff, size_t inlen, u8 *dst_buff, u8 *key, 
   #ifdef HAVE_OPENSSL
     if( o.doCrypto() ){
         int flen=0, flen2=0;
-        #if OPENSSL_VERSION_NUMBER < 0x10100000L
+	#ifndef HAVE_OPAQUE_STRUCTS
           EVP_CIPHER_CTX ctx;
           EVP_CIPHER_CTX_init(&ctx);
           EVP_CIPHER_CTX_set_padding(&ctx, 0);
@@ -231,7 +231,7 @@ int Crypto::aes128_cbc_decrypt(u8 *inbuff, size_t inlen, u8 *dst_buff, u8 *key, 
   #ifdef HAVE_OPENSSL
     if( o.doCrypto() ){
         int flen1=0, flen2=0;
-        #if OPENSSL_VERSION_NUMBER < 0x10100000L
+	#ifndef HAVE_OPAQUE_STRUCTS
           EVP_CIPHER_CTX ctx;
           EVP_CIPHER_CTX_init(&ctx);
           EVP_CIPHER_CTX_set_padding(&ctx, 0);
@@ -286,7 +286,7 @@ int Crypto::aes128_cbc_decrypt(u8 *inbuff, size_t inlen, u8 *dst_buff, u8 *key, 
             //ERR_free_strings();
             //ERR_pop_to_mark();
         }
-        #if OPENSSL_VERSION_NUMBER < 0x10100000L
+	#ifndef HAVE_OPAQUE_STRUCTS
           EVP_CIPHER_CTX_cleanup(&ctx);
         #else
           EVP_CIPHER_CTX_reset(ctx);
@@ -327,7 +327,7 @@ u8 *Crypto::deriveKey(const u8 *from, size_t fromlen, size_t *final_len){
         static u8 hash[MAX(SHA256_HASH_LEN, EVP_MAX_MD_SIZE)];
         static u8 next[MAX(SHA256_HASH_LEN, EVP_MAX_MD_SIZE)];
         unsigned int lastlen;
-      #if OPENSSL_VERSION_NUMBER < 0x10100000L
+      #ifndef HAVE_OPAQUE_STRUCTS
         EVP_MD_CTX ctx;
         EVP_MD_CTX_init(&ctx);
 

--- a/nse_openssl.cc
+++ b/nse_openssl.cc
@@ -281,7 +281,7 @@ static int l_digest(lua_State *L)     /** digest(string algorithm, string messag
   const unsigned char *msg = (unsigned char *) luaL_checklstring( L, 2, &msg_len );
   unsigned char digest[EVP_MAX_MD_SIZE];
   const EVP_MD * evp_md;
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef HAVE_OPAQUE_STRUCTS
   EVP_MD_CTX mdctx;
 #else
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
@@ -291,7 +291,7 @@ static int l_digest(lua_State *L)     /** digest(string algorithm, string messag
 
   if (!evp_md) return luaL_error( L, "Unknown digest algorithm: %s", algorithm );
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef HAVE_OPAQUE_STRUCTS
   EVP_MD_CTX_init(&mdctx);
   if (!(
       EVP_DigestInit_ex( &mdctx, evp_md, NULL ) &&
@@ -394,7 +394,7 @@ static int l_encrypt(lua_State *L) /** encrypt( string algorithm, string key, st
   if (iv[0] == '\0')
     iv = NULL;
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef HAVE_OPAQUE_STRUCTS
   EVP_CIPHER_CTX cipher_ctx;
   EVP_CIPHER_CTX_init( &cipher_ctx );
 
@@ -496,7 +496,7 @@ static int l_decrypt(lua_State *L) /** decrypt( string algorithm, string key, st
   if (iv[0] == '\0')
     iv = NULL;
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef HAVE_OPAQUE_STRUCTS
   EVP_CIPHER_CTX cipher_ctx;
   EVP_CIPHER_CTX_init( &cipher_ctx );
 
@@ -684,7 +684,7 @@ static const struct luaL_Reg openssllib[] = {
 LUALIB_API int luaopen_openssl(lua_State *L) {
 
   OpenSSL_add_all_algorithms();
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef HAVE_OPAQUE_STRUCTS
   ERR_load_crypto_strings();
 #else
   /* This is now deprecated in OpenSSL 1.1.0 _ No explicit initialisation 

--- a/nse_ssl_cert.cc
+++ b/nse_ssl_cert.cc
@@ -529,7 +529,7 @@ static int parse_ssl_cert(lua_State *L, X509 *cert)
     lua_setfield(L, -2, "subject");
   }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef HAVE_OPAQUE_STRUCTS
   const char *sig_algo = OBJ_nid2ln(OBJ_obj2nid(cert->sig_alg->algorithm));
 #else
   const char *sig_algo = OBJ_nid2ln(X509_get_signature_nid(cert));
@@ -556,7 +556,7 @@ static int parse_ssl_cert(lua_State *L, X509 *cert)
     return 2;
   }
   lua_newtable(L);
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef HAVE_OPAQUE_STRUCTS
   pkey_type = EVP_PKEY_type(pubkey->type);
 #else
   pkey_type = EVP_PKEY_base_id(pubkey);
@@ -573,7 +573,7 @@ static int parse_ssl_cert(lua_State *L, X509 *cert)
     bignum_data_t * data = (bignum_data_t *) lua_newuserdata( L, sizeof(bignum_data_t));
     luaL_getmetatable( L, "BIGNUM" );
     lua_setmetatable( L, -2 );
-  #if OPENSSL_VERSION_NUMBER < 0x10100000L
+  #if OPENSSL_VERSION_NUMBER < 0x10100000L || !defined(HAVE_OPAQUE_RSA_DSA_DH)
     data->bn = rsa->e;
   #elif OPENSSL_VERSION_NUMBER < 0x10100006L
     BIGNUM *n, *e, *d;


### PR DESCRIPTION
Hi all,

recently nmap has stopped being libressl friendly, I had to modify a few #if/#ifdefs for that.
I don't have a system with openssl, so please check that this still works on your side.
Let me know if you want me to change anything, or if you don't plan to support libressl. 
