### PR TITLE
ssl-enum-ciphers: Avoid error when compressors is nil

### DIFF
--- a/scripts/ssl-enum-ciphers.nse
+++ b/scripts/ssl-enum-ciphers.nse
@@ -1043,7 +1043,9 @@ local function try_protocol(host, port, protocol, upresults)
   results["ciphers"] = ciphers
 
   -- Format the compressor table.
-  table.sort(compressors)
+  if compressors then
+    table.sort(compressors)
+  end
   results["compressors"] = compressors
 
   results["cipher preference"] = cipher_pref


### PR DESCRIPTION
Error is "bad argument #1 to 'sort' (table expected, got nil)".