### PR TITLE
Adds http fingerprint for Cisco RV320 & RV325 routers unauthenticated diagnostic data & configuration export

### DIFF
--- a/nselib/data/http-fingerprints.lua
+++ b/nselib/data/http-fingerprints.lua
@@ -7150,6 +7150,26 @@ table.insert(fingerprints, {
     }
   });
 
+table.insert(fingerprints, {
+    category = 'attacks',
+    probes = {
+      {
+        path = '/cgi-bin/export_debug_msg.exp',
+        method = 'GET'
+      },
+      {
+        path = '/cgi-bin/config.exp',
+        method = 'GET'
+      }
+    },
+    matches = {
+      {
+        match = '200 OK',
+        output = 'Cisco RV320 & RV325 Routers Unauthenticated Diagnostic Data & Configuration Export (CVE-2019-1653)'
+      }
+    }
+  });
+
 ------------------------------------------------
 ----        Open Source CMS checks          ----
 ------------------------------------------------


### PR DESCRIPTION
Hello.

This commit adds two fingerprints for the following vulnerabilities on Cisco RV320 & RV325 routers under CVE-2019-1653.
You can find more info below:

https://packetstormsecurity.com/files/151311/rt-sa-2018-002.txt
https://packetstormsecurity.com/files/151312/rt-sa-2018-003.txt