### PR TITLE
fixed misspelling that was causing plugin to crash

### DIFF
--- a/nselib/amqp.lua
+++ b/nselib/amqp.lua
@@ -259,7 +259,7 @@ AMQP = {
     end
 
     -- parse protocol version
-    status, tmp = self.amqpsocket:receive_buf(match.num_bytes(2), true)
+    status, tmp = self.amqpsocket:receive_buf(match.numbytes(2), true)
     if ( not(status) ) then
       return status, "ERROR: AMQP:handshake connection closed unexpectedly while reading version"
     end


### PR DESCRIPTION
AMQP plugin was crashing due to the single occurrence of this misspelling. Fixed it up and good as new.