### PR TITLE
Adds unmarshall_lptstr function to msrpctypes library.

### DIFF
--- a/nselib/msrpctypes.lua
+++ b/nselib/msrpctypes.lua
@@ -4531,9 +4531,10 @@ end
 function unmarshall_lptstr(w_str, startpos)
 
   local endpos = startpos
+  local length = w_str:len()
   local s = ""
 
-  while s ~= "\0\0" do
+  while ( s ~= "\0\0" and endpos < length ) do
     -- Reads the next character.
     s = string.sub(w_str, endpos, endpos + 1)
 

--- a/nselib/msrpctypes.lua
+++ b/nselib/msrpctypes.lua
@@ -4530,19 +4530,18 @@ end
 -- @return The unmarshalled string
 function unmarshall_lptstr(w_str, startpos)
 
+  local _
   local endpos = startpos
-  local length = w_str:len()
-  local s = ""
 
-  while ( s ~= "\0\0" and endpos < length ) do
-    -- Reads the next character.
-    s = string.sub(w_str, endpos, endpos + 1)
+  repeat
+    _, endpos = w_str:find("\0\0", endpos, true)
+    if not endpos then
+      return
+    end
+  until endpos % 2 == 0
 
-    -- We add 2 because we are dealing with UTF-16 format.
-    endpos = endpos + 2
-  end
+  return endpos + 1, w_str:sub(startpos, endpos)
 
-  return endpos, string.sub(w_str, startpos, endpos)
 end
 
 local atsvc_DaysOfMonth =

--- a/nselib/msrpctypes.lua
+++ b/nselib/msrpctypes.lua
@@ -4523,6 +4523,26 @@ function unmarshall_SERVICE_STATUS(data, pos)
 end
 
 
+--- Unmarshalls a null-terminated Unicode string based upon a 32-bit offset (LPTSTR)
+-- @param arguments The data being processed
+-- @param startpos  The current position within the data
+-- @return The new position
+-- @return The string with null removed
+function unmarshall_lptstr(arguments, startpos)
+
+  local endpos = startpos
+  local s = ""
+
+  while s ~= "\0\0" do
+    -- Reads the next character.
+    s = string.sub(arguments, endpos, endpos + 1)
+
+    -- We add 2 because we are dealing with UTF-16 format.
+    endpos = endpos + 2
+  end
+
+  return startpos, string.sub(arguments, startpos, endpos)
+end
 
 local atsvc_DaysOfMonth =
 {

--- a/nselib/msrpctypes.lua
+++ b/nselib/msrpctypes.lua
@@ -4523,11 +4523,11 @@ function unmarshall_SERVICE_STATUS(data, pos)
 end
 
 
---- Unmarshalls a null-terminated Unicode string based upon a 32-bit offset (LPTSTR)
+--- Unmarshalls a null-terminated Unicode string (LPTSTR datatype)
 -- @param w_str The data being processed
 -- @param startpos  The current position within the data
 -- @return The new position
--- @return The string with null removed
+-- @return The unmarshalled string
 function unmarshall_lptstr(w_str, startpos)
 
   local endpos = startpos

--- a/nselib/msrpctypes.lua
+++ b/nselib/msrpctypes.lua
@@ -4524,24 +4524,24 @@ end
 
 
 --- Unmarshalls a null-terminated Unicode string based upon a 32-bit offset (LPTSTR)
--- @param arguments The data being processed
+-- @param w_str The data being processed
 -- @param startpos  The current position within the data
 -- @return The new position
 -- @return The string with null removed
-function unmarshall_lptstr(arguments, startpos)
+function unmarshall_lptstr(w_str, startpos)
 
   local endpos = startpos
   local s = ""
 
   while s ~= "\0\0" do
     -- Reads the next character.
-    s = string.sub(arguments, endpos, endpos + 1)
+    s = string.sub(w_str, endpos, endpos + 1)
 
     -- We add 2 because we are dealing with UTF-16 format.
     endpos = endpos + 2
   end
 
-  return startpos, string.sub(arguments, startpos, endpos)
+  return endpos, string.sub(w_str, startpos, endpos)
 end
 
 local atsvc_DaysOfMonth =


### PR DESCRIPTION
This function is a bit slow because we are iterating through each character. 
A customized function can be written, if we know the end position of the string to generate faster output.