### PR TITLE
TFTP Version Script

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -11691,6 +11691,22 @@ match msrpc m|^\x04\x06\0\0\x10\0\0\0\0\0\0\0|
 
 match netprobe m|^\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0$| p/Mega System Technologies NetProbe Lite environmental sensor/ d/specialized/
 
+match tftp m|^\0\x05\0\x02\0The IP address is not in the range of allowable addresses\.\0| p/SolarWinds tftpd/ i/IP disallowed/ o/Windows/ cpe:/a:solarwinds:tftp_server/ cpe:/o:microsoft:windows/a
+match tftp m|^\0\x05\0\0Invalid TFTP Opcode| p/Cisco tftpd/ cpe:/a:cisco:tftp_server/
+match tftp m|^\0\x05\0\x04Illegal TFTP operation\0| p/Plan 9 tftpd/ o/Plan 9/ cpe:/o:belllabs:plan_9/a
+match tftp m|^\0\x05\0\x04Error: Illegal TFTP Operation\0\0\0\0\0| p/Zoom X5 ADSL modem tftpd/ d/broadband router/ cpe:/h:zoom:x5/a
+match tftp m|^\0\x05\0\x04Illegal operation\0$| p/Cisco router tftpd/ d/router/ o/IOS/ cpe:/a:cisco:tftp_server/ cpe:/o:cisco:ios/a
+match tftp m|^\0\x05\0\x04Illegal operation error\.\0$| p/Microsoft Windows Deployment Services tftpd/ o/Windows/ cpe:/o:microsoft:windows/
+# version 10.9.0.25
+match tftp m|^\0\x05\0\x04Unknown operatation code: 0 received from [\d.]+:\d+\0| p/SolarWinds Free tftpd/ cpe:/a:solarwinds:tftp_server/
+# Brother MFC-9340CDW
+match tftp m|^\0\x05\0\x04illegal \(unrecognized\) tftp operation\0$| p/Brother printer tftpd/ d/printer/
+# HP IMC 7.1
+match tftp m|^\0\x05\0\0Not defined, see error message\(if any\)\.\0| p/HP Intelligent Management Center tftpd/ cpe:/a:hp:intelligent_management_center/
+
+# TFTP error
+softmatch tftp m|^\0\x05\0[\0-\x07][^\0]+\0$|
+
 match landesk-rc m|^\0\0\0\0USER\x01\0\x10\0\x08\0:\xd0\x08\0:\xd0\x01\x01\.\0O\0\x03\0T\0\xff\xff\0\0\0\xfd\0\0\0\0\0\0\x02\0\0\0LANDeskWorkgroup Manager ver ([\d.]+)\0| p/LANDesk Workgroup Manager/ v/$1/ o/Windows/ cpe:/o:microsoft:windows/a
 
 
