### PR TITLE
Allow running zenmap as user and only nmap scans as root

### DIFF
--- a/zenmap/zenmapCore/NmapCommand.py
+++ b/zenmap/zenmapCore/NmapCommand.py
@@ -206,12 +206,13 @@ class NmapCommand(object):
     The normal output (stdout and stderr) are written to the file object
     self.stdout_file."""
 
-    def __init__(self, command):
+    def __init__(self, command, root_command=None):
         """Initialize an Nmap command. This creates temporary files for
         redirecting the various types of output and sets the backing
         command-line string."""
         self.command = command
         self.command_process = None
+        self.root_command = root_command
 
         self.stdout_file = None
 
@@ -316,6 +317,8 @@ class NmapCommand(object):
         log.debug("PATH=%s" % env["PATH"])
 
         command_list = self.ops.render()
+        if self.root_command:
+            command_list.insert(0, self.root_command)
         log.debug("Running command: %s" % repr(command_list))
 
         startupinfo = None

--- a/zenmap/zenmapCore/NmapCommand.py
+++ b/zenmap/zenmapCore/NmapCommand.py
@@ -240,8 +240,12 @@ class NmapCommand(object):
                 self.ops[op] = escape_nmap_filename(self.ops[op])
 
         if self.xml_is_temp:
-            self.xml_output_filename = tempfile.mktemp(
-                    prefix=APP_NAME + "-", suffix=".xml")
+            # make sure the file is created, otherwise we will run into
+            # permission problems if nmap is started with root permissions
+            tmpfile = tempfile.NamedTemporaryFile(
+                    prefix=APP_NAME + "-", suffix=".xml", delete=False)
+            self.xml_output_filename = tmpfile.name
+            tmpfile.close()
             self.ops["-oX"] = escape_nmap_filename(self.xml_output_filename)
 
         log.debug(">>> Temporary files:")

--- a/zenmap/zenmapCore/UmitOptionParser.py
+++ b/zenmap/zenmapCore/UmitOptionParser.py
@@ -181,6 +181,15 @@ scan result files."))
 selected. If combined with the -t (--target) option, \
 automatically run the profile against the specified target."))
 
+        ## Add additional button to execute scans as root (GUI)
+        ### Specify a command that is used to start nmap with root
+        ### privileges if the additional button is used.
+        self.add_option("-r", "--root-command",
+                        default=False,
+                        action="store",
+                    help=_("Specify a command that can be used to start \
+nmap scans with root privileges."))
+
         ## Targets (GUI)
         ### Specify a target to be used along with other command line option
         ### or simply opens with the first tab target field filled with
@@ -241,6 +250,11 @@ used more than once to get even more verbosity"))
         if self.options.profile != "":
             return self.options.profile
         return False
+
+    def get_root_command(self):
+        """Return the command that can be used to start nmap with root
+        privileges, or False if no such command was specified by the user """
+        return self.options.root_command
 
     def get_target(self):
         """Returns a string with the target specified, or False if this option

--- a/zenmap/zenmapGUI/App.py
+++ b/zenmap/zenmapGUI/App.py
@@ -346,7 +346,7 @@ Do this now? \
         repair_dialog.destroy()
 
     # Display a "you're not root" warning if appropriate.
-    if not is_root():
+    if not is_root() and not option_parser.get_root_command():
         non_root = NonRootWarning()
         non_root.run()
         non_root.destroy()

--- a/zenmap/zenmapGUI/ScanInterface.py
+++ b/zenmap/zenmapGUI/ScanInterface.py
@@ -621,7 +621,7 @@ class ScanInterface(HIGVBox):
             else:
                 log.debug("Scan finished: %s" % scan.command)
                 self.load_from_command(scan)
-                scan.close()
+            scan.close()
             self.update_cancel_button()
             finished_jobs.append(scan)
 

--- a/zenmap/zenmapGUI/ScanInterface.py
+++ b/zenmap/zenmapGUI/ScanInterface.py
@@ -159,6 +159,7 @@ from zenmapCore.NetworkInventory import NetworkInventory,\
         FilteredNetworkInventory
 from zenmapCore.NmapCommand import NmapCommand
 from zenmapCore.UmitConf import CommandProfile, ProfileNotFound, is_maemo
