### PR TITLE
Support openssl 1.1.0 without compatibility mode

### DIFF
--- a/ncat/ncat_ssl.c
+++ b/ncat/ncat_ssl.c
@@ -173,10 +173,19 @@ SSL_CTX *setup_ssl_listen(void)
     if (sslctx)
         goto done;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     SSL_library_init();
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
     SSL_load_error_strings();
+#else
+  /* This is now deprecated in OpenSSL 1.1.0 _ No explicit initialisation
+    or de-initialisation is necessary */
+    // SSL_library_init();
+    // OpenSSL_add_all_algorithms();
+    // ERR_load_crypto_strings();
+    // SSL_load_error_strings();
+#endif
 
     /* RAND_status initializes the random number generator through a variety of
        platform-dependent methods, then returns 1 if there is enough entropy or
@@ -585,12 +594,35 @@ static int ssl_gen_cert(X509 **cert, EVP_PKEY **key)
     if (X509_add_ext(*cert, ext, -1) == 0)
         goto err;
 
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined LIBRESSL_VERSION_NUMBER
+    {
+        ASN1_TIME *tb, *ta;
+        tb = NULL;
+        ta = NULL;
+
+        if (X509_set_issuer_name(*cert, X509_get_subject_name(*cert)) == 0
+            || (tb = ASN1_STRING_dup(X509_get0_notBefore(*cert))) == 0
+            || X509_gmtime_adj(tb, 0) == 0
+            || X509_set1_notBefore(*cert, tb) == 0
+            || (ta = ASN1_STRING_dup(X509_get0_notAfter(*cert))) == 0
+            || X509_gmtime_adj(ta, 60) == 0
+            || X509_set1_notAfter(*cert, ta) == 0
+            || X509_set_pubkey(*cert, *key) == 0) {
+            ASN1_STRING_free(tb);
+            ASN1_STRING_free(ta);
+            goto err;
+        }
+        ASN1_STRING_free(tb);
+        ASN1_STRING_free(ta);
+    }
+#else
     if (X509_set_issuer_name(*cert, X509_get_subject_name(*cert)) == 0
         || X509_gmtime_adj(X509_get_notBefore(*cert), 0) == 0
         || X509_gmtime_adj(X509_get_notAfter(*cert), DEFAULT_CERT_DURATION) == 0
         || X509_set_pubkey(*cert, *key) == 0) {
         goto err;
     }
+#endif
 
     /* Sign it. */
     if (X509_sign(*cert, *key, EVP_sha1()) == 0)

--- a/ncat/test/test-wildcard.c
+++ b/ncat/test/test-wildcard.c
@@ -12,8 +12,10 @@ are rejected. The SSL transactions happen over OpenSSL BIO pairs.
 #include <unistd.h>
 
 #include <openssl/bio.h>
