### PR TITLE
Impress remote discover

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -15478,3 +15478,10 @@ ports 6715
 sslports 6715
 
 match jmon m|^ACKNOWLEDGE| p/JMON for zOS (FMID HALG300)/ o|z/OS| cpe:/a:ibm:zos_explorer/ cpe:/o:ibm:z%2fos/
+
+##############################NEXT PROBE##############################
+# LibreOffice Impress Remote Server
+Probe TCP LibreOfficeImpressSCPair q|LO_SERVER_CLIENT_PAIR\nFirefox OS\n0000\n\n|
+rarity 9
+ports 1599
+match libreoffice-impress-remote m|^LO_SERVER_VALIDATING_PIN\n$| p/LibreOffice Impress/

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -10,14 +10,7 @@ if requested.
 ]]
 
 ---
--- @usage
--- nmap --script impress-remote-discover -p 1599 <host>
---
--- @args impress-remote-discover.pin PIN number for the remote (default is
---       <code>0000</code>).
---
--- @args impress-remote-discover.bruteforce Boolean to enable bruteforcing the PIN (default is
---       <code>false</code>).
+-- @usage nmap -p 1599 --script impress-remote-discover <host>
 --
 -- @output
 -- PORT     STATE SERVICE
@@ -26,6 +19,12 @@ if requested.
 -- |   Command: id
 -- |   Results: uid=0(root) gid=0(wheel) groups=0(wheel)
 -- |_
+--
+-- @args impress-remote-discover.pin PIN number for the remote (default is
+--       <code>0000</code>).
+--
+-- @args impress-remote-discover.bruteforce Boolean to enable bruteforcing the
+--        PIN (default is <code>false</code>).
 
 author = "Jer Hiebert"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -120,6 +120,10 @@ local bruteforce = function(host, port)
   for i=0,9999 do
     -- Pad the pin with leading zeros if required
     local pin = string.format("%04d", i)
+    if i % 100 == 0 then
+      stdnse.debug1("Bruteforce attempt %d with PIN %s...", i + 1, pin)
+    end
+
     local buffer, socket = remote_connect(host, port, pin)
     if not buffer then
       return

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -52,6 +52,8 @@ local function parse_args()
       return false, "pin argument must be a number."
     elseif pin < 0 or pin > 9999 then
       return false, "pin argument must be in range between 0000 and 9999 inclusive."
