### PR TITLE
Adds HTTP fingerprint for Cisco RV110W VPN firewall password disclosure

### DIFF
--- a/nselib/data/http-fingerprints.lua
+++ b/nselib/data/http-fingerprints.lua
@@ -7150,6 +7150,22 @@ table.insert(fingerprints, {
     }
   });
 
+table.insert(fingerprints, {
+    category = 'attacks',
+    probes = {
+      {
+        path = '/',
+        method = 'GET'
+      }
+    },
+    matches = {
+      {
+        match = 'var admin_name=".*";\nvar guest_name=".*";\nvar admin_pwd=".*";',
+        output = 'Cisco RV110W Wireless-N VPN Firewall Password Disclosure (CVE-2014-0683)'
+      }
+    }
+  });
+
 ------------------------------------------------
 ----        Open Source CMS checks          ----
 ------------------------------------------------


### PR DESCRIPTION
This pull request adds an HTTP fingerprint on category of "attacks" regarding Cisco RV110W Wireless-N VPN firewall where its web interface discloses username and password to unauthenticated users.

For more information:

https://nvd.nist.gov/vuln/detail/CVE-2014-0683