### PR TITLE
snmp-brute.nse: Support non-standard ports, support snmp v1 and v2

### DIFF
--- a/scripts/snmp-brute.nse
+++ b/scripts/snmp-brute.nse
@@ -151,13 +151,16 @@ local send_snmp_queries = function(socket, result, nextcommunity)
       condvar("signal")
       return
     end
-    payload = snmp.encode(snmp.buildPacket(request, 0, community))
-    status, err = socket:send(payload)
-    if not status then
-      result.status = false
-      result.msg = "Could not send SNMP probe"
-      condvar "signal"
-      return
+    -- For each community string, send a request for each version (v1 and v2)
+    for i = 1,2 do
+      payload = snmp.encode(snmp.buildPacket(request, i, community))
+      status, err = socket:send(payload)
+      if not status then
+        result.status = false
+        result.msg = "Could not send SNMP probe"
+        condvar "signal"
+        return
+      end
     end
 
     community = nextcommunity()

--- a/scripts/snmp-brute.nse
+++ b/scripts/snmp-brute.nse
@@ -250,13 +250,12 @@ action = function(host, port)
   end
 
   local recv_co = stdnse.new_thread(sniff_snmp_responses, host, port, lport, result)
-  local send_co = stdnse.new_thread(send_snmp_queries, socket, result, nextcommunity)
+  send_snmp_queries(socket, result, nextcommunity)
 
   local recv_dead, send_dead
   while true do
     condvar "wait"
     recv_dead = (coroutine.status(recv_co) == "dead")
-    send_dead = (coroutine.status(send_co) == "dead")
     if recv_dead then break end
   end
 

--- a/scripts/snmp-brute.nse
+++ b/scripts/snmp-brute.nse
@@ -56,7 +56,7 @@ license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 categories = {"intrusive", "brute"}
 
 
-portrule = shortport.portnumber(161, "udp", {"open", "open|filtered"})
+portrule = shortport.port_or_service(161, "snmp", "udp", {"open", "open|filtered"})
 
 local communitiestable = {}
 
@@ -174,7 +174,7 @@ local sniff_snmp_responses = function(host, port, lport, result)
   local condvar = nmap.condvar(result)
   local pcap = nmap.new_socket()
   pcap:set_timeout(host.times.timeout * 1000 * 3)
-  pcap:pcap_open(host.interface, 300, false, "src host ".. host.ip .." and udp and src port 161 and dst port "..lport)
+  pcap:pcap_open(host.interface, 300, false, "src host ".. host.ip .." and udp and src port ".. port["number"] .." and dst port "..lport)
 
   local communities = creds.Credentials:new(SCRIPT_NAME, host, port)
 


### PR DESCRIPTION
### Changes Overview
These changes for the `snmp-brute.nse` script consist of essentially 3 changes:

1. Changing the script to also run & work on non-standard ports
2. Add support for snmp v2 (before, only snmp v1 requests were sent)
3. Fixing a thrown error when running the script (even before any changes were made)

Each change is represented by one of the commits.
### More info to change 3:
After cloning the git repo and trying the snmp-brute script without making any changes to the source code, I got the following error message:
```
/home/markus/repos/nmap/scripts/snmp-brute.nse:155: Invalid reuse of a socket from one thread to another.
stack traceback:
    [C]: in method 'send'
    /home/markus/repos/nmap/scripts/snmp-brute.nse:155: in function </home/markus/repos/nmap/scripts/snmp-brute.nse:140>
```
It seems like the `socket` created in the action function cannot be passed to a new thread anymore. That is why I replaced the thread creation with a direct function call.

### Question about changelog
Is the changelog within `snmp-brute.nse` still used and should it be updated?