### PR TITLE
Fix to prevent connections to get terminated while still on going

### DIFF
--- a/ncat/ncat_exec_win.c
+++ b/ncat/ncat_exec_win.c
@@ -547,7 +547,8 @@ static DWORD WINAPI subprocess_thread_func(void *data)
             } else {
                 /* Probably read result wasn't ready, but we got here because
                  * there was data on the socket. */
-                if (GetLastError() != ERROR_IO_PENDING)
+                DWORD err = GetLastError();
+                if (err != ERROR_IO_PENDING && err != ERROR_IO_INCOMPLETE)
                 {
                     /* Error or end of file. */
                     goto loop_end;


### PR DESCRIPTION
I don't know how people could use it before this commit. 

Connections get finished whenever the result from `WaitForMultipleObjects` errors to `ERROR_IO_INCOMPLETE`.

Testing:
Listen with:
`ncat.exe -lvp 4444 --ssl`

Connect with:
`ncat.exe 127.0.0.1 4444 -e cmd.exe --ssl -v.`

Run any command (i.e. dir) and it will close the connection.

Standard error is reported in the client and not in the server but I'll open a ticket to fix that.

Cheers

EDIT: stderr issue: https://github.com/nmap/nmap/issues/1373