+#include <openssl/bn.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include <openssl/rsa.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
@@ -347,12 +349,35 @@ static int gen_cert(X509 **cert, EVP_PKEY **key,
     if (set_dNSNames(*cert, dNSNames) == 0)
         goto err;
 
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined LIBRESSL_VERSION_NUMBER
+    {
+        ASN1_TIME *tb, *ta;
+        tb = NULL;
+        ta = NULL;
+
+        if (X509_set_issuer_name(*cert, X509_get_subject_name(*cert)) == 0
+            || (tb = ASN1_STRING_dup(X509_get0_notBefore(*cert))) == 0
+            || X509_gmtime_adj(tb, 0) == 0
+            || X509_set1_notBefore(*cert, tb) == 0
+            || (ta = ASN1_STRING_dup(X509_get0_notAfter(*cert))) == 0
+            || X509_gmtime_adj(ta, 60) == 0
+            || X509_set1_notAfter(*cert, ta) == 0
+            || X509_set_pubkey(*cert, *key) == 0) {
+            ASN1_STRING_free(tb);
+            ASN1_STRING_free(ta);
+            goto err;
+        }
+        ASN1_STRING_free(tb);
+        ASN1_STRING_free(ta);
+    }
+#else
     if (X509_set_issuer_name(*cert, X509_get_subject_name(*cert)) == 0
         || X509_gmtime_adj(X509_get_notBefore(*cert), 0) == 0
         || X509_gmtime_adj(X509_get_notAfter(*cert), 60) == 0
         || X509_set_pubkey(*cert, *key) == 0) {
         goto err;
     }
+#endif
 
     /* Sign it. */
     if (X509_sign(*cert, *key, EVP_sha1()) == 0)
@@ -556,9 +581,17 @@ int main(void)
 {
     unsigned int i;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     SSL_library_init();
     ERR_load_crypto_strings();
     SSL_load_error_strings();
+#else
+  /* This is now deprecated in OpenSSL 1.1.0 _ No explicit initialisation
+    or de-initialisation is necessary */
+    // SSL_library_init();
+    // ERR_load_crypto_strings();
+    // SSL_load_error_strings();
+#endif
 
     /* Test single pattens in both the commonName and dNSName positions. */
     for (i = 0; i < NELEMS(single_tests); i++)

--- a/nse_openssl.cc
+++ b/nse_openssl.cc
@@ -602,12 +602,13 @@ static const struct luaL_Reg openssllib[] = {
 
 LUALIB_API int luaopen_openssl(lua_State *L) {
 
-  OpenSSL_add_all_algorithms();
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
+  OpenSSL_add_all_algorithms();
   ERR_load_crypto_strings();
 #else
   /* This is now deprecated in OpenSSL 1.1.0 _ No explicit initialisation
     or de-initialisation is necessary */
+  // OpenSSL_add_all_algorithms();
   // ERR_load_crypto_strings();
 #endif
 

--- a/nse_ssl_cert.cc
+++ b/nse_ssl_cert.cc
@@ -142,6 +142,7 @@
 #include <openssl/bn.h>
 #include <openssl/bio.h>
 #include <openssl/pem.h>
+#include <openssl/rsa.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
@@ -152,6 +153,9 @@
 /* Technically some of these things were added in 0x10100006
  * but that was pre-release. */
 #define HAVE_OPAQUE_STRUCTS 1
+#else
+#define X509_get0_notBefore X509_get_notBefore
+#define X509_get0_notAfter X509_get_notAfter
 #endif
 
 
@@ -457,9 +461,9 @@ static void x509_validity_to_table(lua_State *L, X509 *cert)
 {
   lua_newtable(L);
 
-  asn1_time_to_obj(L, X509_get_notBefore(cert));
+  asn1_time_to_obj(L, X509_get0_notBefore(cert));
   lua_setfield(L, -2, "notBefore");
-  asn1_time_to_obj(L, X509_get_notAfter(cert));
+  asn1_time_to_obj(L, X509_get0_notAfter(cert));
   lua_setfield(L, -2, "notAfter");
 }
 

--- a/nsock/src/nsock_ssl.c
+++ b/nsock/src/nsock_ssl.c
@@ -84,8 +84,15 @@ extern struct timeval nsock_tod;
 static SSL_CTX *ssl_init_common() {
   SSL_CTX *ctx;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   SSL_load_error_strings();
   SSL_library_init();
+#else
+  /* This is now deprecated in OpenSSL 1.1.0 _ No explicit initialisation
+    or de-initialisation is necessary */
+  // SSL_load_error_strings();
+  // SSL_library_init();
+#endif
 
   ctx = SSL_CTX_new(SSLv23_client_method());
   if (!ctx) {


### PR DESCRIPTION
Currently, the built fails if openssl 1.1.0 is built with --api=1.1. These
changes remedy that.

- Don't use deprecated initialization functions
- Replace X509_get_notBefore and X509_get_notAfter with variants returning
  const objects
- Include a few missing openssl headers

X-Gentoo-Bug: 592490
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=592490