@@ -13850,6 +13866,8 @@ ports 177
 match bacnet m|^\x81\n\0\t\x01\0`\x01\t$| p/BACnet building automation/
 match xdmcp m|^\0\x01\0\x05..\0\0\0.(.+)\0.(.+)|s p/XDMCP/ i/willing; status: $2/ o/Unix/ h/$1/
 match xdmcp m|^\0\x01\0\x06..\0.(.+)\0.(.+)|s p/XDMCP/ i/unwilling; status: $2/ o/Unix/ h/$1/
+match tftp m|^\0\x05\0\x04Illegal TFTP operation\0| p/Windows 2003 Server Deployment Service/ o/Windows/ cpe:/o:microsoft:windows_server_2003/a
+match tftp m|^\0\x05\0\x01File not found\.\0$| p/Enistic zone controller tftpd/
 
 ##############################NEXT PROBE##############################
 # AFS version probing

--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -11691,22 +11691,6 @@ match msrpc m|^\x04\x06\0\0\x10\0\0\0\0\0\0\0|
 
 match netprobe m|^\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0$| p/Mega System Technologies NetProbe Lite environmental sensor/ d/specialized/
 
-match tftp m|^\0\x05\0\x02\0The IP address is not in the range of allowable addresses\.\0| p/SolarWinds tftpd/ i/IP disallowed/ o/Windows/ cpe:/a:solarwinds:tftp_server/ cpe:/o:microsoft:windows/a
-match tftp m|^\0\x05\0\0Invalid TFTP Opcode| p/Cisco tftpd/ cpe:/a:cisco:tftp_server/
-match tftp m|^\0\x05\0\x04Illegal TFTP operation\0| p/Plan 9 tftpd/ o/Plan 9/ cpe:/o:belllabs:plan_9/a
-match tftp m|^\0\x05\0\x04Error: Illegal TFTP Operation\0\0\0\0\0| p/Zoom X5 ADSL modem tftpd/ d/broadband router/ cpe:/h:zoom:x5/a
-match tftp m|^\0\x05\0\x04Illegal operation\0$| p/Cisco router tftpd/ d/router/ o/IOS/ cpe:/a:cisco:tftp_server/ cpe:/o:cisco:ios/a
-match tftp m|^\0\x05\0\x04Illegal operation error\.\0$| p/Microsoft Windows Deployment Services tftpd/ o/Windows/ cpe:/o:microsoft:windows/
-# version 10.9.0.25
-match tftp m|^\0\x05\0\x04Unknown operatation code: 0 received from [\d.]+:\d+\0| p/SolarWinds Free tftpd/ cpe:/a:solarwinds:tftp_server/
-# Brother MFC-9340CDW
-match tftp m|^\0\x05\0\x04illegal \(unrecognized\) tftp operation\0$| p/Brother printer tftpd/ d/printer/
-# HP IMC 7.1
-match tftp m|^\0\x05\0\0Not defined, see error message\(if any\)\.\0| p/HP Intelligent Management Center tftpd/ cpe:/a:hp:intelligent_management_center/
-
-# TFTP error
-softmatch tftp m|^\0\x05\0[\0-\x07][^\0]+\0$|
-
 match landesk-rc m|^\0\0\0\0USER\x01\0\x10\0\x08\0:\xd0\x08\0:\xd0\x01\x01\.\0O\0\x03\0T\0\xff\xff\0\0\0\xfd\0\0\0\0\0\0\x02\0\0\0LANDeskWorkgroup Manager ver ([\d.]+)\0| p/LANDesk Workgroup Manager/ v/$1/ o/Windows/ cpe:/o:microsoft:windows/a
 
 
@@ -13866,8 +13850,6 @@ ports 177
 match bacnet m|^\x81\n\0\t\x01\0`\x01\t$| p/BACnet building automation/
 match xdmcp m|^\0\x01\0\x05..\0\0\0.(.+)\0.(.+)|s p/XDMCP/ i/willing; status: $2/ o/Unix/ h/$1/
 match xdmcp m|^\0\x01\0\x06..\0.(.+)\0.(.+)|s p/XDMCP/ i/unwilling; status: $2/ o/Unix/ h/$1/
-match tftp m|^\0\x05\0\x04Illegal TFTP operation\0| p/Windows 2003 Server Deployment Service/ o/Windows/ cpe:/o:microsoft:windows_server_2003/a
-match tftp m|^\0\x05\0\x01File not found\.\0$| p/Enistic zone controller tftpd/
 
 ##############################NEXT PROBE##############################
 # AFS version probing

--- a/nselib/data/tftp-fingerprints.lua
+++ b/nselib/data/tftp-fingerprints.lua
@@ -120,3 +120,12 @@ table.insert(fingerprints, {
   1, "File not found.", {
   p   = "Enistic zone controller tftpd",
 }});
+
+--------------------------------------------------------------------------------
+-- Netkit
+--------------------------------------------------------------------------------
+table.insert(fingerprints, {
+  1, "File not found", {
+  p   = "Netkit tftpd or atftpd",
+  cpe = {"a:netkit:netkit", "a:lefebvre:atftpd"},
+}})

--- a/nselib/data/tftp-fingerprints.lua
+++ b/nselib/data/tftp-fingerprints.lua
@@ -10,6 +10,23 @@ license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 fingerprints = {};
 
 --------------------------------------------------------------------------------
