### PR TITLE
Partial fix for ncat termination on EOF

### DIFF
--- a/nsock/src/nsock_core.c
+++ b/nsock/src/nsock_core.c
@@ -1345,6 +1345,7 @@ void nsock_trace_handler_callback(struct npool *ms, struct nevent *nse) {
         nsock_log_info("Callback: %s %s %sfor EID %li [%s]",
                        nse_type2str(nse->type), nse_status2str(nse->status),
                        errstr, nse->id, get_peeraddr_string(nsi));
+        fatal("Connection terminated by the server.");
       } else {
         str = nse_readbuf(nse, &strlength);
         if (strlength < 80) {
@@ -1387,4 +1388,3 @@ void nsock_trace_handler_callback(struct npool *ms, struct nevent *nse) {
       fatal("Invalid nsock event type (%d)", nse->type);
   }
 }
-

--- a/nsock/src/nsock_core.c
+++ b/nsock/src/nsock_core.c
@@ -1345,7 +1345,7 @@ void nsock_trace_handler_callback(struct npool *ms, struct nevent *nse) {
         nsock_log_info("Callback: %s %s %sfor EID %li [%s]",
                        nse_type2str(nse->type), nse_status2str(nse->status),
                        errstr, nse->id, get_peeraddr_string(nsi));
-        fatal("Connection terminated by the server.");
+        nsock_loop_quit(ms);
       } else {
         str = nse_readbuf(nse, &strlength);
         if (strlength < 80) {


### PR DESCRIPTION
This partially resolves https://github.com/nmap/nmap/issues/894.

Terminal 1:
`ncat -l 4444 -vv -m 3 -k`

Terminal 2:
`ncat ::1 4444 -vv`

Terminal 3:
`ncat ::1 4444 -vv`

When the server ( terminal 1 ) gets terminated, all the connected clients will be disconnected instantly.  See issue https://github.com/nmap/nmap/issues/894 for the issue.

But the problem with this approach is, it works only when the client is using `-vv` option. If the client fails to use `-vv`, then this fix won't work. This is temporary fix but functional. A permanent fix will be released soon.