### PR TITLE
Fixes packet count error message in ArgParser.cc

### DIFF
--- a/nping/ArgParser.cc
+++ b/nping/ArgParser.cc
@@ -1072,7 +1072,7 @@ int ArgParser::parseArguments(int argc, char *argv[]) {
         }else if( parse_u32(optarg, &aux32) == OP_SUCCESS ){
             o.setPacketCount(aux32);
         }else{
-            nping_fatal(QT_3,"Packet count must be an integer greater than 0.");
+            nping_fatal(QT_3,"Packet count must be an integer greater than or equal to 0.");
         }
     break; /* case 'c': */
 


### PR DESCRIPTION
The error message in nping when given an invalid packet count (-c or --count) is misleading. It says that an integer greater than 0 must be given. However, 0 can be given and it will make nping run continuosly as specified in the manual: "If a value of 0 is specified, Nping will run continuously."