### PR TITLE
Patch snmp.lua to support snmp v2c

### DIFF
--- a/nselib/snmp.lua
+++ b/nselib/snmp.lua
@@ -488,7 +488,7 @@ Helper = {
   request = function (self, message)
     local payload = encode( buildPacket(
         message,
-        self.version,
+        self.options.version,
         self.community
       ) )
 

--- a/nselib/snmp.lua
+++ b/nselib/snmp.lua
@@ -429,7 +429,7 @@ Helper = {
   --- Creates a new Helper instance
   --
   -- @param host string containing the host name or ip
-  -- @param port number containing the port to connect to
+  -- @param port table containing the port details to connect to
   -- @param community string containing SNMP community
   -- @param options A table with appropriate options:
   --  * timeout - the timeout in milliseconds (Default: 5000)


### PR DESCRIPTION
A bug in the helper function prevents generating SNMP v2c requests. The version number is referenced incorrectly in 'request' function. 

Updated 'request' function to get version number from self.options.version instead of self.version.