### PR TITLE
Update error message for timeouts

### DIFF
--- a/ncat/ncat_main.c
+++ b/ncat/ncat_main.c
@@ -414,7 +414,7 @@ int main(int argc, char *argv[])
         case 'd':
             o.linedelay = tval2msecs(optarg);
             if (o.linedelay <= 0)
-                bye("Invalid -d delay \"%s\" (must be greater than 0).", optarg);
+                bye("Invalid -d delay \"%s\" (must be greater than 0 and within practical limits).", optarg);
             if (o.linedelay >= 100 * 1000 && tval_unit(optarg) == NULL)
                 bye("Since April 2010, the default unit for -d is seconds, so your time of \"%s\" is %.1f minutes. Use \"%sms\" for %g milliseconds.", optarg, o.linedelay / 1000.0 / 60, optarg, o.linedelay / 1000.0);
             break;
@@ -432,7 +432,7 @@ int main(int argc, char *argv[])
         case 'i':
             o.idletimeout = tval2msecs(optarg);
             if (o.idletimeout <= 0)
-                bye("Invalid -i timeout (must be greater than 0).");
+                bye("Invalid -i timeout (must be greater than 0 and within practical limits).");
             if (o.idletimeout >= 100 * 1000 && tval_unit(optarg) == NULL)
                 bye("Since April 2010, the default unit for -i is seconds, so your time of \"%s\" is %.1f minutes. Use \"%sms\" for %g milliseconds.", optarg, o.idletimeout / 1000.0 / 60, optarg, o.idletimeout / 1000.0);
             break;
@@ -458,7 +458,7 @@ int main(int argc, char *argv[])
         case 'w':
             o.conntimeout = tval2msecs(optarg);
             if (o.conntimeout <= 0)
-                bye("Invalid -w timeout (must be greater than 0).");
+                bye("Invalid -w timeout (must be greater than 0 and within practical limits).");
             if (o.conntimeout >= 100 * 1000 && tval_unit(optarg) == NULL)
                 bye("Since April 2010, the default unit for -w is seconds, so your time of \"%s\" is %.1f minutes. Use \"%sms\" for %g milliseconds.", optarg, o.conntimeout / 1000.0 / 60, optarg, o.conntimeout / 1000.0);
             break;


### PR DESCRIPTION
Timeouts having a value greater than LONG_MAX give an erroneous error message. Subject to discussion: Should we edit tval2msecs() to handle the return value directly? Issue: #741 