### PR TITLE
smb-vuln-ms17-010: handle error when the SMB connection is reset

### DIFF
--- a/scripts/smb-vuln-ms17-010.nse
+++ b/scripts/smb-vuln-ms17-010.nse
@@ -129,6 +129,13 @@ local function check_ms17010(host, port, sharename)
     end
 
     local result, smb_header, _, _ = smb.smb_read(smbstate)
+    if(result == false) then
+      stdnse.debug1("There was an error while reading the SMB response: it can happen if an (H)IPS resets the connection")
+      -- from smb lib: 'If status is false, header contains an error message'
+      err = smb_header
+      return false, err
+    end
+
     local _ , smb_cmd, err = string.unpack("<c4 B I4", smb_header)
     if smb_cmd == 37 then -- SMB command for Trans is 0x25
       stdnse.debug1("Valid SMB_COM_TRANSACTION response received")


### PR DESCRIPTION
The HIPS feature of Symantec Endpoint Protection resets the SMB connection when trying to scan for MS17-010.
This was not handled by the code and led to the following wrong message:
```
Host script results:
|_smb-vuln-ms17-010: Unexpected SMB response:4f525245
```

We can see that "4f525245" is hex for "ERR". Indeed the return code from `smb.smb_read` is not checked and the code tries to parse `smb_header` as a header, whereas in this case it contains an error message.
I copied the code from a few lines above to properly handle the case where the connection is reset.

The result is now:
```
Host script results:
|_smb-vuln-ms17-010: SMB: ERROR: Server disconnected the connection
```
Which is hopefully more clear!