### PR TITLE
Enhancement in Ncat - Broadcast data by using delimiter

### DIFF
--- a/ncat/ncat_core.c
+++ b/ncat/ncat_core.c
@@ -60,7 +60,7 @@
  * OpenSSL library which is distributed under a license identical to that  *
  * listed in the included docs/licenses/OpenSSL.txt file, and distribute   *
  * linked combinations including the two.                                  *
- *                                                                         * 
+ *                                                                         *
  * The Nmap Project has permission to redistribute Npcap, a packet         *
  * capturing driver and library for the Microsoft Windows platform.        *
  * Npcap is a separate work with it's own license rather than this Nmap    *
@@ -171,6 +171,8 @@ void options_init(void)
     o.proto = IPPROTO_TCP;
     o.broker = 0;
     o.listen = 0;
+    o.delimiter = 0;
+    o.delimiter_used = 0; /* This gets activated when delimiter option gets enabled. (Works as a flag) */
     o.keepopen = 0;
     o.sendonly = 0;
     o.recvonly = 0;

--- a/ncat/ncat_core.h
+++ b/ncat/ncat_core.h
@@ -60,7 +60,7 @@
  * OpenSSL library which is distributed under a license identical to that  *
  * listed in the included docs/licenses/OpenSSL.txt file, and distribute   *
  * linked combinations including the two.                                  *
- *                                                                         * 
+ *                                                                         *
  * The Nmap Project has permission to redistribute Npcap, a packet         *
  * capturing driver and library for the Microsoft Windows platform.        *
  * Npcap is a separate work with it's own license rather than this Nmap    *
@@ -219,6 +219,10 @@ struct options {
     char *ssltrustfile;
     char *sslciphers;
     int zerobyte;
+
+    /* Use of delimiter for sending data */
+    int delimiter;
+    int delimiter_used;
 };
 
 extern struct options o;

--- a/ncat/ncat_listen.c
+++ b/ncat/ncat_listen.c
@@ -187,6 +187,7 @@ static int crlf_state = 0;
 
 static void handle_connection(int socket_accept);
 static int read_stdin(void);
+static int read_stdin_delimiter(void);
 static int read_socket(int recv_fd);
 static void post_handle_connection(struct fdinfo sinfo);
 static void read_and_broadcast(int recv_socket);

--- a/ncat/ncat_main.c
+++ b/ncat/ncat_main.c
@@ -61,7 +61,7 @@
  * OpenSSL library which is distributed under a license identical to that  *
  * listed in the included docs/licenses/OpenSSL.txt file, and distribute   *
  * linked combinations including the two.                                  *
- *                                                                         * 
+ *                                                                         *
  * The Nmap Project has permission to redistribute Npcap, a packet         *
  * capturing driver and library for the Microsoft Windows platform.        *
  * Npcap is a separate work with it's own license rather than this Nmap    *
@@ -280,6 +280,7 @@ int main(int argc, char *argv[])
         {"lua-exec",        required_argument,  NULL,         0},
         {"lua-exec-internal",required_argument, NULL,         0},
 #endif
+        {"use-delimiter",   required_argument,  NULL,         'b'},
         {"max-conns",       required_argument,  NULL,         'm'},
         {"help",            no_argument,        NULL,         'h'},
         {"delay",           required_argument,  NULL,         'd'},
@@ -366,6 +367,12 @@ int main(int argc, char *argv[])
 #endif
         case 'C':
             o.crlf = 1;
+            break;
+        case 'b':
+            o.delimiter_used = 1;
+            o.delimiter = atoi(optarg);
+            if(o.delimiter <= 0 || o.delimiter >= 255)
+                bye("--use-delimiter expects integer less than 255 and greater than 0.");
             break;
         case 'c':
             if (o.cmdexec != NULL)
@@ -618,6 +625,7 @@ int main(int argc, char *argv[])
 "  -w, --wait <time>          Connect timeout\n"
 "  -z                         Zero-I/O mode, report connection status only\n"
 "      --append-output        Append rather than clobber specified output files\n"
