### PR TITLE
Review of tn3270 scripts and changes to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ libpcap/pcap-filter.manmisc
 libpcap/pcap-linktype.manmisc
 libpcap/pcap-savefile.manfile
 libpcap/pcap-tstamp.manmisc
+libpcre/.deps/
+libpcre/pcre-config
+libpcre/stamp-h1

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ libpcap/pcap-tstamp.manmisc
 libpcre/.deps/
 libpcre/pcre-config
 libpcre/stamp-h1
+ndiff/INSTALLED_FILES

--- a/scripts/tn3270-screen.nse
+++ b/scripts/tn3270-screen.nse
@@ -54,8 +54,6 @@ Hidden fields will be listed below the screen with (row, col) coordinates.
 author = "Philip Young aka Soldier of Fortran"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 categories = {"safe", "discovery"}
--- XXX Is this a real script?
---dependencies = {"tn3270-info"}
 
 portrule = shortport.port_or_service({23,992}, {"tn3270"})
 


### PR DESCRIPTION
Reviewed the changes to the tn3270 library and deleted comments/redudant code. 

- In cics-user-enum.nse added support for RACF
- Deleted uneeded dependency in tn3270-screen.nse
- Added entries to .gitignore created during configuration/compilation
