### PR TITLE
Fixes tn3270 screen rendering issues and bug with storing StartField

### DIFF
--- a/nselib/tn3270.lua
+++ b/nselib/tn3270.lua
@@ -653,7 +653,7 @@ Telnet = {
     if self.state == self.TN3270_DATA or self.state == self.TN3270E_DATA then
       -- since we're in TN3270 mode, let's create an empty buffer
       stdnse.debug(3, "Creating Empty IBM-3278-2 Buffer")
-      for i=1, 1920 do
+      for i=0, 1920 do
         self.buffer[i] = "\0"
         self.fa_buffer[i] = "\0"
         self.overwrite_buf[i] = "\0"
@@ -1179,7 +1179,7 @@ Telnet = {
   writeable = function (self)
     -- Returns a list with all writeable fields as {location, length} tuples
     local writeable_list = {}
-    for i = 1,#self.fa_buffer do
+    for i = 0,#self.fa_buffer do
       if ( self.fa_buffer[i] ~= "\00" ) and (self.fa_buffer[i]:byte(1) & 0x20) ~= 0x20 then
         -- found writeable flag
         for j = i,#self.fa_buffer do
@@ -1197,7 +1197,7 @@ Telnet = {
 
   find = function ( self, str )
     local buff = ''
-    for i = 1,#self.buffer do
+    for i = 0,#self.buffer do
       if self.buffer[i] == "\00" then
         buff = buff .. " "
       else
@@ -1205,20 +1205,20 @@ Telnet = {
       end
     end
     --local buff = self:get_screen()
-    stdnse.debug(3, "Looking for: "..str)
+    stdnse.debug(3, "Looking for: " ..str)
     local i, j = string.find(buff, str)
     if i == nil then
-      stdnse.debug(3, "Couldn't find: "..str)
+      stdnse.debug(3, "Couldn't find: " ..str)
       return false
     else
-      stdnse.debug(3, "Found String: "..str)
+      stdnse.debug(3, "Found String: " ..str)
       return i , j
     end
   end,
 
   isClear = function ( self )
     local buff = ''
-    for i = 1,#self.buffer do
+    for i = 0,#self.buffer do
       if self.buffer[i] == "\00" then
         buff = buff .. " "
       else
@@ -1240,7 +1240,7 @@ Telnet = {
   -- @returns true if there are any hidden fields in the buffer
   any_hidden = function ( self )
     local hidden_attrib = 0x0c -- 00001100 is hidden
-    for i = 1,#self.fa_buffer do
+    for i = 0,#self.fa_buffer do
       if (self.fa_buffer[i]:byte(1) & hidden_attrib) == hidden_attrib then
         return true
       end
@@ -1307,7 +1307,7 @@ Telnet = {
     end
     stdnse.debug(3,"Printing the overwritten TN3270 buffer")
     local buff = '\n'
-    for i = 1,#self.overwrite_buf do
+    for i = 0,#self.overwrite_buf do
       if self.overwrite_buf[i] == "\0" then
         buff = buff .. " "
       else

--- a/nselib/tn3270.lua
+++ b/nselib/tn3270.lua
@@ -320,10 +320,10 @@ Telnet = {
   DECODE_BADDR = function ( byte1, byte2 )
     if (byte1 & 0xC0) == 0 then
       -- (byte1 & 0x3F) << 8 | byte2
-      return (((byte1 & 0x3F) << 8) | byte2) + 1
+      return (((byte1 & 0x3F) << 8) | byte2) 
     else
       -- (byte1 & 0x3F) << 6 | (byte2 & 0x3F)
-      return (((byte1 & 0x3F) << 6) | (byte2 & 0x3F)) + 1
+      return (((byte1 & 0x3F) << 6) | (byte2 & 0x3F)) 
     end
   end,
 
@@ -816,10 +816,10 @@ Telnet = {
         stdnse.debug(4,"Writting Zero to buffer at address: " .. self.buffer_address)
         stdnse.debug(4,"Attribute Type: 0x".. stdnse.tohex(data:sub(i,i)))
         self:write_field_attribute(data:sub(i,i))
+        self:write_char("\00")
         self.buffer_address = self:INC_BUF_ADDR(self.buffer_address)
         -- set the current position one ahead (after SF)
         i = i + 1
-        self:write_char("\00")
 
       elseif cp == self.orders.SFE then
         stdnse.debug(4,"Start Field Extended")
@@ -1030,13 +1030,13 @@ Telnet = {
   get_screen = function ( self )
     stdnse.debug(3,"Returning the current TN3270 buffer")
     local buff = '\n'
-    for i = 1,#self.buffer do
+    for i = 0,#self.buffer do
       if self.buffer[i] == "\00" then
         buff = buff .. " "
       else
         buff = buff .. drda.StringUtil.toASCII(self.buffer[i])
       end
-      if i % 80 == 0 then
+      if (i+1) % 80 == 0 then
         buff = buff .. "\n"
       end
     end
@@ -1047,13 +1047,13 @@ Telnet = {
     lvl = lvl or 1
     stdnse.debug(lvl,"---------------------- Printing the current TN3270 buffer ----------------------")
     local buff = ''
-    for i = 1,#self.buffer do
+    for i = 0,#self.buffer do
       if self.buffer[i] == "\00" then
         buff = buff .. " "
       else
         buff = buff .. drda.StringUtil.toASCII(self.buffer[i])
       end
-      if i % 80 == 0 then
+      if (i+1) % 80 == 0 then
         stdnse.debug(lvl, buff)
         buff = ''
       end
@@ -1065,7 +1065,7 @@ Telnet = {
 
   get_screen_raw = function ( self )
     local buff = ''
-    for i = 1,#self.buffer do
+    for i = 0,#self.buffer do
       buff = buff .. drda.StringUtil.toASCII(self.buffer[i])
     end
     return buff

--- a/scripts/tso-brute.nse
+++ b/scripts/tso-brute.nse
@@ -179,7 +179,7 @@ Driver = {
         -- IKJ56425I LOGON rejected User already logged on to system
         register_invalid(user)
         return true, creds.Account:new(user, "<skipped>", "User logged on. Skipped.")
-      elseif (self.tn3270:find("IKJ56425I") and self.tn3270:find("IKJ56418I")
+      elseif (self.tn3270:find("IKJ56425I") and self.tn3270:find("IKJ56418I")) then
         -- IKJ56425I LOGON REJECTED, RACF® TEMPORARILY REVOKING USER ACCESS
         -- IKJ56418I CONTACT YOUR TSO ADMINISTRATOR
         -- The first message (5I) is always followed by the second if the account it revoked

--- a/scripts/tso-brute.nse
+++ b/scripts/tso-brute.nse
@@ -186,6 +186,7 @@ Driver = {
         -- But not followed by the second message if its just logged on already
         register_invalid(user) -- We dont want to keep generating errors
         stdnse.verbose(2,"User: " .. user .. " LOCKED OUT")
+        return false, brute.Error:new("Account Locked out")
       elseif not (self.tn3270:find("IKJ56421I") or
           self.tn3270:find("IKJ56443I") or
           self.tn3270:find("TSS7101E")  or

--- a/scripts/tso-brute.nse
+++ b/scripts/tso-brute.nse
@@ -179,12 +179,22 @@ Driver = {
         -- IKJ56425I LOGON rejected User already logged on to system
         register_invalid(user)
         return true, creds.Account:new(user, "<skipped>", "User logged on. Skipped.")
+      elseif (self.tn3270:find("IKJ56425I") and self.tn3270:find("IKJ56418I")
+        -- IKJ56425I LOGON REJECTED, RACF® TEMPORARILY REVOKING USER ACCESS
+        -- IKJ56418I CONTACT YOUR TSO ADMINISTRATOR
+        -- The first message (5I) is always followed by the second if the account it revoked
+        -- But not followed by the second message if its just logged on already
+        register_invalid(user) -- We dont want to keep generating errors
+        stdnse.verbose(2,"User: " .. user .. " LOCKED OUT")
       elseif not (self.tn3270:find("IKJ56421I") or
+          self.tn3270:find("IKJ56443I") or
           self.tn3270:find("TSS7101E")  or
           self.tn3270:find("TSS714[0-3]E")  or
+          self.tn3270:find("TSS7099E") or
           self.tn3270:find("TSS7120E")) then
         -- RACF:
         -- IKJ56421I PASSWORD NOT AUTHORIZED FOR USERID
+        -- IKJ56443I TSOLOGON RECONNECT REJECTED - USER ACCESS REVOKED BY RACF
 
         -- Top Secret:
         -- TSS7101E Password is Incorrect
@@ -193,6 +203,7 @@ Driver = {
         -- TSS7142E Accessor ID Not Yet Available for Use - Still Inactive
         -- TSS7143E Accessor ID Has Been Inactive Too Long
         -- TSS7120E PASSWORD VIOLATION THRESHOLD EXCEEDED
+        -- TSS7099E Signon credentials invalid
 
         -- The 'MSG allows testers to discern any relevant messages they may get for the account'
         stdnse.verbose(2,"Valid User/Pass: " .. user .. "/" .. pass)

--- a/scripts/tso-brute.nse
+++ b/scripts/tso-brute.nse
@@ -185,7 +185,7 @@ Driver = {
         -- The first message (5I) is always followed by the second if the account it revoked
         -- But not followed by the second message if its just logged on already
         register_invalid(user) -- We dont want to keep generating errors
-        stdnse.verbose(2,"User: " .. user .. " LOCKED OUT")
+        stdnse.verbose(3,"User: " .. user .. " LOCKED OUT")
         return false, brute.Error:new("Account Locked out")
       elseif not (self.tn3270:find("IKJ56421I") or
           self.tn3270:find("IKJ56443I") or


### PR DESCRIPTION
A fix was put in to fix screen rendering which broke this library and the other scripts. 

This update fixes the screen rendering by changing the way to 'screen' is converted to printable as well as fixing a bug with the placement of the StartField character (was happening after the buffer location counter was incremented, now happens before, which is supposed to happen). 