### PR TITLE
Switch to immediate mode

### DIFF
--- a/libnetutil/netutil.cc
+++ b/libnetutil/netutil.cc
@@ -4125,8 +4125,8 @@ pcap_t *my_pcap_open_live(const char *device, int snaplen, int promisc, int to_m
   pcap_set_snaplen(pt, snaplen);
   pcap_set_promisc(pt, promisc);
   pcap_set_timeout(pt, to_ms); // Ignored in immediate mode
-  pcap_set_immediate_mode(pt, 1);
-  pcap_activate(pt);
+  pcap_set_immediate_mode(pt, 1); // TODO: What if we're using the system libpcap and this function doesn't exist?
+  pcap_activate(pt); // TODO: Do we need to check for failure here?
 
 #ifdef WIN32
   if (wait == WAIT_ABANDONED || wait == WAIT_OBJECT_0) {


### PR DESCRIPTION
WIP for #34.

This avoids false packet drops caused by libpcap buffering packets before returning them, making Nmap think that there is no response within its expected round trip timeout, leading to additional probes sent as retries. When the buffered packets then are returned, Nmap assumes that there were packet drops, due to getting responses "after" its retry probes, but not from the first probe (in reality, no packets were lost).

This is based on code seen in here: https://github.com/nmap/nmap/issues/34#issuecomment-246920572

It's just a quick patch to show the change. It doesn't implement error checking on pcap_activate, and doesn't check to see if pcap_set_immediate_mode is supported in the case of OS-provided libpcap.