### PR TITLE
configure.ac: fix AC_CHECK_HEADER call to test for libssh2

### DIFF
--- a/configure
+++ b/configure
@@ -6801,8 +6801,7 @@ if test "${with_libssh2+set}" = set; then :
     CPPFLAGS="-I$with_libssh2/include $CPPFLAGS"
     LDFLAGS="-L$with_libssh2/lib $LDFLAGS"
 
-    ac_fn_c_check_header_compile "$LINENO" "libssh2.h" "ac_cv_header_libssh2_h" "-lm
-"
+    ac_fn_c_check_header_mongrel "$LINENO" "libssh2.h" "ac_cv_header_libssh2_h" "$ac_includes_default"
 if test "x$ac_cv_header_libssh2_h" = xyes; then :
 
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libssh2_version in -lssh2" >&5
@@ -6811,7 +6810,7 @@ if ${ac_cv_lib_ssh2_libssh2_version+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lssh2  $LIBS"
+LIBS="-lssh2 -lm $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 

--- a/configure.ac
+++ b/configure.ac
@@ -674,7 +674,7 @@ AC_HELP_STRING([--without-libssh2], [Compile without libssh2]),
       AC_CHECK_LIB(ssh2, libssh2_version,
         [have_libssh2=yes
         LIBSSH2_INC=$with_libssh2/include
-        LIBSSH2_LIB=$with_libssh2/lib])],,[-lm])
+        LIBSSH2_LIB=$with_libssh2/lib],,[-lm])])
 
     LDFLAGS=$_ldflags
     CPPFLAGS=$_cppflags


### PR DESCRIPTION
The -lm argument is passed as an argument to AC_CHECK_HEADER(), which
doesn't make sense. The intention was to pass it as the fifth
argument of AC_CHECK_LIB().

Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>

This PR fixes issue #1058