### PR TITLE
Removed Cisco model from catchall match

### DIFF
--- a/nselib/data/ike-fingerprints.lua
+++ b/nselib/data/ike-fingerprints.lua
@@ -205,7 +205,7 @@ table.insert(fingerprints, {
 
 table.insert(fingerprints, {
   category = 'vendor',
-  vendor = 'Cisco VPN Concentrator 3000',
+  vendor = 'Cisco VPN Concentrator',
   version = nil,
   ostype = 'pSOS+',
   devicetype = 'security-misc',


### PR DESCRIPTION
The ike-version script incorrectly identified the Cisco VPN Concentrator for a Cisco ASA as “Cisco VPN Concentrator 3000”. This is due to the catchall "Cisco VPN Concentrator 3000" vendor entry matching against a partial fingerprint. I have updated the vendor value to be less specific and more inline with the [ike-scan vendor-ids](https://github.com/royhills/ike-scan/blob/master/ike-vendor-ids#L195) and [NTA-Monitor Wiki](http://www.nta-monitor.com/wiki/index.php/Cisco_PIX#Vendor_IDs).
