### PR TITLE
Enhance support of SMB2. Now smb-os-discovery shows available info

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 #Nmap Changelog ($Id$); -*-text-*-
+o [NSE] Enhance SMB2 support. Now smb-os-discovery can show a reasonable amount 
+  of information  [Ramon Garcia Fernandez]
 
 o [Ncat][GH#197][GH#1049] Fix --ssl connections from dropping on renegotiation,
   the same issue that was partially fixed for server mode in [GH#773]. Reported

--- a/nselib/asn1.lua
+++ b/nselib/asn1.lua
@@ -126,12 +126,13 @@ ASN1Decoder = {
   -- @return The decoded value(s).
   -- @return The position after decoding
   decode = function(self, encStr, pos)
-
     local etype, elen
     local newpos = pos
 
     etype, newpos = string.unpack("c1", encStr, newpos)
     elen, newpos = self.decodeLength(encStr, newpos)
+
+
 
     if self.decoder[etype] then
       return self.decoder[etype]( self, encStr, elen, newpos )
@@ -378,6 +379,14 @@ ASN1Encoder = {
       parts[#parts + 1] = string.char(n % 128 + 0x80)
     end
     return string.reverse(table.concat(parts))
+  end,
+
+  encodeOid = function(oid)
+    result = string.pack("B", oid[1]*40 + oid[2])
+    for i = 3, #oid do
+      result = result .. ASN1Encoder.encode_oid_component(oid[i])
+    end
+    return result
   end,
 
   ---

--- a/nselib/smb2.lua
+++ b/nselib/smb2.lua
@@ -8,6 +8,7 @@
 --  smb.lua but some fields may have changed name or don't exist anymore.
 --
 -- @author Paulino Calderon <paulino@calderonpale.com>
+--         Ramon Garcia Fernandez <ramon.garcia.f@gmail.com>
 -- @copyright Same as Nmap--See https://nmap.org/book/man-legal.html
 ---
 
@@ -251,7 +252,6 @@ function negotiate_v2(smb, overrides)
   else
     DialectCount = 1
   end
-  stdnse.debug2("negotiate_v2 #Dialects '%d'", #overrides['Dialects'])
   -- The client MUST set SecurityMode bit to 0x01 if the SMB2_NEGOTIATE_SIGNING_REQUIRED bit is not set,
   -- and MUST NOT set this bit if the SMB2_NEGOTIATE_SIGNING_REQUIRED bit is set.
   -- The server MUST ignore this bit.
@@ -556,8 +556,6 @@ function start_session_v2(smb, overrides, log_errors)
 end
 
 function find_ntml_in_securiy_blob_challenge(security_blob)
-  stdnse.debug2("find_ntlm_in_securiy_blob %x %x %x %x", 
-    security_blob:byte(1), security_blob:byte(2), security_blob:byte(3), security_blob:byte(4) )
   local decoder = asn1.ASN1Decoder:new()
   decoder:registerTagDecoders(tagdecoders)
   local decoded = decoder:decode(security_blob)

--- a/nselib/smb2.lua
+++ b/nselib/smb2.lua
@@ -549,7 +549,6 @@ function start_session_v2(smb, overrides, log_errors)
     smb['forest_dns'] = host_info['dns_forest_name']
     smb['server'] = host_info['netbios_computer_name']
     smb['domain'] = host_info['netbios_domain_name']
-    smb['time'] = host_info['timestamp']
     smb['os_major'] = host_info['os_major_version']
     smb['os_minor'] = host_info['os_minor_version']
   end

--- a/nselib/smb2.lua
+++ b/nselib/smb2.lua
@@ -17,6 +17,8 @@ local nmap = require "nmap"
 local table = require "table"
 local match = require "match"
 local os = require "os"
+local asn1 = require "asn1"
+local smbauth = require "smbauth"
 
 _ENV = stdnse.module("smb2", stdnse.seeall)
 
@@ -130,7 +132,7 @@ function smb2_send(smb, header, data, overrides)
   local out = string.pack(">I<c" .. #body, #body, body)
   repeat
     attempts = attempts - 1
-    stdnse.debug3("SMB: Sending SMB packet (len: %d, attempts remaining: %d)", #out, attempts)
+    stdnse.debug3("SMB: Sending SMB2 packet (len: %d, attempts remaining: %d)", #out, attempts)
     status, err = smb['socket']:send(out)
   until(status or (attempts == 0))
 
@@ -249,6 +251,7 @@ function negotiate_v2(smb, overrides)
   else
     DialectCount = 1
   end
+  stdnse.debug2("negotiate_v2 #Dialects '%d'", #overrides['Dialects'])
   -- The client MUST set SecurityMode bit to 0x01 if the SMB2_NEGOTIATE_SIGNING_REQUIRED bit is not set,
   -- and MUST NOT set this bit if the SMB2_NEGOTIATE_SIGNING_REQUIRED bit is set.
   -- The server MUST ignore this bit.
@@ -364,12 +367,12 @@ function negotiate_v2(smb, overrides)
     stdnse.debug2("SMB2_COM_NEGOTIATE command failed: Dialect not supported.")
     return false, "SMB2: Dialect is not supported. Exiting."
   end
-
   local data_structure_size, security_mode, negotiate_context_count
   data_structure_size, smb['security_mode'], smb['dialect'],
     negotiate_context_count, smb['server_guid'], smb['capabilities'],
     smb['max_trans'], smb['max_read'], smb['max_write'], smb['time'],
-    smb['start_time'] = string.unpack("<I2 I2 I2 I2 c16 I4 I4 I4 I4 I8 I8", data)
+    smb['start_time'], security_buffer_offset, security_buffer_length, neg_context_offset = 
+      string.unpack("<I2 I2 I2 I2 c16 I4 I4 I4 I4 I8 I8 I2 I2 I4", data)
 
   if(smb['dialect'] == nil or smb['capabilities'] == nil or smb['server_guid'] == nil or smb['security_mode'] == nil) then
     return false, "SMB: ERROR: Server returned less data than it was supposed to (one or more fields are missing)"
@@ -398,14 +401,195 @@ function negotiate_v2(smb, overrides)
   else
     smb['start_date'] = "N/A"
   end
+  security_buffer_offset = security_buffer_offset - #header
+  security_blob = string.sub(data, security_buffer_offset + neg_context_offset + 1)
 
-  local security_buffer_offset, security_buffer_length, neg_context_offset
-  security_buffer_offset, security_buffer_length, neg_context_offset = string.unpack("<I2 I2 I4", data)
+  process_nego_security_blob(security_blob)
+
   if status == 0 then
     return true, overrides['Dialects']
   else
     return false, string.format("Status error code:%s",status)
   end
+end
+
+function process_nego_security_blob(smb, security_blob) 
+  if security_blob and string.len(security_blob) > 2 then 
+    security_data = decode_security_blob(security_blob)
+    if (array_eq(security_data.gss_oid, {1, 3, 6, 1, 5, 5, 2})) then
+      for i, mech in pairs(security_data.oid_data[1][1][1]) do
+        if (array_eq(mech, {1, 3, 6, 1, 4, 1, 311, 2, 2, 10})) then
+          smb['supports_ntml'] = 1
+        elseif (array_eq(mech, {1, 2, 840, 48018, 1, 2, 2})) then
+          smb['supports_mskerberos'] = 1
+        elseif (array_eq(mech, {1, 2, 840, 113554, 1, 2, 2})) then
+          smb['supports_kerberos'] = 1
+        end
+      end
+    end
+  end
+end
+
+tagdecoders = {
+  ["\x0a"] = function( self, encStr, elen, pos )
+    return encStr:byte(pos), pos + elen
+  end,
+  ["\x60"] = function( self, encStr, elen, pos )
+    local s = self:decodeSeq(encStr, elen, pos)
+    return {gss_oid = s[1], oid_data = s[2] }
+  end,
+  ["\xa0"] = function( self, encStr, elen, pos )
+    return self:decodeSeq(encStr, elen, pos)
+  end,
+  ["\xa1"] = function( self, encStr, elen, pos )
+    return self:decodeSeq(encStr, elen, pos)
+  end,
+  ["\xa2"] = function( self, encStr, elen, pos )
+    return self:decodeSeq(encStr, elen, pos)
+  end,
+  ["\xa3"] = function( self, encStr, elen, pos )
+    return self:decodeSeq(encStr, elen, pos)
+  end,
+  ["\x1b"] = function( self, encStr, elen, pos )
+    return string.unpack("c" .. elen, encStr, pos)
+  end,
+
+}
+
+function array_eq(a, b) 
+  if #a ~= #b then
+    return false
+  end
+  for i = 1, #a do
+    if a[i] ~= b[i] then
+      return false
+    end
+  end
+  return true
+end
+
+function decode_security_blob(security_blob)
+  local decoder = asn1.ASN1Decoder:new()
+  decoder:registerTagDecoders(tagdecoders)
+  decoder:setStopOnError(true)
+  return decoder:decode(security_blob)
+end
+
+function start_session_v2(smb, overrides, log_errors)
+  local header
+  local SecurityMode, Capabilities, username, domain, password, password_hash, hash_type
+  header = smb2_encode_header_sync(smb, command_codes['SMB2_COM_SESSION_SETUP'], overrides)
+
+  if (overrides ~= nil) then
+    SecurityMode = overrides["SecurityMode"] or smb2_values['SMB2_NEGOTIATE_SIGNING_ENABLED']
+    Capabilities = overrides["Capabilities"] or 0 -- SMB 3.x dialect requires capabilities to be constructed
+  else 
+    SecurityMode = smb2_values['SMB2_NEGOTIATE_SIGNING_ENABLED']
+    Capabilities = 0
+  end
+
+   -- From smb.lua. Get account.
+   if(overrides ~= nil and overrides['username'] ~= nil) then
+    result = true
+    username      = overrides['username']
+    domain        = overrides['domain']
+    password      = overrides['password']
+    password_hash = overrides['password_hash']
+    hash_type     = overrides['hash_type']
+  else
+    result, username, domain, password, password_hash, hash_type = smbauth.get_account(smb['host'])
+    if(not(result)) then
+      return result, username
+    end
+  end
+  local security_blob, err
+  security_blob, err = make_ntmlreq_security_blob(smb, username, domain, password, password_hash, hash_type)
+  if (not security_blob) then
+      return false, err
+  end
+  local struct_len = 2 + 1 + 1 + 4 + 4 + 2 + 2 + 8
+  local offset = header:len() + struct_len
+  local length = security_blob:len()
+  local smbdata = string.pack("<I2 I1 I1 I4 I4 I2 I2 I8", struct_len | 1, 0, SecurityMode, Capabilities, 0, offset, length, 0)
+  
+  status, err = smb2_send(smb, header, smbdata .. security_blob)
+  if not status then
+    return false, err
+  end
+  status, header, data = smb2_read(smb)
+  local protocol_version, structure_size, credit_charge, status, 
+    command, credits, flags, chain_offset, message_id, 
+    process_id, session_id, signature = string.unpack("<c4 I2 I2 I4 I2 I2 I4 I4 I4 I4 I4 I8 c16", header)
+  
+  if(protocol_version ~= ("\xFESMB") or structure_size ~= 64) then
+    return false, "SMB: Server returned an invalid SMBv2 packet in SMB2_CON_SESSION_SETUP"
+  end
+  stdnse.debug2("SMB2_COM_SESSION_SETUP returned status '%s'", status)
+  if (status ~= 0xC0000016) then
+    return false, "SMB2: SMB2_COM_SESSION_SETUP failed. Server does not support NTLM?"
+  end
+  smb["SessionId"] = session_id
+
+  local structure_size, session_flags, security_blob_offset, security_blob_length = 
+    string.unpack("<I2 I2 I2 I2", data)
+  local offset_in_data = 1 + security_blob_offset - string.len(header)
+  security_blob = string.sub(data, 
+    offset_in_data,
+    offset_in_data + security_blob_length)
+
+  local ntlm_data, err = find_ntml_in_securiy_blob_challenge(security_blob)
+  if (not ntlm_data) then
+    return false, err
+  end
+
+  local host_info, err = smbauth.get_host_info_from_security_blob(ntlm_data)
+  if (host_info) then
+    smb['fqdn'] = host_info['fqdn']
+    smb['domain_dns'] = host_info['dns_domain_name']
+    smb['forest_dns'] = host_info['dns_forest_name']
+    smb['server'] = host_info['netbios_computer_name']
+    smb['domain'] = host_info['netbios_domain_name']
+    smb['time'] = host_info['timestamp']
+    smb['os_major'] = host_info['os_major_version']
+    smb['os_minor'] = host_info['os_minor_version']
+  end
+end
+
+function find_ntml_in_securiy_blob_challenge(security_blob)
+  stdnse.debug2("find_ntlm_in_securiy_blob %x %x %x %x", 
+    security_blob:byte(1), security_blob:byte(2), security_blob:byte(3), security_blob:byte(4) )
+  local decoder = asn1.ASN1Decoder:new()
+  decoder:registerTagDecoders(tagdecoders)
+  local decoded = decoder:decode(security_blob)
+  if (not decoded) then
+    return nil, "SMB2 bad NTLM challenge: error parsing ASN1 data"
+  end
+  local nego_chall = decoded[1]
+  local neg_result = nego_chall[1]
+  if neg_result[1] ~= 1 then
+    return nil, "SMB2 bad NTLM challenge: challenge byte missing"
+  end
+  local authOid = nego_chall[2][1]
+  if (not array_eq(authOid, {1, 3, 6, 1, 4, 1, 311, 2, 2, 10})) then
+    return nil, "SMB2 bad NTLM challenge: missing NTLM OID"
+  end
+  return nego_chall[3][1], nil
+end
+
+function make_ntmlreq_security_blob(smb, username, domain, password, password_hash, hash_type)
+  local encoder = asn1.ASN1Encoder:new()
+
+  local gssOid = encoder:encode({type = '06', value = encoder.encodeOid({1,3,6,1,5,5,2})})
+  local ntlm_ssp = {1, 3, 6, 1, 4, 1, 311, 2, 2, 10}
+  local mech_id = encoder:encode({type = 'A0', value = encoder:encode({type = '30', 
+    value = encoder:encode({type = '06', value = encoder.encodeOid(ntlm_ssp)} )} )})
+  local ntlm_flags = 0x62088215 -- NEGOTIATE_KEY_EXCHANGE |  NEGOTIATE_EXTENDED_SECURITY | NEGOTIATE_VERSION
+                                -- NEGOTIATE_SIGN_ALWAYS | NEGOTIATE_NTLM | NEGOTIATE_SIGN | REQUEST_TARGET | NEGOTIATE_UNICODE
+  local ok, ntlm_data, mac_key  = smbauth.get_security_blob(nil, nil, username, domain, password, password_hash, hash_type, ntlm_flags, 0x6010000, 0xF)
+  local mech_data = encoder:encode({type = 'A2', value = encoder:encode({type = '04', value = ntlm_data})})
+  local mech_struct = encoder:encode({type = 'A0', value = encoder:encode({type = '30', value = mech_id .. mech_data })})
+
+  return encoder:encode({type = '60', value = gssOid .. mech_struct})
 end
 
 return _ENV;

--- a/nselib/smbauth.lua
+++ b/nselib/smbauth.lua
@@ -756,21 +756,31 @@ end
 --                     set if password is set.
 --@param hash_type The way in which to hash the password.
 --@param flags The NTLM flags as a number
-function get_security_blob(security_blob, ip, username, domain, password, password_hash, hash_type, flags)
+--@params ntlm_version [optional] the version of NTLM used (32 bits: byte major, byte minor, 16 bits build number)
+--@params                  example 0x6010000 for version 6.1
+--@params ntlm_revision [optional] the revision of the NTLM protocol used
+function get_security_blob(security_blob, ip, username, domain, password, password_hash, hash_type, flags, ntlm_version, ntlm_revision)
   local pos = 1
   local new_blob
-  local flags = flags or 0x00008215 -- (NEGOTIATE_SIGN_ALWAYS | NEGOTIATE_NTLM | NEGOTIATE_SIGN | REQUEST_TARGET | NEGOTIATE_UNICODE)
+  -- (NEGOTIATE_SIGN_ALWAYS | NEGOTIATE_NTLM | NEGOTIATE_SIGN | REQUEST_TARGET | NEGOTIATE_UNICODE)
+  -- add NEGOTIATE_VERSION when ntlm_version is defiened
+
+  local flags = flags or ((ntlm_version and 0x02008215 ) or 0x00008215) 
 
   if(security_blob == nil) then
     -- If security_blob is nil, this is the initial packet
     new_blob = bin.pack("<zIILL",
     "NTLMSSP",            -- Identifier
     NTLMSSP_NEGOTIATE,    -- Type
-    flags,                -- Flags
+    flags,         -- Flags
     0,                    -- Calling workstation domain
     0                     -- Calling workstation name
     )
-
+    if ntlm_version ~= nil then
+      local ntlm_revision = ntlm_revision or 0
+      stdnse.debug2("NTLM version '%x' rev '%x'", ntlm_version, ntlm_revision)
+      new_blob = new_blob .. bin.pack(">II", ntlm_version, ntlm_revision)
+    end
     return true, new_blob, "", ""
   else
     -- Parse the old security blob
@@ -854,7 +864,7 @@ function get_host_info_from_security_blob(security_blob)
     stdnse.debug1("SMB: Invalid NTLM challenge message: unexpected message type: %d.", message_type )
     return false, "Invalid message type in NTLM challenge message"
   end
-
+  
   local ntlm_challenge = {}
 
   -- Parse the TargetName data (i.e. the server authentication realm)
@@ -865,12 +875,13 @@ function get_host_info_from_security_blob(security_blob)
     pos, target_realm = bin.unpack( string.format( "A%d", length ), security_blob, pos )
     ntlm_challenge[ "target_realm" ] = unicode.utf16to8( target_realm )
   end
-
+  
   if hpos + domain_length > #security_blob then
     -- Context, Target Information, and OS Version structure are all omitted
     -- Probably Win9x
     return ntlm_challenge
   end
+
 
   local hpos, context, target_info_length, target_info_max, target_info_offset = bin.unpack("<LSSI", security_blob, hpos)
 
@@ -885,6 +896,7 @@ function get_host_info_from_security_blob(security_blob)
       stdnse.debug2("smbauth: Unknown OS info structure in NTLM handshake")
     end
   end
+
 
   -- Parse the TargetInfo data (Wireshark calls this the "Address List")
   if ( target_info_length > 0 ) then
@@ -939,6 +951,9 @@ function get_host_info_from_security_blob(security_blob)
       end
     until ( pos >= #target_info )
   end
+
+
+
 
   return ntlm_challenge
 end

--- a/nselib/smbauth.lua
+++ b/nselib/smbauth.lua
@@ -778,7 +778,6 @@ function get_security_blob(security_blob, ip, username, domain, password, passwo
     )
     if ntlm_version ~= nil then
       local ntlm_revision = ntlm_revision or 0
-      stdnse.debug2("NTLM version '%x' rev '%x'", ntlm_version, ntlm_revision)
       new_blob = new_blob .. bin.pack(">II", ntlm_version, ntlm_revision)
     end
     return true, new_blob, "", ""

--- a/scripts/smb-os-discovery.nse
+++ b/scripts/smb-os-discovery.nse
@@ -176,9 +176,6 @@ action = function(host)
     return stdnse.format_output(false, result)
   end
 
-  for k, v in pairs(result) do
-    stdnse.debug("get os result %s %s", k, v)
-  end
 
   -- Collect results.
   response.cpe = make_cpe(result)

--- a/scripts/smb-os-discovery.nse
+++ b/scripts/smb-os-discovery.nse
@@ -134,31 +134,42 @@ function make_cpe(result)
         parts[6] = "professional"
       end
     end
-
+    if (#parts > 0) then
+      return "cpe:/" .. stdnse.strjoin(":", parts)
+    end
   elseif (result.os_major and result.os_minor) then
+    local posible_os = {}
     if (result.os_major == 6) then
       if (result.os_minor == 0) then
         result.os = "Windows Vista or Windows Server 2008"
-        parts = {"o", "microsoft", "windows_vista"}
+        posible_os = {"windows_vista", "windows_server_2008"}
       elseif (result.os_minor == 1) then
         result.os = "Windows 7 or Windows Server 2008 R2"
-        parts = {"o", "microsoft", "windows_7"}
+        posible_os = {"windows_7", "windows_server_2008r2"}
       elseif (result.os_minor == 2) then
         result.os = "Windows 8 or Windows Server 2012"
-        parts = {"o", "microsoft", "windows_8"}
+        posible_os = {"windows_8", "windows_server_2012"}
       elseif (result.os_minor == 3) then
         result.os = "Windows 8.1 or Windows Server 2012 R2"
-        parts = {"o", "microsoft", "windows_8.1"}
+        posible_os = {"windows_8.1", "windows_server_2012r2"}
       end
     elseif (result.os_major == 10 and result.os_minor == 0) then
       result.os = "Windows 10 or Windows Server 2016"
-      parts = {"o", "microsoft", "windows_10"}
+      posible_os = {"windows_10", "windows_server_2016"}
+    end
+    if (#posible_os > 0) then
+      cpes = ""
+      for _, v in ipairs(posible_os) do
+        if #cpes > 0 then
+          cpes = cpes .. " "
+        end
+        cpes = cpes .. "cpe:/o/microsoft/" .. v
+      end
+      return cpes
     end
   end
   
-  if (#parts > 0) then
-    return "cpe:/" .. stdnse.strjoin(":", parts)
-  end
+
 end
 
 function add_to_output(output_table, label, value)

--- a/scripts/smb-os-discovery.nse
+++ b/scripts/smb-os-discovery.nse
@@ -98,44 +98,65 @@ end
 function make_cpe(result)
   local os = result.os
   local parts = {}
-
-  if string.match(os, "^Windows 5%.0") then
-    parts = {"o", "microsoft", "windows_2000"}
-  elseif string.match(os, "^Windows 5%.1") then
-    parts = {"o", "microsoft", "windows_xp"}
-  elseif string.match(os, "^Windows Server.*2003") then
-    parts = {"o", "microsoft", "windows_server_2003"}
-  elseif string.match(os, "^Windows Vista") then
-    parts = {"o", "microsoft", "windows_vista"}
-  elseif string.match(os, "^Windows Server.*2008") then
-    parts = {"o", "microsoft", "windows_server_2008"}
-  elseif string.match(os, "^Windows 7") then
-    parts = {"o", "microsoft", "windows_7"}
-  elseif string.match(os, "^Windows 8%f[^%d.]") then
-    parts = {"o", "microsoft", "windows_8"}
-  elseif string.match(os, "^Windows 8.1") then
-    parts = {"o", "microsoft", "windows_8.1"}
-  elseif string.match(os, "^Windows 10%f[^%d.]") then
-    parts = {"o", "microsoft", "windows_10"}
-  elseif string.match(os, "^Windows Server.*2012") then
-    parts = {"o", "microsoft", "windows_server_2012"}
-  end
-
-  if parts[1] == "o" and parts[2] == "microsoft"
-    and string.match(parts[3], "^windows") then
-    parts[4] = ""
-    local sp = string.match(os, "Service Pack (%d+)")
-    if sp then
-      parts[5] = "sp" .. tostring(sp)
-    else
-      parts[5] = "-"
+  if (os) then
+    if string.match(os, "^Windows 5%.0") then
+      parts = {"o", "microsoft", "windows_2000"}
+    elseif string.match(os, "^Windows 5%.1") then
+      parts = {"o", "microsoft", "windows_xp"}
+    elseif string.match(os, "^Windows Server.*2003") then
+      parts = {"o", "microsoft", "windows_server_2003"}
+    elseif string.match(os, "^Windows Vista") then
+      parts = {"o", "microsoft", "windows_vista"}
+    elseif string.match(os, "^Windows Server.*2008") then
+      parts = {"o", "microsoft", "windows_server_2008"}
+    elseif string.match(os, "^Windows 7") then
+      parts = {"o", "microsoft", "windows_7"}
+    elseif string.match(os, "^Windows 8%f[^%d.]") then
+      parts = {"o", "microsoft", "windows_8"}
+    elseif string.match(os, "^Windows 8.1") then
+      parts = {"o", "microsoft", "windows_8.1"}
+    elseif string.match(os, "^Windows 10%f[^%d.]") then
+      parts = {"o", "microsoft", "windows_10"}
+    elseif string.match(os, "^Windows Server.*2012") then
+      parts = {"o", "microsoft", "windows_server_2012"}
     end
-    if string.match(os, "Professional") then
-      parts[6] = "professional"
+
+    if parts[1] == "o" and parts[2] == "microsoft"
+      and string.match(parts[3], "^windows") then
+      parts[4] = ""
+      local sp = string.match(os, "Service Pack (%d+)")
+      if sp then
+        parts[5] = "sp" .. tostring(sp)
+      else
+        parts[5] = "-"
+      end
+      if string.match(os, "Professional") then
+        parts[6] = "professional"
+      end
+    end
+
+  elseif (result.os_major and result.os_minor) then
+    if (result.os_major == 6) then
+      if (result.os_minor == 0) then
+        result.os = "Windows Vista or Windows Server 2008"
+        parts = {"o", "microsoft", "windows_vista"}
+      elseif (result.os_minor == 1) then
+        result.os = "Windows 7 or Windows Server 2008 R2"
+        parts = {"o", "microsoft", "windows_7"}
+      elseif (result.os_minor == 2) then
+        result.os = "Windows 8 or Windows Server 2012"
+        parts = {"o", "microsoft", "windows_8"}
+      elseif (result.os_minor == 3) then
+        result.os = "Windows 8.1 or Windows Server 2012 R2"
+        parts = {"o", "microsoft", "windows_8.1"}
+      end
+    elseif (result.os_major == 10 and result.os_minor == 0) then
+      result.os = "Windows 10 or Windows Server 2016"
+      parts = {"o", "microsoft", "windows_10"}
     end
   end
-
-  if #parts > 0 then
+  
+  if (#parts > 0) then
     return "cpe:/" .. stdnse.strjoin(":", parts)
   end
 end
@@ -155,7 +176,12 @@ action = function(host)
     return stdnse.format_output(false, result)
   end
 
+  for k, v in pairs(result) do
+    stdnse.debug("get os result %s %s", k, v)
+  end
+
   -- Collect results.
+  response.cpe = make_cpe(result)
   response.os = result.os
   response.lanmanager = result.lanmanager
   response.domain = result.domain
@@ -168,12 +194,14 @@ action = function(host)
   response.domain_dns = result.domain_dns
   response.forest_dns = result.forest_dns
   response.workgroup = result.workgroup
-  response.cpe = make_cpe(result)
+  
 
   -- Build normal output.
   local output_lines = {}
   if response.os and response.lanmanager then
     add_to_output(output_lines, "OS", string.format("%s (%s)", smb.get_windows_version(response.os), response.lanmanager))
+  elseif response.os then
+    add_to_output(output_lines, "OS", response.os)
   else
     add_to_output(output_lines, "OS", "Unknown")
   end

--- a/scripts/smb-os-discovery.nse
+++ b/scripts/smb-os-discovery.nse
@@ -183,9 +183,13 @@ action = function(host)
   response.lanmanager = result.lanmanager
   response.domain = result.domain
   response.server = result.server
-  if result.time and result.timezone then
-    response.date = stdnse.format_timestamp(result.time, result.timezone * 60 * 60)
-    datetime.record_skew(host, result.time - result.timezone * 60 * 60, request_time)
+  if result.time then
+    if result.timezone then
+      response.date = stdnse.format_timestamp(result.time, result.timezone * 60 * 60)
+      datetime.record_skew(host, result.time - result.timezone * 60 * 60, request_time)
+    else
+      response.date = stdnse.format_timestamp(result.time, 0)
+    end
   end
   response.fqdn = result.fqdn
   response.domain_dns = result.domain_dns


### PR DESCRIPTION
Hello,
This patch contributes enhancement to SMB2 support. Previously, with servers that have SMB1 disabled, smb-os-discovery provided no useful output.

Therefore, now the SMB2 module has a function to start a session. More functionality like open tree request will be addressed in further patches.

Here is some sample output of smb-os-discovery.nse

> Host script results:
> | smb-os-discovery: 
> |   OS: Windows 8.1 or Windows Server 2012 R2
> |   OS CPE: cpe:/o/microsoft/windows_8.1 cpe:/o/microsoft/windows_server_2012r2
> |   Computer name: redacted
> |   NetBIOS computer name: redacted
> |   Workgroup: redacted
> |_  System time: 2018-03-18T21:04:23+00:00
