### PR TITLE
oracle-tns-version: fix connection timeout & improve error code checking

### DIFF
--- a/scripts/oracle-tns-version.nse
+++ b/scripts/oracle-tns-version.nse
@@ -25,12 +25,14 @@ end
 -- Lifted from nmap-service-probes
 -- TODO: Figure out if we can send a better probe than this. We might need to
 --       send ADDRESS, CID, etc.
-local oracle_tns_probe = "\0Z\0\0\x01\0\0\0\x016\x01,\0\0\x08\0\x7F\xFF\x7F\x08\0\0\0\x01\0 \0:\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\04\xE6\0\0\0\x01\0\0\0\0\0\0\0\0(CONNECT_DATA=(COMMAND=version))"
+local oracle_tns_probe = "\0Z\0\0\x01\0\0\0\x016\x01,\0\0\x08\0\x7F\xFF\x7F\x08\0\0\0\x01\0 \0:\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x004\xE6\0\0\0\x01\0\0\0\0\0\0\0\0(CONNECT_DATA=(COMMAND=version))"
 
 local ERR_CODES = {
   ["1189"] = "unauthorized",
   ["1194"] = "insecure transport",
+  ["12154"] = "unknown identifier",
   ["12504"] = "requires service name",
+  ["12505"] = "unknown sid",
   ["12514"] = "unknown service name",
 }
 
@@ -78,6 +80,9 @@ action = function (host, port)
   local errno = response and response:match("%(ERR=(%d+)%)", 12)
   if errno then
     port.version.extrainfo = ERR_CODES[errno] or ("error: "..errno)
+    -- Add Oracle Error Code Reference URL
+    port.version.extrainfo = port.version.extrainfo ..
+    string.format(", see http://psoug.org/oraerror/TNS-%05d.htm", errno)
   end
 
   if vsnnum or errno then


### PR DESCRIPTION
- Fixed `NSE: [oracle-tns-version 192.168.1.2:1251] Couldn't get a response:
TIMEOUT`. This happens because Version probe length is shorter than
announced to server.

- Added `Oracle Error Code Reference` URL. It looks like this:

PORT     STATE SERVICE    VERSION
1521/tcp open  oracle-tns Oracle TNS listener 11.2.0.3.0 (error: 1153, see http://psoug.org/oraerror/TNS-01153.htm)

- Added a few error codes.