+"      --use-delimiter        Breaks the data till delimiter before broadcasting data; expects ascii value of character (Max range: 255)\n"
 "      --send-only            Only send data, ignoring received; quit on EOF\n"
 "      --recv-only            Only receive data, never send anything\n"
 "      --allow                Allow only given hosts to connect to Ncat\n"
@@ -650,6 +658,12 @@ int main(int argc, char *argv[])
             /* We consider an unrecognised option fatal. */
             bye("Unrecognised option.");
         }
+    }
+
+    /*  --use-delimiter can be used only for broadcasting purposes.
+        So checking for listen mode is necessary before moving forward. */
+    if(o.delimiter_used == 1 && o.listen != 1) {
+        bye("Currently --use-delimiter option is available only with -l option.");
     }
 
 #ifndef HAVE_OPENSSL

--- a/ncat/ncat_main.c
+++ b/ncat/ncat_main.c
@@ -371,7 +371,8 @@ int main(int argc, char *argv[])
         case 'b':
             o.delimiter_used = 1;
             o.delimiter = atoi(optarg);
-            if(o.delimiter <= 0 || o.delimiter >= 255)
+            /* 0, -1 are considered as ASCII values for EOF. */
+            if(o.delimiter < -1 || o.delimiter >= 255)
                 bye("--use-delimiter expects integer less than 255 and greater than 0.");
             break;
         case 'c':
@@ -663,7 +664,7 @@ int main(int argc, char *argv[])
     /*  --use-delimiter can be used only for broadcasting purposes.
         So checking for listen mode is necessary before moving forward. */
     if(o.delimiter_used == 1 && o.listen != 1) {
-        bye("Currently --use-delimiter option is available only with -l option.");
+        bye("--use-delimiter option is binded with -l option.");
     }
 
 #ifndef HAVE_OPENSSL


### PR DESCRIPTION
**Enhancement in Ncat - Broadcast data by using delimiter**

`--use-delimiter` option added to Ncat. It can be used while broadcasting the data. Use delay option to have see the change in how the data is being sent on using delimiter.

**Note :** If delay option is not used you cannot observe any change. The whole file will be broadcasted in a single instance.

`--use-delimiter` expects the ascii value of the delimiter as an argument.

0, -1 are assumed to be the ASCII values for EOF. If these are used the whole file will be broadcasted as a whole.

Change to the Ncat directory in terminal.
*Terminal 1* : `cat INSTALL | ./ncat --use-delimiter 10 -d 2 -l 1337 -vv`
*Terminal 2* : `./ncat localhost 1337`

**Explanation of the above commands used in Terminal 1**
* `--use-delimiter` takes 10 as an argument which is the ascii value of next line.
* `-d` takes 2 as an argument and it delays broadcasting data by 2 seconds.
   *   It sleeps for every 2 seconds while broadcasting data, when it hits the delimiter.
* `-l` takes 1337 as an argument which is the port number to be listened on.
*`-vv` for verbose output, using this will let you see when the file reaches EOF.

**Output**
The data is broadcasted in chunks when delimiter is met in the buffer. The program sleeps for every two seconds after broadcasting the data.

To have more closer observation, you can pass `101` as an argument to `--use-delimiter` which breaks the data till `e` everytime before broadcasting.

Terminal 1 and Terminal 2 are using `e` as a delimiter (ASCII value of `e` is 101)
*Terminal 1* : `cat INSTALL | ./ncat --use-delimiter 101 -d 1 -l 1337 -vv`
*Terminal 2* : `./ncat localhost 1337`

Terminal 3 and Terminal 4 are using EOF as a delimiter (ASCII value of EOF taken as 0), the complete file will be sent in a single shot.
*Terminal 3* : `cat INSTALL | ./ncat --use-delimiter 0 -d 1 -l 1337 -vv`
*Terminal 4* : `./ncat localhost 1337`