### PR TITLE
Make make nbase work on Solaris 9

### DIFF
--- a/nbase/nbase.h
+++ b/nbase/nbase.h
@@ -207,9 +207,7 @@
 #include <netdb.h>
 #endif
 
-#if HAVE_INTTYPES_H
 #include <inttypes.h>
-#endif
 
 #include <stdio.h>
 
@@ -231,7 +229,6 @@
 #undef NDEBUG
 
 /* Integer types */
-#include <stdint.h>
 typedef uint8_t u8;
 typedef int8_t s8;
 typedef uint16_t u16;


### PR DESCRIPTION
Don't know if this still an issue (since I don't have a Solaris 9 machine), but removed the ```have_inttypes_h``` part to make it default, so that we don't have to rely on stdint.h anymore. Besides, stdint.h is a part of inttypes.h, so we don't have any problems there. 

Related: #309 