### PR TITLE
[nse]: ssh2-enum-algos: Add dropbear server support

### DIFF
--- a/scripts/ssh2-enum-algos.nse
+++ b/scripts/ssh2-enum-algos.nse
@@ -165,13 +165,7 @@ action = function(host, port)
     return
   end
 
-  status = sock:receive_lines(1)
-  if not status then
-    sock:close()
-    return
-  end
-
-  status = sock:send("SSH-2.0-Nmap-SSH2-Enum-Algos\r\n")
+  local status, banner = sock:receive_buf("\r?\n", false)
   if not status then
     sock:close()
     return
@@ -179,20 +173,30 @@ action = function(host, port)
 
   local ssh = ssh2.transport
 
-  -- I would think that the server would send its kex data right after
-  -- receiving and verifying our protocol id string above, then we could
-  -- just use it here, but I've seen no definitive documentation saying
-  -- that we don't ever send ours first.  All I've seen is that if the
-  -- server doesn't care about compatibility with older clients then it
-  -- MAY send its kex data after the protocol id string.  So I guess I'll
-  -- send it here until I know for sure (removing this send works against
-  -- OpenSSH though).
-  local pkt = ssh.build(ssh.kex_init())
+  -- Dropbear servers send kex algos in the first response along with
+  -- the banner so do not send a separate kex init request.
+  if not string.find(banner, "^SSH%-2%-%d%-dropbear") then
+    status = sock:send("SSH-2.0-Nmap-SSH2-Enum-Algos\r\n")
+    if not status then
+      sock:close()
+      return
+    end
 
-  status = sock:send(pkt)
-  if not status then
-    sock:close()
-    return
+    -- I would think that the server would send its kex data right after
+    -- receiving and verifying our protocol id string above, then we could
+    -- just use it here, but I've seen no definitive documentation saying
+    -- that we don't ever send ours first.  All I've seen is that if the
+    -- server doesn't care about compatibility with older clients then it
+    -- MAY send its kex data after the protocol id string.  So I guess I'll
+    -- send it here until I know for sure (removing this send works against
+    -- OpenSSH though).
+    local pkt = ssh.build(ssh.kex_init())
+
+    status = sock:send(pkt)
+    if not status then
+      sock:close()
+      return
+    end
   end
 
   local status, response = ssh.receive_packet(sock)


### PR DESCRIPTION
Dropbear servers send key exchange algorithms as part of the first
transfer along with the banner.

There is no need to send a separate kex-init request and the server
ignores the request anyway resulting in no output from the script.