### PR TITLE
Allow the RMI script to connect using SSL

### DIFF
--- a/nselib/rmi.lua
+++ b/nselib/rmi.lua
@@ -47,6 +47,7 @@ local bit = require "bit"
 local nmap = require "nmap"
 local stdnse = require "stdnse"
 local string = require "string"
+local shortport = require "shortport"
 local table = require "table"
 _ENV = stdnse.module("rmi", stdnse.seeall)
 -- Some lazy shortcuts
@@ -705,12 +706,21 @@ RmiDataStream = {
 -- we are definitely talking to an RMI service.
 function RmiDataStream:connect(host, port)
   local status, err
-
   local socket = nmap.new_socket()
   socket:set_timeout(5000)
+  local sslenabled = shortport.ssl(host, port)
+  
+  -- Connect over SSL if the RMI Registry uses a SSL Server Socket
+  if sslenabled then
+    status, err = socket:connect(host, port, "ssl")
+    dbg("SSL RMI Registry")
+  else
+    status, err = socket:connect(host, port, "tcp")
+  end
 
-  --  local bsocket = BufferedSocket:new()
-  socket:connect(host,port, "tcp")
+  if not socket then
+    return doh(err)
+  end
 
   -- Output and input
   local dos = JavaDOS:new(BufferedWriter:new(socket))


### PR DESCRIPTION
The rmi-dumpregistry is a very popular nmap script which uses rmi.lua to make a connection to a rmi registry. However, this script will not work for RMI registries accepting only SSL connections. I've modified the rmi.lua script to allow connections to the RMI registry over SSL. Now the RMI script will check if the port accepts SSL connections and if it does, it will connect over SSL.