### PR TITLE
Added ndmp fixes for getting info from Veritas Backup Exec Agent 15 and 16.

### DIFF
--- a/nselib/ndmp.lua
+++ b/nselib/ndmp.lua
@@ -24,6 +24,11 @@ NDMP = {
     CONNECT_CLIENT_AUTH = 0x00000901,
   },
 
+  -- Error types
+  ErrorType = {
+    NOT_AUTHORIZED_ERROR = 0x00000004
+  },
+
   -- The fragment header, 4 bytes where the highest bit is used to determine
   -- whether the fragment is the last or not.
   FragmentHeader = {
@@ -166,6 +171,10 @@ NDMP.Message.ConfigGetHostInfo = {
     msg.frag_header = NDMP.FragmentHeader.parse(data)
     data = data:sub(NDMP.FragmentHeader.size + 1)
     msg.header = NDMP.Header.parse(data)
+    if ( msg.header.error == NDMP.ErrorType.NOT_AUTHORIZED_ERROR ) then
+      -- no data to parse
+      return msg
+    end
     msg.data = data:sub(NDMP.Header.size + 1)
 
     msg.hostinfo = {}
@@ -202,6 +211,10 @@ NDMP.Message.ConfigGetFsInfo = {
     msg.frag_header = NDMP.FragmentHeader.parse(data)
     data = data:sub(NDMP.FragmentHeader.size + 1)
     msg.header = NDMP.Header.parse(data)
+    if ( msg.header.error == NDMP.ErrorType.NOT_AUTHORIZED_ERROR ) then
+      -- no data to parse
+      return msg
+    end
     msg.data = data:sub(NDMP.Header.size + 1)
 
     local pos, err, count = bin.unpack(">II", msg.data)

--- a/scripts/ndmp-fs-info.nse
+++ b/scripts/ndmp-fs-info.nse
@@ -54,6 +54,7 @@ action = function(host, port)
 
   status, msg = helper:getFsInfo()
   if ( not(status) ) then return fail("Failed to get filesystem information from server") end
+  if ( msg.header.error == ndmp.NDMP.ErrorType.NOT_AUTHORIZED_ERROR ) then return fail("Not authorized to get filesystem information from server") end
   helper:close()
 
   local result = tab.new(3)

--- a/scripts/ndmp-version.nse
+++ b/scripts/ndmp-version.nse
@@ -50,15 +50,22 @@ action = function(host, port)
   if ( not(status) ) then return fail("Failed to get server information from server") end
   helper:close()
 
-  local major, minor, build, smajor, sminor = hi.hostinfo.osver:match("Major Version=(%d+) Minor Version=(%d+) Build Number=(%d+) ServicePack Major=(%d+) ServicePack Minor=(%d+)")
   port.version.name = "ndmp"
   port.version.product = vendorLookup(si.serverinfo.vendor)
-  port.version.ostype = hi.hostinfo.ostype
-  if ( hi.hostinfo.hostname ) then
-    port.version.extrainfo = ("Name: %s; "):format(hi.hostinfo.hostname)
+
+  -- hostinfo can be nil if we get an auth error
+  if ( hi.hostinfo ) then
+    if ( hi.hostinfo.hostname ) then
+      port.version.extrainfo = ("Name: %s; "):format(hi.hostinfo.hostname)
+    end
+
+    local major, minor, build, smajor, sminor = hi.hostinfo.osver:match("Major Version=(%d+) Minor Version=(%d+) Build Number=(%d+) ServicePack Major=(%d+) ServicePack Minor=(%d+)")
+    if ( major and minor and build and smajor and sminor ) then
+      port.version.extrainfo = port.version.extrainfo .. ("OS ver: %d.%d; OS Build: %d; OS Service Pack: %d"):format(major, minor, build, smajor)
+    end
+
+    port.version.ostype = hi.hostinfo.ostype
   end
-  if ( major and minor and build and smajor and sminor ) then
-    port.version.extrainfo = port.version.extrainfo .. ("OS ver: %d.%d; OS Build: %d; OS Service Pack: %d"):format(major, minor, build, smajor)
-  end
+
   nmap.set_port_version(host, port)
 end


### PR DESCRIPTION
When scanning Veritas Backup Exec Agent 15 or 16 port 10000 (ndmp),  both ndmp-version.nse and ndmp-fs-info.nse throw errors.

Veritas returns a NOT_AUTHORIZED_ERROR response on both these versions when doing either a get hostinfo request (which is done in ndmp-version.nse), or a get fsinfo request (done in ndmp-fs-info.nse).

This commit adds some checking for that error code in the header and some simple handling in that case. Curiously enough, it replies properly to a get serverinfo request without any authentication, so ndmp-version.nse is still useful in this case.

Here's a gist with a sanitized debug scan before the changes, which shows the errors, and after, which shows how it is now handled: https://gist.github.com/xorrbit/9b149f6074a8339fd5bcf6a467a4f557