### PR TITLE
[NSE] ldap.lua vs AD objectSID

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Nmap Changelog ($Id$); -*-text-*-
 
+o [NSE] Fix handling of the objectSID Active Directory attribute
+  by ldap.lua. [Tom Sellers]
+
 o [NSE] Fix line endings in the list of Oracle SIDs used by oracle-sid-brute.
   Carriage Return characters were being sent in the connection packets, likely
   resulting in failure of the script. [Anant Shrivastava]

--- a/nselib/ldap.lua
+++ b/nselib/ldap.lua
@@ -739,7 +739,7 @@ function searchResultToFile( searchEntries, filename )
         for i=2, #attrib do
           -- do some additional Windows decoding
           if ( attrib[1] == "objectSid" ) then
-            host_table[string.format("%s", v.objectName)].attributes[attrib[1]] = string.format( "%d", convertObjectSid( attrib[i] ) )
+            host_table[string.format("%s", v.objectName)].attributes[attrib[1]] = string.format( "%s", convertObjectSid(attrib[i]))
 
           elseif ( attrib[1] == "objectGUID") then
             local o = {string.unpack(("B"):rep(16), attrib[i] )}

--- a/nselib/ldap.lua
+++ b/nselib/ldap.lua
@@ -739,7 +739,7 @@ function searchResultToFile( searchEntries, filename )
         for i=2, #attrib do
           -- do some additional Windows decoding
           if ( attrib[1] == "objectSid" ) then
-            host_table[string.format("%s", v.objectName)].attributes[attrib[1]] = string.format( "%s", convertObjectSid(attrib[i]))
+            host_table[string.format("%s", v.objectName)].attributes[attrib[1]] = string.format( "%s", convertObjectSid( attrib[i] ) )
 
           elseif ( attrib[1] == "objectGUID") then
             local o = {string.unpack(("B"):rep(16), attrib[i] )}
@@ -892,7 +892,7 @@ function convertObjectSid(data)
   sub_auth_size, pos = string.unpack('I1', data, pos)
 
   -- IdentifierAuthority = 6 bytes unsigned int, big endian, authority under
-  -- which the side was created. Typically '5' which indicates SECURITY_NT_AUTHORITY
+  -- which the side was created. Typically '5' which indicates NT_AUTHORITY
   auth, pos = string.unpack('>I6', data, pos)
 
 

--- a/nselib/ldap.lua
+++ b/nselib/ldap.lua
@@ -6,7 +6,7 @@
 --
 -- Credit goes out to Martin Swende who provided me with the initial code that got me started writing this.
 --
--- Version 0.7
+-- Version 0.8
 -- Created 01/12/2010 - v0.1 - Created by Patrik Karlsson <patrik@cqure.net>
 -- Revised 01/28/2010 - v0.2 - Revised to fit better fit ASN.1 library
 -- Revised 02/02/2010 - v0.3 - Revised to fit OO ASN.1 Library
@@ -15,6 +15,7 @@
 -- Revised 10/29/2011 - v0.5 - Added support for performing wildcard searches via the substring filter.
 -- Revised 10/30/2011 - v0.6 - Added support for the ldap extensibleMatch filter type for searches
 -- Revised 04/04/2016 - v0.7 - Added support for searchRequest over upd ( udpSearchRequest ) - Tom Sellers
+-- Revised 07/11/2017 - v0.8 - Added support for decoding the objectSID Active Directory attribute - Tom Sellers
 --
 
 local asn1 = require "asn1"
@@ -654,7 +655,7 @@ function searchResultToTable( searchEntries )
         for i=2, #attrib do
           -- do some additional Windows decoding
           if ( attrib[1] == "objectSid" ) then
