### PR TITLE
Fix a typo

### DIFF
--- a/docs/nmap.xsl
+++ b/docs/nmap.xsl
@@ -936,7 +936,7 @@
     <xsl:attribute name="name">postscript</xsl:attribute>
   </xsl:element>
 
-  <h2>Post-Scan Script Putput</h2>
+  <h2>Post-Scan Script Output</h2>
 	
   <table>
     <tr class="head">


### PR DESCRIPTION
This fixes a trivial typo in the HTML output of an XSL stylesheet for Nmap XML reports.