### PR TITLE
fix ncat http proxy failing to work on macos due to a EAGAIN error re…

### DIFF
--- a/ncat/http.c
+++ b/ncat/http.c
@@ -192,7 +192,7 @@ char *socket_buffer_readline(struct socket_buffer *buf, size_t *n, size_t maxlen
             do {
                 errno = 0;
                 i = fdinfo_recv(&buf->fdn, buf->buffer, sizeof(buf->buffer));
-            } while (i == -1 && errno == EINTR);
+            } while (i == -1 && (errno == EINTR || errno == EAGAIN));
             if (i <= 0) {
                 free(line);
                 return NULL;


### PR DESCRIPTION
…turned on socket_buffer_readline

this resolves #585 on my host and should have no effect on any other use case. 