### PR TITLE
Changes to tso-enum, tso-brute, cics-info and cics-enum

### DIFF
--- a/scripts/cics-enum.nse
+++ b/scripts/cics-enum.nse
@@ -316,7 +316,7 @@ local function cics_test( host, port, commands, user, pass )
   end
   tn:get_screen_debug(2)
 
-  if tn:find('Sign-off is complete.') then
+  if tn:find('off is complete.') then
       cics = true
   end
 

--- a/scripts/cics-info.nse
+++ b/scripts/cics-info.nse
@@ -150,7 +150,7 @@ local function cics_info( host, port, commands, user, pass, cemt, trans )
   end
   tn:get_screen_debug(2)
 
-  if not tn:find('Sign-off is complete.') then
+  if not tn:find('off is complete.') then
     return false, 'Unable to get to CICS. Try --script-args cics-info.commands="logon applid(<applid>)"'
   end
 

--- a/scripts/tso-brute.nse
+++ b/scripts/tso-brute.nse
@@ -112,7 +112,7 @@ Driver = {
       self.tn3270:get_all_data()
     end
 
-    if self.tn3270:find("***") then -- For ACF2/TopSecret if required
+    if self.tn3270:find("%*%*%*") then -- For ACF2/TopSecret if required
       self.tn3270:send_enter()
       self.tn3270:get_all_data()
     end

--- a/scripts/tso-enum.nse
+++ b/scripts/tso-enum.nse
@@ -110,7 +110,7 @@ Driver = {
       self.tn3270:get_all_data()
     end
 
-    if self.tn3270:find("***") then
+    if self.tn3270:find("%*%*%*") then
       self.tn3270:send_enter()
       self.tn3270:get_all_data()
     end


### PR DESCRIPTION
There was a change to the TN3270 library 'find' function which caused a search in tso-enum and tso-brute to interpret `***` as a search and not the literal `***`. I've since changed it to `%*%*%*` which fixes the issue. 