### PR TITLE
ncat: add AF_VSOCK support

### DIFF
--- a/ncat/config.h.in
+++ b/ncat/config.h.in
@@ -125,6 +125,9 @@
 /* Define to 1 if you have the <sys/un.h> header file. */
 #undef HAVE_SYS_UN_H
 
+/* Define to 1 if you have the <linux/vm_sockets.h> header file. */
+#undef HAVE_LINUX_VM_SOCKETS_H
+
 /* Define to 1 if you have the `vprintf' function. */
 #undef HAVE_VPRINTF
 

--- a/ncat/configure
+++ b/ncat/configure
@@ -3813,6 +3813,19 @@ fi
 
 done
 
+for ac_header in linux/vm_sockets.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "linux/vm_sockets.h" "ac_cv_header_linux_vm_sockets_h" "#include <sys/socket.h>
+"
+if test "x$ac_cv_header_linux_vm_sockets_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LINUX_VM_SOCKETS_H 1
+_ACEOF
+
+fi
+
+done
+
 
 # Checks for typedefs, structures, and compiler characteristics.
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether stat file-mode macros are broken" >&5

--- a/ncat/configure.ac
+++ b/ncat/configure.ac
@@ -40,6 +40,7 @@ AC_PATH_TOOL([STRIP], [strip], [/bin/true])
 AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
 AC_CHECK_HEADERS([fcntl.h limits.h netdb.h netinet/in.h stdlib.h string.h strings.h sys/param.h sys/socket.h sys/time.h sys/timeb.h unistd.h sys/un.h])
