### PR TITLE
Update su-to-zenmap.sh for use with kde-frameworks 5

### DIFF
--- a/zenmap/install_scripts/unix/su-to-zenmap.sh
+++ b/zenmap/install_scripts/unix/su-to-zenmap.sh
@@ -24,12 +24,16 @@ else
         if test "X$KDE_FULL_SESSION" = "Xtrue" ; then
           if which kdesu >/dev/null 2>&1 ; then
             SU_TO_ROOT_X=kdesu
+          elif which kdesu5 >/dev/null 2>&1 ; then
+            SU_TO_ROOT_X=kdesu5
           elif test -x /usr/lib/kde4/libexec/kdesu ; then
             SU_TO_ROOT_X=kde4su
           fi;
         fi;
       elif which kdesu >/dev/null 2>&1 ; then 
         SU_TO_ROOT_X=kdesu
+      elif which kdesu5 >/dev/null 2>&1 ; then
+        SU_TO_ROOT_X=kdesu5
       elif test -x /usr/lib/kde4/libexec/kdesu ; then
         SU_TO_ROOT_X=kde4su
       elif which ktsuss >/dev/null 2>&1 ; then
@@ -47,6 +51,7 @@ else
     case $SU_TO_ROOT_X in
       gksu) gksu -u "$PRIV" "$COMMAND";;
       kdesu) kdesu -u "$PRIV" -c "$COMMAND";;
+      kdesu5) kdesu5 -u "$PRIV" -c "$COMMAND";;
       kde4su) /usr/lib/kde4/libexec/kdesu -u "$PRIV" -c "$COMMAND";;
       ktsuss) ktsuss -u "$PRIV" "$COMMAND";;
   # As a last resort, open a new xterm use sudo/su


### PR DESCRIPTION
Pure KDE5 systems no longer have the kdesu or kde4su binary, so the script fails to launch zenmap as root. This patch adds the kdesu5 option to use the /usr/bin/kdesu5 binary to launch zenmap as root.