### PR TITLE
added message box for handling error while creating file. Fixes #639

### DIFF
--- a/zenmap/zenmapGUI/ScanInterface.py
+++ b/zenmap/zenmapGUI/ScanInterface.py
@@ -455,7 +455,10 @@ class ScanInterface(HIGVBox):
             warn_dialog.destroy()
             return
 
-        self.execute_command(command, target, profile)
+        try:
+            self.execute_command(command, target, profile)
+        except IOError, e:
+            self.toolbar.scan_button.set_sensitive(False)
 
     def _displayed_scan_change_cb(self, widget):
         self.update_cancel_button()

--- a/zenmap/zenmapGUI/ScanInterface.py
+++ b/zenmap/zenmapGUI/ScanInterface.py
@@ -459,6 +459,13 @@ class ScanInterface(HIGVBox):
             self.execute_command(command, target, profile)
         except IOError, e:
             self.toolbar.scan_button.set_sensitive(False)
+            warn_dialog = HIGAlertDialog(
+                        message_format=_("No Suitable Temp Directory Was Found"),
+                        secondary_text=_("Error Message:%s") % str(e),
+                        type=gtk.MESSAGE_ERROR)
+            warn_dialog.run()
+            warn_dialog.destroy()
+
 
     def _displayed_scan_change_cb(self, widget):
         self.update_cancel_button()


### PR DESCRIPTION
Checks whether the temp directory is usable and tries to create a temp file. Displays a message box if it is not usable or if the temp file cannot be generated.