### PR TITLE
mysql-info.nse: remove custom socket timeout

### DIFF
--- a/scripts/mysql-info.nse
+++ b/scripts/mysql-info.nse
@@ -74,7 +74,6 @@ end
 action = function(host, port)
   local output = stdnse.output_table()
   local socket = nmap.new_socket()
-  socket:set_timeout(5000)
 
   local status, err = socket:connect(host, port)
 


### PR DESCRIPTION
I've observed in a prod environment some MySQL servers that took around 15s to send their greetings.
The timeout set to 5s did not allow this.