+from zenmapCore.UmitOptionParser import option_parser
 from zenmapCore.NmapParser import NmapParser
 from zenmapCore.Paths import Path, get_extra_executable_search_paths
 from zenmapCore.UmitLogging import log
@@ -342,6 +343,10 @@ class ScanInterface(HIGVBox):
                     'changed', self._profile_entry_changed)
 
         self.toolbar.scan_button.connect('clicked', self.start_scan_cb)
+        root_cmd = option_parser.get_root_command()
+        if root_cmd:
+            self.toolbar.scan_root_button.connect(
+                'clicked', lambda widget: self.start_scan_cb(widget, root_cmd))
         self.toolbar.cancel_button.connect('clicked', self._cancel_scan_cb)
 
     def __create_command_toolbar(self):
@@ -424,7 +429,7 @@ class ScanInterface(HIGVBox):
         self.toolbar.profile_entry.handler_unblock(
                 self.profile_entry_changed_handler)
 
-    def start_scan_cb(self, widget=None):
+    def start_scan_cb(self, widget=None, root_command=None):
         target = self.toolbar.selected_target
         command = self.command_toolbar.command
         profile = self.toolbar.selected_profile
@@ -455,7 +460,7 @@ class ScanInterface(HIGVBox):
             warn_dialog.destroy()
             return
 
-        self.execute_command(command, target, profile)
+        self.execute_command(command, target, profile, root_command)
 
     def _displayed_scan_change_cb(self, widget):
         self.update_cancel_button()
@@ -531,12 +536,13 @@ class ScanInterface(HIGVBox):
         self.jobs.remove(command)
         self.update_cancel_button()
 
-    def execute_command(self, command, target=None, profile=None):
+    def execute_command(self, command, target=None, profile=None,
+                        root_command=None):
         """Run the given Nmap command. Add it to the list of running scans.
         Schedule a timer to refresh the output and check the scan for
         completion."""
         try:
-            command_execution = NmapCommand(command)
+            command_execution = NmapCommand(command, root_command)
         except IOError, e:
             warn_dialog = HIGAlertDialog(
                         message_format=_("Error building command"),

--- a/zenmap/zenmapGUI/ScanToolbar.py
+++ b/zenmap/zenmapGUI/ScanToolbar.py
@@ -137,6 +137,8 @@ import zenmapCore.I18N
 from zenmapGUI.ProfileCombo import ProfileCombo
 from zenmapGUI.TargetCombo import TargetCombo
 
+from zenmapCore.UmitOptionParser import option_parser
+
 
 class ScanCommandToolbar(HIGHBox):
     """This class builds the toolbar devoted to Command entry. It allows you to
@@ -177,7 +179,11 @@ class ScanToolbar(HIGHBox):
         self._create_target()
         self._create_profile()
 
+        root_command = option_parser.get_root_command()
+
         self.scan_button = gtk.Button(_("Scan"))
+        if root_command:
+            self.scan_root_button = gtk.Button(_("Scan (root)"))
         #self.scan_button = HIGButton(_("Scan "), gtk.STOCK_MEDIA_PLAY)
         self.cancel_button = gtk.Button(_("Cancel"))
         #self.cancel_button = HIGButton(_("Cancel "), gtk.STOCK_CANCEL)
@@ -189,6 +195,8 @@ class ScanToolbar(HIGHBox):
         self._pack_expand_fill(self.profile_entry)
 
         self._pack_noexpand_nofill(self.scan_button)
+        if root_command:
+            self._pack_noexpand_nofill(self.scan_root_button)
         self._pack_noexpand_nofill(self.cancel_button)
 
         # Skip over the dropdown arrow so you can tab to the profile entry.


### PR DESCRIPTION
I'd like to be able to run zenmap as normal user and only nmap as root. My idea was that there is an extra button "Scan (root)" which invokes nmap using a `--root-command` that can be given on the command line.

I implemented that in this pull request. The button "Scan (root)" is only added to the UI if zenmap is started with a `--root-command` on the command line.