### PR TITLE
Password profiling in NSE

### DIFF
--- a/nselib/brute.lua
+++ b/nselib/brute.lua
@@ -593,7 +593,7 @@ Engine = {
       tps = {},
       iterator = nil,
       usernames = usernames_iterator(),
-      passwords = passwords_iterator(),
+      passwords = passwords_iterator(stdnse.get_script_args("brute.passprofile")),
       found_accounts = {},
       account_guesses = {},
       options = Options:new(),
@@ -1285,7 +1285,11 @@ end
 
 --- Default password iterator that uses unpwdb
 --
-function passwords_iterator ()
+function passwords_iterator (passprofile_arg)
+  if (passprofile_arg=="true" or passprofile_arg==true or tonumber(passprofile_arg)==1) then
+    unpwdb.add_profiled_pwds()
+  end
+
   local status, passwords = unpwdb.passwords()
   if not status then
     return "Failed to load passwords"

--- a/scripts/ftp-brute.nse
+++ b/scripts/ftp-brute.nse
@@ -4,6 +4,7 @@ local nmap = require "nmap"
 local shortport = require "shortport"
 local stdnse = require "stdnse"
 local string = require "string"
+local unpwdb = require "unpwdb"
 
 description = [[
 Performs brute force password auditing against FTP servers.
@@ -37,8 +38,10 @@ Based on old ftp-brute.nse script by Diman Todorov, Vlatko Kosturjak and Ron Bow
 author = "Aleksandar Nikolic"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 categories = {"intrusive", "brute"}
+dependencies = unpwdb.PWDPROFILE_SCRIPTS
 
 portrule = shortport.port_or_service(21, "ftp")
+
 
 local arg_timeout = stdnse.parse_timespec(stdnse.get_script_args(SCRIPT_NAME .. ".timeout"))
 arg_timeout = (arg_timeout or 5) * 1000

--- a/scripts/http-form-brute.nse
+++ b/scripts/http-form-brute.nse
@@ -7,6 +7,7 @@ local stdnse = require "stdnse"
 local string = require "string"
 local table = require "table"
 local url = require "url"
+local unpwdb = require "unpwdb"
 
 description = [[
 Performs brute force password auditing against http form-based authentication.
@@ -105,7 +106,7 @@ the following rules:
 author = {"Patrik Karlsson", "nnposter"}
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 categories = {"intrusive", "brute"}
-
+dependencies = unpwdb.PWDPROFILE_SCRIPTS
 
 portrule = shortport.port_or_service( {80, 443}, {"http", "https"}, "tcp", "open")
 

--- a/scripts/http-title.nse
+++ b/scripts/http-title.nse
@@ -3,6 +3,7 @@ local nmap = require "nmap"
 local shortport = require "shortport"
 local stdnse = require "stdnse"
 local string = require "string"
+local unpwdb = require "unpwdb"
 
 description = [[
 Shows the title of the default page of a web server.
@@ -30,7 +31,6 @@ author = "Diman Todorov"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 
 categories = {"default", "discovery", "safe"}
-
 
 portrule = shortport.http
 
@@ -78,6 +78,7 @@ action = function(host, port)
   if redirect_url then
     output_str = output_str .. "\n" .. ("Requested resource was %s"):format( redirect_url )
   end
+  unpwdb.save_for_pwdprofiling( host, title )
 
   return output_tab, output_str
 end


### PR DESCRIPTION
This Pull Request a) introduces password profiling in NSE and b) modifies three scripts (http-title, http-form-brute and ftp-brute) to leverage the new capabilities.

For a more detailed description of this feature, please read my <a href="http://seclists.org/nmap-dev/2016/q2/46">post on the list</a>.

To test this PR, setup an environment that runs both FTP (e.g. vsftpd) and web (e.g. Apache) servers. Serve a website with a title and create an FTP user with the same title as password. Run nmap as

`./nmap -n -Pn -p21,80 -oN output-local-pwdprof --script http-title,ftp-brute --script-args brute.passprofile=1,unpwdb.timelimit=0 -d 127.0.0.1`

Nmap should use the retrieved HTML title as a password candidate and successfully retrieve a valid account for the FTP server.