+    elseif bruteforce then
+      return false, "When bruteforcing is enabled, a PIN cannot be set."
     end
   end
   args.pin = pin or 0

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -1,0 +1,161 @@
+local nmap = require "nmap"
+local shortport = require "shortport"
+local stdnse = require "stdnse"
+
+-- -*- mode: lua -*-
+-- vim: set filetype=lua :
+
+description = [[
+Tests for the presence of the LibreOffice Impress Remote server.
+]]
+
+---
+-- @usage
+-- nmap --script impress-remote-discover -p 1599 <host>
+--
+-- @args impress-remote-discover.pin PIN number for the remote (default is
+--       <code>0000</code>).
+--
+-- @args impress-remote-discover.bruteforce Boolean to enable bruteforcing the PIN (default is
+--       <code>false</code>).
+--
+-- @output
+-- PORT   STATE SERVICE
+-- 1599/tcp open  LibreOffice Impress
+-- | impress-remote-discover:
+-- |   Command: id
+-- |   Results: uid=0(root) gid=0(wheel) groups=0(wheel)
+-- |_
+
+author = "Jer Hiebert"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"exploit", "intrusive", "malware", "vuln"}
+
+local function parse_args()
+  local args = {}
+
+  local pin = stdnse.get_script_args(SCRIPT_NAME .. '.pin')
+  if pin then
+    -- Sanity check the value from the user.
+    pin = tonumber(pin)
+    if type(pin) ~= "number" then
+      return false, "pin argument must be a number."
+    elseif pin < 0 or pin > 9999 then
+      return false, "pin argument must be in range between 0000 and 9999 inclusive."
+    end
+  else
+    -- Default the pin to 0.
+    pin = 0
+  end
+  -- Pad the pin with zeros to make it four digits.
+  pin = string.format("%04d", pin)
+  args.pin = pin
+
+  local bruteforce = stdnse.get_script_args(SCRIPT_NAME .. '.bruteforce')
+  if bruteforce then
+    -- Sanity check the value from the user.
+    if type(bruteforce) ~= "string" then
+      return false, "bruteforce argument must be a string."
+    elseif bruteforce ~= "true" then
+      return false, "bruteforce argument must be either true or left out entirely."
+    end
+  else
+    -- Default bruteforce to false.
+    bruteforce = false
+  end
+  args.bruteforce = bruteforce
+
+  return true, args
+end
+
+local remote_connect = function(host, port, pin)
+  local socket = nmap.new_socket()
+  local result;
+  local status = true;
+
+  socket:connect(host, port)
+  socket:set_timeout(5000)
+
+  local buffer, err = stdnse.make_buffer(socket, "\n")
+  if err then
+    stdnse.debug1("Failed to create buffer from socket: %s", err)
+    return
+  end
+  socket:send("LO_SERVER_CLIENT_PAIR\nFirefox OS\n"..pin.."\n\n")
+
+  return buffer, socket
+end
+
+local remote_version = function(buffer, socket, pin)
+  for j=0,3 do
+    line, err = buffer()
+    if not line then
+      stdnse.debug1("Failed to receive line from socket: %s", err)
+      return
+    end
+
+    if string.match(line, "^LO_SERVER_INFO$") then
+      line, err = buffer()
+      stdnse.debug1("Here's the version: %s", line)
+      return "Remote PIN: "..pin.."\nImpress Version: "..line
+    end
+  end
+end
+
+local check_pin = function(host, port, pin)
+  local buffer, socket = remote_connect(host, port, pin)
+
+  line, err = buffer()
+  if not line then
+    stdnse.debug1("Failed to receive line from socket: %s", err)
+    socket:close()
+    return line, err
+  elseif string.match(line, "^LO_SERVER_SERVER_PAIRED$") then
+    return remote_version(buffer, socket, pin)
+  end
+  socket:close()
+  
+  return "Remote Server present but incorrect PIN"
+end
+
+local bruteforce = function(host, port)
+  for i=0,9999 do
+    local pin = string.format("%04d", i)
+    local buffer, socket = remote_connect(host, port, pin)
+
+    line, err = buffer()
+    if not line then
+      stdnse.debug1("Failed to receive line from socket: %s", err)
+      socket:close()
+      return line, err
+    elseif string.match(line, "^LO_SERVER_SERVER_PAIRED$") then
+      return remote_version(buffer, socket, pin)
+    end
+    socket:close()
+  end
+
+  return "Failed to bruteforce PIN"
+end
+
+portrule = shortport.port_or_service(1599, "libreoffice-impress-remote", "tcp")
+
+action = function(host, port)
+  local result
+    -- Parse and sanity check the command line arguments.
+  local status, options = parse_args()
+  if not status then
+    return
+  end
+
+  if options.bruteforce then
+    result = bruteforce(host, port)
+  else
+    result = check_pin(host, port, options.pin)
+  end
+
+  if not result then
+  	return
+  end
+
+  return stdnse.format_output(true, result)
+end

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -17,8 +17,7 @@ if requested.
 -- 1599/tcp open  LibreOffice Impress
 -- | impress-remote-discover:
 -- |   Command: id
--- |   Results: uid=0(root) gid=0(wheel) groups=0(wheel)
--- |_
+-- |_  Results: uid=0(root) gid=0(wheel) groups=0(wheel)
 --
 -- @args impress-remote-discover.bruteforce Boolean to enable bruteforcing the
 --        PIN (default is <code>false</code>).
@@ -37,9 +36,9 @@ local function parse_args()
   if bruteforce then
     -- Sanity check the value from the user.
     if type(bruteforce) ~= "string" then
-      return false, "bruteforce argument must be a string."
+      return false, "Bruteforce argument must be a string."
     elseif bruteforce ~= "true" then
-      return false, "bruteforce argument must be either true or left out entirely."
+      return false, "Bruteforce argument must be either true or left out entirely."
     end
   end
   args.bruteforce = bruteforce or false
@@ -49,9 +48,9 @@ local function parse_args()
     -- Sanity check the value from the user.
     pin = tonumber(pin)
     if type(pin) ~= "number" then
-      return false, "pin argument must be a number."
+      return false, "PIN argument must be a number."
     elseif pin < 0 or pin > 9999 then
-      return false, "pin argument must be in range between 0000 and 9999 inclusive."
+      return false, "PIN argument must be in range between 0000 and 9999 inclusive."
     elseif bruteforce then
       return false, "When bruteforcing is enabled, a PIN cannot be set."
     end
@@ -160,7 +159,7 @@ local bruteforce = function(host, port)
   return
 end
 
