### PR TITLE
Added SSL-Port 7000 to irc-botnet-channels.nse

### DIFF
--- a/scripts/irc-botnet-channels.nse
+++ b/scripts/irc-botnet-channels.nse
@@ -73,7 +73,7 @@ local DEFAULT_CHANNELS = {
   "RxBot",
 }
 
-portrule = shortport.port_or_service({6666, 6667, 6697, 6679}, {"irc", "ircs"})
+portrule = shortport.port_or_service({6666, 6667, 6697, 6679, 7000}, {"irc", "ircs"})
 
 -- Parse an IRC message. Returns nil, errmsg in case of error. Otherwise returns
 -- true, prefix, command, params. prefix may be nil. params is an array of


### PR DESCRIPTION
Port 7000 is a quite common port for SSL connections.This port often appeared to be in use before the bigger networks agreed on 6697.
Quite some servers nowadays still use port 7000. For example:

Some IRCNet-Servers: http://irc.tu-ilmenau.de/all_servers/
All LinkNet Servers: http://www.link-net.org/?l=1&sec=12
All Freenode Servers: https://freenode.net/kb/answer/chat

I guess some more people are using port 7000 for IRC. Hence this might help when scanning.