### PR TITLE
Add SlimProto service probe

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -15430,6 +15430,14 @@ ports 3483
 
 match squeezecenter m|^ENAME.{1}(.+)JSON.{1}(\d+)VERS.{1}(.+)UUID.{1}(.+)$| p/Logitech SqueezeCenter music server/ v/$3/ i/Server Name: $1, JSON: $2, UUID: $4/
 
+##############################NEXT PROBE##############################
+# SqueezeCenter SlimProto
+# http://wiki.slimdevices.com/index.php/SlimProto_TCP_protocol
+Probe TCP SqueezeCenter q|HELO\x00\x00\x00\x13\x03\x0100:00:00:00:00:00|
+rarity 8
+ports 3483
+
+match squeezecenter m|^.{2}vers([\d.]+)| p/Logitech SqueezeCenter music server/ v/$1/
 
 ##############################NEXT PROBE##############################
 # AFP - Request GetStatus


### PR DESCRIPTION
Base: http://wiki.slimdevices.com/index.php/SlimProto_TCP_protocol
Install of the service: https://www.mysqueezebox.com/download

Description of the request:
HELO -> http://wiki.slimdevices.com/index.php/SlimProto_TCP_protocol#HELO
\x00\x00\x00\x13 -> Request length after the HELO
\x03 -> DeviceID, have chosen "softsqueeze" here
\x01 -> Our Revision, have randomly chosen revision 1 here
00:00:00:00:00:00 -> Normally we should send the MAC address of us but the service is answering with a 00 one as well. 

Response looks similar like below. AFAICT the first two bytes should be the length of the response and variable so i have chosen a ``.{2}`` for the match.


```
SF-Port3483-TCP:V=7.70%I=7%D=1/3%Time=5C2E0D52%P=x86_64-pc-linux-gnu%r(Squ
SF:eezeCenter,AF7,"\0\tvers7\.7\.2\0\x1cstrmq0m\?\?\?\?\0\0\x000\0\0\0\0\0
SF:\0\0\0\0\0\0\0\0\0\x06grfb\0\x04\x05\x08grfe\0\0c\0\0\0\0\0\0\0\0\0\0\0
SF:\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
SF:0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0
SF:\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
SF:0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0
SF:\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
SF:0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0
SF:\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
SF:0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0
SF:\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
SF:0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0
SF:\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
SF:0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0
SF:\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
SF:0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0
SF:\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
SF:0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0
SF:\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
SF:0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0
SF:\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
SF:0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0
SF:\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
SF:0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0
SF:\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
SF:0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
```


Response with the match:

```
Starting Nmap 7.70 ( https://nmap.org ) at 2019-01-03 14:24 CET
Nmap scan report for xyz
Host is up (0.00035s latency).

PORT     STATE SERVICE       VERSION
3483/tcp open  squeezecenter Logitech SqueezeCenter music server 7.7.2

Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
```