### PR TITLE
Added "Scanning host" headers.

### DIFF
--- a/nmap.cc
+++ b/nmap.cc
@@ -1855,6 +1855,12 @@ int nmap_main(int argc, char *argv[]) {
   Strncpy(mytime, ctime(&timep), sizeof(mytime));
   chomp(mytime);
 
+  char scanninghost[1024];
+  scanninghost[1023] = '\0';
+  gethostname(scanninghost, 1023);
+  struct hostent* h_scanninghost = NULL;
+  h_scanninghost = gethostbyname(scanninghost);
+
   if (!o.resuming) {
     /* Brief info in case they forget what was scanned */
     char *xslfname = o.XSLStyleSheet();
@@ -1869,6 +1875,10 @@ int nmap_main(int argc, char *argv[]) {
 
     xml_start_comment();
     xml_write_escaped(" %s %s scan initiated %s as: %s ", NMAP_NAME, NMAP_VERSION, mytime, join_quoted(argv, argc).c_str());
+    xml_end_comment();
+    xml_newline();
+    xml_start_comment();
+    xml_write_escaped(" Scanning host: %s ", h_scanninghost->h_name);
     xml_end_comment();
     xml_newline();
 
@@ -1899,6 +1909,7 @@ int nmap_main(int argc, char *argv[]) {
   log_write(LOG_NORMAL | LOG_MACHINE, "# ");
   log_write(LOG_NORMAL | LOG_MACHINE, "%s %s scan initiated %s as: %s", NMAP_NAME, NMAP_VERSION, mytime, join_quoted(argv, argc).c_str());
   log_write(LOG_NORMAL | LOG_MACHINE, "\n");
+  log_write(LOG_NORMAL | LOG_MACHINE, "# Scanning host: %s\n", h_scanninghost->h_name);
 
   /* Before we randomize the ports scanned, lets output them to machine
      parseable output */


### PR DESCRIPTION
Added a simple header to the gnmap, nmap and xml output file formats. The header records the hostname of the machine which generated the files, the idea being to facilitate easier generation of network flow diagrams or maps without having to encode the scanning hostname somehow into the output file names and then parse it out again later.