### PR TITLE
Fix "attempt to call a nil value" in http-vuln-cve2017-5638.nse

### DIFF
--- a/scripts/http-vuln-cve2017-5638.nse
+++ b/scripts/http-vuln-cve2017-5638.nse
@@ -62,7 +62,7 @@ vulnerability via the Content-Type header.
 
   local method = stdnse.get_script_args(SCRIPT_NAME..".method") or "GET"
   local path = stdnse.get_script_args(SCRIPT_NAME..".path") or "/"
-  local value = rand.rand_alpha(8)
+  local value = rand.random_alpha(8)
 
   local header = {
     ["Content-Type"] = string.format("%%{#context['com.opensymphony.xwork2.dispatcher.HttpServletResponse'].addHeader('X-Check-Struts', '%s')}.multipart/form-data", value)


### PR DESCRIPTION
When scanning for hosts vulnerable to cve2017-5638, I received the following error trace:

```
nmap --script http-vuln-cve2017-5638 10.X.X.X -n -d
...
NSE: Script scanning 10.X.X.X.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 20:44
NSE: Starting http-vuln-cve2017-5638 against 10.200.13.156:80.
NSE: http-vuln-cve2017-5638 against 10.200.13.156:80 threw an error!
...cal/bin/../share/nmap/scripts/http-vuln-cve2017-5638.nse:65: attempt to call a nil value (field 'rand_alpha')
stack traceback:
 ...cal/bin/../share/nmap/scripts/http-vuln-cve2017-5638.nse:65: in function <...cal/bin/../share/nmap/scripts/http-vuln-cve2017-5638.nse:41>
 (...tail calls...)
...
```

The script was calling rand.rand_alpha() when it should have been calling rand.random_alpha().