### PR TITLE
Fix setMaxThreads in http-wordpress-brute NSE script

### DIFF
--- a/scripts/http-wordpress-brute.nse
+++ b/scripts/http-wordpress-brute.nse
@@ -134,7 +134,7 @@ action = function( host, port )
   local thread_num = stdnse.get_script_args("http-wordpress-brute.threads") or DEFAULT_THREAD_NUM
 
   engine = brute.Engine:new( Driver, host, port, { uservar = uservar, passvar = passvar } )
-  engine:setMaxThreads(thread_num)
+  engine:setMaxThreads(tonumber(thread_num))
   engine.options.script_name = SCRIPT_NAME
   status, result = engine:start()
 


### PR DESCRIPTION
The `setMaxThreads` function requires an `Int` as parameter as the `nselib/brute.lua` will die, if we provide a string: https://github.com/nmap/nmap/blob/master/nselib/brute.lua#L1188

The script sets the max threads number after the Engine initialization, but uses the parameter string without converting it to an int.