### PR TITLE
Add script for D-Link router directory traversal vulnerability

### DIFF
--- a/nselib/data/http-fingerprints.lua
+++ b/nselib/data/http-fingerprints.lua
@@ -7150,6 +7150,23 @@ table.insert(fingerprints, {
     }
   });
 
+table.insert(fingerprints, {
+    category = 'attacks',
+    probes = {
+      {
+        path = '/uir//etc/passwd',
+        method = 'GET'
+      }
+    },
+    matches = {
+      {
+        match = '200',
+        output = 'D-Link router directory traversal vulnerability (CVE-2018-10822)'
+      }
+    }
+  });
+
+
 ------------------------------------------------
 ----        Open Source CMS checks          ----
 ------------------------------------------------


### PR DESCRIPTION
Hello everyone.

This pull request adds a script for CVE-2018-10822, the directory traversal vulnerability in the web interface on D-Link routers disclosed earlier this month.

References:
- https://seclists.org/fulldisclosure/2018/Oct/36
- https://sploit.tech/2018/10/12/D-Link.html

It attempts a GET HTTP request and inspects the response code and headers to find out if the target is vulnerable.