### PR TITLE
add port and add web2py fingerprint

### DIFF
--- a/nselib/data/http-devframework-fingerprints.lua
+++ b/nselib/data/http-devframework-fingerprints.lua
@@ -383,4 +383,22 @@ tools = { Django = { rapidDetect = function(host, port)
     end
   },
 
+  Web2py = { rapidDetect = function(host, port)
+
+      local response = http.get(host, port, "/admin/default/index")
+
+      if response and response.body then
+          if(string.find(response.body, "web2py™ Web Framework") or 
+             string.find(response.body, "Massimo Di Pierro") or
+             string.find(response.body, "<span>web2py™ administrative interface</span>")) then
+              return "Web2py detected. Found traces on /admin/default/index"
+          end
+      end
+   end,
+
+   consumingDetect = function(page, path)
+     return
+   end
+  },         
+
 }

--- a/scripts/http-devframework.nse
+++ b/scripts/http-devframework.nse
@@ -47,7 +47,7 @@ local stdnse = require "stdnse"
 local httpspider = require "httpspider"
 local _G = require "_G"
 
-portrule = shortport.port_or_service( {80, 443}, {"http", "https"}, "tcp", "open")
+portrule = shortport.port_or_service( {80, 443, 8000}, {"http", "https"}, "tcp", "open")
 
 local function loadFingerprints(filename)
 
@@ -60,7 +60,6 @@ local function loadFingerprints(filename)
   stdnse.debug1("Loading fingerprints: %s", filename)
   local env = setmetatable({fingerprints = {}}, {__index = _G});
   file = loadfile(filename, "t", env)
-
   if( not(file) ) then
     stdnse.debug1("Couldn't load the file: %s", filename)
     return
@@ -68,7 +67,7 @@ local function loadFingerprints(filename)
 
   file()
   fingerprints = env.tools
-
+  
   return fingerprints
 
 end


### PR DESCRIPTION
Added the web2py frameworks in rapiddetect in http-devframework-fingerprints.lua and added the port 8000 in http-devframework.nse to check for web2py running on that port.