### PR TITLE
Add new interactive keyboard command (o) to show open ports during a scan

### DIFF
--- a/nmap.cc
+++ b/nmap.cc
@@ -497,6 +497,7 @@ struct ftpinfo ftp = get_default_ftpinfo();
 static std::vector<std::string> route_dst_hosts;
 
 struct scan_lists ports = { 0 };
+std::vector<Target *> *extTargets;
 
 /* This struct is used is a temporary storage place that holds options that
    can't be correctly parsed and interpreted before the entire command line has
@@ -1763,6 +1764,7 @@ void nmap_free_mem() {
 int nmap_main(int argc, char *argv[]) {
   int i;
   std::vector<Target *> Targets;
+  extTargets = &Targets;
   time_t now;
   struct hostent *target = NULL;
   time_t timep;

--- a/nmap_tty.cc
+++ b/nmap_tty.cc
@@ -325,6 +325,9 @@ bool keyWasPressed()
     } else if (c == 'V') {
        if (o.verbose > 0) o.verbose--;
        log_write(LOG_STDOUT, "Verbosity Decreased to %d.\n", o.verbose);
+    } else if (c == 'o') {
+       log_write(LOG_STDOUT, "Scanning %d host(s)\n", o.numhosts_scanning);
+       printOpenPorts();
     } else if (c == 'd') {
        if (o.debugging < 10) o.debugging++;
        log_write(LOG_STDOUT, "Debugging Increased to %d.\n", o.debugging);
@@ -341,6 +344,7 @@ bool keyWasPressed()
       log_write(LOG_STDOUT,
                 "Interactive keyboard commands:\n"
                 "?               Display this information\n"
+                "o               Show open ports\n"
                 "v/V             Increase/decrease verbosity\n"
                 "d/D             Increase/decrease debugging\n"
                 "p/P             Enable/disable packet tracing\n"

--- a/output.cc
+++ b/output.cc
@@ -2479,6 +2479,28 @@ void printtimes(Target *currenths) {
   }
 }
 
+void printOpenPorts() {
+  Port *p = NULL;
+  Port port;
+  std::vector<Target *> t = *extTargets;
+  unsigned int x = 0, y = t.size();
+
+  for (x = 0; x < y; x++) {
+    log_write(LOG_STDOUT, "Target %s\n", t[x]->targetipstr());
+    if (t[x]->ports.hasOpenPorts()) {
+      log_write(LOG_STDOUT, "Found open port(s):");
+      p = NULL;
+      while ((p = t[x]->ports.nextPort(p, &port, TCPANDUDPANDSCTP, PORT_OPEN))) {
+        log_write(LOG_STDOUT, " %d/%s", p->portno, IPPROTO2STR(p->proto));
+      }
+      log_write(LOG_STDOUT, "\n");
+    } else {
+      log_write(LOG_STDOUT, "No open port yet.\n");
+    }
+    log_write(LOG_STDOUT, "\n");
+  }
+}
+
 /* Prints a status message while the program is running */
 void printStatusMessage() {
   // Pre-computations

--- a/output.h
+++ b/output.h
@@ -280,6 +280,9 @@ void printtimes(Target *currenths);
    normal/skiddy/stdout output */
 int print_iflist(void);
 
+/* Print open ports founds during scan */
+void printOpenPorts();
+
 /* Prints a status message while the program is running */
 void printStatusMessage();
 
@@ -298,6 +301,8 @@ void printdatafilepaths();
 /* nsock logging interface */
 void nmap_adjust_loglevel(bool trace);
 void nmap_nsock_stderr_logger(const struct nsock_log_rec *rec);
+
+extern std::vector<Target *> *extTargets;
 
 #endif /* OUTPUT_H */
 


### PR DESCRIPTION
Hi,
I added a new feature to show open ports during a scan, in some situations it can be useful (ex. screen session, large scan, etc ...), in others not :)

```
# ./nmap -A scanme.nmap.org
Starting Nmap 7.70SVN ( https://nmap.org ) at 2018-11-14 20:46 CET
Interactive keyboard commands:
?               Display this information
o               Show open ports
v/V             Increase/decrease verbosity
d/D             Increase/decrease debugging
p/P             Enable/disable packet tracing
anything else   Print status
More help: https://nmap.org/book/man-runtime-interaction.html
Scanning 1 host(s)
Target 45.33.32.156
Found open port(s): 22/tcp 80/tcp 9929/tcp

Scanning 1 host(s)
Target 45.33.32.156
Found open port(s): 22/tcp 80/tcp 9929/tcp 31337/tcp
```