### PR TITLE
Adding fingerprints for Netscaler, ActiveMQ, Purestorage

### DIFF
--- a/nselib/data/http-default-accounts-fingerprints.lua
+++ b/nselib/data/http-default-accounts-fingerprints.lua
@@ -1566,7 +1566,6 @@ table.insert(fingerprints, {
 })
 
 table.insert(fingerprints, {
-  -- Version 8.1, 9.2, 10.3.4, 10.3.6, 12.1.2
   name = "Citrix Netscaler",
   category = "web",
   paths = {
@@ -1578,7 +1577,6 @@ table.insert(fingerprints, {
            and loc:find("/login/do_login")
   end,
   login_combos = {
-    -- WebLogic 9.x
     {username = "nsroot", password = "nsroot"},
   },
   login_check = function (host, port, path, user, pass)
@@ -1586,9 +1584,7 @@ table.insert(fingerprints, {
                                 url.absolute(path, "do_login"), nil,
                                 {username=user,password=pass,j_character_encoding="UTF-8"})
     local loc = req.header["location"] or ""
-    -- WebLogic 8.x, 9.x
     if req.status == 403 then return false end
-    -- WebLogic 10.x, 12.x
     if req.status == 302 and loc:find("/login/do_login") then return false end
     return true
   end

--- a/nselib/data/http-default-accounts-fingerprints.lua
+++ b/nselib/data/http-default-accounts-fingerprints.lua
@@ -1564,3 +1564,69 @@ table.insert(fingerprints, {
            and (resp.body or ""):find("../cgi/url_redirect.cgi?url_name=mainmenu", 1, true)
   end
 })
+
+table.insert(fingerprints, {
+  -- Version 8.1, 9.2, 10.3.4, 10.3.6, 12.1.2
+  name = "Citrix Netscaler",
+  category = "web",
+  paths = {
+    {path = "/login/"}
+  },
+  target_check = function (host, port, path, response)
+    local loc = response.header["location"] or ""
+    return response.status == 302
+           and loc:find("/login/do_login")
+  end,
+  login_combos = {
+    -- WebLogic 9.x
+    {username = "nsroot", password = "nsroot"},
+  },
+  login_check = function (host, port, path, user, pass)
+    local req = http_post_simple(host, port,
+                                url.absolute(path, "do_login"), nil,
+                                {username=user,password=pass,j_character_encoding="UTF-8"})
+    local loc = req.header["location"] or ""
+    -- WebLogic 8.x, 9.x
+    if req.status == 403 then return false end
+    -- WebLogic 10.x, 12.x
+    if req.status == 302 and loc:find("/login/do_login") then return false end
+    return true
+  end
+})
+
+table.insert(fingerprints, {
+  name = "Pure Storage",
+  category = "web",
+  paths = {
+    {path = "/"}
+  },
+  target_check = function (host, port, path, response)
+    return response.status == 200
+           and response.body:find("<title>Pure Storage Login</title>", 1, true)
+  end,
+  login_combos = {
+    {username = "pureuser", password = "pureuser"}
+  },
+  login_check = function (host, port, path, user, pass)
+    return try_http_post_login(host, port, path, "login",
+                               "{%s*Welcome%s*:%s*Invalid%s*}",
+                               {["username"]=user, ["password"]=pass})
+  end
+})
+
+table.insert(fingerprints, {
+  name = "Active MQ",
+  category = "web",
+  paths = {
+    {path = "/admin"}
+  },
+  target_check = function (host, port, path, response)
+    return http_auth_realm(response) == "ActiveMQRealm"
+  end,
+  login_combos = {
+    {username = "admin", password = "admin"}
+  },
+  login_check = function (host, port, path, user, pass)
+    return try_http_basic_login(host, port, path, user, pass, false)
+  end
+})


### PR DESCRIPTION
Added lua fingerprints for Citrix Netscaler (portal for loadbalancers), ActiveMQ (portal for managing message queues) and Purestorage (portal for flash storage arrays)