### PR TITLE
Remove redundant statement

### DIFF
--- a/nping/ProbeMode.cc
+++ b/nping/ProbeMode.cc
@@ -64,7 +64,7 @@
  * OpenSSL library which is distributed under a license identical to that  *
  * listed in the included docs/licenses/OpenSSL.txt file, and distribute   *
  * linked combinations including the two.                                  *
- *                                                                         * 
+ *                                                                         *
  * The Nmap Project has permission to redistribute Npcap, a packet         *
  * capturing driver and library for the Microsoft Windows platform.        *
  * Npcap is a separate work with it's own license rather than this Nmap    *
@@ -423,7 +423,7 @@ int ProbeMode::start(){
                             nping_fatal(QT_3, "normalProbeMode(): Error in packet creation");
                         }
                         /* Safe checks */
-                        if (pkt == NULL || pktLen <=0)
+                        if (pktLen <=0)
                             nping_fatal(QT_3, "normalProbeMode(): Invalid packet returned by fillPacket() ");
 
                         /* Store relevant info so we can pass it to the handler */
@@ -474,7 +474,7 @@ int ProbeMode::start(){
 
                     if ( fillPacket( target, 0, pkt, MAX_IP_PACKET_LEN, &pktLen, rawipsd ) != OP_SUCCESS )
                         nping_fatal(QT_3, "normalProbeMode(): Error in packet creation");
-                    if (pkt == NULL || pktLen <=0)
+                    if (pktLen <=0)
                         nping_fatal(QT_3, "normalProbeMode(): Error packet returned by createPacket() ");
 
                     /* Store relevant info so we can pass it to the handler */
@@ -1863,7 +1863,7 @@ void ProbeMode::probe_delayed_output_handler(nsock_pool nsp, nsock_event nse, vo
 #define RESERVED_DESCRIPTORS 8
 
 /* Default timeout for UDP socket nsock_read() operations */
-#define DEFAULT_UDP_READ_TIMEOUT_MS  1000 
+#define DEFAULT_UDP_READ_TIMEOUT_MS  1000
 
 /** This function handles nsock events related to TCP_CONNECT mode
   * Basically the handler receives nsock events and takes the appropriate


### PR DESCRIPTION
If pkt is compared to a NULL pointer, it always returns false. So instead of having a false statement OR another statement in the if, we can have a single statement. 