### PR TITLE
[ncat] Fix v6 connectivity

### DIFF
--- a/ncat/ncat_connect.c
+++ b/ncat/ncat_connect.c
@@ -353,7 +353,7 @@ static const char *sock_to_url(char *host_str, unsigned short port)
            Snprintf(buf, sizeof(buf), "%s:%hu", host_str, port);
            break;
        case 2:
-           Snprintf(buf, sizeof(buf), "[%s]:%hu]", host_str, port);
+           Snprintf(buf, sizeof(buf), "[%s]:%hu", host_str, port);
     }
 
     return buf;


### PR DESCRIPTION
When you pass in a v6 literal (to work around #1230), you run into the problem
that ncat adds an extra square-bracket breaking the syntax.