### PR TITLE
smb.lua: fix SMB Extended Security parsing by resetting the offset index

### DIFF
--- a/nselib/smb.lua
+++ b/nselib/smb.lua
@@ -1024,15 +1024,16 @@ function negotiate_v1(smb, overrides)
   end
   smb.server_challenge, pos = string.unpack(string.format("<c%d", smb['key_length']), data)
   if(smb['extended_security'] == true) then
+    local data_pos = 1 -- offset index in the 'data' section
     if #data < 16 then
       return false, "SMB: ERROR: not enough data for extended security"
     end
-    smb.server_guid, pos = string.unpack("<c16", data, pos)
+    smb.server_guid, data_pos = string.unpack("<c16", data, data_pos)
 
     -- do we have a security blob?
-    if ( #data - pos > 0 ) then
-      smb.security_blob = data:sub(pos)
-      pos = #data + 1
+    if ( #data - data_pos > 0 ) then
+      smb.security_blob = data:sub(data_pos)
+      data_pos = #data + 1
     end
   else
     -- Get the (null-terminated) domain as a Unicode string


### PR DESCRIPTION
The SMB library (smb.lua) fails to properly parse "Negotiate Protocol Response" messages when SMB Extended Security is enabled. This cause many SMB scripts to fail, in particular against Samba servers based on my observations in real networks. Below are some observations with smb-os-discovery, but I've also noticed that with smb-vuln-ms17-010 which cause it to not run since it generates an exception in the early phase.

Example before the patch and with the latest public Nmap 7.70 release:
```
# nmap -p445 --script smb-os-discovery a.b.c.d -vv -dd
Starting Nmap 7.70 ( https://nmap.org ) at ....
[...]
NSE: [smb-os-discovery M:55db8b26fb38 a.b.c.d] Couldn't negotiate a SMBv1 connection:SMB: ERROR: Server returned less data than it was supposed to (one or more fields are missing); aborting [12]
Host script results:
| smb-os-discovery: 
|   OS: Unix (Samba 3.0.20b)
|   NetBIOS computer name: 
|   Workgroup: WORKGROUP\x00
|_  System time: 2019-02-14T07:43:25+01:00
```
Example before the patch and with the latest Nmap version from Git as of now. The error is more visible:
```
# nmap -p445 --script smb-os-discovery a.b.c.d -vv -dd
Starting Nmap 7.70SVN ( https://nmap.org ) at ...
[...]
NSE: smb-os-discovery M:55fe86116508 against a.b.c.d threw an error!
/root/tools/nmap/nselib/smb.lua:1030: bad argument #2 to 'unpack' (data string too short)
stack traceback:
	[C]: in function 'string.unpack'
	/root/tools/nmap/nselib/smb.lua:1030: in function 'smb.negotiate_v1'
	/root/tools/nmap/nselib/smb.lua:1074: in function 'smb.negotiate_protocol'
	/root/tools/nmap/nselib/smb.lua:372: in function 'smb.start_ex'
	/root/tools/nmap/nselib/smb.lua:3363: in function 'smb.get_os'
	/root/tools/nmap/scripts/smb-os-discovery.nse:152: in function </root/tools/nmap/scripts/smb-os-discovery.nse:149>
	(...tail calls...)
```
This difference seems to be caused by the change from `bin.unpack` to `string.unpack` but this is just a symptom, not the problem itself.
https://github.com/nmap/nmap/blob/cadb66231f9c24f7a29f5d830df04e03ae7f555e/nselib/smb.lua#L1070

And after the patch, no error. The results aren't very good, but it is an unrelated issue:
```
Host script results:
| smb-os-discovery: 
|   OS: Unix (Samba 3.0.20b)
|   Computer name: A19FP-REDACTED
|   NetBIOS computer name: 
|   Domain name: 
|   FQDN: A19FP-REDACTED
|_  System time: 2019-02-14T07:43:57+01:00
```

My detailed thoughts are the following.
This section of the function `negotiate_v1`  parses the "Negotiate Protocol Response" message, where SMB Extended Security is true.
In this case, as explained in [[MS-SMB]](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/d883d0a5-5a0a-4626-8e3e-87b0b66b79aa), the response has two parts: `parameters` and `data`.
These are returned by `smb_read()`:
https://github.com/nmap/nmap/blob/16504696a54c3cdd8aeb4ebabff8abf24e9adddd/nselib/smb.lua#L952
I understand that the `pos` variable is used as an offset index. It is first used against `parameters`, like:
https://github.com/nmap/nmap/blob/16504696a54c3cdd8aeb4ebabff8abf24e9adddd/nselib/smb.lua#L982

But then it is reused against `data` without being reset to 1. Which creates a read problem.
https://github.com/nmap/nmap/blob/16504696a54c3cdd8aeb4ebabff8abf24e9adddd/nselib/smb.lua#L1030

The patch creates a new index `data_pos` dedicated to parse this `data` array.

I've confirmed this by adding `print` statements to view the variables values along the way.
With the patch, the `smb.server_guid` is properly filled which wasn't the case before:
```
smb.server_guid: a19fp-REDACTED
```

Wireshark parsing, if that helps:
![image](https://user-images.githubusercontent.com/550823/52899890-b4191c00-31ef-11e9-88b2-7d2f1b713743.png)

I've tested against hosts that didn't show this problem (no Extended Security in this Negotiate Protocol Response) and I didn't observe any regression.