-            table.insert( attribs, string.format( "%s: %d", attrib[1], decode( attrib[i] ) ) )
+            table.insert( attribs, string.format( "%s: %s", attrib[1], convertObjectSid( attrib[i] ) ) )
           elseif ( attrib[1] == "objectGUID") then
             local o = {string.unpack(("B"):rep(16), attrib[i] )}
             table.insert( attribs, string.format( "%s: %x%x%x%x-%x%x-%x%x-%x%x-%x%x%x%x%x%x",
@@ -738,7 +739,7 @@ function searchResultToFile( searchEntries, filename )
         for i=2, #attrib do
           -- do some additional Windows decoding
           if ( attrib[1] == "objectSid" ) then
-            host_table[string.format("%s", v.objectName)].attributes[attrib[1]] = string.format( "%d", decode( attrib[i] ) )
+            host_table[string.format("%s", v.objectName)].attributes[attrib[1]] = string.format( "%d", convertObjectSid( attrib[i] ) )
 
           elseif ( attrib[1] == "objectGUID") then
             local o = {string.unpack(("B"):rep(16), attrib[i] )}
@@ -865,6 +866,35 @@ function convertZuluTimeStamp(timestamp)
   else
     return 'Invalid date format'
   end
+
+end
+
+--- Converts the objectSid Active Directory attribute
+--  from hex to a human readable string
+--
+--  Example: 1-5-21-542885397-2936741293-3965599772-500
+--
+-- @param hex string form of objectSid from LDAP response
+-- @return string containing human readable form
+function convertObjectSid(data)
+
+  local pos, revision, auth, sub_auth_size, sub_auth, result
+
+  revision, pos = string.unpack('I1', data, 1)
+  sub_auth_size, pos = string.unpack('I1', data, pos)
+  auth, pos = string.unpack('>I6', data, pos)
+
+  sub_auth = ''
+  local tmp
+  local cnt = 0
+  while (cnt < sub_auth_size) do
+    tmp, pos = string.unpack('<I4', data, pos)
+    sub_auth = sub_auth .. '-' .. tmp
+    cnt = cnt + 1
+  end
+
+  result = revision .. '-' .. auth .. sub_auth
+  return result
 
 end
 


### PR DESCRIPTION
The *ldap.lua* NSE library currently in SVN doesn't correctly handle the Active Directory objectSID attribute.  Instead it attempts to perform additional asn.1 decoding on it.  Attached is a patch that implements the correct conversion from bytes to the human readable string such as `1-5-21-542895397-2936746693-3965599772-500`.

If there aren't any issues or concerns I'll commit the code later this week.

### Testing command ###

This command was tested against a Windows 2012 R2 host functioning as a Active Directory Controller. The user had Domain Admin privileges and so should be able to access all attributes.

```
nmap -d -p 389 --script ldap-search --script-args \
'ldap.username="CN=Administrator,CN=Users,DC=adlab,DC=pwnable", \
ldap.password="UserPasswordHere", \
ldap.qfilter=users, \
ldap.attrib=*, \
ldap.savesearch=test' \
-Pn  192.168.50.231
```



#### Before patch ####
```
<snip>
NSE: ldap-search against 192.168.50.231:389 threw an error!
/usr/local/bin/../share/nmap/nselib/ldap.lua:657: bad argument #3 to 'format' (number expected, got boolean)
stack traceback:
	[C]: in function 'string.format'
	/usr/local/bin/../share/nmap/nselib/ldap.lua:657: in function 'ldap.searchResultToTable'
	/usr/local/bin/../share/nmap/scripts/ldap-search.nse:263: in function </usr/local/bin/../share/nmap/scripts/ldap-search.nse:119>
	(...tail calls...)

<snip>
```

#### After patch ####
Screen output below as well as output to CSV file. The correct objectSID, `objectSid: 1-5-21-542895397-2936746693-3965599772-500` was extracted.

```
PORT    STATE SERVICE REASON
389/tcp open  ldap    syn-ack
| ldap-search: 
|   Context: DC=adlab,DC=pwnable; QFilter: users; Attributes: *
|     dn: CN=Administrator,CN=Users,DC=adlab,DC=pwnable
|         objectClass: top
|         objectClass: person
|         objectClass: organizationalPerson
|         objectClass: user
|         cn: Administrator
|         description: Built-in account for administering the computer/domain
|         distinguishedName: CN=Administrator,CN=Users,DC=adlab,DC=pwnable
|         instanceType: 4
|         whenCreated: 2017/07/08 17:53:55 UTC
|         whenChanged: 2017/07/08 18:10:24 UTC
|         uSNCreated: 8196
|         memberOf: CN=Group Policy Creator Owners,CN=Users,DC=adlab,DC=pwnable
|         memberOf: CN=Domain Admins,CN=Users,DC=adlab,DC=pwnable
|         memberOf: CN=Enterprise Admins,CN=Users,DC=adlab,DC=pwnable
|         memberOf: CN=Schema Admins,CN=Users,DC=adlab,DC=pwnable
|         memberOf: CN=Administrators,CN=Builtin,DC=adlab,DC=pwnable
|         uSNChanged: 12749
|         name: Administrator
|         objectGUID: 28b03a96-697b-244d-9b27-c7c3d67cd268
|         userAccountControl: 512
|         badPwdCount: 0
|         codePage: 0
|         countryCode: 0
|         badPasswordTime: 2017/07/09 13:51:26 UTC
|         lastLogoff: 0
|         lastLogon: 2017/07/11 12:20:09 UTC
|         logonHours: \xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF
|         pwdLastSet: 2017/07/08 17:00:21 UTC
|         primaryGroupID: 513
|         objectSid: 1-5-21-542895397-2936746693-3965599772-500
|         adminCount: 1
|         accountExpires: Never
|         logonCount: 11
|         sAMAccountName: Administrator
|         sAMAccountType: 805306368
|         objectCategory: CN=Person,CN=Schema,CN=Configuration,DC=adlab,DC=pwnable
|         isCriticalSystemObject: TRUE
|         dSCorePropagationData: 2017/07/08 18:10:24 UTC
|         dSCorePropagationData: 2017/07/08 18:10:24 UTC
|         dSCorePropagationData: 2017/07/08 17:55:14 UTC
|         dSCorePropagationData: 1601/01/01 18:12:16 UTC
|         lastLogonTimestamp: 2017/07/08 17:56:13 UTC
|     dn: CN=Guest,CN=Users,DC=adlab,DC=pwnable
|         objectClass: top
|         objectClass: person
|         objectClass: organizationalPerson
|         objectClass: user
|         cn: Guest
|         description: Built-in account for guest access to the computer/domain
|         distinguishedName: CN=Guest,CN=Users,DC=adlab,DC=pwnable
|         instanceType: 4
|         whenCreated: 2017/07/08 17:53:55 UTC
|         whenChanged: 2017/07/08 17:53:55 UTC
|         uSNCreated: 8197
|         memberOf: CN=Guests,CN=Builtin,DC=adlab,DC=pwnable
|         uSNChanged: 8197
|         name: Guest
|         objectGUID: 47f9e07a-577-164d-a948-7220d99e8e
|         userAccountControl: 66082
|         badPwdCount: 0
|         codePage: 0
|         countryCode: 0
|         badPasswordTime: Never
|         lastLogoff: 0
|         lastLogon: Never
|         pwdLastSet: Never
|         primaryGroupID: 514
|         objectSid: 1-5-21-542895397-2936746693-3965599772-501
|         accountExpires: 30828/09/14 02:48:05 UTC
|         logonCount: 0
|         sAMAccountName: Guest
|         sAMAccountType: 805306368
|         objectCategory: CN=Person,CN=Schema,CN=Configuration,DC=adlab,DC=pwnable
|         isCriticalSystemObject: TRUE
|         dSCorePropagationData: 2017/07/08 17:55:14 UTC
|         dSCorePropagationData: 1601/01/01 00:00:01 UTC
|     dn: CN=PWNWINDC01,OU=Domain Controllers,DC=adlab,DC=pwnable
|         objectClass: top
|         objectClass: person
|         objectClass: organizationalPerson
|         objectClass: user
|         objectClass: computer
|         cn: PWNWINDC01
<SNIP>
```