### PR TITLE
Verify if HSTS is enabled in the web service

### DIFF
--- a/scripts/http-hsts-verify.nse
+++ b/scripts/http-hsts-verify.nse
@@ -1,29 +1,32 @@
 local http = require "http"
-local nmap = require "nmap"
 local shortport = require "shortport"
 local stdnse = require "stdnse"
 local table = require "table"
 
 description = [[
-This script verify if the HTTP Strict Transport Security (HSTS) (RFC 6797) is enable in a web service.
+Verify that HTTP Strict Transport Security is enabled.
+
+HTTP Strict-Transport-Security (HSTS) (RFC 6797) forces a web browser to communicate with a web server over HTTPS.
+This script examines HTTP Response Headers to determine whether HSTS is configured.
+
+References: https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet
 ]]
 
 ---
 -- @usage
--- nmap -p <port> --script=http-hsts-verify.nse <target>
+-- nmap -p <port> --script http-hsts-verify <target>
 --
 -- @output
 -- PORT    STATE SERVICE
 -- 443/tcp open  https
 -- | http-hsts-verify:
--- |   HTTP Strict-Transport-Security (RFC 6797) forces the browser to send all communications over HTTPS.
--- |   References: https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet
--- |   Banner: Strict-Transport-Security: max-age=31536000
--- |_  State: HSTS is configured. (ENABLED)
+-- |  HSTS is configured.
+-- |_ Header: Strict-Transport-Security: max-age=31536000
+--
+-- @args http-hsts-verify.path The URL path to request. The default path is "/".
 
 author = "Icaro Torres"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
-
 categories = {"discovery", "safe"}
 
 portrule = shortport.http
@@ -32,36 +35,31 @@ local function fail (err) return stdnse.format_output(false, err) end
 
 action = function(host, port)
   local path = stdnse.get_script_args(SCRIPT_NAME..".path") or "/"
-  local status = false
-  local get_response
+  local response
   local output_info = {}
-  local is_not_hsts = 0
-  local is_hsts = 0
+  local hsts_header = {}
 
-  get_response = http.get(host, port, path)
+  response = http.head(host, port, path)
 
-  if(get_response == nil) then
-    return fail("Header request failed")
+  if response == nil then
+    return fail("Request failed")
   end
 
-  if(get_response.rawheader == nil) then
-    return fail("GET header request didn't return a proper header")
+  if response.rawheader == nil then
+    return fail("Response didn't include a proper header")
   end
 
-  table.insert(output_info, "HTTP Strict-Transport-Security (RFC 6797) forces the browser to send all communications over HTTPS.")
-  table.insert(output_info, "References: https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet")
-
-  for _,line in pairs(get_response.rawheader) do
+  for _, line in pairs(response.rawheader) do
     if line:match("strict.transport.security") or line:match("Strict.Transport.Security") then
-      is_hsts = is_hsts + 1
-      table.insert(output_info, "Banner: " .. line)
+      table.insert(hsts_header, line)
     end
   end
 
-  if is_hsts >= 1 then
-    table.insert(output_info, "State: HSTS is configured. (ENABLED)")
+  if #hsts_header > 0 then
+    table.insert(output_info, "HSTS is configured.")
+    table.insert(output_info, "Header: " .. table.concat(hsts_header, " "))
   else
-    table.insert(output_info, "State: HSTS IS NOT CONFIGURED. (DISABLED)")
+    table.insert(output_info, "HSTS is not configured.")
   end
 
   return stdnse.format_output(true, output_info)

--- a/scripts/http-hsts-verify.nse
+++ b/scripts/http-hsts-verify.nse
@@ -1,0 +1,69 @@
+local http = require "http"
+local nmap = require "nmap"
+local shortport = require "shortport"
+local stdnse = require "stdnse"
+local table = require "table"
+
+description = [[
+This script verify if the HTTP Strict Transport Security (HSTS) (RFC 6797) is enable in a web service.
+]]
+
+---
+-- @usage
+-- nmap -p <port> --script=http-hsts-verify.nse <target>
+--
+-- @output
+-- PORT    STATE SERVICE
+-- 443/tcp open  https
+-- | http-hsts-verify:
+-- |   HTTP Strict-Transport-Security (RFC 6797) forces the browser to send all communications over HTTPS.
+-- |   References: https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet
+-- |   Banner: Strict-Transport-Security: max-age=31536000
+-- |_  State: HSTS is configured. (ENABLED)
+
+author = "Icaro Torres"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+
+categories = {"discovery", "safe"}
+
+portrule = shortport.http
+
+local function fail (err) return stdnse.format_output(false, err) end
+
+action = function(host, port)
+  local path = stdnse.get_script_args(SCRIPT_NAME..".path") or "/"
+  local status = false
+  local get_response
+  local output_info = {}
+  local is_not_hsts = 0
+  local is_hsts = 0
+
+  get_response = http.get(host, port, path)
+
+  if(get_response == nil) then
+    return fail("Header request failed")
+  end
+
+  if(get_response.rawheader == nil) then
+    return fail("GET header request didn't return a proper header")
+  end
+
+  table.insert(output_info, "HTTP Strict-Transport-Security (RFC 6797) forces the browser to send all communications over HTTPS.")
+  table.insert(output_info, "References: https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet")
+
+  for _,line in pairs(get_response.rawheader) do
+    if line:match("strict.transport.security") or line:match("Strict.Transport.Security") then
+      is_hsts = is_hsts + 1
+      table.insert(output_info, "Banner: " .. line)
+    end
+  end
+
+  if is_hsts >= 1 then
+    table.insert(output_info, "State: HSTS is configured. (ENABLED)")
+  else
+    table.insert(output_info, "State: HSTS IS NOT CONFIGURED. (DISABLED)")
+  end
+
+  return stdnse.format_output(true, output_info)
+
+end


### PR DESCRIPTION
File http-hsts-verify

Script types: portrule 
Categories: discovery, safe
Download: <TO DEFINE> Link suggestion: http://nmap.org/svn/scripts/http-hsts-verify.nse


User Summary

The Strict-Transport-Security (RFC 6797) forces the browser to send all communications over HTTPS. This script verify if the HTTP Strict Transport Security (HSTS) is enable in a web service. Using a GET request and analysing the response.


Example Usage

nmap -p <port> --script=http-hsts-verify.nse <target>


Script Output

PORT    STATE SERVICE
443/tcp open  https
| http-hsts-verify:
|   HTTP Strict-Transport-Security (RFC 6797) forces the browser to send all communications over HTTPS.
|   References: https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet
|   Banner: Strict-Transport-Security: max-age=31536000
|_  State: HSTS is configured. (ENABLED)


Requires

http
nmap
shortport
stdnse
table


Authors:

Icaro Torres

License: Same as Nmap--See https://nmap.org/book/man-legal.html