### PR TITLE
ncat: Iterate the loop using fd list entries.

### DIFF
--- a/ncat/util.c
+++ b/ncat/util.c
@@ -712,6 +712,10 @@ void free_fdlist(fd_list_t *fdl)
     fdl->fdmax = -1;
 }
 
+int get_fdlist_fds(const fd_list_t fdl,const int fd_index)
+{
+    return fdl.fds[fd_index].fd;
+}
 
 /*  If any changes need to be made to EOL sequences to comply with --crlf
  *  then dst will be populated with the modified src, len will be adjusted

--- a/ncat/util.h
+++ b/ncat/util.h
@@ -227,7 +227,7 @@ void free_fdlist(fd_list_t *);
 void init_fdlist(fd_list_t *, int);
 int get_maxfd(fd_list_t *);
 struct fdinfo *get_fdinfo(const fd_list_t *, int);
-
+int get_fdlist_fds(const fd_list_t ,const int);
 int fix_line_endings(char *src, int *len, char **dst, int *state);
 
 unsigned char *next_protos_parse(size_t *outlen, const char *in);


### PR DESCRIPTION
These changes address a `FIXME` in the `ncat` code.  

Instead of checking all possible file descriptors these changes traverse through `fdlist` and check only those file descriptors which have been inserted into the fdlist.

Can someone please review this and let me know if any changes are required :)