### PR TITLE
fix bad argument exception when using smb-ls script

### DIFF
--- a/nselib/smb.lua
+++ b/nselib/smb.lua
@@ -2805,7 +2805,7 @@ function find_files(smbstate, fname, options)
         pos, fe.s_fname = bin.unpack("A24", response.data, pos)
 
         local time = fe.created
-        time = (time / 10000000) - 11644473600
+        time = (time // 10000000) - 11644473600
         fe.created = os.date("%Y-%m-%d %H:%M:%S", time)
 
         -- TODO: cleanup fe.s_fname


### PR DESCRIPTION
After updating to nmap7.25BETA2 from nmap7.25BETA1 I started consistently encountering a bad date argument exception when trying to run the smb-ls script on a target

On line 1068 an additional / was added to the expression in commit "Merge branch 'nse-lua53'"

Adding a / to the expression on line 2808 to match line 1068 fixes the issue.

Alternatively, removing the newly added / to the expression on line 1068 should also fix it.

I do not know which solution is preferred/correct. 
