### PR TITLE
Service Detection: Add Ubiquiti Discovery Service on 10001/udp

### DIFF
--- a/nmap-payloads
+++ b/nmap-payloads
@@ -242,6 +242,10 @@ udp 5353
 # CoAP GET .well-known/core
 udp 5683 "@\x01\x01\xce\xbb.well-known\x04core"
 
+# Ubiquiti Discovery Service - v1
+udp 10001 "\x01\x00\x00\x00"
+
+
 # Amanda backup service noop request. I think that this does nothing on the
 # server but only asks it to send back its feature list. In reply we expect an
 # ACK or (more likely) an ERROR. I couldn't find good online documentation of

--- a/nmap-payloads
+++ b/nmap-payloads
@@ -245,7 +245,6 @@ udp 5683 "@\x01\x01\xce\xbb.well-known\x04core"
 # Ubiquiti Discovery Service - v1
 udp 10001 "\x01\x00\x00\x00"
 
-
 # Amanda backup service noop request. I think that this does nothing on the
 # server but only asks it to send back its feature list. In reply we expect an
 # ACK or (more likely) an ERROR. I couldn't find good online documentation of

--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -16299,18 +16299,18 @@ ports 10001
 
 # Valid response is protocol version (\x01) and cmd (\0) followed
 # by 2 bytes of length then TLV groups
-match ubiquiti-discovery m|^\x01\0.[^\0].{48,}|s p/Ubiquiti Discovery Service/ i/v2 protocol/ cpe:/h:ubnt/ cpe:/a:ubnt/
+match ubiquiti-discovery m|^\x01\0.[^\0].{48}|s p/Ubiquiti Discovery Service/ i/v1 protocol/
 
 ##############################NEXT PROBE##############################
 # Ubiquiti Discovery Protocol
-Probe UDP UbiquitiDiscoverv2 q|\x02\x08\0\0|
+Probe UDP UbiquitiDiscoveryv2 q|\x02\x08\0\0|
 rarity 9
 ports 10001
 
 # Valid response is protocol version (\x02 ) and cmd followed
 # by 2 bytes of length then TLV groups
 # Known cmd values are \x06, \x09, and \x0b
-match ubiquiti-discovery m|^\x02[\x06\x09\x0b].[^\0].{48,}|s p/Ubiquiti Discovery Service/ i/v2 protocol/ cpe:/h:ubnt/ cpe:/a:ubnt/
+match ubiquiti-discovery m|^\x02[\x06\x09\x0b].[^\0].{48}|s p/Ubiquiti Discovery Service/ i/v2 protocol/
 
 ##############################NEXT PROBE##############################
 # Sharp TV IP/Serial remote control protocol

--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -16292,6 +16292,15 @@ ports 4533
 match rotctld m|^get_info: (.*)\nRPRT 0\n| p/Hamlib rotctld/ i/model: $1/
 
 ##############################NEXT PROBE##############################
+# Ubiquiti Discovery Protocol
+Probe UDP UbiquitiDiscovery q|\x01\0\0\0|
+rarity 9
+ports 10001
+
+# Valid response is signature \x01\0\0 followed by length then TLV groups
+match ubiquiti-discovery m|^\x01\0\0[^\0].{48,}|s p/Ubiquiti Discovery Service/ cpe:/h:ubnt/
+
+##############################NEXT PROBE##############################
 # Sharp TV IP/Serial remote control protocol
 # 4 requests: device name, model name, software version, IP protocol version.
 # http://files.sharpusa.com/Downloads/ForHome/HomeEntertainment/LCDTVs/Manuals/tel_man_LC70LE734U.pdf

--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -16299,7 +16299,14 @@ ports 10001
 
 # Valid response is protocol version (\x01) and cmd (\0) followed
 # by 2 bytes of length then TLV groups
-match ubiquiti-discovery m|^\x01\0.[^\0].{48}|s p/Ubiquiti Discovery Service/ i/v1 protocol/
+match ubiquiti-discovery m|^\x01\0.[^\0].*\x0c\0\x06AirCam|s p/Ubiquiti Discovery Service/ i/v1 protocol, AirCam/ cpe:/h:ubnt:aircam:/
+match ubiquiti-discovery m|^\x01\0.[^\0].*\x0c\0\nAirCamDome|s p/Ubiquiti Discovery Service/ i/v1 protocol, AirCamDome/ cpe:/h:ubnt:aircam_dome:/
+
+# Match short model name = \x0c followed by 2 byte len then value
+# No known type bytes fall in \w the following regex should be safe
+match ubiquiti-discovery m|^\x01\0.[^\0].*\x0c\0.([\w-]+)|s p/Ubiquiti Discovery Service/ i/v1 protocol, $1/
+
+softmatch ubiquiti-discovery m|^\x01\0.[^\0].{48}|s p/Ubiquiti Discovery Service/ i/v1 protocol/
 
 ##############################NEXT PROBE##############################
 # Ubiquiti Discovery Protocol
