### PR TITLE
[Patch] prohibit RC4 as per RFC7465

### DIFF
--- a/ncat/docs/ncat.xml
+++ b/ncat/docs/ncat.xml
@@ -394,7 +394,7 @@
             when connecting to servers or when accepting SSL connections from
             clients. The syntax is described in the OpenSSL ciphers(1) man
             page, and defaults to
-            <literal>ALL:!aNULL:!eNULL:!LOW:!EXP:!MD5:@STRENGTH</literal></para>
+            <literal>ALL:!aNULL:!eNULL:!LOW:!EXP:!RC4:!MD5:@STRENGTH</literal></para>
         </listitem>
       </varlistentry>
 

--- a/ncat/docs/ncatguide.xml
+++ b/ncat/docs/ncatguide.xml
@@ -440,7 +440,7 @@ Content-Type: text/html; charset=UTF-8
     client) or accept (as a server) is a matter of choice between the greatest
     compatibility and the greatest security. The default set, expressed as an
     OpenSSL cipherlist, is
-    <literal>ALL:!aNULL:!eNULL:!LOW:!EXP:!MD5:@STRENGTH</literal>, a reasonable balance
+    <literal>ALL:!aNULL:!eNULL:!LOW:!EXP:!RC4:!MD5:@STRENGTH</literal>, a reasonable balance
     between the two ends of the spectrum. To set a different priority or
     initial choice, use the <option>--ssl-ciphers</option> option.
     <indexterm><primary><option>--ssl-ciphers</option> (Ncat option)</primary></indexterm>

--- a/ncat/ncat_connect.c
+++ b/ncat/ncat_connect.c
@@ -248,7 +248,7 @@ static void set_ssl_ctx_options(SSL_CTX *ctx)
             bye("The --ssl-key and --ssl-cert options must be used together.");
     }
     if (o.sslciphers == NULL) {
-      if (!SSL_CTX_set_cipher_list(ctx, "ALL:!aNULL:!eNULL:!LOW:!EXP:!MD5:@STRENGTH"))
+      if (!SSL_CTX_set_cipher_list(ctx, "ALL:!aNULL:!eNULL:!LOW:!EXP:!RC4:!MD5:@STRENGTH"))
         bye("Unable to set OpenSSL cipher list: %s", ERR_error_string(ERR_get_error(), NULL));
     }
     else {

--- a/ncat/ncat_ssl.c
+++ b/ncat/ncat_ssl.c
@@ -197,7 +197,7 @@ SSL_CTX *setup_ssl_listen(void)
 
     /* Secure ciphers list taken from Nsock. */
     if (o.sslciphers == NULL) {
-      if (!SSL_CTX_set_cipher_list(sslctx, "ALL:!aNULL:!eNULL:!LOW:!EXP:!MD5:@STRENGTH"))
+      if (!SSL_CTX_set_cipher_list(sslctx, "ALL:!aNULL:!eNULL:!LOW:!EXP:!RC4:!MD5:@STRENGTH"))
         bye("Unable to set OpenSSL cipher list: %s", ERR_error_string(ERR_get_error(), NULL));
     }
     else {

--- a/nsock/src/nsock_ssl.c
+++ b/nsock/src/nsock_ssl.c
@@ -71,7 +71,7 @@
  *  OpenSSL. To see exactly what ciphers are enabled, use the command
  *   openssl ciphers -v '...'
  * where ... is the string below. */
-#define CIPHERS_SECURE "ALL:!aNULL:!eNULL:!LOW:!EXP:!MD5:@STRENGTH"
+#define CIPHERS_SECURE "ALL:!aNULL:!eNULL:!LOW:!EXP:!RC4:!MD5:@STRENGTH"
 
 /* This list of ciphers is for speed and compatibility, not security. Any cipher
  *  is accepted, and the list is sorted by speed based on Brian Hatch's


### PR DESCRIPTION
As per RFC 7465,
We disallow the usage of RC4 cipher suites as they are no longer secure.

Reference:
https://tools.ietf.org/html/rfc7465