### PR TITLE
Update to display vuln obj to user for CVE2006-3392

### DIFF
--- a/scripts/http-vuln-cve2006-3392.nse
+++ b/scripts/http-vuln-cve2006-3392.nse
@@ -74,6 +74,6 @@ to bypass the removal of "../" directory traversal sequences.
   if detection_session and detection_session.status == 200 then
     vuln.state = vulns.STATE.EXPLOIT
     stdnse.debug1(detection_session.body)
-    return vuln_report:make_output(detection_session.body)
+    return vuln_report:make_output(vuln)
   end
 end


### PR DESCRIPTION
Previously, the function would return vuln_report:make_output(detection_session.body). 

The expected output is that the nmap scan finishes and shows the "vuln" structure (title, state, IDs, description) if the instance is vulnerable.

This was not the case when run against a vulnerable instance (pwnOs1 vulnerable VM). The nmap script would finish and not display anything to the user unless --script-trace or -d flags were set.

After updating make_output to make_output(vuln), the finished nmap scan correctly displays the vuln structure after completion.

A further enhancement could be made to add detection_session.body to the vuln obj.