@@ -16310,7 +16317,9 @@ ports 10001
 # Valid response is protocol version (\x02 ) and cmd followed
 # by 2 bytes of length then TLV groups
 # Known cmd values are \x06, \x09, and \x0b
-match ubiquiti-discovery m|^\x02[\x06\x09\x0b].[^\0].{48}|s p/Ubiquiti Discovery Service/ i/v2 protocol/
+match ubiquiti-discovery m|^\x02[\x06\x09\x0b].[^\0].*\x15\0.([\w-]+)\x16\0.([\d.]+)|s p/Ubiquiti Discovery Service/ i/v2 protocol, $1 software ver. $2/
+match ubiquiti-discovery m|^\x02[\x06\x09\x0b].[^\0].*\x15\0.([\w-]+)|s p/Ubiquiti Discovery Service/ i/v2 protocol, $1/
+softmatch ubiquiti-discovery m|^\x02[\x06\x09\x0b].[^\0].{48}|s p/Ubiquiti Discovery Service/ i/v2 protocol/
 
 ##############################NEXT PROBE##############################
 # Sharp TV IP/Serial remote control protocol

--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -16297,8 +16297,8 @@ Probe UDP UbiquitiDiscovery q|\x01\0\0\0|
 rarity 9
 ports 10001
 
-# Valid response is signature \x01\0\0 followed by length then TLV groups
-match ubiquiti-discovery m|^\x01\0\0[^\0].{48,}|s p/Ubiquiti Discovery Service/ cpe:/h:ubnt/
+# Valid response is signature \x01\0 followed by 2 bytes of length then TLV groups
+match ubiquiti-discovery m|^\x01\0.[^\0].{48,}|s p/Ubiquiti Discovery Service/ cpe:/h:ubnt/
 
 ##############################NEXT PROBE##############################
 # Sharp TV IP/Serial remote control protocol

--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -16293,12 +16293,24 @@ match rotctld m|^get_info: (.*)\nRPRT 0\n| p/Hamlib rotctld/ i/model: $1/
 
 ##############################NEXT PROBE##############################
 # Ubiquiti Discovery Protocol
-Probe UDP UbiquitiDiscovery q|\x01\0\0\0|
+Probe UDP UbiquitiDiscoveryv1 q|\x01\0\0\0|
 rarity 9
 ports 10001
 
-# Valid response is signature \x01\0 followed by 2 bytes of length then TLV groups
-match ubiquiti-discovery m|^\x01\0.[^\0].{48,}|s p/Ubiquiti Discovery Service/ cpe:/h:ubnt/
+# Valid response is protocol version (\x01) and cmd (\0) followed
+# by 2 bytes of length then TLV groups
+match ubiquiti-discovery m|^\x01\0.[^\0].{48,}|s p/Ubiquiti Discovery Service/ i/v2 protocol/ cpe:/h:ubnt/ cpe:/a:ubnt/
+
+##############################NEXT PROBE##############################
+# Ubiquiti Discovery Protocol
+Probe UDP UbiquitiDiscoverv2 q|\x02\x08\0\0|
+rarity 9
+ports 10001
+
+# Valid response is protocol version (\x02 ) and cmd followed
+# by 2 bytes of length then TLV groups
+# Known cmd values are \x06, \x09, and \x0b
+match ubiquiti-discovery m|^\x02[\x06\x09\x0b].[^\0].{48,}|s p/Ubiquiti Discovery Service/ i/v2 protocol/ cpe:/h:ubnt/ cpe:/a:ubnt/
 
 ##############################NEXT PROBE##############################
 # Sharp TV IP/Serial remote control protocol


### PR DESCRIPTION
This PR adds UDP service probe and match lines for Ubiquiti Discovery Service on `10001/udp`.

**NOTE** : The PR has been updated to include coverage of v2 of the protocol.

The Discovery Service is used by various Ubiquiti networking gear.  The Ubiquiti Discovery Tool sends a 4 byte payload of `\x01\0\0\0` and devices with the service will respond with hostname, model, firmware, MAC addresses, IP Addresses, etc. 

v1 output
```
PORT      STATE SERVICE            REASON       VERSION
10001/udp open  ubiquiti-discovery udp-response Ubiquiti Discovery Service (v1 protocol)
```

v2 output
```
PORT      STATE SERVICE            REASON       VERSION
10001/udp open  ubiquiti-discovery udp-response Ubiquiti Discovery Service (v2 protocol)
```
This is related to PR #1457

Context: https://blog.rapid7.com/2019/02/01/ubiquiti-discovery-service-exposures/

If there aren't any objections or changes requested I will commit this code and the corresponding Changelog entry this weekend. 