-portrule = shortport.port_or_service(80, "libreoffice-impress-remote", "tcp")
+portrule = shortport.port_or_service(1599, "libreoffice-impress-remote", "tcp")
 
 action = function(host, port)
   -- Parse and sanity check the command line arguments.

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -145,13 +145,13 @@ end
 portrule = shortport.port_or_service(1599, "libreoffice-impress-remote", "tcp")
 
 action = function(host, port)
-  local result
   -- Parse and sanity check the command line arguments.
   local status, options = parse_args()
   if not status then
     return
   end
 
+  local result
   if options.bruteforce then
     result = bruteforce(host, port)
   else

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -61,10 +61,10 @@ end
 
 local remote_connect = function(host, port, pin)
   local socket = nmap.new_socket()
-  local result
-  local status = true
-
-  socket:connect(host, port)
+  local status, err = socket:connect(host, port)
+  if not status then
+     return string.format("Can't connect: %s", err)
+  end
   socket:set_timeout(5000)
 
   local buffer, err = stdnse.make_buffer(socket, "\n")

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -2,6 +2,7 @@ local nmap = require "nmap"
 local shortport = require "shortport"
 local stdnse = require "stdnse"
 local string = require "string"
+local table = require "table"
 
 description = [[
 Tests for the presence of the LibreOffice Impress Remote server.
@@ -96,7 +97,8 @@ local remote_version = function(buffer, socket, pin)
     if string.match(line, "^LO_SERVER_INFO$") then
       line, err = buffer()
       socket:close()
-      return pin, line
+      -- return pin, line -- "Remote PIN: " .. pin .. "\nImpress Version: " .. line
+      return {["Remote PIN"] = pin, ["Impress Version"] = line}
     end
   end
 
@@ -179,5 +181,5 @@ action = function(host, port)
     return
   end
 
-  return stdnse.format_output(true, result)
+  return result, stdnse.format_output(true, result)
 end

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -1,6 +1,7 @@
 local nmap = require "nmap"
 local shortport = require "shortport"
 local stdnse = require "stdnse"
+local string = require "string"
 
 -- -*- mode: lua -*-
 -- vim: set filetype=lua :
@@ -90,6 +91,7 @@ end
 
 -- Returns the PIN and Remote Server version if the PIN is correct
 local remote_version = function(buffer, socket, pin)
+  local line, err
   for j=0,3 do
     line, err = buffer()
     if not line then
@@ -107,8 +109,7 @@ end
 
 local check_pin = function(host, port, pin)
   local buffer, socket = remote_connect(host, port, pin)
-
-  line, err = buffer()
+  local line, err = buffer()
   if not line then
     stdnse.debug1("Failed to receive line from socket: %s", err)
     socket:close()
@@ -127,7 +128,7 @@ local bruteforce = function(host, port)
     local pin = string.format("%04d", i)
     local buffer, socket = remote_connect(host, port, pin)
 
-    line, err = buffer()
+    local line, err = buffer()
     if not line then
       stdnse.debug1("Failed to receive line from socket: %s", err)
       socket:close()

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -84,6 +84,8 @@ end
 -- Returns the PIN and Remote Server version if the PIN is correct
 local remote_version = function(buffer, socket, pin)
   local line, err
+  -- The line we are looking for is 4 down in the response
+  -- so we loop through lines until we get to that one
   for j=0,3 do
     line, err = buffer()
     if not line then
@@ -127,6 +129,7 @@ local check_pin = function(host, port, pin)
 end
 
 local bruteforce = function(host, port)
+  -- There are 10000 possible PINs which we loop through
   for i=0,9999 do
     -- Pad the pin with leading zeros if required
     local pin = string.format("%04d", i)

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -16,8 +16,8 @@ if requested.
 -- PORT     STATE SERVICE
 -- 1599/tcp open  LibreOffice Impress
 -- | impress-remote-discover:
--- |   Command: id
--- |_  Results: uid=0(root) gid=0(wheel) groups=0(wheel)
+-- |   Remote PIN: pin
+-- |_  Impress Version: version
 --
 -- @args impress-remote-discover.bruteforce Boolean to enable bruteforcing the
 --        PIN (default is <code>false</code>).

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -76,7 +76,7 @@ local remote_connect = function(host, port, pin)
     stdnse.debug1("Failed to create buffer from socket: %s", err)
     return
   end
-  socket:send("LO_SERVER_CLIENT_PAIR\nFirefox OS\n"..pin.."\n\n")
+  socket:send("LO_SERVER_CLIENT_PAIR\nFirefox OS\n" .. pin .. "\n\n")
 
   return buffer, socket
 end

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -20,11 +20,11 @@ if requested.
 -- |   Results: uid=0(root) gid=0(wheel) groups=0(wheel)
 -- |_
 --
--- @args impress-remote-discover.pin PIN number for the remote (default is
---       <code>0000</code>).
---
 -- @args impress-remote-discover.bruteforce Boolean to enable bruteforcing the
 --        PIN (default is <code>false</code>).
+--
+-- @args impress-remote-discover.pin PIN number for the remote (default is
+--       <code>0000</code>).
 
 author = "Jer Hiebert"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
@@ -32,6 +32,20 @@ categories = {"exploit", "intrusive", "bruteforce", "vuln"}
 
 local function parse_args()
   local args = {}
+
+  local bruteforce = stdnse.get_script_args(SCRIPT_NAME .. '.bruteforce')
+  if bruteforce then
+    -- Sanity check the value from the user.
+    if type(bruteforce) ~= "string" then
+      return false, "bruteforce argument must be a string."
+    elseif bruteforce ~= "true" then
+      return false, "bruteforce argument must be either true or left out entirely."
+    end
+  else
+    -- Default bruteforce to false.
+    bruteforce = false
+  end
+  args.bruteforce = bruteforce
 
   local pin = stdnse.get_script_args(SCRIPT_NAME .. '.pin')
   if pin then
@@ -49,20 +63,6 @@ local function parse_args()
   -- Pad the pin with leading zeros to make it four digits.
   pin = string.format("%04d", pin)
   args.pin = pin
-
-  local bruteforce = stdnse.get_script_args(SCRIPT_NAME .. '.bruteforce')
-  if bruteforce then
-    -- Sanity check the value from the user.
-    if type(bruteforce) ~= "string" then
-      return false, "bruteforce argument must be a string."
-    elseif bruteforce ~= "true" then
-      return false, "bruteforce argument must be either true or left out entirely."
-    end
-  else
-    -- Default bruteforce to false.
-    bruteforce = false
-  end
-  args.bruteforce = bruteforce
 
   return true, args
 end

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -7,6 +7,8 @@ local stdnse = require "stdnse"
 
 description = [[
 Tests for the presence of the LibreOffice Impress Remote server.
+Checks if a PIN is valid if provided and will bruteforce the PIN
+if requested.
 ]]
 
 ---
@@ -29,7 +31,7 @@ Tests for the presence of the LibreOffice Impress Remote server.
 
 author = "Jer Hiebert"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
-categories = {"exploit", "intrusive", "malware", "vuln"}
+categories = {"exploit", "intrusive", "bruteforce", "vuln"}
 
 local function parse_args()
   local args = {}

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -26,7 +26,7 @@ if requested.
 -- @args impress-remote-discover.pin PIN number for the remote (default is
 --       <code>0000</code>).
 
-author = "Jer Hiebert"
+author = "Jer Hiebert (jkhiebert@gmail.com)"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 categories = {"exploit", "intrusive", "bruteforce", "vuln"}
 

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -61,8 +61,8 @@ end
 
 local remote_connect = function(host, port, pin)
   local socket = nmap.new_socket()
-  local result;
-  local status = true;
+  local result
+  local status = true
 
   socket:connect(host, port)
   socket:set_timeout(5000)

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -3,9 +3,6 @@ local shortport = require "shortport"
 local stdnse = require "stdnse"
 local string = require "string"
 
--- -*- mode: lua -*-
--- vim: set filetype=lua :
-
 description = [[
 Tests for the presence of the LibreOffice Impress Remote server.
 Checks if a PIN is valid if provided and will bruteforce the PIN

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -49,7 +49,7 @@ local function parse_args()
     -- Default the pin to 0.
     pin = 0
   end
-  -- Pad the pin with zeros to make it four digits.
+  -- Pad the pin with leading zeros to make it four digits.
   pin = string.format("%04d", pin)
   args.pin = pin
 
@@ -88,6 +88,7 @@ local remote_connect = function(host, port, pin)
   return buffer, socket
 end
 
+-- Returns the PIN and Remote Server version if the PIN is correct
 local remote_version = function(buffer, socket, pin)
   for j=0,3 do
     line, err = buffer()
@@ -122,6 +123,7 @@ end
 
 local bruteforce = function(host, port)
   for i=0,9999 do
+    -- Pad the pin with leading zeros if required
     local pin = string.format("%04d", i)
     local buffer, socket = remote_connect(host, port, pin)
 
@@ -143,7 +145,7 @@ portrule = shortport.port_or_service(1599, "libreoffice-impress-remote", "tcp")
 
 action = function(host, port)
   local result
-    -- Parse and sanity check the command line arguments.
+  -- Parse and sanity check the command line arguments.
   local status, options = parse_args()
   if not status then
     return

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -23,7 +23,7 @@ if requested.
 --       <code>false</code>).
 --
 -- @output
--- PORT   STATE SERVICE
+-- PORT     STATE SERVICE
 -- 1599/tcp open  LibreOffice Impress
 -- | impress-remote-discover:
 -- |   Command: id
@@ -118,7 +118,7 @@ local check_pin = function(host, port, pin)
     return remote_version(buffer, socket, pin)
   end
   socket:close()
-  
+
   return "Remote Server present but incorrect PIN"
 end
 
@@ -159,7 +159,7 @@ action = function(host, port)
   end
 
   if not result then
-  	return
+    return
   end
 
   return stdnse.format_output(true, result)

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -20,8 +20,8 @@ if requested.
 -- |   Remote PIN: pin
 -- |_  Impress Version: version
 --
--- @args impress-remote-discover.bruteforce Boolean to enable bruteforcing the
---        PIN (default is <code>false</code>).
+-- @args impress-remote-discover.bruteforce No value needed (default is 
+--       <code>false</code>).
 --
 -- @args impress-remote-discover.client String value of the client name
 --       (default is <code>Firefox OS</code>).
@@ -47,13 +47,11 @@ local function parse_args()
   args.client_name = client_name or "Firefox OS"
 
   local bruteforce = stdnse.get_script_args(SCRIPT_NAME .. ".bruteforce")
-  if bruteforce then
-    -- Sanity check the value from the user.
-    if type(bruteforce) ~= "string" then
-      return false, "Bruteforce argument must be a string."
-    elseif bruteforce ~= "true" then
-      return false, "Bruteforce argument must be either true or left out entirely."
-    end
+  if bruteforce and bruteforce ~= "false" then
+    -- accept any value but false.
+    bruteforce = true
+  else
+    bruteforce = false
   end
   args.bruteforce = bruteforce or false
 

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -33,7 +33,7 @@ categories = {"exploit", "intrusive", "bruteforce", "vuln"}
 local function parse_args()
   local args = {}
 
-  local bruteforce = stdnse.get_script_args(SCRIPT_NAME .. '.bruteforce')
+  local bruteforce = stdnse.get_script_args(SCRIPT_NAME .. ".bruteforce")
   if bruteforce then
     -- Sanity check the value from the user.
     if type(bruteforce) ~= "string" then
@@ -41,13 +41,10 @@ local function parse_args()
     elseif bruteforce ~= "true" then
       return false, "bruteforce argument must be either true or left out entirely."
     end
-  else
-    -- Default bruteforce to false.
-    bruteforce = false
   end
-  args.bruteforce = bruteforce
+  args.bruteforce = bruteforce or false
 
-  local pin = stdnse.get_script_args(SCRIPT_NAME .. '.pin')
+  local pin = stdnse.get_script_args(SCRIPT_NAME .. ".pin")
   if pin then
     -- Sanity check the value from the user.
     pin = tonumber(pin)
@@ -56,13 +53,8 @@ local function parse_args()
     elseif pin < 0 or pin > 9999 then
       return false, "pin argument must be in range between 0000 and 9999 inclusive."
     end
-  else
-    -- Default the pin to 0.
-    pin = 0
   end
-  -- Pad the pin with leading zeros to make it four digits.
-  pin = string.format("%04d", pin)
-  args.pin = pin
+  args.pin = pin or 0
 
   return true, args
 end

--- a/scripts/impress-remote-discover.nse
+++ b/scripts/impress-remote-discover.nse
@@ -136,7 +136,7 @@ action = function(host, port)
   -- Parse and sanity check the command line arguments.
   local status, options = parse_args()
   if not status then
-    return
+    return false, options
   end
 
   local result


### PR DESCRIPTION
Script idea link:
https://secwiki.org/w/Nmap/Script_Ideas#impress-remote-discover

Example Output:
1599/tcp open  libreoffice-impress-remote syn-ack LibreOffice Impress
| impress-remote-discover:
|   Impress Version: 4.2.4.2
|_  Remote PIN: 1234

Version of LibreOffice Impress tested against: 4.2.4.2
https://downloadarchive.documentfoundation.org/libreoffice/old/4.2.4.2/