### PR TITLE
http-vuln-cve2017-1001000: fix detection

### DIFF
--- a/scripts/http-vuln-cve2017-1001000.nse
+++ b/scripts/http-vuln-cve2017-1001000.nse
@@ -106,15 +106,17 @@ Versions 4.7.0 and 4.7.1 are known to be affected.
 
     --Modifying the uri and checking for response.
     --Date modification request is being sent.
-    uri = uri ..id..'/'..'?id=' .. id ..'abc'..'&date='..content
+    uri = uri ..id..'/'..'?id=' .. id ..'abc'
 
     local request_opts = {
     header = {
+        ["Content-Type"] = "application/json"
       },
     }
 
-    request_opts["header"]["Content-type"] = 'application/json'
-    local response1 = http.post(host, port, uri, request_opts)
+    local json_body = '{ "date": "' .. content .. '" }'
+
+    local response1 = http.post(host, port, uri, request_opts, nil, json_body)
 
     --If response is correct, means the site allowed the modification
     --of the post and it is vulnerable.


### PR DESCRIPTION
The problem is that the current version fails to detect the vulnerability on a default 4.7(.0) instance of Wordpress.
The detection works by trying to change the post date with itself. This date is passed as a GET parameter, but the API expects a JSON payload.
In my testing I observed the following error:
```
400 Bad Request
[...]
{"code":"rest_invalid_json","message":"Invalid JSON body passed.","data":{"status":400,"json_error_code":4,"json_error_message":"Syntax error"}}
```

I fixed it by passing the data as a body payload, in correct JSON format.
I tested it on a test instance and the detection works now.

As requested in the #775 PR, I verified that it does not actually change the post. It does not show in the post revisions either.
I tested against a patched instance too, and it did not trigger a false-positive.

Pinging @vinamrabhatia the original author