### PR TITLE
http-default-accounts-fingerprints.lua: add tomcat:s3cret for Tomcat

### DIFF
--- a/nselib/data/http-default-accounts-fingerprints.lua
+++ b/nselib/data/http-default-accounts-fingerprints.lua
@@ -404,6 +404,8 @@ table.insert(fingerprints, {
     {username = "admin", password = ""},
     -- https://github.com/seshendra/vagrant-ubuntu-tomcat7/
     {username = "admin", password = "tomcat"},
+    -- https://github.com/apache/tomcat/blob/2b8f9665dbfb89c78878784cd9b63d2b976ba623/webapps/manager/WEB-INF/jsp/403.jsp#L66
+    {username = "tomcat", password = "s3cret"},
     -- https://cve.mitre.org/cgi-bin/cvename.cgi?name=2010-4094
     {username = "ADMIN", password = "ADMIN"},
     -- https://cve.mitre.org/cgi-bin/cvename.cgi?name=2009-4189


### PR DESCRIPTION
"tomcat:s3cret" are the default credentials suggested in the page explaining how to create a user for the Tomcat manager ([source](https://github.com/apache/tomcat/blob/2b8f9665dbfb89c78878784cd9b63d2b976ba623/webapps/manager/WEB-INF/jsp/403.jsp#L66))
Therefore, I think it's important to have it in this default credentials DB.