### PR TITLE
fixed build with 'clang' compiler, added 'ctime' header in the requiring files

### DIFF
--- a/nmap_error.cc
+++ b/nmap_error.cc
@@ -135,6 +135,7 @@
 #include "xml.h"
 
 #include <errno.h>
+#include <ctime>
 
 extern NmapOps o;
 

--- a/nping/EchoServer.cc
+++ b/nping/EchoServer.cc
@@ -138,6 +138,8 @@
 #include "ProbeMode.h"
 #include <signal.h>
 
+#include <ctime>
+
 extern NpingOps o;
 extern EchoServer es;
 
@@ -288,7 +290,7 @@ int EchoServer::nep_listen_socket(){
             server_addr6.sin6_addr = in6addr_any;
             if( bind(master_sd, (struct sockaddr *)&server_addr6, sizeof(server_addr6)) != 0 ){
                 nping_fatal(QT_3, "Could not bind to port %d (%s).", port, strerror(errno));
-            }else{ 
+            }else{
                 nping_print(VB_1, "Server bound to port %d", port);
             }
         }
@@ -560,7 +562,7 @@ clientid_t EchoServer::nep_match_headers(IPv4Header *ip4, IPv6Header *ip6, TCPHe
                             nping_print(DBG_3, ";");
                             /* The payload magic may affect the score only between
                              * zero and 4 bytes. This is done to prevent long
-                             * common strings like "GET / HTTP/1.1\r\n" 
+                             * common strings like "GET / HTTP/1.1\r\n"
                              * increasing the score a lot and cause problems for
                              * the matching logic. */
                             current_score+= MIN(4, fspec->len)*FACTOR_PAYLOAD_MAGIC;
@@ -570,7 +572,7 @@ clientid_t EchoServer::nep_match_headers(IPv4Header *ip4, IPv6Header *ip6, TCPHe
                     default:
                         nping_warning(QT_2, "Bogus field specifier found in client #%d context. Please report a bug", ctx->getIdentifier());
                     break;
-                }           
+                }
             } /* End of field specifiers loop */
 
             nping_print(DBG_3, "%s() current_score=%.02f candidate_score=%.02f", __func__, current_score, candidate_score);
@@ -649,7 +651,7 @@ clientid_t EchoServer::nep_match_packet(const u8 *pkt, size_t pktlen){
                 }else{
                     if( (tcplen=tcp.validate())==OP_FAILURE){
                         return CLIENT_NOT_FOUND;
-                    }else{                        
+                    }else{
                         if( (int)pktlen > (iplen+tcplen) ){
                            if( payload.storeRecvData(pkt+iplen+tcplen, pktlen-iplen-tcplen)!=OP_FAILURE)
                                payload_included=true;

--- a/nping/nping.h
+++ b/nping/nping.h
@@ -249,7 +249,7 @@
  * things like "%d target IPs resolved". We don't want that message to always
  * get printed during  Nping's execution. We only want it out when the user
  * has increase the verbosity.
- * 
+ *
  * So the thing here is that there are two things that should be taken
  * into account:
  *  1. The current verbosity level that user has supplied from the command line
@@ -283,7 +283,7 @@
  *
  *  Check the comments after each level definition to see how they should be
  *  used. Here are some examples:
- * 
+ *
  *  nping_fatal(QT_3,"createIPv4(): NULL pointer supplied.");
  *  nping_print(DBG_2,"Resolving specified targets...");
  *  nping_print(VB_0, "Raw packets sent: %llu ", this->stats.getSentPackets() );
@@ -350,7 +350,7 @@
 
 
 /**< Default number of probes that are sent to each target */
-#define DEFAULT_PACKET_COUNT 5          
+#define DEFAULT_PACKET_COUNT 5
 
 /* When doing traceroute, the number of packets sent to each host must be
  * higher because 5 is probably not enough to reach the average target on the
@@ -367,7 +367,7 @@
 #define DEFAULT_DELAY 1000              /**< Milliseconds between each probe */
 
  /** Milliseconds Nping waits for replies after all probes have been sent */
-#define DEFAULT_WAIT_AFTER_PROBES 1000 
+#define DEFAULT_WAIT_AFTER_PROBES 1000
 
 #define DEFAULT_IP_TTL 64               /**< Default IP Time To Live         */
 #define DEFAULT_IP_TOS 0                /**< Default IP Type of Service      */
@@ -382,7 +382,7 @@
 #define DEFAULT_TCP_WINDOW_SIZE 1480    /**< Default TCP Window size         */
 
 /**< MTU used when user just supplies option -f but no MTU value */
-#define DEFAULT_MTU_FOR_FRAGMENTATION 72   
+#define DEFAULT_MTU_FOR_FRAGMENTATION 72
 
 #define DEFAULT_ICMP_TYPE 8  /**< Default ICMP message: Echo Request         */
 #define DEFAULT_ICMP_CODE 0  /**< Default ICMP code: 0 (standard)            */

--- a/osscan.cc
+++ b/osscan.cc
@@ -139,16 +139,8 @@
 
 #include <errno.h>
 #include <stdarg.h>
-#if TIME_WITH_SYS_TIME
-# include <sys/time.h>
-# include <time.h>
-#else
-# if HAVE_SYS_TIME_H
-#  include <sys/time.h>
-# else
-#  include <time.h>
-# endif
-#endif
+
+#include <ctime>
 
 #include <algorithm>
 #include <list>

--- a/osscan2.cc
+++ b/osscan2.cc
@@ -147,6 +147,7 @@
 
 #include <list>
 #include <math.h>
+#include <ctime>
 
 extern NmapOps o;
 #ifdef WIN32

--- a/output.cc
+++ b/output.cc
@@ -153,6 +153,7 @@
 #include "libnetutil/netutil.h"
 
 #include <math.h>
+#include <ctime>
 
 #include <set>
 #include <vector>

--- a/payload.cc
+++ b/payload.cc
@@ -136,6 +136,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <ctime>
+
 #include <string>
 #include <map>
 

--- a/portlist.cc
+++ b/portlist.cc
@@ -139,6 +139,8 @@
 #include "tcpip.h"
 #include "libnetutil/netutil.h"
 
+#include <ctime>
+
 #if HAVE_STRINGS_H
 #include <strings.h>
 #endif /* HAVE_STRINGS_H */


### PR DESCRIPTION
There fails a build if you try to build nmap with 'clang' family of compilers
I fixed the build by adding necessary ctime files in several .cc files so that types 'time_t' and functions 'time' have become revealed

Also I see no point in including sys/time.h but is included in some places where actually sys/time.h is not used. I think ctime will do in majority of places. In one file 'osscan.cc' I deleted a piece of code with sys/time.h and included only c++-fair ctime

Also the next my suggestion is for the C-like headers included in cpp files to be substituted by C++-like headers 