+-- Example Fingerprint
+--------------------------------------------------------------------------------
+-- Based on the format of the 'match' directive used in service probes.
+-- https://nmap.org/book/vscan-fileformat.html#vscan-tbl-versioninfo
+--------------------------------------------------------------------------------
+-- table.insert(fingerprints, {
+--   TFTP_ERRCODE, "TFTP_ERRMSG", {
+--   p   = "Product",
+--   v   = "Version",
+--   i   = "Extra Info",
+--   h   = "Hostname",
+--   o   = "Operating System",
+--   d   = "Device Type",
+--   cpe = {"CPE", ...},
+-- }});
+
+--------------------------------------------------------------------------------
 -- SolarWinds
 --------------------------------------------------------------------------------
 table.insert(fingerprints, {

--- a/nselib/data/tftp-fingerprints.lua
+++ b/nselib/data/tftp-fingerprints.lua
@@ -1,0 +1,122 @@
+local table = require 'table'
+
+--[[
+This is compiled list of known TFTP responses.
+]]
+
+author = {"Mak Kolybabi <mak@kolybabi.com>"}
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+
+fingerprints = {};
+
+--------------------------------------------------------------------------------
+-- SolarWinds
+--------------------------------------------------------------------------------
+table.insert(fingerprints, {
+  2, "The IP address is not in the range of allowable addresses.", {
+  p   = "SolarWinds tftpd",
+  e   = "IP disallowed",
+  o   = "Windows",
+  cpe = {"a:solarwinds:tftp_server", "o:microsoft:windows/a"},
+}});
+
+--------------------------------------------------------------------------------
+-- Cisco
+--------------------------------------------------------------------------------
+table.insert(fingerprints, {
+  0, "Invalid TFTP Opcode", {
+  p   = "Cisco tftpd",
+  cpe = {"a:cisco:tftp_server"},
+}});
+
+--------------------------------------------------------------------------------
+-- Plan 9
+--------------------------------------------------------------------------------
+table.insert(fingerprints, {
+  4, "Illegal TFTP operation", {
+  p   = "Plan 9 tftpd",
+  o   = "Plan 9",
+  cpe = {"o:belllabs:plan_9/a"},
+}});
+
+--------------------------------------------------------------------------------
+-- Zoom X5 ADSL Modem
+--------------------------------------------------------------------------------
+table.insert(fingerprints, {
+  4, "Error: Illegal TFTP Operation", {
+  p   = "Zoom X5 ADSL modem tftpd",
+  d   = "broadband router",
+  cpe = {"h:zoom:x5/a"},
+}});
+
+--------------------------------------------------------------------------------
+-- Cisco Router
+--------------------------------------------------------------------------------
+table.insert(fingerprints, {
+  4, "Illegal operation", {
+  p   = "Cisco router tftpd",
+  o   = "IOS",
+  d   = "router",
+  cpe = {"a:cisco:tftp_server", "o:cisco:ios/a"},
+}});
+
+--------------------------------------------------------------------------------
+-- Microsoft Windows Deployment Services
+--------------------------------------------------------------------------------
+table.insert(fingerprints, {
+  4, "Illegal operation error.", {
+  p   = "Microsoft Windows Deployment Services tftpd",
+  o   = "Windows",
+  cpe = {"o:microsoft:windows"},
+}});
+
+--------------------------------------------------------------------------------
+-- SolarWinds Free
+--------------------------------------------------------------------------------
+table.insert(fingerprints, {
+  4, "Unknown operatation code: 0 received from", {
+  p   = "SolarWinds Free tftpd",
+  cpe = {"a:solarwinds:tftp_server"},
+}});
+
+table.insert(fingerprints, {
+  4, "Could not find file '", {
+  p   = "SolarWinds Free tftpd",
+  cpe = {"a:solarwinds:tftp_server"},
+}});
+
+--------------------------------------------------------------------------------
+-- Brother MFC-9340CDW
+--------------------------------------------------------------------------------
+table.insert(fingerprints, {
+  4, "illegal (unrecognized) tftp operation", {
+  p   = "Brother printer tftpd",
+  d   = "printer",
+}});
+
+--------------------------------------------------------------------------------
+-- HP Intelligent Management Center
+--------------------------------------------------------------------------------
+table.insert(fingerprints, {
+  0, "Not defined, see error message(if any).", {
+  p   = "HP Intelligent Management Center tftpd",
+  cpe = {"a:hp:intelligent_management_center"},
+}});
+
+--------------------------------------------------------------------------------
+-- Windows 2003 Server Deployment Service
+--------------------------------------------------------------------------------
+table.insert(fingerprints, {
+  4, "Illegal TFTP operation", {
+  p   = "Windows 2003 Server Deployment Service",
+  o   = "Windows",
+  cpe = {"o:microsoft:windows_server_2003/a"},
+}});
+
+--------------------------------------------------------------------------------
+-- Enistic Zone Controller
+--------------------------------------------------------------------------------
+table.insert(fingerprints, {
+  1, "File not found.", {
+  p   = "Enistic zone controller tftpd",
+}});

--- a/scripts/script.db
+++ b/scripts/script.db
@@ -514,6 +514,7 @@ Entry { filename = "telnet-brute.nse", categories = { "brute", "intrusive", } }
 Entry { filename = "telnet-encryption.nse", categories = { "discovery", "safe", } }
 Entry { filename = "telnet-ntlm-info.nse", categories = { "default", "discovery", "safe", } }
 Entry { filename = "tftp-enum.nse", categories = { "discovery", "intrusive", } }
+Entry { filename = "tftp-version.nse", categories = {"default", "discovery", "safe", "version", } }
 Entry { filename = "tls-nextprotoneg.nse", categories = { "default", "discovery", "safe", } }
 Entry { filename = "tor-consensus-checker.nse", categories = { "external", "safe", } }
 Entry { filename = "traceroute-geolocation.nse", categories = { "discovery", "external", "safe", } }

--- a/scripts/tftp-version.nse
+++ b/scripts/tftp-version.nse
@@ -1,0 +1,326 @@
+local nmap = require "nmap"
+local re = require "re"
+local stdnse = require "stdnse"
+local string = require "string"
+local shortport = require "shortport"
+local table = require "table"
+
+description=[[
+Obtains information (such as vendor and device type where available) from a
+TFTP service. Software vendor information is deduced based on error messages.
+]]
+
+author = "Mak Kolybabi <mak@kolybabi.com>"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"default", "discovery", "safe", "version"}
+
+portrule = shortport.version_port_or_service(69, "tftp", "udp")
+
+local OPCODE_RRQ   = 1
+local OPCODE_DATA  = 3
+local OPCODE_ERROR = 5
+
+local responses = {
+  -- match tftp m|^\0\x05\0\x02\0The IP address is not in the range of allowable addresses\.\0| p/SolarWinds tftpd/ i/IP disallowed/ o/Windows/ cpe:/a:solarwinds:tftp_server/ cpe:/o:microsoft:windows/a
+  {
+    2,
+    "The IP address is not in the range of allowable addresses\\.",
+    {
+      ["p"] = "SolarWinds tftpd",
+      ["i"] = "IP disallowed",
+      ["o"] = "Windows",
+      ["cpe"] = {
+	"a:solarwinds:tftp_server",
+	"o:microsoft:windows/a"
+      }
+    }
+  },
+  -- match tftp m|^\0\x05\0\0Invalid TFTP Opcode| p/Cisco tftpd/ cpe:/a:cisco:tftp_server/
+  {
+    0,
+    "Invalid TFTP Opcode",
+    {
+      ["p"] = "Cisco tftpd",
+      ["cpe"] = {
+	"a:cisco:tftp_server"
+      }
+    }
+  },
+  -- match tftp m|^\0\x05\0\x04Illegal TFTP operation\0| p/Plan 9 tftpd/ o/Plan 9/ cpe:/o:belllabs:plan_9/a
+  {
+    4,
+    "Illegal TFTP operation",
+    {
+      ["p"] = "Plan 9 tftpd",
+      ["o"] = "Plan 9",
+      ["cpe"] = {
+	"o:belllabs:plan_9/a"
+      }
+    }
+  },
+  -- match tftp m|^\0\x05\0\x04Error: Illegal TFTP Operation\0\0\0\0\0| p/Zoom X5 ADSL modem tftpd/ d/broadband router/ cpe:/h:zoom:x5/a
+  {
+    4,
+    "Error: Illegal TFTP Operation",
+    {
+      ["p"] = "Zoom X5 ADSL modem tftpd",
+      ["d"] = "broadband router",
+      ["cpe"] = {
+	"h:zoom:x5/a"
+      }
+    }
+  },
+  -- match tftp m|^\0\x05\0\x04Illegal operation\0$| p/Cisco router tftpd/ d/router/ o/IOS/ cpe:/a:cisco:tftp_server/ cpe:/o:cisco:ios/a
+  {
+    4,
+    "Illegal operation",
+    {
+      ["p"] = "Cisco router tftpd",
+      ["d"] = "router",
+      ["o"] = "IOS",
+      ["cpe"] = {
+	"a:cisco:tftp_server",
+	"o:cisco:ios/a"
+      }
+    }
+  },
+  -- match tftp m|^\0\x05\0\x04Illegal operation error\.\0$| p/Microsoft Windows Deployment Services tftpd/ o/Windows/ cpe:/o:microsoft:windows/
+  {
+    4,
+    "Illegal operation error\\.",
+    {
+      ["p"] = "Microsoft Windows Deployment Services tftpd",
+      ["o"] = "Windows",
+      ["cpe"] = {
+	"o:microsoft:windows"
+      }
+    }
+  },
+  -- # version 10.9.0.25
+  -- match tftp m|^\0\x05\0\x04Unknown operatation code: 0 received from [\d.]+:\d+\0| p/SolarWinds Free tftpd/ cpe:/a:solarwinds:tftp_server/
+  {
+    4,
+    "Unknown operatation code: 0 received from [\\d.]+:\\d+",
+    {
+      ["p"] = "SolarWinds Free tftpd",
+      ["cpe"] = {
+	"a:solarwinds:tftp_server"
+      }
+    }
+  },
+  -- # Brother MFC-9340CDW
+  -- match tftp m|^\0\x05\0\x04illegal \(unrecognized\) tftp operation\0$| p/Brother printer tftpd/ d/printer/
+  {
+    4,
+    "illegal \\(unrecognized\\) tftp operation",
+    {
+      ["p"] = "Brother printer tftpd",
+      ["d"] = "printer"
+    }
+  },
+  -- # HP IMC 7.1
+  -- match tftp m|^\0\x05\0\0Not defined, see error message\(if any\)\.\0| p/HP Intelligent Management Center tftpd/ cpe:/a:hp:intelligent_management_center/
+  {
+    0,
+    "Not defined, see error message\\(if any\\)\\.",
+    {
+      ["p"] = "HP Intelligent Management Center tftpd",
+      ["cpe"] = {
+	"a:hp:intelligent_management_center"
+      }
+    }
+  },
+  -- match tftp m|^\0\x05\0\x04Illegal TFTP operation\0| p/Windows 2003 Server Deployment Service/ o/Windows/ cpe:/o:microsoft:windows_server_2003/a
+  {
+    4,
+    "Illegal TFTP operation",
+    {
+      ["p"] = "Windows 2003 Server Deployment Service",
+      ["o"] = "Windows",
+      ["cpe"] = {
+	"o:microsoft:windows_server_2003/a"
+      }
+    }
+  },
+  -- match tftp m|^\0\x05\0\x01File not found\.\0$| p/Enistic zone controller tftpd/
+  {
+    1,
+    "File not found\\\\.",
+    {
+      ["p"] = "Enistic zone controller tftpd"
+    }
+  },
+}
+
+local record_match = function(port, sw)
+  if sw.p then
+    port.version.product = sw.p
+  end
+
+  if sw.v then
+    port.version.version = sw.v
+  end
+
+  if sw.i then
+    port.version.extrainfo = sw.i
+  end
+
+  if sw.h then
+    port.version.hostname = sw.h
+  end
+
+  if sw.o then
+    port.version.ostype = sw.o
+  end
+
+  if sw.d then
+    port.version.devicetype = sw.d
+  end
+
+  if not sw.cpe then
+    return
+  end
+
+  for _, cpe in ipairs(sw.cpe) do
+    table.insert(port.version.cpe, "cpe:/" .. cpe)
+  end
+end
+
+local identify_software = function(pkt, port)
+  -- There's not enough information in anything but an ERROR packet to deduce
+  -- the software that responded, and only if it has an error message
+  if pkt.opcode ~= OPCODE_ERROR or pkt.errmsg == nil then
+    return
+  end
+
+  -- Try to match the packet against our table of responses.
+  for _, res in ipairs(responses) do
+    stdnse.debug1(pkt.errmsg .. " <=> " .. res[2])
+    if pkt.errcode == res[1] then
+      local patt = re.compile(res[2])
+      if re.find(pkt.errmsg, patt) then
+	record_match(port, res[3])
+	break
+      end
+    end
+  end
+end
+
+local parse = function(buf)
+  -- Every TFTP packet is at least 4 bytes.
+  if #buf < 4 then
+    return nil
+  end
+
+  local opcode, num = string.unpack(">HH", buf)
+  local ret = {["opcode"] = opcode}
+
+  if opcode == OPCODE_DATA then
+    -- The block number, which must be one.
+    if num ~= 1 then
+      return nil
+    end
+
+    -- The data remaining in the response must be from 0 to 512 bytes in length.
+    if #buf > 2 + 2 + 512 then
+      return nil
+    end
+
+    return ret
+  end
+
+  if opcode == OPCODE_ERROR then
+    -- The last byte in the packet must be zero to terminate the error message.
+    if buf:byte(#buf) ~= 0 then
+      return nil
+    end
+    ret.errcode = num
+
+    -- Extract the error message, if there is one.
+    if #buf > 2 + 2 + 1 then
+      ret.errmsg = string.unpack("z", buf, 5)
+    end
+
+    return ret
+  end
+
+  -- Any other opcode, defined or otherwise, should not be coming back from the
+  -- service, so we treat it as an error.
+  return nil
+end
+
+action = function(host, port)
+  local output = stdnse.output_table()
+
+  -- Generate a random, unlikely filename in a format unlikely to be rejected,
+  -- specifically DOS 8.3 format.
+  local name = stdnse.generate_random_string(8, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_")
+  local extn = stdnse.generate_random_string(3, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
+  local path = name .. "." .. extn
+
+  -- Create and connect a socket.
+  local socket = nmap.new_socket("udp")
+  local status, err = socket:connect(host, port)
+  if not status then
+    socket:close()
+    output.ERROR = err
+    return output, output.ERROR
+  end
+
+  -- Remember the source port this socket used, for listening later.
+  local status, err, lport, _, _ = socket:get_info()
+  if not status then
+    socket:close()
+    output.ERROR = err
+    return output, output.ERROR
+  end
+
+  -- Generate a Read Request.
+  local req = string.pack(">Hzz", OPCODE_RRQ, path, "octet")
+
+  -- Send the Read Request.
+  socket:send(req)
+  socket:close()
+
+  -- Create a listening socket on the port from which we just sent.
+  local socket = nmap.new_socket("udp")
+  local status, err = socket:bind(nil, lport)
+  if not status then
+    socket:close()
+    output.ERROR = err
+    return output, output.ERROR
+  end
+
+  -- Listen for a response, but if nothing comes back we have to assume that
+  -- this is not a TFTP service and exit quietly.
+  --
+  -- We don't have to worry about other instance of this script running on other
+  -- ports of the same host confounding our results, because TFTP services
+  -- should respond back to the port matching the sending script.
+  --
+  -- Note that due to API limitations, we can't know if the response came from
+  -- the host we sent the request to, so we must assume it does.
+  local status, res = socket:receive()
+  socket:close()
+  if not status then
+    return nil
+  end
+
+  -- Parse the response.
+  local pkt = parse(res)
+  if not pkt then
+    return nil
+  end
+
+  -- Now we are convinced that the service speaks TFTP.
+  port.version.name = "tftp"
+
+  -- Populate the service information by referencing our list of software
+  -- responses.
+  identify_software(pkt, port)
+
+  nmap.set_port_version(host, port, "hardmatched")
+  nmap.set_port_state(host, port, "open")
+
+  return output
+end

--- a/scripts/tftp-version.nse
+++ b/scripts/tftp-version.nse
@@ -11,7 +11,7 @@ TFTP service. Software vendor information is deduced based on error messages.
 
 author = "Mak Kolybabi <mak@kolybabi.com>"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
-categories = {"default", "discovery", "safe", "version"}
+categories = {"default", "safe", "version"}
 
 portrule = shortport.version_port_or_service(69, "tftp", "udp")
 

--- a/scripts/tftp-version.nse
+++ b/scripts/tftp-version.nse
@@ -195,7 +195,6 @@ local identify_software = function(pkt, port)
 
   -- Try to match the packet against our table of responses.
   for _, res in ipairs(responses) do
-    stdnse.debug1(pkt.errmsg .. " <=> " .. res[2])
     if pkt.errcode == res[1] then
       if pkt.errmsg:find(res[2]) then
 	record_match(port, res[3])

--- a/scripts/tftp-version.nse
+++ b/scripts/tftp-version.nse
@@ -197,7 +197,7 @@ action = function(host, port)
   if not sw then
     nmap.set_port_version(host, port, "hardmatched")
     pkt.script = "tftp-version"
-    pkt = json.generate(pkt)
+    local pkt = json.generate(pkt)
     return ("If you know the name or version of the software running on this port, please submit the following information to dev@nmap.org: %s."):format(pkt)
   end
 

--- a/scripts/tftp-version.nse
+++ b/scripts/tftp-version.nse
@@ -1,5 +1,4 @@
 local nmap = require "nmap"
-local re = require "re"
 local stdnse = require "stdnse"
 local string = require "string"
 local shortport = require "shortport"

--- a/scripts/tftp-version.nse
+++ b/scripts/tftp-version.nse
@@ -212,7 +212,7 @@ local parse = function(buf)
     return nil
   end
 
-  local opcode, num = string.unpack(">HH", buf)
+  local opcode, num = (">HH"):unpack(buf)
   local ret = {["opcode"] = opcode}
 
   if opcode == OPCODE_DATA then
@@ -238,7 +238,7 @@ local parse = function(buf)
 
     -- Extract the error message, if there is one.
     if #buf > 2 + 2 + 1 then
-      ret.errmsg = string.unpack("z", buf, 5)
+      ret.errmsg = ("z"):unpack(buf, 5)
     end
 
     return ret
@@ -276,7 +276,7 @@ action = function(host, port)
   end
 
   -- Generate a Read Request.
-  local req = string.pack(">Hzz", OPCODE_RRQ, path, "octet")
+  local req = (">Hzz"):pack(OPCODE_RRQ, path, "octet")
 
   -- Send the Read Request.
   socket:send(req)

--- a/scripts/tftp-version.nse
+++ b/scripts/tftp-version.nse
@@ -187,12 +187,10 @@ local record_match = function(port, sw)
     port.version.devicetype = sw.d
   end
 
-  if not sw.cpe then
-    return
-  end
-
-  for _, cpe in ipairs(sw.cpe) do
-    table.insert(port.version.cpe, "cpe:/" .. cpe)
+  if sw.cpe then
+    for _, cpe in ipairs(sw.cpe) do
+      table.insert(port.version.cpe, "cpe:/" .. cpe)
+    end
   end
 end
 

--- a/scripts/tftp-version.nse
+++ b/scripts/tftp-version.nse
@@ -320,5 +320,5 @@ action = function(host, port)
   nmap.set_port_version(host, port, "hardmatched")
   nmap.set_port_state(host, port, "open")
 
-  return output
+  return nil
 end

--- a/scripts/tftp-version.nse
+++ b/scripts/tftp-version.nse
@@ -108,6 +108,16 @@ local responses = {
       }
     }
   },
+  {
+    1,
+    "Could not find file '",
+    {
+      ["p"] = "SolarWinds Free tftpd",
+      ["cpe"] = {
+	"a:solarwinds:tftp_server"
+      }
+    }
+  },
   -- # Brother MFC-9340CDW
   -- match tftp m|^\0\x05\0\x04illegal \(unrecognized\) tftp operation\0$| p/Brother printer tftpd/ d/printer/
   {

--- a/scripts/tftp-version.nse
+++ b/scripts/tftp-version.nse
@@ -194,11 +194,14 @@ action = function(host, port)
       break
     end
   end
+
   if not sw then
     nmap.set_port_version(host, port, "hardmatched")
     pkt.script = "tftp-version"
     local pkt = json.generate(pkt)
-    return ("If you know the name or version of the software running on this port, please submit the following information to dev@nmap.org: %s."):format(pkt)
+    local msg = ("If you know the name or version of the software running on this port, please submit it to dev@nmap.org along with the following information: %s."):format(pkt)
+    stdnse.verbose(msg)
+    return msg
   end
 
   if not port.version.product and sw.p then

--- a/scripts/tftp-version.nse
+++ b/scripts/tftp-version.nse
@@ -144,12 +144,21 @@ action = function(host, port)
   -- We don't have to worry about other instance of this script running on other
   -- ports of the same host confounding our results, because TFTP services
   -- should respond back to the port matching the sending script.
-  --
-  -- Note that due to API limitations, we can't know if the response came from
-  -- the host we sent the request to, so we must assume it does.
   local status, res = socket:receive()
+  if not status then
+    stdnse.debug1("Failed to receive response from server: %s", res)
+    return nil
+  end
+
+  local status, err, _, rhost, _ = socket:get_info()
   socket:close()
   if not status then
+    stdnse.debug1("Failed to determine source of response: %s", err)
+    return nil
+  end
+
+  if rhost ~= host.ip then
+    stdnse.debug1("UDP response came from unexpected host: %s", rhost)
     return nil
   end
 

--- a/scripts/tftp-version.nse
+++ b/scripts/tftp-version.nse
@@ -197,6 +197,7 @@ local identify_software = function(pkt, port)
   -- There's not enough information in anything but an ERROR packet to deduce
   -- the software that responded, and only if it has an error message
   if pkt.opcode ~= OPCODE_ERROR or pkt.errmsg == nil then
+    stdnse.debug1("Response contains no data that can be used to check software.")
     return
   end
 
@@ -214,6 +215,7 @@ end
 local parse = function(buf)
   -- Every TFTP packet is at least 4 bytes.
   if #buf < 4 then
+    stdnse.debug1("Packet was %d bytes, but TFTP packets are a minimum of 4 bytes.", #buf)
     return nil
   end
 
@@ -223,11 +225,13 @@ local parse = function(buf)
   if opcode == OPCODE_DATA then
     -- The block number, which must be one.
     if num ~= 1 then
+      stdnse.debug1("DATA packet should have a block number of 1, not %d.", num)
       return nil
     end
 
     -- The data remaining in the response must be from 0 to 512 bytes in length.
     if #buf > 2 + 2 + 512 then
+      stdnse.debug1("DATA packet should be 0 to 512 bytes, but is %d bytes.", #buf)
       return nil
     end
 
@@ -237,6 +241,7 @@ local parse = function(buf)
   if opcode == OPCODE_ERROR then
     -- The last byte in the packet must be zero to terminate the error message.
     if buf:byte(#buf) ~= 0 then
+      stdnse.debug1("ERROR packet does not end with a zero byte.")
       return nil
     end
     ret.errcode = num
@@ -251,6 +256,7 @@ local parse = function(buf)
 
   -- Any other opcode, defined or otherwise, should not be coming back from the
   -- service, so we treat it as an error.
+  stdnse.debug1("Unexpected opcode %d received.", opcode)
   return nil
 end
 

--- a/scripts/tftp-version.nse
+++ b/scripts/tftp-version.nse
@@ -24,7 +24,7 @@ local responses = {
   -- match tftp m|^\0\x05\0\x02\0The IP address is not in the range of allowable addresses\.\0| p/SolarWinds tftpd/ i/IP disallowed/ o/Windows/ cpe:/a:solarwinds:tftp_server/ cpe:/o:microsoft:windows/a
   {
     2,
-    "The IP address is not in the range of allowable addresses\\.",
+    "The IP address is not in the range of allowable addresses.",
     {
       ["p"] = "SolarWinds tftpd",
       ["i"] = "IP disallowed",
@@ -87,7 +87,7 @@ local responses = {
   -- match tftp m|^\0\x05\0\x04Illegal operation error\.\0$| p/Microsoft Windows Deployment Services tftpd/ o/Windows/ cpe:/o:microsoft:windows/
   {
     4,
-    "Illegal operation error\\.",
+    "Illegal operation error.",
     {
       ["p"] = "Microsoft Windows Deployment Services tftpd",
       ["o"] = "Windows",
@@ -100,7 +100,7 @@ local responses = {
   -- match tftp m|^\0\x05\0\x04Unknown operatation code: 0 received from [\d.]+:\d+\0| p/SolarWinds Free tftpd/ cpe:/a:solarwinds:tftp_server/
   {
     4,
-    "Unknown operatation code: 0 received from [\\d.]+:\\d+",
+    "Unknown operatation code: 0 received from",
     {
       ["p"] = "SolarWinds Free tftpd",
       ["cpe"] = {
@@ -112,7 +112,7 @@ local responses = {
   -- match tftp m|^\0\x05\0\x04illegal \(unrecognized\) tftp operation\0$| p/Brother printer tftpd/ d/printer/
   {
     4,
-    "illegal \\(unrecognized\\) tftp operation",
+    "illegal (unrecognized) tftp operation",
     {
       ["p"] = "Brother printer tftpd",
       ["d"] = "printer"
@@ -122,7 +122,7 @@ local responses = {
   -- match tftp m|^\0\x05\0\0Not defined, see error message\(if any\)\.\0| p/HP Intelligent Management Center tftpd/ cpe:/a:hp:intelligent_management_center/
   {
     0,
-    "Not defined, see error message\\(if any\\)\\.",
+    "Not defined, see error message(if any).",
     {
       ["p"] = "HP Intelligent Management Center tftpd",
       ["cpe"] = {
@@ -145,7 +145,7 @@ local responses = {
   -- match tftp m|^\0\x05\0\x01File not found\.\0$| p/Enistic zone controller tftpd/
   {
     1,
-    "File not found\\\\.",
+    "File not found.",
     {
       ["p"] = "Enistic zone controller tftpd"
     }
@@ -197,8 +197,7 @@ local identify_software = function(pkt, port)
   for _, res in ipairs(responses) do
     stdnse.debug1(pkt.errmsg .. " <=> " .. res[2])
     if pkt.errcode == res[1] then
-      local patt = re.compile(res[2])
-      if re.find(pkt.errmsg, patt) then
+      if pkt.errmsg:find(res[2]) then
 	record_match(port, res[3])
 	break
       end


### PR DESCRIPTION
As suggested [here](https://secwiki.org/w/Nmap/Script_Ideas#tftp-version), I've made a TFTP version script.

The script could use a lot more testing on different targets. I have successfully tested against a new free download of SolarWinds TFTP and against non-TFTP services and unrecognized TFTP services.

The way matching against fingerprints occurs is the simplest thing I could think of. If there's a good way to either parse a file of fingerprints to generate the hardwired table, that would be good. Also, regexes are not in use, but could be added if necessary. Couldn't find any PCRE exposed, only LPeg which doesn't match up very well with the fingerprint format. I also removed the probe matches. Not sure if that was appropriate.

Finally, if `recvfrom()` was exposed to the NSE that would be desirable. I worry about receiving packets from other hosts unintentionally, or receiving packets during the brief window during which we're swapping sockets. Not sure if Nmap has protections against that.

Anyways, if you want things changed or hit bugs, let me know and I'll fix them as soon as I can. Next up: [nbd-info](https://secwiki.org/w/Nmap/Script_Ideas#nbd-info)!
