### PR TITLE
Fix ipmi-cipher-zero detection

### DIFF
--- a/scripts/ipmi-cipher-zero.nse
+++ b/scripts/ipmi-cipher-zero.nse
@@ -95,7 +95,7 @@ functionality
   nmap.set_port_state(host, port, "open")
 
   local info = ipmi.parse_open_session_reply(reply)
-  if info["session_payload_type"] == ipmi.PAYLOADS["RMCPPLUSOPEN_REP"] then
+  if info["session_payload_type"] == ipmi.PAYLOADS["RMCPPLUSOPEN_REP"] and info["error_code"] == 0 then
     vuln_table.state = vulns.STATE.VULN
   end
 


### PR DESCRIPTION
The script says it's a rewrite of metasploits implementation:
https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.rb

However there is a bug: The servers response code, whether the connection was accepted or not is not checked. 
Therefore current version of nmap ipmi-cipher-zero reports false positives for all ipmi services that respond to a request to open connection with cipher zero, even if the response was to deny the connection.

This pull request fixes that.
