### PR TITLE
Replaced goto with equivalent looping statements

### DIFF
--- a/liblua/lcode.c
+++ b/liblua/lcode.c
@@ -758,19 +758,19 @@ void luaK_exp2val (FuncState *fs, expdesc *e) {
 int luaK_exp2RK (FuncState *fs, expdesc *e) {
   luaK_exp2val(fs, e);
   switch (e->k) {  /* move constants to 'k' */
-    case VTRUE: e->u.info = boolK(fs, 1); goto vk;
-    case VFALSE: e->u.info = boolK(fs, 0); goto vk;
-    case VNIL: e->u.info = nilK(fs); goto vk;
-    case VKINT: e->u.info = luaK_intK(fs, e->u.ival); goto vk;
-    case VKFLT: e->u.info = luaK_numberK(fs, e->u.nval); goto vk;
-    case VK:
-     vk:
-      e->k = VK;
-      if (e->u.info <= MAXINDEXRK)  /* constant fits in 'argC'? */
-        return RKASK(e->u.info);
-      else break;
+    case VTRUE: e->u.info = boolK(fs, 1); e->k = VK; break;
+    case VFALSE: e->u.info = boolK(fs, 0); e->k = VK; break;
+    case VNIL: e->u.info = nilK(fs); e->k = VK; break;
+    case VKINT: e->u.info = luaK_intK(fs, e->u.ival); e->k = VK; break;
+    case VKFLT: e->u.info = luaK_numberK(fs, e->u.nval); e->k = VK; break;
+    case VK: e->k = VK; break;
+    
     default: break;
   }
+
+  if (e->u.info <= MAXINDEXRK)  /* constant fits in 'argC'? */
+        return RKASK(e->u.info);
+
   /* not a constant in the right range: put it in a register */
   return luaK_exp2anyreg(fs, e);
 }

--- a/liblua/lcode.c
+++ b/liblua/lcode.c
@@ -764,8 +764,7 @@ int luaK_exp2RK (FuncState *fs, expdesc *e) {
     case VKINT: e->u.info = luaK_intK(fs, e->u.ival); e->k = VK; break;
     case VKFLT: e->u.info = luaK_numberK(fs, e->u.nval); e->k = VK; break;
     case VK: e->k = VK; break;
-    
-    default: break;
+    default: return luaK_exp2anyreg(fs, e);
   }
 
   if (e->u.info <= MAXINDEXRK)  /* constant fits in 'argC'? */

--- a/ncat/ncat_ssl.c
+++ b/ncat/ncat_ssl.c
@@ -171,7 +171,7 @@ SSL_CTX *setup_ssl_listen(void)
     const SSL_METHOD *method;
 
     if (sslctx)
-        goto done;
+        return sslctx;
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
     SSL_library_init();
@@ -234,9 +234,6 @@ SSL_CTX *setup_ssl_listen(void)
         if (SSL_CTX_use_PrivateKey_file(sslctx, o.sslkey, SSL_FILETYPE_PEM) != 1)
             bye("SSL_CTX_use_Privatekey_file(): %s.", ERR_error_string(ERR_get_error(), NULL));
     }
-
-done:
-    return sslctx;
 }
 
 SSL *new_ssl(int fd)

--- a/targets.cc
+++ b/targets.cc
@@ -553,7 +553,7 @@ static Target *setup_target(const HostGroupState *hs,
       log_bogus_target(inet_ntop_ez(ss, sslen));
       error("%s: failed to determine route to %s", __func__, t->NameIP());
       delete t;
-      return NULL:
+      return NULL;
     }
     if (rnfo.direct_connect) {
       t->setDirectlyConnected(true);


### PR DESCRIPTION
This PR is keeping in mind the general coding principles to minimise use of goto statements. I have replaced the goto statements with equivalent looping statements keeping the same flow of control. 