### PR TITLE
CICS Scripts additions and fixes

### DIFF
--- a/scripts/cics-enum.nse
+++ b/scripts/cics-enum.nse
@@ -222,9 +222,11 @@ Driver = {
       else
         return false, brute.Error:new( "Correct Transaction ID - Access Denied" )
       end
-    elseif not (cics_user == nil and cics_pass == nil) and self.tn3270:find('TSS7251E') then
+    elseif not (cics_user == nil and cics_pass == nil) and 
+           self.tn3270:find('TSS7251E') or self.tn3270:find('DFHAC2033') then
       -- We've logged on but we don't have access to this transaction
-      -- TSS7251E : TSS7251E Access Denied to PROGRAM <X>
+      -- TSS7251E  : Access Denied to PROGRAM <X>
+      -- DFHAC2033 : You are not authorized to use transaction <X>
       stdnse.verbose("Valid CICS Transaction ID [Access Denied]: %s", string.upper(pass))
       if nmap.verbosity() > 3 then 
         return true, creds.Account:new("CICS ID [Access Denied]", string.upper(pass), creds.State.VALID)
@@ -334,7 +336,8 @@ local function cics_test( host, port, commands, user, pass )
     tn:get_screen_debug(2)
     count = 1
     while not tn:find('DFHCE3549') and count < 6 do
-	tn:get_all_data(1000) -- loop for 6 seconds
+	      tn:get_all_data(1000) -- loop for 6 seconds
+        tn:get_screen_debug(2)
         count = count + 1
     end
     if not tn:find('DFHCE3549') then
@@ -390,7 +393,7 @@ action = function(host, port)
     "CSPG", "CSPK", "CSPP", "CSPQ", "CSPS", "CSQC", "CSRK", "CSRS", "CSSF",
     "CSSY", "CSTE", "CSTP", "CSXM", "CSZI", "CTIN", "CTSD", "CVMI", "CWBA",
     "CWBG", "CWTO", "CWWU", "CWXN", "CWXU", "CW2A", "CXCU", "CXRE", "CXRT",
-  "DSNC"} -- Default CICS from https://www-01.ibm.com/support/knowledgecenter/SSGMCP_5.2.0/com.ibm.cics.ts.systemprogramming.doc/topics/dfha726.html
+    "DSNC"} -- Default CICS from https://www-01.ibm.com/support/knowledgecenter/SSGMCP_5.2.0/com.ibm.cics.ts.systemprogramming.doc/topics/dfha726.html
 
   cics_id_file = ( (cics_id_file and nmap.fetchfile(cics_id_file)) or cics_id_file )
   

--- a/scripts/cics-enum.nse
+++ b/scripts/cics-enum.nse
@@ -53,6 +53,7 @@ found for CICS transaction IDs.
 -- @changelog
 -- 2015-07-04 - v0.1 - created by Soldier of Fortran
 -- 2015-11-14 - v0.2 - rewrote iterator
+-- 2017-01-22 - v0.3 - added authenticated CICS ID enumeration
 --
 -- @author Philip Young
 -- @copyright Same as Nmap--See https://nmap.org/book/man-legal.html
