### PR TITLE
Openflow info

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -2241,8 +2241,20 @@ match oftp m|^\x10\0\0\x17IODETTE FTP READY \r$| p/ODETTE File Transfer Protocol
 match oo-defrag m|^\x99\0\0\0\x01\0\0\0\x03\0\0\0\xb9\x08\0\0\x02\0\0\0\x01\0\0\0\0\0\0\0N\x06\0\0\0\0\0\0\x01\0\0\0\0\0\0\0\n\x0b\0\0\0\xe8\xff\x01\0\x95\x8a\x01\0\0\0\0\0\0\0\0\0\x12\0\0\0 o\0\0\x13\0\0\0p\0\0\0\xf5\x01\0\0\x8c\x02\0\0\x1c\x01\0\0\x01\0\0\0\x03\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0gM1\x06\0\0\0\0\x01\0\0\0gM1\x06\0\0\0\0\x98\xadm\t\0\0\0\0\x02\0\0\0\xff\xfa\x9e\x0f\0\0\0\0\0\xff\r\x06\0\0\0\0\x99\0\0\0\x01\0\0\0\x03\0\0\0\xb9\x08\0\0\x02\0\0\0\x01\0\0\0\0\0\0\0N\x06\0\0\0\0\0\0\x01\0\0\0\0\0\0\0\x04\x0b\0\0\0\xe8\xff\x01\0\x95\x8a\x01\0\0\0\0\0\0\0\0\0\x12\0\0\0!o\0\0\x13\0\0\0p\0\0\0\xf5\x01\0\0\x8c\x02\0\0\x1c\x01\0\0\0\0\0\0\x03\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0gM1\x06\0\0\0\0\x01\0\0\0gM1\x06\0\0\0\0\x98\xadm\t\0\0\0\0\x02\0\0\0\xff\xfa\x9e\x0f\0\0\0\0\0\xff\r\x06\0\0\0\0\x99\0\0\0\x01\0\0\0\x03\0\0\0\xb9\x08\0\0\x02\0\0\0\x01\0\0\0\0\0\0\0o\x0e\0\0\0\0\0\0\x01\0\0\0\0\0\0\0\n\x0b\0\0\0\xe8\xff\x01\0\x95\x8a\x01\0\0\0\0\0\0\0\0\0\x12\0\0\0 o\0\0\x13\0\0\0p\0\0\0\xf5\x01\0\0\x8c\x02\0\0\x1c\x01\0\0\x01\0\0\0\x03\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0gM1\x06\0\0\0\0\x01\0\0\0gM1\x06\0\0\0\0\x98\xadm\t\0\0\0\0\x02\0\0\0\xff\xfa\x9e\x0f\0\0\0\0\0\xff\r\x06\0\0\0\x006\x01\0\0\x01\0\0\0\x03\0\0\0\x07\x08\0\0\x02\0\0\0\x07\x052Q\0\0L\^\x03\0\0\0\0\0\xa2\x88\0\0\0\0\0\0\xd9\xe6\x03\0\0\0\0\0\xb9\x02\0\0\0\0\0\0\x0e\x0b\0\0\0\0\0\0\)\xb8\x02\0\0\0\0\0\xed\x07\x95\?\0\0C\xad/\+i\0t\r\0\0\0\0\0\0{{\x16\x05\0\0\0\0\0\0\0\0\xd0\0\0\0((?:[^\0]\0)+)\0\x006\x01\0\0\x01\0\0\0\x03\0\0\0\x07\x08\0\0\x02\0\0\0\x07\x052Q\0\0L\^\x03\0\0\0\0\0\xa2\x88\0\0\0\0\0\0\xd9\xe6\x03\0\0\0\0\0\xb9\x02\0\0\0\0\0\0\x0e\x0b\0\0\0\0\0\0\)\xb8\x02\0\0\0\0\0\xed\x07\x95\?\0\0C\xad/\+i\0t\r\0\0\0\0\0\0{{\x16\x05\0$|s p/O&O Defrag Professional/ v/15/ i/path: $P(1)/
 
 # https://wiki.wireshark.org/OpenFlow
-# 4-byte TXID is random in OpenDaylight, sequential in POX
-softmatch openflow m|^\x01\0\0\x08....$| i/OpenFlow 1.0/
+# 4-byte TXID is random in OpenDaylight, sequential in POX, and decrementing from 0xFFFFFFFF in floodlight.
+# An extension may or may not be sent, account for both cases.
+match openflow m|^\x06\0\0\x08....$| p/OpenFlow/ v/1.5.x/
+match openflow m|^\x05\0\0\x08....$| p/OpenFlow/ v/1.4.x/
+match openflow m|^\x04\0\0\x08....$| p/OpenFlow/ v/1.3.x/
+match openflow m|^\x03\0\0\x08....$| p/OpenFlow/ v/1.2/
+match openflow m|^\x02\0\0\x08....$| p/OpenFlow/ v/1.1/
+match openflow m|^\x01\0\0\x08....$| p/OpenFlow/ v/1.0/
+match openflow m|^\x06\0\0\x10....\0\x01\0\x08\0\0\0.$| p/OpenFlow/ v/1.5.x/
+match openflow m|^\x05\0\0\x10....\0\x01\0\x08\0\0\0.$| p/OpenFlow/ v/1.4.x/
+match openflow m|^\x04\0\0\x10....\0\x01\0\x08\0\0\0.$| p/OpenFlow/ v/1.3.x/
+match openflow m|^\x03\0\0\x10....\0\x01\0\x08\0\0\0.$| p/OpenFlow/ v/1.2/
+match openflow m|^\x02\0\0\x10....\0\x01\0\x08\0\0\0.$| p/OpenFlow/ v/1.1/
+match openflow m|^\x01\0\0\x10....\0\x01\0\x08\0\0\0.$| p/OpenFlow/ v/1.0/
 
 match openfpc m|^OFPC READY\n$| p/OpenFPC packet capture/
 

--- a/scripts/openflow-info.nse
+++ b/scripts/openflow-info.nse
@@ -158,7 +158,7 @@ retrieve_version_bitmap = function(message)
   local body = message.body
   while pos + 4 < #body - 1 do
     local element_length, element_type
-    element_type, element_type, pos = string.unpack(">I2 I2", body, pos)
+    element_type, element_length, pos = string.unpack(">I2 I2", body, pos)
     if pos + element_length < #body then
       stdnse.debug1("Ran out of data parsing element type %d at position %d.", element_type, pos)
       return

--- a/scripts/openflow-info.nse
+++ b/scripts/openflow-info.nse
@@ -9,6 +9,9 @@ description = [[
 Queries OpenFlow controllers for information. Newer versions of the OpenFlow
 protocol (1.3 and greater) will return a list of all protocol versions supported
 by the controller. Versions prior to 1.3 only return their own version number.
+
+For additional information:
+* https://www.opennetworking.org/images/stories/downloads/sdn-resources/onf-specifications/openflow/openflow-switch-v1.5.0.noipr.pdf
 ]]
 
 ---

--- a/scripts/openflow-info.nse
+++ b/scripts/openflow-info.nse
@@ -60,7 +60,6 @@ local HELLO_MESSAGE = "\x01\x00\x00\x08\xff\xff\xff\xff"
 portrule = shortport.version_port_or_service({6633, 6653}, "openflow", "tcp")
 
 receive_message = function(host, port)
-
   -- Handshake Info:
   -- Versions 1.3.1 and later say hello with a bitmap of versions supported
   -- Earlier versions either say hello without the bitmap.

--- a/scripts/openflow-info.nse
+++ b/scripts/openflow-info.nse
@@ -15,7 +15,9 @@ For additional information:
 ]]
 
 ---
---@output
+-- @usage nmap -p 6633,6653 --script openflow-info <target>
+-- @output
+-- PORT     STATE SERVICE REASON
 -- 6653/tcp open  openflow
 -- | openflow-info:
 -- |   OpenFlow Running Version: 1.5.X

--- a/scripts/openflow-info.nse
+++ b/scripts/openflow-info.nse
@@ -29,7 +29,7 @@ For additional information:
 -- |     1.4.X
 -- |_    1.5.X
 
-author = "Jay Smith"
+author = {"Jay Smith", "Mak Kolybabi <mak@kolybabi.com>"}
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 categories = {"default", "safe"}
 

--- a/scripts/openflow-info.nse
+++ b/scripts/openflow-info.nse
@@ -115,12 +115,12 @@ receive_message = function(host, port)
   local message_id, pos = string.unpack(">I4", response, pos)
   message.id = message_id
 
-  -- All remaining data up to the message_length is the body.
-  assert(pos == 9)
-  message.body = response:sub(pos, message_length - 1)
+  -- All remaining data from the response, up until the message length, is the body.
+  assert(pos == OPENFLOW_HEADER_SIZE + 1)
+  message.body = response:sub(pos, message_length)
 
   -- If we have the whole packet, pass it up the call stack.
-  if message_length <= #message then
+  if message_length <= #response then
     socket:close()
     return message
   end
@@ -134,7 +134,7 @@ receive_message = function(host, port)
     stdnse.debug1("Failed to receive missing %d bytes of response: %s", missing_bytes, body)
     return
   end
-  message.body = (response .. body):sub(pos, message_length - 1)
+  message.body = (response .. body):sub(pos, message_length)
 
   return message
 end
@@ -168,7 +168,7 @@ retrieve_version_bitmap = function(message)
       return string.unpack(">I4", body, pos)
     end
 
-    pos = pos + element_length
+    pos = pos + element_length - 4
   end
 
   return

--- a/scripts/openflow-info.nse
+++ b/scripts/openflow-info.nse
@@ -1,0 +1,133 @@
+local comm = require "comm"
+local shortport = require "shortport"
+local stdnse = require "stdnse"
+local string = require "string"
+local match = require "match"
+local table = require "table"
+
+description = [[
+Queries OpenFlow controllers for information
+]]
+
+---
+--@output
+-- 6653/tcp open  openflow
+-- | openflow-info:
+-- |   OpenFlow Running Version: 1.5.X
+-- |   OpenFlow Versions Supported:
+-- |     1.0
+-- |     1.1
+-- |     1.2
+-- |     1.3.X
+-- |     1.4.X
+-- |_    1.5.X
+
+author = "Jay Smith"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"default", "safe"}
+
+-- OpenFlow versions released:
+-- 0x01 = 1.0
+-- 0x02 = 1.1
+-- 0x03 = 1.2
+-- 0x04 = 1.3.X
+-- 0x05 = 1.4.X
+-- 0x06 = 1.5.X
+-- The bits in the version bitmap are indexed by the ofp version number of the
+-- protocol. If the bit identified by the number of left bitshift equal
+-- to a ofp version number is set, this OpenFlow version is supported.
+local openflow_versions = {
+  [0x02] = '1.0',
+  [0x04] = '1.1',
+  [0x08] = '1.2',
+  [0x10] = '1.3.X',
+  [0x20] = '1.4.X',
+  [0x40] = '1.5.X'
+}
+
+local OPENFLOW_HEADER_SIZE = 8
+local OFPT_HELLO = 0
+local OFPHET_VERSIONBITMAP = 1
+local HELLO_MESSAGE = "\x01\x00\x00\x08\xff\xff\xff\xff"
+
+portrule = shortport.version_port_or_service({6633, 6653}, "openflow", "tcp")
+
+receive_message = function(host, port)
+
+  -- Handshake Info:
+  -- Versions 1.3.1 and later say hello with a bitmap of versions supported
+  -- Earlier versions either say hello without the bitmap.
+  -- Some implementations are shy and don't make the first move, so we'll say
+  -- hello first. We'll pretend to be a switch using version 1.0 of the protocol
+  local socket, message = comm.tryssl(host, port, HELLO_MESSAGE, { recv_first = false, bytes = 8 } )
+
+  -- third and fourth bytes contain the length of the message, including the header
+  local message_length = string.unpack(">I2", message, 3)
+  if message_length > OPENFLOW_HEADER_SIZE then
+    local status, body = socket:receive_buf(match.numbytes(message_length - OPENFLOW_HEADER_SIZE), true)
+    if not status then
+      return false, body
+    end
+    message = message .. body
+  end
+  socket:close()
+  return true, message
+end
+
+retrieve_version_bitmap = function(message)
+  -- HELLO message structure:
+  -- /* OFPT_HELLO. This message includes zero or more hello elements having
+  -- * variable size. Unknown elements types must be ignored/skipped, to allow
+  -- * for future extensions. */
+  -- struct ofp_hello {
+  -- struct ofp_header header;
+  -- /* Hello element list */
+  -- struct ofp_hello_elem_header elements[0]; /* List of elements - 0 or more */
+  -- };
+  -- The HELLO message may contain zero or more hello elements. One of these
+  -- hello elements may be of the type OFPHET_VERSIONBITMAP. We must search
+  -- through elements until we find OFPHET_VERSIONBITMAP.
+  -- Note: As of version 1.5, OFPHET_VERSIONBITMAP is the only standard hello element type.
+  -- However, we can not assume that this will be the case for long.
+  local index = OPENFLOW_HEADER_SIZE + 1
+  while index < #message do
+    local element_type = string.unpack(">I2", message, index)
+    local element_length = string.unpack(">I2", message, index + 2)
+
+    if element_type == OFPHET_VERSIONBITMAP then
+      stdnse.debug(1, "Version Index: %i", index + 4)
+      return string.unpack(">I4", message, index + 4)
+    end
+
+    index = index + element_length
+  end
+  return nil
+end
+
+action = function(host, port)
+  local supported_versions = {}
+  local results = {}
+
+  local status, message = receive_message(host, port)
+  if not status then
+    return false, message
+  end
+  local current_version = string.unpack(">I1", message, 1)
+  results['OpenFlow Running Version'] = openflow_versions[2^current_version]
+
+  local message_type = string.unpack(">I1", message, 2)
+  if message_type == OFPT_HELLO then
+    local version_bitmap = retrieve_version_bitmap(message)
+    if version_bitmap ~= nil then
+      for mask, version in pairs(openflow_versions) do
+        if mask & version_bitmap then
+          table.insert(supported_versions, version)
+        end
+      end
+      table.sort(supported_versions)
+      results['OpenFlow Versions Supported'] = supported_versions
+    end
+  end
+
+  return results
+end

