### PR TITLE
Add script for D-Link router plaintext password file exposure

### DIFF
--- a/nselib/data/http-fingerprints.lua
+++ b/nselib/data/http-fingerprints.lua
@@ -7150,6 +7150,22 @@ table.insert(fingerprints, {
     }
   });
 
+table.insert(fingerprints, {
+    category = 'attacks',
+    probes = {
+      {
+        path = '/uir//tmp/csman/0',
+        method = 'GET'
+      }
+    },
+    matches = {
+      {
+        match = '200',
+        output = 'D-Link router plaintext password file exposure (CVE-2018-10824)'
+      }
+    }
+  });
+
 ------------------------------------------------
 ----        Open Source CMS checks          ----
 ------------------------------------------------


### PR DESCRIPTION
Hello everyone.

This pull request adds a script for CVE-2018-10824, the plaintext password file exposure vulnerability in the web interface on D-Link routers disclosed earlier this month.

References:
- https://seclists.org/fulldisclosure/2018/Oct/36
- https://sploit.tech/2018/10/12/D-Link.html

It makes a GET HTTP to the target to the special URL that exposes the router configuration.
Then it inspects the response code and headers to identify if the target is vulnerable.