### PR TITLE
Improve the accuracy of script http-vuln-cve2017-1001000.nse

### DIFF
--- a/scripts/http-vuln-cve2017-1001000.nse
+++ b/scripts/http-vuln-cve2017-1001000.nse
@@ -96,6 +96,11 @@ Versions 4.7.0 and 4.7.1 are known to be affected.
 
     local status, json_data = json.parse(response.body)
 
+    --Check for empty dataset
+    if (json_data[1]==nil) then
+      return vulnReport:make_output(vuln_table)
+    end
+
     --Parsing the json_data to get the ID of the first post and the date.
     local id=json_data[1].id
     local content=json_data[1].date
@@ -120,6 +125,12 @@ Versions 4.7.0 and 4.7.1 are known to be affected.
     --of the post and it is vulnerable.
     if(response1.status and response1.status==200) then
       vuln_table.state = vulns.STATE.VULN
+
+      --Despite the http status being 200, check if the response contains an error
+      local response1_json_status, response1_json_data = json.parse(response1.body)
+      if (response1_json_status and response1_json_data.data and response1_json_data.data.status~=200) then
+        vuln_table.state = vulns.STATE.NOT_VULN
+      end
     end
     return vulnReport:make_output(vuln_table)
   end


### PR DESCRIPTION
The objective of this is to improve the accuracy of the script `http-vuln-cve2017-1001000.nse`.

Made two fixes where the script:
1. failed when the Wordpress API returned an empty response on the GET request.
2. incorrectly marked the target as vulnerable when the Wordpress API returned an error to the vulnerability check:
```
{
  "code": "rest_invalid_param",
  "message": "Ungültige(r) Parameter: id",
  "data": {
    "status": 400,
    "params": {
      "id": "id ist nicht vom Typ integer."
    }
  }
}
```

which roughly translates to:
```
// ...
"message": "Invalid parameter(s): id",
// ...
"id": "Id is not of type integer."
// ..
```

Both conditions are now checked and the target is marked as non vulnerable.
I can provide a few targets to test by email.