### PR TITLE
update outdated nselib/data/psexec/README

### DIFF
--- a/nselib/data/psexec/README
+++ b/nselib/data/psexec/README
@@ -8,15 +8,8 @@ It is uploaded to the remote host and runs the programs it's directed to run,
 redirecting their output to a file. This file is then downloaded by the
 script and displayed to the user.
 
-When Nmap released version 5.20, it was discovered that some over-zealous
-antivirus software tagged this program as spyware[1]. For that reason, when
-stored on the host machine, it is now encoded by xoring every byte of the
-file with 0xFF. When uploaded to a target machine, it is decoded in-stream.
-This prevents programs on the host machine from tagging it as malicious, but
-does not prevent the target from detecting it (which is arguably a good thing).
-
-The encoder.c program reads a program from stdin, encodes it by xoring with
-0xFF, and writes it to stdout.
-
-[1] http://seclists.org/nmap-dev/2010/q1/198
-
+Because nmap_service.exe is tagged as spyware by some antivirus software, it is
+no longer distributed together with nmap. You can download it from
+https://nmap.org/psexec/nmap_service.exe or compile it from the provided
+sources. The smb-psexec.nse script will remind you if you run it and
+nmap_service.exe is not available.


### PR DESCRIPTION
as per CHANGELOG, nmap_service.exe is no longer distributed as part of
nmap sice version 5.50