### PR TITLE
Fix traceroute over PPP connections

### DIFF
--- a/traceroute.cc
+++ b/traceroute.cc
@@ -1635,6 +1635,8 @@ int traceroute(std::vector<Target *> &Targets) {
        target_iter++) {
     if ((*target_iter)->ifType() == devt_loopback)
       ; /* Ignore */
+    else if ((*target_iter)->ifType() == devt_p2p)
+      remote.push_back(*target_iter);
     else if ((*target_iter)->directlyConnected())
       direct.push_back(*target_iter);
     else


### PR DESCRIPTION
I have observed that traceroute tasks are completely ignored when they are executed through a PPP connection.

Having following configuration (a standard PPPoE home configuration):

```
$ ifconfig -a
[...removed output...]
eth1      Link encap:Ethernet  HWaddr 00:e0:7d:e1:9c:10  
          inet6 addr: fe80::2e0:7dff:fee1:9c10/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          [...removed output...]

eth1.20   Link encap:Ethernet  HWaddr 00:e0:7d:e1:9c:10  
          inet6 addr: fe80::2e0:7dff:fee1:9c10/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          [...removed output...]

ppp0      Link encap:Point-to-Point Protocol  
          inet addr:100.64.130.110  P-t-P:100.64.128.1  Mask:255.255.255.255
          UP POINTOPOINT RUNNING NOARP MULTICAST  MTU:1492  Metric:1
          RX packets:4448395 errors:0 dropped:0 overruns:0 frame:0
          TX packets:2528589 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:3 
          RX bytes:4906634151 (4.9 GB)  TX bytes:461943020 (461.9 MB)
[...removed output...]
```
If we try executing a nmap traceroute we will obtain the following deceiving results:

```
$ sudo nmap -sn -Pn --traceroute kung-foo.net

Starting Nmap 7.01 ( https://nmap.org ) at 2018-02-08 12:27 CET
Nmap scan report for kung-foo.net (5.135.152.106)
Host is up.

TRACEROUTE
HOP RTT ADDRESS
1   --  kung-foo.net (5.135.152.106)

Nmap done: 1 IP address (1 host up) scanned in 0.01 seconds
```
Instead of obtaining the following output if we apply this little patch:

```
$ sudo ./nmap -sn -Pn --traceroute kung-foo.net
Starting Nmap 7.60SVN ( https://nmap.org ) at 2018-02-08 12:28 CET
Nmap scan report for kung-foo.net (5.135.152.106)
Host is up (0.059s latency).

TRACEROUTE (using proto 1/icmp)
HOP RTT      ADDRESS
1   47.48 ms 100.64.128.1
2   46.07 ms 10.15.0.49
3   46.34 ms 10.15.246.6
4   44.17 ms 10.15.2.14
5   44.68 ms decix.mad-1-a9.es.eu (185.1.68.65)
6   58.78 ms be100-1157.gsw-1-a9.fr.eu (91.121.131.153)
7   62.99 ms be100-1044.rbx-g2-nc5.fr.eu (94.23.122.214)
8   60.31 ms 10.95.64.3
9   84.75 ms vl7.vss-10a-6k.fr.eu (178.33.100.204)
10  59.01 ms kung-foo.net (5.135.152.106)

Nmap done: 1 IP address (1 host up) scanned in 0.24 seconds
```