--- a/scripts/openflow-info.nse
+++ b/scripts/openflow-info.nse
@@ -6,7 +6,9 @@ local match = require "match"
 local table = require "table"
 
 description = [[
-Queries OpenFlow controllers for information
+Queries OpenFlow controllers for information. Newer versions of the OpenFlow
+protocol (1.3 and greater) will return a list of all protocol versions supported
+by the controller. Versions prior to 1.3 only return their own version number.
 ]]
 
 ---
@@ -37,12 +39,12 @@ categories = {"default", "safe"}
 -- protocol. If the bit identified by the number of left bitshift equal
 -- to a ofp version number is set, this OpenFlow version is supported.
 local openflow_versions = {
-  [0x02] = '1.0',
-  [0x04] = '1.1',
-  [0x08] = '1.2',
-  [0x10] = '1.3.X',
-  [0x20] = '1.4.X',
-  [0x40] = '1.5.X'
+  [0x02] = "1.0",
+  [0x04] = "1.1",
+  [0x08] = "1.2",
+  [0x10] = "1.3.X",
+  [0x20] = "1.4.X",
+  [0x40] = "1.5.X"
 }
 
 local OPENFLOW_HEADER_SIZE = 8
@@ -59,7 +61,7 @@ receive_message = function(host, port)
   -- Earlier versions either say hello without the bitmap.
   -- Some implementations are shy and don't make the first move, so we'll say
   -- hello first. We'll pretend to be a switch using version 1.0 of the protocol
