### PR TITLE
Fix HTTP Path header

### DIFF
--- a/nselib/http.lua
+++ b/nselib/http.lua
@@ -158,7 +158,7 @@ end
 --- Get a value suitable for the Host header field.
 -- See RFC 2616 sections 14.23 and 5.2.
 local function get_host_field(host, port)
-  return stdnse.get_hostname(host)
+  return stdnse.get_hostname(host)..":"..tostring(port.number)
 end
 
 -- Skip *( SP | HT ) starting at offset. See RFC 2616, section 2.2.


### PR DESCRIPTION
According to RFC2616  (https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23) Host header have to contain port number except well-known ports (80, 443).