### PR TITLE
Adds function for enumservicestatusA in msrpc.lua

### DIFF
--- a/nselib/msrpc.lua
+++ b/nselib/msrpc.lua
@@ -5056,16 +5056,16 @@ local function enumservicestatusparams(handle, tyepofservice, servicestate, cbbu
   return msrpctypes.marshall_policy_handle(handle)
 
   -- [in] uint32 type
-  .. msrpctypes.marshall_int32(tyepofservice, true)
+  .. msrpctypes.marshall_int32(tyepofservice, unicodeFlag)
 
   -- [in] svcctl_ServiceState
-  .. msrpctypes.marshall_int32(servicestate, true)
+  .. msrpctypes.marshall_int32(servicestate, unicodeFlag)
 
   -- [in] [range(0,0x40000)] uint32 cbufsize
-  .. msrpctypes.marshall_int32(cbbufsize, true)
+  .. msrpctypes.marshall_int32(cbbufsize, unicodeFlag)
 
   -- [in,out,unique] uint32 *resume_handle
-  .. msrpctypes.marshall_int32_ptr(lpresumehandle, true)
+  .. msrpctypes.marshall_int32_ptr(lpresumehandle, unicodeFlag)
 
 end
 


### PR DESCRIPTION
Reference: 
https://github.com/samba-team/samba/blob/d8a5565ae647352d11d622bd4e73ff4568678a7c/librpc/idl/svcctl.idl#L461

`enumservicestatusparams` is already implemented in the svn repo but its not up on github yet but while merging I will use the same function with a slight modification which I showed here.

Have a look at this, @dmiller-nmap 