### PR TITLE
Nsock iod delete bugfix

### DIFF
--- a/nsock/src/nsock_iod.c
+++ b/nsock/src/nsock_iod.c
@@ -221,8 +221,24 @@ void nsock_iod_delete(nsock_iod nsockiod, enum nsock_del_mode pending_response) 
     }
   }
 
+  if (nsi->events_pending != 0 && nsi->first_pcap_read != NULL){
+	  for (current = nsi->first_pcap_read; current != NULL; current = next) {
+		  struct nevent *nse;
+
+		  next = gh_lnode_next(current);
+		  nse = lnode_nevent2(current);
+
+		  /* we're done with this list of events for the current IOD */
+		  if (nse->iod != nsi)
+			  break;
+
+		  nevent_delete(nsi->nsp, nse, &nsi->nsp->pcap_read_events, current, pending_response == NSOCK_PENDING_NOTIFY);
+	  }
+
+  }
+
   if (nsi->events_pending != 0)
-    fatal("Trying to delete NSI, but could not find %d of the purportedly pending events on that IOD.\n", nsi->events_pending);
+    fatal("Trying to delete NSI, but could not find %d of the purportedly pending events on that IOD (nsi: %lx).\n", nsi->events_pending, (long)nsi );
 
   /* Make sure we no longer select on this socket, in case the socket counts
    * weren't already decremented to zero. */

--- a/nsock/src/nsock_iod.c
+++ b/nsock/src/nsock_iod.c
@@ -222,6 +222,7 @@ void nsock_iod_delete(nsock_iod nsockiod, enum nsock_del_mode pending_response) 
   }
 
   if (nsi->events_pending != 0 && nsi->first_pcap_read != NULL){
+	  /* Check pcap specific queue */
 	  for (current = nsi->first_pcap_read; current != NULL; current = next) {
 		  struct nevent *nse;
 

--- a/nsock/src/nsock_iod.c
+++ b/nsock/src/nsock_iod.c
@@ -239,7 +239,7 @@ void nsock_iod_delete(nsock_iod nsockiod, enum nsock_del_mode pending_response) 
   }
 
   if (nsi->events_pending != 0)
-    fatal("Trying to delete NSI, but could not find %d of the purportedly pending events on that IOD (nsi: %lx).\n", nsi->events_pending, (long)nsi );
+	  fatal("Trying to delete NSI, but could not find %d of the purportedly pending events on that IOD.\n", nsi->events_pending);
 
   /* Make sure we no longer select on this socket, in case the socket counts
    * weren't already decremented to zero. */


### PR DESCRIPTION
This fixes a problem with nsock_iod_delete that occurred for IPv6 OS detection on a Windows 7 platform. In nsock_pcap.c/nsock_pool_add_event, a pcap read event was being added. However, under windows, the pcap descriptor was not present, so this event was added to a pcap specific queue. Later, when this IOD was being reused for a different host, it had one pending event on it (a pcap read), so the code in nsock_iod.c/nsock_iod_delete was executed to clean this up. However, this code did not check the pcap specific queue, so the event was not deleted, and a fatal error occurred with the message "Trying to delete NSI, but could  not find the event....". The bug-fix code adds a check to the pcap-specific read queue if deletion from the normal queues are not successful. This error did not occur for the same testing environment under Linux, as the pcap read event was added to the normal queues in nsock_pcap.c/nsock_pool_add_event function as the pcap descriptor was present. It is not known why the pcap read event was not deleted by normal action of event insertion/deletion; this clean up code is present for the normal queues so it makes sense that the pcap read queue needs to have the same clean up code.
