### PR TITLE
Update http-devframework.nse

### DIFF
--- a/scripts/http-devframework.nse
+++ b/scripts/http-devframework.nse
@@ -57,7 +57,7 @@ local function loadFingerprints(filename)
   filename = nmap.fetchfile('nselib/data/' .. filename) or filename
 
   -- Load the file
-  stdnse.debug1("Loading fingerprints: %s", filename)
+  --stdnse.debug1("Loading fingerprints: %s", filename)
   local env = setmetatable({fingerprints = {}}, {__index = _G});
   file = loadfile(filename, "t", env)
 


### PR DESCRIPTION
Solve error: variable 'dnse' is not declared 
stack traceback:
	[C]: in function 'error'
	/usr/local/bin/../share/nmap/nselib/strict.lua:80: in function '__index'
	htt-devframework.nse:53: in function 'loadFingerprints'
	htt-devframework.nse:72: in function <htt-devframework.nse:69>
	(...tail calls...)