### PR TITLE
Case insensitive pattern generator function for stdnse library

### DIFF
--- a/nselib/stdnse.lua
+++ b/nselib/stdnse.lua
@@ -1445,4 +1445,28 @@ function keys(t)
   return ret
 end
 
+-- Returns the case insensitive pattern of given parameter
+-- Useful while doing case insensitive pattern match using string library.
+--
+-- Ex: generate_case_insensitive_pattern("user") = "[uU][sS][eE][rR]"
+--
+-- @param pattern The string
+-- @return A case insensitive patterned string
+function generate_case_insensitive_pattern(pattern)
+  -- Find an optional '%' (group 1) followed by any character (group 2)
+  local p = pattern:gsub("(%%?)(.)", function(percent, letter)
+
+    if percent ~= "" or not letter:match("%a") then
+      -- If the '%' matched, or `letter` is not a letter, return "as is"
+      return percent .. letter
+    else
+      -- Else, return a case-insensitive character class of the matched letter
+      return string.format("[%s%s]", letter:lower(), letter:upper())
+    end
+
+  end)
+
+  return p
+end
+
 return _ENV;

--- a/nselib/stdnse.lua
+++ b/nselib/stdnse.lua
@@ -1447,6 +1447,7 @@ end
 
 -- Returns the case insensitive pattern of given parameter
 -- Useful while doing case insensitive pattern match using string library.
+-- https://stackoverflow.com/questions/11401890/case-insensitive-lua-pattern-matching
 --
 -- Ex: generate_case_insensitive_pattern("user") = "[uU][sS][eE][rR]"
 --
@@ -1461,7 +1462,7 @@ function generate_case_insensitive_pattern(pattern)
       return percent .. letter
     else
       -- Else, return a case-insensitive character class of the matched letter
-      return string.format("[%s%s]", letter:lower(), letter:upper())
+      return format("[%s%s]", letter:lower(), letter:upper())
     end
 
   end)

--- a/nselib/stdnse.lua
+++ b/nselib/stdnse.lua
@@ -1447,7 +1447,7 @@ end
 
 -- Returns the case insensitive pattern of given parameter
 -- Useful while doing case insensitive pattern match using string library.
--- https://stackoverflow.com/questions/11401890/case-insensitive-lua-pattern-matching
+-- https://stackoverflow.com/questions/11401890/case-insensitive-lua-pattern-matching/11402486#11402486
 --
 -- Ex: generate_case_insensitive_pattern("user") = "[uU][sS][eE][rR]"
 --


### PR DESCRIPTION
The string.match function doesn't provide any option for doing a case insensitive pattern match. This new function provides a feature that allows the user to generate a case-insensitive pattern for any expression.

For example, the user wants to match a pattern in a huge body of text.
One solution is to convert the huge body of text into lower case and then process your check but this process is not so efficient, if the text of very large size.

I added a new function to stdnse which makes this processing fast. Here, there is no need to convert the whole file into lower case instead this function generates a case insensitive pattern for any given normal pattern.

```
> pattern = "user"
> string = "<tag>User</tag>"
> print(string.match(string, pattern))
> nil
> print(string.match(string, stdnse.generate_case_insensitive_pattern("user"))
> User
```

```
> regex = stdnse.generate_case_insensitive_pattern("user")
> print(regex)
> [uU][sS][eE][rR]
```
If there are multiple patterns to be matched case insensitively then this function will be of great use. For example,
```
  local regex = {
    "[uU][sS][eE][rR][nN][aA][mM][eE]", -- English (Username)
    "[pP][aA][sS][sS][wW][oO][rR][dD]", -- English (Password)
    "[pP]/[wW]", -- English (P/W)
    "[aA][dD][mM][iI][nN] [pP][aA][sS][sS][wW][oO][rR][dD]", -- English (Admin Password)
    "[pP][eE][rR][sS][oO][nN][aA][lL]", -- English (Personal)
    "[wW][aA][cC][hH][tT][wW][oO][oO][rR][dD]", --Dutch (Password)
    "[sS][eE][nN][hH][aA]", --Portuguese (Password)
    "[cC][lL][aA][vV][eE]", --Spanish (Key)
    "[uU][sS][aA][gG][eE][rR]" --French (User)
  }

```
The above code is so untidy, instead it can be written so prettily as

```
  local regex = {
    stdnse.generate_case_insensitive_pattern("username"), -- English (Username)
    stdnse.generate_case_insensitive_pattern("password"), -- English (Password)
    stdnse.generate_case_insensitive_pattern("p/w"), -- English (P/W)
    stdnse.generate_case_insensitive_pattern("admin password"), -- English (Admin Password)
    stdnse.generate_case_insensitive_pattern("personal"), -- English (Personal)
    stdnse.generate_case_insensitive_pattern("watchwoord"), --Dutch (Password)
    stdnse.generate_case_insensitive_pattern("sneha"), --Portuguese (Password)
    stdnse.generate_case_insensitive_pattern("clave"), --Spanish (Key)
    stdnse.generate_case_insensitive_pattern("usager") --French (User)
  }
```