-  local socket, message = comm.tryssl(host, port, HELLO_MESSAGE, { recv_first = false, bytes = 8 } )
+  local socket, message = comm.tryssl(host, port, HELLO_MESSAGE, { recv_first = false, bytes = OPENFLOW_HEADER_SIZE } )
 
   -- third and fourth bytes contain the length of the message, including the header
   local message_length = string.unpack(">I2", message, 3)
@@ -113,7 +115,7 @@ action = function(host, port)
     return false, message
   end
   local current_version = string.unpack(">I1", message, 1)
-  results['OpenFlow Running Version'] = openflow_versions[2^current_version]
+  results["OpenFlow Running Version"] = openflow_versions[2^current_version]
 
   local message_type = string.unpack(">I1", message, 2)
   if message_type == OFPT_HELLO then
@@ -125,7 +127,7 @@ action = function(host, port)
         end
       end
       table.sort(supported_versions)
-      results['OpenFlow Versions Supported'] = supported_versions
+      results["OpenFlow Versions Supported"] = supported_versions
     end
   end
 


### PR DESCRIPTION
[https://secwiki.org/w/Nmap/Script_Ideas#.60openflow-info.60_and_service_probe](https://secwiki.org/w/Nmap/Script_Ideas#.60openflow-info.60_and_service_probe)
Script for gathering information from openflow controllers and a service probe for all versions.

Unfortunately, all of the really interesting information gathering packets in openflow, such as feature request or description request, are designed to be sent from the openflow controller to the switch (played here by nmap) rather than the other way around. For newer versions of openflow (>= 1.3), we are able to at least enumerate all supported versions of the protocol spoken by the controller.