### PR TITLE
SMB share_get_list fixed to try anonymous users first; added missing param in documentation for file_write

### DIFF
--- a/nselib/smb.lua
+++ b/nselib/smb.lua
@@ -3189,7 +3189,7 @@ function share_get_list(host)
   -- Ensure that the server returns the proper error message
   -- first try anonymously, then using a user account (in case anonymous connections are not supported)
   for _, anon in ipairs({true, false}) do
-    status, result = share_host_returns_proper_error(host)
+    status, result = share_host_returns_proper_error(host, anon)
 
     if(status == true and result == false) then
       return false, "Server doesn't return proper value for non-existent shares; can't enumerate shares"

--- a/nselib/smb.lua
+++ b/nselib/smb.lua
@@ -2498,6 +2498,7 @@ end
 -- data is given as a string, not a file.
 --
 --@param host          The host object
+--@param data          The string containing the data to be written
 --@param share         The share to upload it to (eg, C$).
 --@param remotefile    The remote file on the machine. It is relative to the share's root.
 --@param use_anonymous [optional] If set to 'true', test is done by the anonymous user rather than the current user.


### PR DESCRIPTION
As documented in the `share_get_list`, the function should try anonymous connections first before trying the current user but failed to do so due to a missing parameter. The error lead to it using the current username first, which could potentially leak information on who the attacker is.

The scripts affected are as follows:
- smb-enum-shares.nse

The modification should not lead to any breakage, as by default, if the username is not authenticated, the connection will downgrade to an anonymous connection (if supported).

This pull request also adds the missing param data to the documentation of the file_write method.