### PR TITLE
Add missing word to complete sentence in COPYING

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -88,8 +88,8 @@
  * Covered Software without special permission from the copyright holders. *
  *                                                                         *
  * If you have any questions about the licensing restrictions on using     *
- * Nmap in other works, are happy to help.  As mentioned above, we also    *
- * offer alternative license to integrate Nmap into proprietary            *
+ * Nmap in other works, we are happy to help.  As mentioned above, we      *
+ * also offer alternative license to integrate Nmap into proprietary       *
  * applications and appliances.  These contracts have been sold to dozens  *
  * of software vendors, and generally include a perpetual license as well  *
  * as providing for priority support and updates.  They also fund the      *


### PR DESCRIPTION
The sentence, without some subject, is an incomplete fragment. As such, the subject of "who" or "what" are happy to help must be defined. As such, this adds "we" representing the nmap organization.