### PR TITLE
improving run_tests.py

### DIFF
--- a/zenmap/test/run_tests.py
+++ b/zenmap/test/run_tests.py
@@ -10,9 +10,10 @@ if __name__ == "__main__":
         print("Python unittest discovery missing. Requires Python 2.7 or newer.")  # noqa
         sys.exit(0)
 
-    os.chdir("..")
+    test_dir = os.path.dirname(os.path.realpath(__file__))
+    os.chdir(os.path.join(test_dir, os.pardir))
     suite = unittest.defaultTestLoader.discover(
-        start_dir=glob.glob("build/lib.*")[0],
+        start_dir=glob.glob("build/lib*")[0],
         pattern="*.py"
         )
     unittest.TextTestRunner().run(suite)


### PR DESCRIPTION
Enhance run_tests.py so it can be called from anywhere
Fix bug for running tests on OS X

python run_tests.py had to be called from inside test directory,
now be called from anywhere, and not hard-coded anymore.

on Linux the directory created inside build/ name is started with
"lib." but on OS X it is just named "lib". removing the dot in
matching pattern will let the user to run the script on OS X as well.