### PR TITLE
Free nsock_pool if proxy connection failed

### DIFF
--- a/ncat/ncat_connect.c
+++ b/ncat/ncat_connect.c
@@ -1049,6 +1049,7 @@ int ncat_connect(void)
         }
 
         if (connect_socket == -1)
+            nsock_pool_delete(mypool);
             return 1;
         /* Clear out whatever is left in the socket buffer which may be
            already sent by proxy server along with http response headers. */

--- a/ncat/ncat_connect.c
+++ b/ncat/ncat_connect.c
@@ -1049,8 +1049,10 @@ int ncat_connect(void)
         }
 
         if (connect_socket == -1)
+	{
             nsock_pool_delete(mypool);
             return 1;
+	}
         /* Clear out whatever is left in the socket buffer which may be
            already sent by proxy server along with http response headers. */
         //line = socket_buffer_remainder(&stateful_buf, &n);


### PR DESCRIPTION
Not critical memory leak because it happens in exit flow but it makes static analyse tools angry.