+AC_CHECK_HEADERS([linux/vm_sockets.h], , , [#include <sys/socket.h>])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STAT

--- a/ncat/docs/ncat.1
+++ b/ncat/docs/ncat.1
@@ -51,6 +51,7 @@ Options taking a time assume seconds\&. Append \*(Aqms\*(Aq for milliseconds,
   \-4                         Use IPv4 only
   \-6                         Use IPv6 only
   \-U, \-\-unixsock             Use Unix domain sockets only
+      \-\-vsock                Use vsock sockets only
   \-C, \-\-crlf                 Use CRLF for EOL sequence
   \-c, \-\-sh\-exec <command>    Executes the given command via /bin/sh
   \-e, \-\-exec <command>       Executes the given command
@@ -155,6 +156,16 @@ Use UDP for the connection (the default is TCP)\&.
 \fB\-\-sctp\fR (Use SCTP)
 .RS 4
 Use SCTP for the connection (the default is TCP)\&. SCTP support is implemented in TCP\-compatible mode\&.
+.RE
+.PP
+\fB\-\-vsock\fR (Use AF_VSOCK sockets)
+.RS 4
+Use AF_VSOCK sockets rather than the default TCP sockets\&. This option may be used on its own for stream sockets, or combined with
+\fB\-\-udp\fR
+for datagram sockets\&. A description of
+\fB\-\-vsock\fR
+mode is in
+the section called \(lqAF_VSOCK SOCKETS\(rq\&.
 .RE
 .SH "CONNECT MODE OPTIONS"
 .PP
@@ -508,6 +519,23 @@ on its own for stream sockets, or combine it with
 for datagram sockets\&. Datagram sockets require a source socket to connect from\&. By default, a source socket with a random filename will be created as needed, and deleted when the program ends\&. Use the
 \fB\-\-source\fR
 with a path to use a source socket with a specific name\&.
+.SH "AF_VSOCK SOCKETS"
+.PP
+The
+\fB\-\-vsock\fR
+option causes Ncat to use AF_VSOCK sockets rather than network sockets\&. A CID must be given instead of a hostname or IP address\&. For example, to make a connection to the host,
+.PP
+\fBncat \-\-vsock 2 1234\fR
+.PP
+To listen on a socket:
+.PP
+\fBncat \-l \-\-vsock 1234\fR
+.PP
+Both stream and datagram domain sockets are supported but socket type availability depends on the hypervisor\&. Use
+\fB\-\-vsock\fR
+on its own for stream sockets, or combine it with
+\fB\-\-udp\fR
+for datagram sockets\&.
 .SH "EXAMPLES"
 .PP
 Connect to example\&.org on TCP port 8080\&.

--- a/ncat/ncat_connect.c
+++ b/ncat/ncat_connect.c
@@ -1164,6 +1164,21 @@ static void try_nsock_connect(nsock_pool nsp, struct sockaddr_list *conn_addr)
     }
     else
 #endif
+#ifdef HAVE_LINUX_VM_SOCKETS_H
+    if (o.af == AF_VSOCK) {
+        if (o.proto == IPPROTO_UDP) {
+            nsock_connect_vsock_datagram(nsp, cs.sock_nsi, connect_handler,
+                    (void *)conn_addr->next, &conn_addr->addr.sockaddr,
+                    conn_addr->addrlen, conn_addr->addr.vm.svm_port);
+        } else {
+            nsock_connect_vsock_stream(nsp, cs.sock_nsi, connect_handler,
+                    o.conntimeout, (void *)conn_addr->next,
+                    &conn_addr->addr.sockaddr, conn_addr->addrlen,
+                    conn_addr->addr.vm.svm_port);
+        }
+    }
+    else
+#endif
     if (o.proto == IPPROTO_UDP) {
         nsock_connect_udp(nsp, cs.sock_nsi, connect_handler, (void *)conn_addr->next,
                           &conn_addr->addr.sockaddr, conn_addr->addrlen,

--- a/ncat/ncat_core.c
+++ b/ncat/ncat_core.c
@@ -686,6 +686,17 @@ void setup_environment(struct fdinfo *info)
         setenv_portable("NCAT_REMOTE_PORT", "");
     } else
 #endif
+#ifdef HAVE_LINUX_VM_SOCKETS_H
+    if (su.sockaddr.sa_family == AF_VSOCK) {
+        char char_u32[11];
+
+        snprintf(char_u32, sizeof(char_u32), "%u", su.vm.svm_cid);
+        setenv_portable("NCAT_REMOTE_ADDR", char_u32);
+
+        snprintf(char_u32, sizeof(char_u32), "%u", su.vm.svm_port);
+        setenv_portable("NCAT_REMOTE_PORT", char_u32);
+    } else
+#endif
     if (getnameinfo((struct sockaddr *)&su, alen, ip, sizeof(ip),
             port, sizeof(port), NI_NUMERICHOST | NI_NUMERICSERV) == 0) {
         setenv_portable("NCAT_REMOTE_ADDR", ip);
@@ -702,6 +713,17 @@ void setup_environment(struct fdinfo *info)
         /* say localhost to keep it backwards compatible, else su.un.sun_path */
         setenv_portable("NCAT_LOCAL_ADDR", "localhost");
         setenv_portable("NCAT_LOCAL_PORT", "");
+    } else
+#endif
+#ifdef HAVE_LINUX_VM_SOCKETS_H
+    if (su.sockaddr.sa_family == AF_VSOCK) {
+        char char_u32[11];
+
+        snprintf(char_u32, sizeof(char_u32), "%u", su.vm.svm_cid);
+        setenv_portable("NCAT_LOCAL_ADDR", char_u32);
+
+        snprintf(char_u32, sizeof(char_u32), "%u", su.vm.svm_port);
+        setenv_portable("NCAT_LOCAL_PORT", char_u32);
     } else
 #endif
     if (getnameinfo((struct sockaddr *)&su, alen, ip, sizeof(ip),

--- a/ncat/ncat_core.h
+++ b/ncat/ncat_core.h
@@ -165,7 +165,7 @@ enum exec_mode {
 #define PROXYDNS_REMOTE 2
 
 struct options {
-    unsigned short portno;
+    unsigned int portno;
 
     int verbose;
     int debug;

--- a/ncat/ncat_listen.c
+++ b/ncat/ncat_listen.c
@@ -993,6 +993,14 @@ int ncat_listen()
             return ncat_listen_stream(0);
     else
 #endif
+#if HAVE_LINUX_VM_SOCKETS_H
+    if (o.af == AF_VSOCK) {
+        if (o.proto == IPPROTO_UDP)
+            return ncat_listen_dgram(0);
+        else
+            return ncat_listen_stream(0);
+    } else
+#endif
     if (o.httpserver)
         return ncat_http_server();
     else if (o.proto == IPPROTO_UDP)

--- a/ncat/sockaddr_u.h
+++ b/ncat/sockaddr_u.h
@@ -138,6 +138,9 @@ union sockaddr_u {
 #ifdef HAVE_SYS_UN_H
     struct sockaddr_un un;
 #endif
+#ifdef HAVE_LINUX_VM_SOCKETS_H
+    struct sockaddr_vm vm;
+#endif
     struct sockaddr_in in;
     struct sockaddr_in6 in6;
     struct sockaddr sockaddr;

--- a/ncat/util.c
+++ b/ncat/util.c
@@ -464,6 +464,11 @@ int do_listen(int type, int proto, const union sockaddr_u *srcaddr_u)
         sa_len = SUN_LEN(&srcaddr_u->un);
         break;
 #endif
+#ifdef HAVE_LINUX_VM_SOCKETS_H
+      case AF_VSOCK:
+        sa_len = sizeof (struct sockaddr_vm);
+        break;
+#endif
 #ifdef HAVE_SOCKADDR_SA_LEN
       default:
         sa_len = srcaddr_u->sockaddr.sa_len;
@@ -490,6 +495,14 @@ int do_listen(int type, int proto, const union sockaddr_u *srcaddr_u)
                 socket_strerror(socket_errno()));
         else
 #endif
+#ifdef HAVE_LINUX_VM_SOCKETS_H
+        if (srcaddr_u->storage.ss_family == AF_VSOCK)
+            bye("bind to %u:%u: %s.",
+                srcaddr_u->vm.svm_cid,
+                srcaddr_u->vm.svm_port,
+                socket_strerror(socket_errno()));
+        else
+#endif
             bye("bind to %s:%hu: %s.", inet_socktop(srcaddr_u),
                 inet_port(srcaddr_u), socket_strerror(socket_errno()));
     }
@@ -501,6 +514,13 @@ int do_listen(int type, int proto, const union sockaddr_u *srcaddr_u)
 #ifdef HAVE_SYS_UN_H
         if (srcaddr_u->storage.ss_family == AF_UNIX)
             loguser("Listening on %s\n", srcaddr_u->un.sun_path);
+        else
+#endif
+#ifdef HAVE_LINUX_VM_SOCKETS_H
+        if (srcaddr_u->storage.ss_family == AF_VSOCK)
+            loguser("Listening on %u:%u\n",
+                    srcaddr_u->vm.svm_cid,
+                    srcaddr_u->vm.svm_port);
         else
 #endif
             loguser("Listening on %s:%hu\n", inet_socktop(srcaddr_u), inet_port(srcaddr_u));

--- a/ncat/util.h
+++ b/ncat/util.h
@@ -142,6 +142,10 @@
 #include <sys/un.h>
 #endif
 
+#if HAVE_LINUX_VM_SOCKETS_H
+#include <linux/vm_sockets.h>
+#endif
+
 #ifdef HAVE_OPENSSL
 #include <openssl/ssl.h>
 #endif

--- a/nsock/include/nsock.h
+++ b/nsock/include/nsock.h
@@ -88,6 +88,10 @@
 #endif
 #endif  /* HAVE_SYS_UN_H */
 
+#if HAVE_LINUX_VM_SOCKETS_H
+#include <linux/vm_sockets.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -529,6 +533,37 @@ nsock_event_id nsock_connect_unixsock_stream(nsock_pool nsp, nsock_iod nsiod, ns
 nsock_event_id nsock_connect_unixsock_datagram(nsock_pool nsp, nsock_iod nsiod, nsock_ev_handler handler,
                                                void *userdata, struct sockaddr *ss, size_t sslen);
 #endif /* HAVE_SYS_UN_H */
+
+#if HAVE_LINUX_VM_SOCKETS_H
+/* Request a vsock stream connection to another system.  ss should be a
+ * sockaddr_storage or sockaddr_vm, as appropriate (just like what you would
+ * pass to connect).  sslen should be the sizeof the structure you are passing
+ * in. */
+nsock_event_id nsock_connect_vsock_stream(nsock_pool nsp, nsock_iod ms_iod,
+                                          nsock_ev_handler handler,
+                                          int timeout_msecs, void *userdata,
+                                          struct sockaddr *saddr, size_t sslen,
+                                          unsigned int port);
+
+/* Request a vsock datagram "connection" to another system.  Since this is a
+ * datagram socket, no packets are actually sent.  The destination CID and port
+ * are just associated with the nsiod (an actual OS connect() call is made).
+ * You can then use the normal nsock write calls on the socket.  There is no
+ * timeout since this call always calls your callback at the next opportunity.
+ * The advantages to having a connected datagram socket (as opposed to just
+ * specifying an address with sendto() are that we can now use a consistent set
+ * of write/read calls for stream and datagram sockets, received packets from
+ * the non-partner are automatically dropped by the OS, and the OS can provide
+ * asynchronous errors (see Unix Network Programming pp224).  ss should be a
+ * sockaddr_storage or sockaddr_vm, as appropriate (just like what you would
+ * pass to connect).  sslen should be the sizeof the structure you are passing
+ * in. */
+nsock_event_id nsock_connect_vsock_datagram(nsock_pool nsp, nsock_iod nsiod,
+                                            nsock_ev_handler handler,
+                                            void *userdata,
+                                            struct sockaddr *saddr,
+                                            size_t sslen, unsigned int port);
+#endif /* HAVE_LINUX_VM_SOCKETS_H */
 
 /* Request a TCP connection to another system (by IP address).  The in_addr is
  * normal network byte order, but the port number should be given in HOST BYTE

--- a/nsock/include/nsock_config.h.in
+++ b/nsock/include/nsock_config.h.in
@@ -78,6 +78,8 @@
 /* Define to 1 if you have the <sys/un.h> header file. */
 #undef HAVE_SYS_UN_H
 
+#undef HAVE_LINUX_VM_SOCKETS_H
+
 #undef HAVE_NETDB_H
 
 #undef HAVE_OPENSSL

--- a/nsock/src/configure
+++ b/nsock/src/configure
@@ -4694,6 +4694,19 @@ fi
 
 done
 
+for ac_header in linux/vm_sockets.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "linux/vm_sockets.h" "ac_cv_header_linux_vm_sockets_h" "#include <sys/socket.h>
+"
+if test "x$ac_cv_header_linux_vm_sockets_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LINUX_VM_SOCKETS_H 1
+_ACEOF
+
+fi
+
+done
+
 
 # We test whether they specified openssl desires explicitly
 use_openssl="yes"

--- a/nsock/src/configure.ac
+++ b/nsock/src/configure.ac
@@ -206,6 +206,7 @@ AC_CHECK_FUNC(nanosleep, , AC_CHECK_LIB(posix4, nanosleep))
 dnl Checks for header files.
 AC_HEADER_STDC
 AC_CHECK_HEADERS(net/bpf.h sys/ioctl.h sys/un.h netdb.h)
+AC_CHECK_HEADERS([linux/vm_sockets.h], , , [#include <sys/socket.h>])
 
 # We test whether they specified openssl desires explicitly
 use_openssl="yes"

--- a/nsock/src/nsock_internal.h
+++ b/nsock/src/nsock_internal.h
@@ -473,7 +473,7 @@ void event_delete(struct npool *nsp, struct nevent *nse);
  * etc. */
 void nsock_pool_add_event(struct npool *nsp, struct nevent *nse);
 
-void nsock_connect_internal(struct npool *ms, struct nevent *nse, int type, int proto, struct sockaddr_storage *ss, size_t sslen, unsigned short port);
+void nsock_connect_internal(struct npool *ms, struct nevent *nse, int type, int proto, struct sockaddr_storage *ss, size_t sslen, unsigned int port);
 
 /* Comments on using the following handle_*_result functions are available in nsock_core.c */
 


### PR DESCRIPTION
This pull request adds support for the AF_VSOCK address family that has been in Linux since 3.9.  AF_VSOCK facilitates host<->guest communication for VMware, KVM, and Hyper-V hypervisors.  Addresses are represented as <u32 cid, u32 port> pairs.  Both SOCK_STREAM and SOCK_DGRAM socket types are available (depending on hypervisor support).

AF_VSOCK is used for guest agents and hypervisor services.  It is useful to have ncat support for shell scripting and testing.

This pull request adds an `ncat --vsock` address family option (similar to how UNIX domain sockets and SCTP are supported).  Please see the ncat.1 changes in the last commit for details.