@@ -105,6 +106,8 @@ Driver = {
   login = function (self, user, pass) -- pass is actually the CICS transaction we want to try
     local commands = self.options['key1']
     local path = self.options['key2']
+    local cics_user = self.options['user']
+    local cics_pass = self.options['pass']
     local timeout = 300
     local max_blank = 1
     local loop = 1
@@ -143,8 +146,31 @@ Driver = {
       -- something is wrong but we can still try transactions. Print error to debug.
       stdnse.debug('Error. Failed to get to a blank screen under CICS (sending F3 followed by CLEAR). Try lowering maxthreads to fix.')
     end
+    -- If username/password provided try to authenticate first
+    if not (cics_user == nil and cics_pass == nil) then -- We're doing authenticated CICS testing now baby!
+      stdnse.debug(2,'Logging in with %s / %s for auth testing', cics_user, cics_pass)
+      self.tn3270:send_cursor('CESN')
+      self.tn3270:get_all_data()
+      self.tn3270:get_screen_debug()
+      local fields = self.tn3270:writeable() -- Get the writeable field areas
+      local user_loc = {fields[1][1],cics_user}   -- This is the 'UserID:' field
+      local pass_loc = {fields[3][1],cics_pass}   -- This is the 'Password:' field ([2] is a group ID)
+      stdnse.debug(2,'Trying CICS: %s : %s', user, pass)
+      self.tn3270:send_locations({user_loc,pass_loc})
+      self.tn3270:get_all_data()
+      stdnse.debug(2,"Screen Recieved for User ID: %s / %s", user, pass)
+      self.tn3270:get_screen_debug()
+      local count = 1
+      while not self.tn3270:find('DFHCE3549') and count < 6 do -- some systems show a message for a bit before we get to CICS again
+          self.tn3270:get_all_data(1000) -- loop for 6 seconds
+          count = count + 1
+      end
+    end
+    self.tn3270:get_screen_debug()
+    self.tn3270:send_clear()
+    self.tn3270:get_all_data()
+    self.tn3270:get_screen_debug()
     stdnse.verbose("Trying Transaction ID: %s", pass)
-    stdnse.debug(2,"Sending Transaction ID: %s", pass)
     self.tn3270:send_cursor(pass)
     self.tn3270:get_all_data()
 
@@ -172,6 +198,39 @@ Driver = {
       -- This will be the same screen for each so we dont bother saving it either
       stdnse.verbose("Valid CICS Transaction ID [requires auth]: %s", string.upper(pass))
       return true, creds.Account:new("CICS ID [requires auth]", string.upper(pass), creds.State.VALID)
+    elseif self.tn3270:find('DFHAC2008') or self.tn3270:find('DFHAC2206') or self.tn3270:find('DFHAC2028') or 
+           self.tn3270:find('DFHRT4415') or self.tn3270:find('DFHRT4480') or self.tn3270:find('TSS7254E') then
+      -- these are technically valid CICS transactions
+      -- but they are of little/no value. If verbosity is turned way up we'll return these/save a screenshot
+      -- otherwise there's no point
+      -- DFHAC2008 -- TranID has been Disabled
+      -- DFHAC2206 -- Abend
+      -- DFHRT4415 -- Cannot access through terminal
+      -- DFHRT4480 -- No Longer Supported
+      -- DFHAC2028 -- cannot be used
+      -- TSS7254E  -- Access not available through this facility
+      stdnse.verbose("Valid CICS Transaction ID [Abbend or ID Disabled]: %s", string.upper(pass))
+      if nmap.verbosity() > 3 then
+        if path ~= nil then
+          stdnse.verbose(2,"Writting screen to: %s", path..string.upper(pass)..".txt")
+          status, err = save_screens(path..string.upper(pass)..".txt",self.tn3270:get_screen())
+          if not status then
+            stdnse.verbose(2,"Failed writting screen to: %s", path..string.upper(pass)..".txt")
+          end
+        end
+        return true, creds.Account:new("CICS ID [Abbend]", string.upper(pass), creds.State.VALID)
+      else
+        return false, brute.Error:new( "Correct Transaction ID - Access Denied" )
+      end
+    elseif not (cics_user == nil and cics_pass == nil) and self.tn3270:find('TSS7251E') then
+      -- We've logged on but we don't have access to this transaction
+      -- TSS7251E : TSS7251E Access Denied to PROGRAM <X>
+      stdnse.verbose("Valid CICS Transaction ID [Access Denied]: %s", string.upper(pass))
+      if nmap.verbosity() > 3 then 
+        return true, creds.Account:new("CICS ID [Access Denied]", string.upper(pass), creds.State.VALID)
+      else
+        return false, brute.Error:new( "Correct Transaction ID - Access Denied" )
+      end
     else
       stdnse.verbose("Valid CICS Transaction ID: %s", string.upper(pass))
       if path ~= nil then
@@ -191,13 +250,16 @@ Driver = {
 --
 -- @param host host NSE object
 -- @param port port NSE object
+-- @param user CICS userID
+-- @param pass CICS userID password
 -- @param commands optional script-args of commands to use to get to CICS
 -- @return status true on success, false on failure
 
-local function cics_test( host, port, commands )
+local function cics_test( host, port, commands, user, pass )
   stdnse.debug("Checking for CICS")
   local tn = tn3270.Telnet:new()
   local status, err = tn:initiate(host,port)
+  local msg = 'Unable to get to CICS'
   local cics = false -- initially we're not at CICS
   if not status then
     stdnse.debug("Could not initiate TN3270: %s", err )
@@ -251,11 +313,41 @@ local function cics_test( host, port, commands )
   tn:get_screen_debug(2)
 
   if tn:find('Sign-off is complete.') then
-    tn:disconnect()
-    cics = true
+      cics = true
   end
+
+  if not (user == nil and pass == nil) then -- We're doing authenticated CICS testing now baby!
+    stdnse.verbose(2,'Logging in with %s / %s for auth testing', user, pass)
+    tn:send_clear()
+    tn:get_all_data()
+    tn:get_screen_debug()
+    tn:send_cursor('CESN')
+    tn:get_all_data()
+    tn:get_screen_debug()
+    local fields = tn:writeable() -- Get the writeable field areas
+    local user_loc = {fields[1][1],user}   -- This is the 'UserID:' field
+    local pass_loc = {fields[3][1],pass}   -- This is the 'Password:' field ([2] is a group ID)
+    stdnse.verbose('Trying CICS: %s : %s', user, pass)
+    tn:send_locations({user_loc,pass_loc})
+    tn:get_all_data()
+    stdnse.debug(2,"Screen Recieved for User ID: %s / %s", user, pass)
+    tn:get_screen_debug()
+    count = 1
+    while not tn:find('DFHCE3549') and count < 6 do
+	tn:get_all_data(1000) -- loop for 6 seconds
+        count = count + 1
+    end
+    if not tn:find('DFHCE3549') then
+        cics = false
+        msg = 'Unable to access CICS with User: '..user..' / Pass: '..pass
+    else
+        tn:send_cursor('CESF')
+        tn:get_all_data()
+    end
+  end
+
   tn:disconnect()
-  return cics
+  return cics,msg
 end
 
 -- Filter iterator for unpwdb
@@ -276,6 +368,8 @@ action = function(host, port)
   local cics_id_file = stdnse.get_script_args("idlist")
   local path = stdnse.get_script_args(SCRIPT_NAME .. '.path') -- Folder for screenshots
   local commands = stdnse.get_script_args(SCRIPT_NAME .. '.commands') or 'cics'-- VTAM commands/macros to get to CICS
+  local username = stdnse.get_script_args(SCRIPT_NAME .. '.user') or nil
+  local password = stdnse.get_script_args(SCRIPT_NAME .. '.pass') or nil
   local cics_ids = {"CADP", "CATA", "CATD", "CATR", "CBAM", "CCIN", "CCRL", "CDBC", "CDBD",
     "CDBF", "CDBI", "CDBM", "CDBN", "CDBO", "CDBQ", "CDBT", "CDFS", "CDST",
     "CDTS", "CEBR", "CEBT", "CECI", "CECS", "CEDA", "CEDB", "CEDC", "CEDF",
@@ -299,7 +393,7 @@ action = function(host, port)
   "DSNC"} -- Default CICS from https://www-01.ibm.com/support/knowledgecenter/SSGMCP_5.2.0/com.ibm.cics.ts.systemprogramming.doc/topics/dfha726.html
 
   cics_id_file = ( (cics_id_file and nmap.fetchfile(cics_id_file)) or cics_id_file )
-
+  
   if cics_id_file then
     for l in io.lines(cics_id_file) do
       if not l:match("#!comment:") then
@@ -307,19 +401,21 @@ action = function(host, port)
       end
     end
   end
-
-  if cics_test(host, port, commands) then
-    local options = { key1 = commands, key2 = path }
+  local cicstst,msg = cics_test(host, port, commands, username, password)
+  if cicstst then
+    local title = 'CICS Transaction IDs'
+    if not(username == nil and password == nil) then title = 'CICS Transaction IDs for User: '.. username end
+    local options = { key1 = commands, key2 = path, user = username, pass = password }
     stdnse.debug("Starting CICS Transaction ID Enumeration")
     if path ~= nil then stdnse.verbose(2,"Saving Screenshots to: %s", path) end
     local engine = brute.Engine:new(Driver, host, port, options)
     engine.options.script_name = SCRIPT_NAME
     engine:setPasswordIterator(unpwdb.filter_iterator(iter(cics_ids), valid_cics))
     engine.options.passonly = true
-    engine.options:setTitle("CICS Transaction ID")
+    engine.options:setTitle(title)
     local status, result = engine:start()
     return result
   else
-    return "Could not get to CICS. Aborting."
+    return msg
   end
 end

--- a/scripts/cics-enum.nse
+++ b/scripts/cics-enum.nse
@@ -28,6 +28,8 @@ found for CICS transaction IDs.
 --  to access CICS. Defaults to <code>CICS</code>.
 -- @args cics-enum.path Folder used to store valid transaction id 'screenshots'
 --  Defaults to <code>None</code> and doesn't store anything.
+-- @args cics-enum.user Username to use for authenticated enumeration
+-- @args cics-enum.pass Password to use for authenticated enumeration
 --
 -- @usage
 -- nmap --script=cics-enum -p 23 <targets>

--- a/scripts/cics-enum.nse
+++ b/scripts/cics-enum.nse
@@ -151,7 +151,7 @@ Driver = {
       stdnse.debug(2,'Logging in with %s / %s for auth testing', cics_user, cics_pass)
       self.tn3270:send_cursor('CESN')
       self.tn3270:get_all_data()
-      self.tn3270:get_screen_debug()
+      self.tn3270:get_screen_debug(2)
       local fields = self.tn3270:writeable() -- Get the writeable field areas
       local user_loc = {fields[1][1],cics_user}   -- This is the 'UserID:' field
       local pass_loc = {fields[3][1],cics_pass}   -- This is the 'Password:' field ([2] is a group ID)
@@ -159,17 +159,17 @@ Driver = {
       self.tn3270:send_locations({user_loc,pass_loc})
       self.tn3270:get_all_data()
       stdnse.debug(2,"Screen Recieved for User ID: %s / %s", user, pass)
-      self.tn3270:get_screen_debug()
+      self.tn3270:get_screen_debug(2)
       local count = 1
       while not self.tn3270:find('DFHCE3549') and count < 6 do -- some systems show a message for a bit before we get to CICS again
           self.tn3270:get_all_data(1000) -- loop for 6 seconds
           count = count + 1
       end
     end
-    self.tn3270:get_screen_debug()
+    self.tn3270:get_screen_debug(2)
     self.tn3270:send_clear()
     self.tn3270:get_all_data()
-    self.tn3270:get_screen_debug()
+    self.tn3270:get_screen_debug(2)
     stdnse.verbose("Trying Transaction ID: %s", pass)
     self.tn3270:send_cursor(pass)
     self.tn3270:get_all_data()
@@ -184,7 +184,7 @@ Driver = {
 
     stdnse.debug(2,"Screen Recieved for Transaction ID: %s", pass)
     self.tn3270:get_screen_debug(2)
-    if self.tn3270:find('not recognized') then -- known invalid command
+    if self.tn3270:find('not recognized') or self.tn3270:find('DFHAC2002') then -- known invalid command
       stdnse.debug("Invalid CICS Transaction ID: %s", string.upper(pass))
       return false,  brute.Error:new( "Incorrect CICS Transaction ID" )
     elseif self.tn3270:isClear() then
@@ -320,10 +320,10 @@ local function cics_test( host, port, commands, user, pass )
     stdnse.verbose(2,'Logging in with %s / %s for auth testing', user, pass)
     tn:send_clear()
     tn:get_all_data()
-    tn:get_screen_debug()
+    tn:get_screen_debug(2)
     tn:send_cursor('CESN')
     tn:get_all_data()
-    tn:get_screen_debug()
+    tn:get_screen_debug(2)
     local fields = tn:writeable() -- Get the writeable field areas
     local user_loc = {fields[1][1],user}   -- This is the 'UserID:' field
     local pass_loc = {fields[3][1],pass}   -- This is the 'Password:' field ([2] is a group ID)
@@ -331,7 +331,7 @@ local function cics_test( host, port, commands, user, pass )
     tn:send_locations({user_loc,pass_loc})
     tn:get_all_data()
     stdnse.debug(2,"Screen Recieved for User ID: %s / %s", user, pass)
-    tn:get_screen_debug()
+    tn:get_screen_debug(2)
     count = 1
     while not tn:find('DFHCE3549') and count < 6 do
 	tn:get_all_data(1000) -- loop for 6 seconds

--- a/scripts/cics-enum.nse
+++ b/scripts/cics-enum.nse
@@ -223,7 +223,7 @@ Driver = {
         return false, brute.Error:new( "Correct Transaction ID - Access Denied" )
       end
     elseif not (cics_user == nil and cics_pass == nil) and 
-           self.tn3270:find('TSS7251E') or self.tn3270:find('DFHAC2033') then
+           (self.tn3270:find('TSS7251E') or self.tn3270:find('DFHAC2033')) then
       -- We've logged on but we don't have access to this transaction
       -- TSS7251E  : Access Denied to PROGRAM <X>
       -- DFHAC2033 : You are not authorized to use transaction <X>

--- a/scripts/cics-info.nse
+++ b/scripts/cics-info.nse
@@ -397,7 +397,7 @@ local function cics_info( host, port, commands, user, pass, cemt, trans )
       end
     end
     results["Transaction / Program"] = transactions
-  end
+  end -- Done with Transaction IDs
   tn:disconnect()
   return results
 end

--- a/scripts/cics-info.nse
+++ b/scripts/cics-info.nse
@@ -1,0 +1,414 @@
+local nmap      = require "nmap"
+local stdnse    = require "stdnse"
+local shortport = require "shortport"
+local tn3270    = require "tn3270"
+local brute     = require "brute"
+local creds     = require "creds"
+local unpwdb    = require "unpwdb"
+local io        = require "io"
+local table     = require "table"
+local string   = require "string"
+
+
+description = [[
+Using the CICS transaction CEMT, this script attempts to gather information
+about the current CICS transaction server region. It gathers OS information,
+Datasets (files), transactions and user ids. Based on CICSpwn script by
+Ayoub ELAASSAL.
+]]
+
+---
+-- @args cics-info.commands Command used to access cics. Defaults to <code>cics</code>
+-- @args cics-info.cemt CICS Transaction ID to be used. Default is <code>CEMT</code>
+-- @args cics-info.trans Instead of gathering all transaction IDs supplying a name here
+-- will make the script only look up one transaction ID 
+-- @args cics-info.user Username to use if access to CEMT requires authentication
+-- @args cics-info.pass Password to use if access to CEMT requires authentication
+--
+-- @usage
+-- nmap --script=cics-info -p 23 <targets>
+--
+-- nmap --script=cics-info --script-args cics-info.commands='logon applid(coolcics)',
+-- cics-info.user=test,cics-info.pass=test,cics-info.cemt='ZEMT',
+-- cics-info.trans=CICA -p 23 <targets>
+--
+-- @output
+-- PORT   STATE SERVICE VERSION
+-- 23/tcp open  tn3270  IBM Telnet TN3270 (TN3270E)
+-- | cics-info:
+-- |   Security: Disabled
+-- |   z/OS Version: 02.01.00
+-- |   CICS Version: 05.02.00
+-- |   System ID: CICS
+-- |   Application ID: CICSFAKE
+-- |   Default User: USERCICS
+-- |   Transaction / Program:
+-- |     AADD / DFH$AALL
+-- |     ABRW / DFH$ABRW
+-- |     AINQ / DFH$AALL
+-- |     AMNU / DFH$AMNU
+-- |     AORD / DFH$AREN
+-- |     AORQ / DFH$ACOM
+-- |     AREP / DFH$AREP
+-- |     AUPD / DFH$AALL
+-- |     CADP / DFHDPLU
+-- ...
+-- |     CEDX / DFHEDFP
+-- |     CEGN / DFHCEGN
+-- |     CEHP / DFHCHS
+-- |     CEHS / DFHCHS
+-- |     CEJR / DFHEJITL
+-- |     CEMN / DFHCEMNA
+-- |     CEMT / DFHEMTP
+-- |     CEOT / DFHEOTP
+-- |     CXRT / DFHCRT
+-- |     DSNC / DFHD2CM1
+-- |   Users:
+-- |     USERCICS
+-- |   Libraries:
+-- |     HLQ123.CICS.SDFHLOAD
+-- |   Datasets:
+-- |     CICS.FILEA
+-- |     HLQ123.CICS.DFHCSD
+-- |_    HLQ123.CICS.DFHLRQ
+-- 
+-- @changelog
+-- 2017-01-30 - v0.1 - created by Soldier of Fortran
+--
+-- @author Philip Young
+-- @copyright Same as Nmap--See https://nmap.org/book/man-legal.html
+--
+
+author = "Philip Young aka Soldier of Fortran"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"version"}
+portrule = shortport.port_or_service({23,992}, "tn3270")
+
+
+
+--- Gathers CICS transaction server information
+--
+-- @param host host NSE object
+-- @param port port NSE object
+-- @param user CICS userID
+-- @param pass CICS userID password
+-- @param commands optional script-args of commands to use to get to CICS
+-- @param cemt transaction ID to use instead of CEMT
+-- @param trans transaction ID to check instead of gathering all
+-- @return Table of information or error message 
+
+local function cics_info( host, port, commands, user, pass, cemt, trans )
+  stdnse.debug("Checking for CICS")
+  local tn = tn3270.Telnet:new()
+  local status, err = tn:initiate(host,port)
+  local msg = 'Unable to get to CICS'
+  local cics = false -- initially we're not at CICS
+  local more = true
+  local count = 1
+  local results = {}
+  if not status then
+    stdnse.debug("Could not initiate TN3270: %s", err )
+    return msg
+  end
+  tn:get_screen_debug(2) -- prints TN3270 screen to debug
+  stdnse.debug("Getting to CICS")
+  local run = stdnse.strsplit(";%s*", commands)
+  for i = 1, #run do
+    stdnse.debug(1,"Issuing Command (#%s of %s): %s", i, #run ,run[i])
+    tn:send_cursor(run[i])
+    tn:get_all_data()
+    tn:get_screen_debug(2)
+  end
+  tn:get_all_data()
+  tn:get_screen_debug(2) -- for debug purposes
+  -- we should technically be at CICS. So we send:
+  --   * F3 to exit the CICS program
+  --   * CLEAR (a tn3270 command) to clear the screen.
+  --     (you need to clear before sending a transaction ID)
+  --   * a known default CICS transaction ID with predictable outcome
+  --     (CESF with 'Sign-off is complete.' as the result)
+  -- to confirm that we were in CICS. If so we return true
+  -- otherwise we return false
+  local count = 1
+  while not tn:isClear() and count < 6 do
+    -- some systems will just kick you off others are slow in responding
+    -- this loop continues to try getting out of CESL 6 times. If it can't
+    -- then we probably weren't in CICS to begin with.
+    if tn:find("Signon") then
+      stdnse.debug(2,"Found CESL/CESN 'Signon' sending PF3")
+      tn:send_pf(3)
+      tn:get_all_data()
+    end
+    tn:get_all_data()
+    stdnse.debug(2,"Clearing the Screen")
+    tn:send_clear()
+    tn:get_all_data()
+    tn:get_screen_debug(2)
+    count = count + 1
+  end
+  if count == 6 then
+    return msg
+  end
+  stdnse.debug(2,"Sending CESF (CICS Default Sign-off)")
+  tn:send_cursor('CESF')
+  tn:get_all_data()
+  if tn:isClear() then
+    tn:get_all_data(1000)
+  end
+  tn:get_screen_debug(2)
+
+  if not tn:find('Sign-off is complete.') then
+    return 'Unable to get to CICS. Try --script-args cics-info.commands="logon applid(<applid>)"'
+  end
+
+
+  if not (user == nil and pass == nil) then -- We're doing authenticated CICS testing now baby!
+    stdnse.verbose(2,'Logging in with %s / %s for auth testing', user, pass)
+    tn:send_clear()
+    tn:get_all_data()
+    tn:get_screen_debug(2)
+    tn:send_cursor('CESN')
+    tn:get_all_data()
+    tn:get_screen_debug(2)
+    local fields = tn:writeable() -- Get the writeable field areas
+    local user_loc = {fields[1][1],user}   -- This is the 'UserID:' field
+    local pass_loc = {fields[3][1],pass}   -- This is the 'Password:' field ([2] is a group ID)
+    stdnse.verbose('Trying CICS: %s : %s', user, pass)
+    tn:send_locations({user_loc,pass_loc})
+    tn:get_all_data()
+    stdnse.debug(2,"Screen Recieved for User ID: %s / %s", user, pass)
+    tn:get_screen_debug(2)
+    count = 1
+    while not tn:find('DFHCE3549') and count < 6 do
+	      tn:get_all_data(1000) -- loop for 6 seconds
+        tn:get_screen_debug(2)
+        count = count + 1
+    end
+    if not tn:find('DFHCE3549') then
+        cics = false
+        msg = 'Unable to access CICS with User: '..user..' / Pass: '..pass
+        return msg
+    end
+  end
+  cics = true
+  -- By now it's time to start trying to gather information
+  tn:send_clear()
+  tn:get_all_data()
+  tn:send_cursor('CESN')
+  tn:get_all_data()
+  tn:get_screen_debug(2)
+
+  if not tn:find('DFHCE3547') then 
+    table.insert(results, 'Security: Enabled') 
+  else
+    table.insert(results, 'Security: Disabled') 
+  end
+  stdnse.debug(2,"Sending F3")
+  tn:send_pf(3)
+  tn:get_all_data()
+  tn:get_screen_debug(2)
+  stdnse.debug(2,"Sending 'Clear Screen'")
+  tn:send_clear()
+  tn:get_all_data()
+  tn:get_screen_debug(2)
+  stdnse.verbose(2,"Sending 'CEMT INQUIRE SYSTEM'")
+  tn:send_cursor('CEMT INQUIRE SYSTEM')
+  tn:get_all_data()
+  tn:get_screen_debug(2)
+  if tn:find('DFHAC2002') then
+    table.insert(results, 'CEMT Access Denied.')
+    return results
+  elseif tn:find('NOT AUTHORIZED') then 
+    table.insert(results, 'CEMT \'INQURE SYSTEM\' Access Denied.')
+  else
+    local l1, l2 = tn:find('Oslevel')
+    local oslevel = tn:get_screen_raw():sub(l2+2,l2+7)
+    l1, l2 = tn:find('Cicstslevel')
+    local cicstslevel = tn:get_screen_raw():sub(l2+2,l2+7)
+    l1, l2 = tn:find('Dfltuser')
+    local Dfltuser = tn:get_screen_raw():sub(l2+2,l2+10)
+    local Dfltuser_len = Dfltuser:find(')')
+    l1, l2 = tn:find('Db2conn')
+    local Db2conn = tn:get_screen_raw():sub(l2+2,l2+10)
+    local Db2conn_len = Db2conn:find(')')
+    l1, l2 = tn:find('Mqconn')
+    local Mqconn = tn:get_screen_raw():sub(l2+2,l2+10)
+    local Mqconn_len = Mqconn:find(')')
+    l1, l2 = tn:find('SYSID')
+    local SYSID = tn:get_screen_raw():sub(l2+2,l2+10)
+    local SYSID_len = SYSID:find('\00')
+    l1, l2 = tn:find('APPLID')
+    local APPLID = tn:get_screen_raw():sub(l2+2,l2+10)
+    local APPLID_len = APPLID:find('\00')
+    table.insert(results,("z/OS Version: %s.%s.%s"):format( oslevel:sub(1,2),oslevel:sub(3,4),oslevel:sub(5,6) ))
+    table.insert(results,("CICS Version: %s.%s.%s"):format( cicstslevel:sub(1,2),cicstslevel:sub(3,4),cicstslevel:sub(5,6) ))
+    table.insert(results,("System ID: %s"):format(SYSID:sub(1,SYSID_len-1)))
+    table.insert(results,("Application ID: %s"):format(APPLID:sub(1,APPLID_len-1)))
+    table.insert(results,("Default User: %s"):format(Dfltuser:sub(1,Dfltuser_len-1)))
+    if Db2conn_len > 1 then
+      table.insert(results,("DB2 Connection: %s"):format(Db2conn:sub(1,Db2conn_len-1)))
+    end
+    if Mqconn_len > 1 then
+      table.insert(results,("MQ Connection: %s"):format(Mqconn:sub(1,Mqconn_len-1)))
+    end
+  end -- Done with INQUIRE SYSTEM
+    
+  stdnse.debug(2,"Sending F3")
+  tn:send_pf(3)
+  tn:get_all_data()
+  tn:get_screen_debug(2)
+  stdnse.debug(2,"Sending 'Clear Screen'")
+  tn:send_clear()
+  tn:get_all_data()
+  tn:get_screen_debug(2)
+  stdnse.verbose(2,"Sending 'CEMT INQUIRE DSNAME'")
+  tn:send_cursor('CEMT INQUIRE DSNAME')
+  tn:get_all_data()
+  tn:get_screen_debug(2)
+
+  if tn:find('NOT AUTHORIZED') then 
+    table.insert(results, 'CEMT \'INQURE DSNAME\' Access Denied.')
+  else
+    local datasets = {}
+    while more do
+      more = false
+      for line in tn:get_screen():gmatch("[^\r\n]+") do 
+        if line:find('Dsn') then
+          table.insert(datasets,line:sub(line:find('%(')+1, line:find(')')-1):match( "(.-)%s*$" ))
+          if count >= 9 and line:find('+') then
+            more = true
+            count = 1
+            stdnse.debug(2,"Sending F11")
+            tn:send_pf(11)
+            tn:get_all_data()
+            tn:get_screen_debug(2) 
+          else
+            count = count + 1
+          end
+        end
+      end
+    end
+    results["Datasets"] = datasets
+  end -- Done with DSNAME
+  
+  stdnse.debug(2,"Sending F3")
+  tn:send_pf(3)
+  tn:get_all_data()
+  tn:get_screen_debug(2)
+  stdnse.debug(2,"Sending 'Clear Screen'")
+  tn:send_clear()
+  tn:get_all_data()
+  tn:get_screen_debug(2)
+  stdnse.verbose(2,"Sending 'CEMT INQUIRE LIBRARY'")
+  tn:send_cursor('CEMT INQUIRE LIBRARY')
+  tn:get_all_data()
+  tn:get_screen_debug(2)
+
+  if tn:find('NOT AUTHORIZED') then 
+    table.insert(results, 'CEMT \'INQURE LIBRARY\' Access Denied.')
+  else
+    local libraries = {}
+    for line in tn:get_screen():gmatch("[^\r\n]+") do 
+      if line:find('Dsname') then
+        table.insert(libraries,line:sub(line:find('%(')+1, line:find(')')-1):match( "(.-)%s*$" ))
+      end
+    end
+    results["Libraries"] = libraries
+  end -- Done with Library
+
+  stdnse.debug(2,"Sending F3")
+  tn:send_pf(3)
+  tn:get_all_data()
+  tn:get_screen_debug(2)
+  stdnse.debug(2,"Sending 'Clear Screen'")
+  tn:send_clear()
+  tn:get_all_data()
+  tn:get_screen_debug(2)
+  stdnse.verbose(2,"Sending 'CEMT INQUIRE TASK'")
+  tn:send_cursor('CEMT INQUIRE TASK')
+  tn:get_all_data()
+  tn:get_screen_debug(2)
+  
+  if tn:find('NOT AUTHORIZED') then 
+    table.insert(results, 'CEMT \'INQURE TASK\' Access Denied.')
+  else
+    count = 1
+    more = true
+    local users = {}
+    while more do
+      more = false
+      for line in tn:get_screen():gmatch("[^\r\n]+") do 
+        if line:find('Use') then
+          table.insert(users,line:sub(line:find('Use')+4, line:find(')',line:find('Use'))-1):match( "(.-)%s*$" ))
+          if count >= 9 and line:find('+') then
+            more = true
+            count = 1
+            stdnse.debug(2,"Sending F11")
+            tn:send_pf(11)
+            tn:get_all_data()
+            tn:get_screen_debug(2)
+          else
+            count = count + 1
+          end
+        end
+      end
+    end 
+    results["Users"] = users
+  end -- End of TASK
+
+  stdnse.debug(2,"Sending F3")
+  tn:send_pf(3)
+  tn:get_all_data()
+  tn:get_screen_debug(2)
+  stdnse.debug(2,"Sending 'Clear Screen'")
+  tn:send_clear()
+  tn:get_all_data()
+  tn:get_screen_debug(2)
+  stdnse.verbose(2,"Sending 'CEMT INQUIRE TRANSACTION(".. trans ..") en'")
+  tn:send_cursor('CEMT INQUIRE TRANSACTION('.. trans ..') en')
+  tn:get_all_data()
+  tn:get_screen_debug(2)
+
+  if tn:find('NOT AUTHORIZED') then
+    table.insert(results, 'CEMT \'INQURE TRANSACION\' Access Denied.')
+  else
+    local transactions = {}
+    count = 1
+    more = true
+    local tra, pro = ''
+    while more do
+      more = false
+      for line in tn:get_screen():gmatch("[^\r\n]+") do
+        if line:find('Tra%(') then
+          tra = line:sub(line:find('%(')+1,line:find(')')-1)
+          pro = line:sub(line:find('Pro%(')+4,line:find(')',line:find('Pro%('))-1)
+          table.insert(transactions,tra..' / '..pro)
+          if count >= 9 and line:find('+') then 
+            more = true
+            count = 1
+            stdnse.debug(2,"Sending F11")
+            tn:send_pf(11)
+            tn:get_all_data()
+            tn:get_screen_debug(2)
+          else
+            count = count + 1
+          end
+        end
+      end
+    end
+    results["Transaction / Program"] = transactions
+  end
+  tn:disconnect()
+  return results
+end
+
+
+action = function(host, port)
+  local commands = stdnse.get_script_args(SCRIPT_NAME .. '.commands') or 'cics'-- VTAM commands/macros to get to CICS
+  local username = stdnse.get_script_args(SCRIPT_NAME .. '.user') or nil
+  local password = stdnse.get_script_args(SCRIPT_NAME .. '.pass') or nil
+  local CEMT = stdnse.get_script_args(SCRIPT_NAME .. '.cemt') or 'cemt' -- to supply a different transaction ID if they've changed it
+  local transaction = stdnse.get_script_args(SCRIPT_NAME .. '.trans') or '*'
+  local results = cics_info(host, port, commands, username, password, CEMT, transaction)
+  return results
+end

--- a/scripts/cics-user-brute.nse
+++ b/scripts/cics-user-brute.nse
@@ -1,0 +1,295 @@
+local stdnse    = require "stdnse"
+local shortport = require "shortport"
+local tn3270    = require "tn3270"
+local brute     = require "brute"
+local creds     = require "creds"
+local unpwdb    = require "unpwdb"
+
+description = [[
+CICS User ID brute forcing script for the CESL login screen.
+]]
+
+-- @args cics-user-enum.commands Commands in a semi-colon seperated list needed
+--  to access CICS. Defaults to <code>CICS</code>.
+--
+-- @usage
+-- nmap --script=cics-user-enum -p 23 <targets>
+--
+-- nmap --script=cics-user-enum --script-args userdb=users.txt,
+-- cics-user-enum.commands="exit;logon applid(cics42)" -p 23 <targets>
+--
+-- @output
+-- PORT   STATE SERVICE
+-- 23/tcp open  tn3270
+-- | cics-user-enum:
+-- |   Accounts:
+-- |     PLAGUE: Valid - CICS User ID
+-- |_  Statistics: Performed 31 guesses in 114 seconds, average tps: 0
+--
+-- @changelog
+-- 2016-08-29 - v0.1 - created by Soldier of Fortran
+-- 2016-10-26 - v0.2 - Added RACF support
+-- 2017-01-23 - v0.3 - Rewrote script to use fields and skip enumeration to speed up testing
+--
+-- @author Philip Young
+-- @copyright Same as Nmap--See http://nmap.org/book/man-legal.html
+--
+
+author = "Philip Young aka Soldier of Fortran"
+license = "Same as Nmap--See http://nmap.org/book/man-legal.html"
+categories = {"intrusive", "brute"}
+portrule = shortport.port_or_service({23,992}, "tn3270")
+
+--- Registers User IDs that no longer need to be tested
+--
+-- @param username to stop checking
+local function register_invalid( username )
+  if nmap.registry.cicsinvalid == nil then
+    nmap.registry.cicsinvalid = {}
+  end
+  stdnse.debug(2,"Registering %s", username)
+  nmap.registry.cicsinvalid[username] = true
+end
+
+Driver = {
+  new = function(self, host, port, options)
+    local o = {}
+    setmetatable(o, self)
+    self.__index = self
+    o.host = host
+    o.port = port
+    o.options = options
+    o.tn3270 = tn3270.Telnet:new()
+    return o
+  end,
+  connect = function( self )
+    local status, err = self.tn3270:initiate(self.host,self.port)
+    self.tn3270:get_screen_debug(2)
+    if not status then
+      stdnse.debug("Could not initiate TN3270: %s", err )
+      return false
+    end
+    stdnse.debug(2,"Connect Successful")
+    return true
+  end,
+  disconnect = function( self )
+    self.tn3270:disconnect()
+    self.tn3270 = nil
+    return true
+  end,
+  login = function (self, user, pass)
+    local commands = self.options['key1']
+    local timeout = 300
+    local max_blank = 1
+    local loop = 1
+    local err
+    stdnse.debug(2,"Getting to CICS")
+    local run = stdnse.strsplit(";%s*", commands)
+    for i = 1, #run do
+      stdnse.debug(2,"Issuing Command (#%s of %s): %s", i, #run ,run[i])
+      self.tn3270:send_cursor(run[i])
+      self.tn3270:get_all_data()
+      self.tn3270:get_screen_debug(2)
+    end
+    -- Are we at the logon transaction? 
+    if not (self.tn3270:find('SIGN ON TO CICS') or self.tn3270:find("Signon to CICS")) then
+      -- We might be at some weird screen, lets try and exit it then clear it out
+      stdnse.debug(2,"Sending: F3")
+      self.tn3270:send_pf(3) -- send F3
+      self.tn3270:get_all_data()
+      stdnse.debug(2,"Clearing the Screen")
+      self.tn3270:send_clear()
+      self.tn3270:get_all_data()
+      self.tn3270:get_screen_debug(2)
+      stdnse.debug(2,"Sending 'CESL'")
+      self.tn3270:send_cursor('CESL')
+      self.tn3270:get_all_data()
+      -- Have we encoutered a slow system?
+      if self.tn3270:isClear() then
+          self.tn3270:get_all_data(1000)
+        end
+        self.tn3270:get_screen_debug(2)
+    end
+      -- At this point we MUST be at CESL to try accounts. 
+      -- If we're not then we quit with an error
+    if not (self.tn3270:find('SIGN ON TO CICS') or self.tn3270:find("Signon to CICS")) then
+      local err = brute.Error:new( "Can't get to CESL")
+      err:setRetry( true )
+      return false, err
+    end
+
+      -- Ok we're good we're at CESL. Send the Userid and Password.
+    local fields = self.tn3270:writeable() -- Get the writeable field areas
+    local user_loc = {fields[1][1],user}   -- This is the 'UserID:' field
+    local pass_loc = {fields[3][1],pass}   -- This is the 'Password:' field ([2] is a group ID)
+    stdnse.verbose('Trying CICS: ' .. user ..' : ' .. pass)
+    self.tn3270:send_locations({user_loc,pass_loc})
+    self.tn3270:get_all_data()
+    stdnse.debug(2,"Screen Recieved for User ID: %s/%s", user, pass)
+    self.tn3270:get_screen_debug(2)
+    
+    local loop = 1
+    while loop < 300 and self.tn3270:find('DFHCE3520') do -- still at Enter UserID message?
+      stdnse.verbose('Trying CICS: ' .. user ..' : ' .. pass)
+      self.tn3270:send_locations({user_loc,pass_loc})
+      self.tn3270:get_all_data()
+      stdnse.debug(2,"Screen Recieved for User ID: %s/%s", user, pass)
+      self.tn3270:get_screen_debug(2)
+      loop = loop + 1 -- We don't want this to loop forever
+    end
+
+    if loop == 300 then 
+      local err = brute.Error:new( "Error with UserID entry")
+      err:setRetry( true )
+      return false, err
+    end
+
+    -- Now check what we recieved if its valid or not
+    if self.tn3270:find('TSS7101E') or 
+       self.tn3270:find('DFHCE3530') or
+       self.tn3270:find('DFHCE3532') then
+      -- Top Secret:
+      -- TSS7101E Password is Incorrect
+      -- RACF:
+      -- DFHCE3530/2 Your userid or password is invalid. Please retype both.
+      return false, brute.Error:new( "Incorrect password" )       
+    elseif self.tn3270:find('TSS7145E') or
+           self.tn3270:find("TSS714[0-3]E")  or
+           self.tn3270:find('TSS7160E') or
+           self.tn3270:find('TSS7120E') then
+      -- Top Secret:
+      -- TSS7140E Accessor ID Has Expired: No Longer Valid
+      -- TSS7141E Use of Accessor ID Suspended
+      -- TSS7142E Accessor ID Not Yet Available for Use - Still Inactive
+      -- TSS7143E Accessor ID Has Been Inactive Too Long
+      -- TSS7120E PASSWORD VIOLATION THRESHOLD EXCEEDED
+	    -- TSS7145E ACCESSOR ID <acid> NOT DEFINED TO SECURITY
+      -- TSS7160E Facility <X> Not Authorized for Your Use
+      -- Store the invalid ID in the registry so we don't keep trying it with subsequent passwords
+      -- when using default brute library.
+      register_invalid(user)
+      return false,  brute.Error:new( "User ID Not Able to Use CICS" )
+    elseif self.tn3270:find("DFHCE3549") or 
+           self.tn3270:find('TSS7000I')  or
+           self.tn3270:find('TSS7110E Password Has Expired. New Password Missing')  or
+           self.tn3270:find('TSS7001I')  then
+      stdnse.verbose("Valid CICS UserID / Password: " .. user .. "/" .. pass)
+      return true, creds.Account:new(user, pass, creds.State.VALID)
+    else
+      -- ok whoa, something happened, print the screen but don't store as valid
+      stdnse.verbose("Valid(?) user/pass with current output " .. user .. "/" .. pass .. "\n" ..  self.tn3270:get_screen())
+      return false, brute.Error:new( "Incorrect password" )
+    end
+    return false, brute.Error:new("Something went wrong, we didn't get a proper response")
+  end
+}
+
+--- Tests the target to see if we can even get to CICS
+--
+-- @param host host NSE object
+-- @param port port NSE object
+-- @param commands optional script-args of commands to use to get to CICS
+-- @return status true on success, false on failure
+
+local function cics_test( host, port, commands )
+  stdnse.verbose(2,"Checking for CICS Login Page")
+  local tn = tn3270.Telnet:new()
+  local status, err = tn:initiate(host,port)
+  local cesl = false -- initially we're not at CICS
+  if not status then
+    stdnse.debug("Could not initiate TN3270: %s", err )
+    return false
+  end
+  tn:get_screen_debug(2) -- prints TN3270 screen to debug
+  stdnse.debug(2,"Getting to CICS")
+  local run = stdnse.strsplit(";%s*", commands)
+  for i = 1, #run do
+    stdnse.debug(2,"Issuing Command (#%s of %s): %s", i, #run ,run[i])
+    tn:send_cursor(run[i])
+    tn:get_all_data()
+    tn:get_screen_debug(2)
+  end
+  tn:get_all_data()
+  tn:get_screen_debug(2) -- for debug purposes
+  -- We should now be at CICS. Check if we're already at the logon screen
+  if tn:find('SIGN ON TO CICS') and tn:find("Signon to CICS") then
+    stdnse.verbose(2,"At CICS Login Transaction (CESL)")
+    tn:disconnect()
+    return true
+  end
+  -- Uh oh. We're not at the logon screen. Now we need to send:
+  --   * F3 to exit the CICS program
+  --   * CLEAR (a tn3270 command) to clear the screen.
+  --     (you need to clear before sending a transaction ID)
+  --   * a known default CICS transaction ID with predictable outcome
+  --     (CESF with 'Sign-off is complete.' as the result)
+  -- to confirm that we were in CICS. If so we return true
+  -- otherwise we return false
+  count = 1
+  while not tn:isClear() and count < 6 do
+    -- some systems will just kick you off others are slow in responding
+    -- this loop continues to try getting out of whatever transaction 5 times. If it can't
+    -- then we probably weren't in CICS to begin with.
+    stdnse.debug(2,"Sending: F3")
+    tn:send_pf(3) -- send F3
+    tn:get_all_data()
+    stdnse.debug(2,"Clearing the Screen")
+    tn:send_clear()
+    tn:get_all_data()
+    tn:get_screen_debug(2)
+    count = count + 1
+  end
+  if count == 5 then
+    return false, 'Could not get to CICS after 5 attempts. Is this even CICS?'
+  end
+  stdnse.debug(2,"Sending 'CESL'")
+  tn:send_cursor('CESL')
+  tn:get_all_data()
+  if tn:isClear() then
+    tn:get_all_data(1000)
+  end
+  tn:get_screen_debug(2)
+
+  if tn:find("Signon to CICS") then
+      stdnse.verbose(2,"At CICS Login Transaction (CESL)")
+      tn:disconnect()
+      return true
+  end
+  tn:disconnect()
+  return false, 'Could not get to CESL (CICS Logon Screen)'
+end
+
+-- Filter iterator for unpwdb
+-- IDs are limited to 8 alpha numeric and @, #, $ and can't start with a number
+-- pattern:
+--  ^%D     = The first char must NOT be a digit
+-- [%w@#%$] = All letters including the special chars @, #, and $.
+local valid_name = function(x)
+  if  nmap.registry.tsoinvalid and nmap.registry.tsoinvalid[x] then
+    return false
+  end
+  return (string.len(x) <= 8 and string.match(x,"^%D+[%w@#%$]"))
+end
+
+-- Checks string to see if it follows valid password limitations
+local valid_pass = function(x)
+  return (string.len(x) <= 8 )
+end
+
+action = function(host, port)
+  local commands = stdnse.get_script_args(SCRIPT_NAME .. '.commands') or "cics"
+  local cicstst, err = cics_test(host, port, commands)
+  if cicstst then
+    local options = { key1 = commands }
+    local engine = brute.Engine:new(Driver, host, port, options)
+    stdnse.debug(2,"Starting CICS Brute Forcing")
+    engine:setUsernameIterator(unpwdb.filter_iterator(brute.usernames_iterator(),valid_name))
+    engine:setPasswordIterator(unpwdb.filter_iterator(brute.passwords_iterator(),valid_pass))
+    engine.options.script_name = SCRIPT_NAME
+    engine.options:setTitle("CICS User Accounts")
+    status, result = engine:start()
+    return result
+  else
+    return err
+  end
+end

--- a/scripts/cics-user-enum.nse
+++ b/scripts/cics-user-enum.nse
@@ -108,7 +108,7 @@ Driver = {
     -- At this point we MUST be at CESL/CESN to try accounts.
     -- If we're not then we quit with an error
     if not (self.tn3270:find('SIGN ON TO CICS') or self.tn3270:find("Signon to CICS")) then
-    local err = brute.Error:new( "Can't get to CESL")
+    local err = brute.Error:new( "Can't get to Transaction")
       err:setRetry( true )
       return false, err
     end
@@ -228,7 +228,7 @@ end
 --  ^%D     = The first char must NOT be a digit
 -- [%w@#%$] = All letters including the special chars @, #, and $.
 local valid_name = function(x)
-  return (string.len(x) <= 7 and string.match(x,"^%D+[%w@#%$]"))
+  return (string.len(x) <= 8 and string.match(x,"^%D+[%w@#%$]"))
 end
 
 action = function(host, port)
@@ -244,8 +244,6 @@ action = function(host, port)
     engine.options.passonly = true
     engine.options:setTitle("CICS User ID")
     local status, result = engine:start()
-    -- port.version.extrainfo = "Security: " .. secprod
-    -- nmap.set_port_version(host, port)
     return result
   else
     return err

--- a/scripts/cics-user-enum.nse
+++ b/scripts/cics-user-enum.nse
@@ -213,7 +213,7 @@ local function cics_test( host, port, commands, transaction )
   end
   tn:get_screen_debug(2)
 
-  if tn:find('SIGN ON TO CICS') and tn:find("Signon to CICS") then
+  if tn:find('SIGN ON TO CICS') or tn:find("Signon to CICS") then
       stdnse.verbose(2,"At CICS Login Transaction (%s)", transaction)
       tn:disconnect()
       return true


### PR DESCRIPTION
This pull request adds/fixes the following

- `cics-enum` support for testing transaction IDs with a valid username/password (transaction IDs that need auth can now be discovered)

- `cics-user-enum` added support for RACF messages and other fixes

- **New** `cics-user-brute` A new script for brute forcing CICS user IDs

- **New** `cics-info` A new script which uses the CEMT cics transaction ID to gather system information. 