### PR TITLE
Warn user when passing invalid IPv6 address

### DIFF
--- a/targets.cc
+++ b/targets.cc
@@ -353,6 +353,17 @@ TargetGroup::~TargetGroup() {
    as 192.168.0.0/16 , 10.1.0-5.1-254 , or fe80::202:e3ff:fe14:1102 .
    Returns 0 for success */
 int TargetGroup::parse_expr(const char *target_expr, int af) {
+  if (strlen(o.device) == 0) {
+    // No device given. If this is a link-local IPv6 address, it must bear an
+    // interface identifier or connect() will fail with EINVAL.
+    bool is_link_local = strcspn(target_expr, "fe80:") == 0;
+    bool has_interface_identifier = strstr(target_expr, "%") != NULL;
+    if (af == AF_INET6 && is_link_local && !has_interface_identifier) {
+      error("Address \"%s\" is link-local. You must use an interface identifier (e.g. %%eth0) or give an interface with -e.", target_expr);
+      return 1;
+    }
+  }
+
   if (this->netblock != NULL)
     delete this->netblock;
   this->netblock = NetBlock::parse_expr(target_expr, af);


### PR DESCRIPTION
When passing an IPv6 address that is link-local (`fe80::/10`), the interface to be used *must* be specified. This can be done with either `-e <iface>` or by appending `%iface` to the address (e.g. `2001:db8::1%eth0`). If the user does neither, they should be warned that this is invalid.

Previously a connect call would later fail with EINVAL (invalid argument). This code prevents that from happening and instead returns a helpful message.