### PR TITLE
Add Eclipse Equinoxe OSGi console fingerprint.

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -4803,6 +4803,8 @@ match telnet m|^\xff\xfe\x01\n\rAquaController Login\n\rlogin: | p/Neptune Syste
 match telnet m|^\xff\xfe\x01\xff\xfb\x01\r\n\r\n\r\nUser: | p/Teldat CIT telnetd/ d/router/
 match telnet m|^\r\nSystem administrator is connecting from ([^,]+), \r\nReject the connection request !!!\r\n| p/Draytek Vigor router telnetd/ i/admin connecting from $1/ d/router/
 match telnet m|^\xff\xfb\x01\r\0\n\n\nBlackboard (AT\d+) Configuration\r\0\n\nEnter Password > | p/Blackboard $1 POS device telnetd/ cpe:/h:blackboard:$1/
+match telnet m|^\xff\xfb\x01\xff\xfb\x03\xff\xfd\x1f\xff\xfd\x18$| p/Eclipse Equinoxe OSGi Shell (direct mode)/
+match telnet m|^(\r\n)*osgi>\x20$| p/Eclipse Equinoxe OSGi Shell (telnetd mode)/
 
 #(insert telnet)
 


### PR DESCRIPTION
Add fingerprints for OSGi console from Eclipse Equinoxe. Some Java middlewares are now exposing an "OSGi console" over Telnet. This commit add fingerprints for this telnet service.

To test it locally, you can follow the Eclipse guide (see first reference) or use my setup script at https://gist.github.com/QKaiser/66c8a618eef2a7801c0bbb1aa43d724a

OSGi consoles can work in two modes:
- **direct mode**: when launched with `java -jar org.eclipse.osgi.jar -console <port>`
- **telnetd mode**: a mode that is activated by config or manually by issuing `telnetd start` on OSGi console 

Direct mode enforce terminal type negotiation "IAC Do Terminal Type" (hence the first fingerprint) while telnetd mode greets the client with `osgi> ` (hence the second fingerprint).

**References**
* https://www.eclipse.org/equinox/documents/quickstart-framework.php
* https://www.ibm.com/support/knowledgecenter/en/SSTVLU_8.6.0/com.ibm.websphere.extremescale.doc/txsinstallstartplugs.html