### PR TITLE
fixed a bug for str case conversion before str compare

### DIFF
--- a/nselib/sip.lua
+++ b/nselib/sip.lua
@@ -804,7 +804,7 @@ SipAuth = {
     assert(self.uri, "SipAuth: No uri specified")
 
     local result
-    if ( self.algorithm == "MD5" ) then
+    if ( self.algorithm:upper() == "MD5" ) then
       local HA1 = select(2, bin.unpack("H16", openssl.md5(self.username .. ":" .. self.realm .. ":" .. self.password)))
       local HA2 = select(2, bin.unpack("H16", openssl.md5(self.method .. ":" .. self.uri)))
       result = openssl.md5(HA1:lower() .. ":" .. self.nonce ..":" .. HA2:lower())


### PR DESCRIPTION
without conversion, the small case "md5" string fails to match, condition fails and the result variable remains uninitialized, due to which "attempt to index a nil value" error is thrown on line 812. the authorization string is converted to uppercase before comparison everywhere except on line 807