### PR TITLE
Added toggling text for toggling button in XML output

### DIFF
--- a/docs/nmap.xsl
+++ b/docs/nmap.xsl
@@ -356,7 +356,8 @@
       function toggle(divID) {
         var item = document.getElementById(divID);
         if (item) {
-          item.className=(item.className=='hidden')?'unhidden':'hidden';
+          item.className = (item.className=='hidden')?'unhidden':'hidden';
+          document.getElementsByClassName("noprint")[2].innerHTML = (item.className=='hidden')?"<small>(click to expand)</small>":"<small>(click to close)</small>";
         }
       }
            


### PR DESCRIPTION
Added code for toggling the text of the button when button is toggled in XML output.

Before clicking on the toggling button

![inked_before_expanding_li](https://cloud.githubusercontent.com/assets/22347290/26253528/545f828c-3cd1-11e7-8102-19872b05579e.png)

Before code was changed, on clicking the toggling button, the output is shown in the image below

![inked_old_after_expanding1](https://cloud.githubusercontent.com/assets/22347290/26253034/934054c4-3ccf-11e7-9058-da23f1758d22.jpg)

The text of the toggling button shows *( click to expand )* even after expanding the dialog which is not appropriate.

New and modified output toggles the text of the button along with the output being displayed.

![inked_new_after_expanding1_li](https://cloud.githubusercontent.com/assets/22347290/26253448/160639f4-3cd1-11e7-8813-ffd01dc45534.png)

![inked_before_expanding_li](https://cloud.githubusercontent.com/assets/22347290/26253528/545f828c-3cd1-11e7-8102-19872b05579e.png)
