### PR TITLE
Missing common web-files-extension is added to http-web-files-extensions.lst

### DIFF
--- a/nselib/data/http-web-files-extensions.lst
+++ b/nselib/data/http-web-files-extensions.lst
@@ -20,6 +20,7 @@ awm
 axd
 bml
 bok
+brf
 browser
 btapp
 bwp


### PR DESCRIPTION
A common file extension brf(Braille Ready Format) is missing from nselib/data/http-web-files-extensions.lst
Now its updated perfectly.