### PR TITLE
Zenmap install error

### DIFF
--- a/zenmap/setup.py
+++ b/zenmap/setup.py
@@ -246,6 +246,8 @@ class my_install(install):
         # default). Because we need the unchanged value later, remember it
         # here.
         self.saved_prefix = self.prefix
+        if self.saved_prefix == None:
+            self.saved_prefix = os.path.normpath(sys.prefix)
         install.finalize_options(self)
 
     def run(self):


### PR DESCRIPTION
On OS X and Ubuntu, I run into a problem when trying to install Zenmap using
`$ python setup.py install`

```
...
File "setup.py", line 408, in fix_paths
    "CONFIG_DIR": os.path.join(self.saved_prefix, config_dir),
File "/usr/lib/python2.7/posixpath.py", line 77, in join
    elif path == '' or path.endswith('/'):
AttributeError: 'NoneType' object has no attribute 'endswith'
```

Error is caused by `self.saved_prefix` being `None` as a result of inherited `self.prefix` from `distutils.command.install` being `None`.

In `distutils.command.install` the only way `self.prefix` is initialized is with `os.path.normpath(sys.prefix)` so I did the same for `self.saved_prefix` but it may not be the best way to fix the issue.
