### PR TITLE
Update Zenmap to consider the -v0 option

### DIFF
--- a/zenmap/zenmapCore/NmapOptions.py
+++ b/zenmap/zenmapCore/NmapOptions.py
@@ -716,6 +716,8 @@ class NmapOptions(object):
                 arg = ""
             try:
                 self["-v"] = int(arg)
+                if self["-v"] == 0:
+                    self["-v"] = -1
             except ValueError:
                 if reduce(lambda x, y: x and y,
                         map(lambda z: z == "v", arg), True):
@@ -778,6 +780,8 @@ class NmapOptions(object):
         if self["-f"]:
             opt_list.extend(["-f"] * self["-f"])
         if self["-v"]:
+            if self["-v"] == -1:
+                opt_list.append("-v0")
             opt_list.extend(["-v"] * self["-v"])
 
         if self["-F"]:


### PR DESCRIPTION
Done with reference to #601. Zenmap does not consider the `-v0` option as `NmapOptions.py` simply uses the `arg` and renders multiple copies of `-v` as @dmiller-nmap mentioned. 

In this fix, `self["-v"]` has been assigned the value of `-1` for the case of `-v0` because,

1. Default value for `self["-v"]` has been set to `0` (when there is no option "-v" in the command itself).
2. In `render()` ,` opt_list` does not include "-v" if `self["-v"]` is `0`