### PR TITLE
Add safe tag to default NSE scripts which are missing it

### DIFF
--- a/scripts/dns-nsid.nse
+++ b/scripts/dns-nsid.nse
@@ -40,7 +40,7 @@ References:
 author = "John R. Bond"
 license = "Simplified (2-clause) BSD license--See https://nmap.org/svn/docs/licenses/BSD-simplified"
 
-categories = {"discovery", "default"}
+categories = {"discovery", "default", "safe"}
 
 
 portrule = function (host, port)

--- a/scripts/http-vuln-cve2009-3960.nse
+++ b/scripts/http-vuln-cve2009-3960.nse
@@ -61,7 +61,7 @@ For more information see:
 
 author = "Hani Benhabiles"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
-categories = {"exploit", "intrusive"}
+categories = {"exploit", "intrusive", "vuln"}
 
 
 portrule = shortport.http

--- a/scripts/maxdb-info.nse
+++ b/scripts/maxdb-info.nse
@@ -32,7 +32,7 @@ Retrieves version and database information from a SAP Max DB database.
 
 author = "Patrik Karlsson"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
-categories = { "default", "version" }
+categories = { "default", "version", "safe" }
 
 
 portrule = shortport.version_port_or_service(7210, "maxdb", "tcp")

--- a/scripts/sstp-discover.nse
+++ b/scripts/sstp-discover.nse
@@ -28,7 +28,7 @@ Current SSTP server implementations:
 --    - http://billing.purevpn.com/sstp-manual-setup-hostname-list.php
 
 author = "Niklaus Schiess <nschiess@adversec.com>"
-categories = {'discovery', 'default'}
+categories = {'discovery', 'default', 'safe'}
 
 ---
 --@output

--- a/scripts/wdb-version.nse
+++ b/scripts/wdb-version.nse
@@ -40,7 +40,7 @@ http://www.kb.cert.org/vuls/id/362332
 author = "Daniel Miller"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 -- may also be "safe", but need testing to determine
-categories = {"default", "version", "discovery", "vuln"}
+categories = {"default", "safe", "version", "discovery", "vuln"}
 
 
 -- WDB protocol information


### PR DESCRIPTION
Issues reported by @djcater at #725 and #726 