### PR TITLE
Allow user-specified EHLO domains in SMTP STARTTLS

### DIFF
--- a/nselib/sslcert.lua
+++ b/nselib/sslcert.lua
@@ -468,7 +468,7 @@ StartTLS = {
     end
 
     local status
-    status, result = smtp.ehlo(s, "example.com")
+    status, result = smtp.ehlo(s, smtp.get_domain())
     if not status then
       stdnse.debug1("EHLO with errors or timeout.  Enable --script-trace to see what is happening.")
       return false, string.format("Failed to connect to SMTP server: %s", result)


### PR DESCRIPTION
The web documentation for [ssl-enum-ciphers](https://nmap.org/nsedoc/scripts/ssl-enum-ciphers.html) implies that a user can specify an EHLO hostname on the command line as a script argument:

```shell-session
 nmap -sV --script ssl-enum-ciphers --script-args smtp.domain=foo.example -p 25 bar.example
```

But currently, "EHLO example.com" is sent regardless of `smtp.domain` being specified.

The hardcoded `"example.com"` is replaced by `smtp.get_domain()` allowing the EHLO hostname to be specified as an arg, or to fall back to the default in `smtp.lua` (currenly `"nmap.scanme.org"`)
