### PR TITLE
smb.lua: fix request header in start_session_basic

### DIFF
--- a/nselib/smb.lua
+++ b/nselib/smb.lua
@@ -1141,7 +1141,7 @@ local function start_session_basic(smb, log_errors, overrides)
   local username, domain, password, password_hash, hash_type
   local busy_count = 0
 
-  header = smb_encode_header(smb, command_codes['SMB_COM_SESSION_SETUP_ANDX'], overrides)
+  req_header = smb_encode_header(smb, command_codes['SMB_COM_SESSION_SETUP_ANDX'], overrides)
 
   -- Get the first account, unless they overrode it
   if(overrides ~= nil and overrides['username'] ~= nil) then
@@ -1187,7 +1187,7 @@ local function start_session_basic(smb, log_errors, overrides)
 
     -- Send the session setup request
     stdnse.debug2("SMB: Sending SMB_COM_SESSION_SETUP_ANDX")
-    result, err = smb_send(smb, header, parameters, data, overrides)
+    result, err = smb_send(smb, req_header, parameters, data, overrides)
     if(result == false) then
       return false, err
     end


### PR DESCRIPTION
I've noticed something strange when using the smb-os-discovery script. Both with the current public 7.70 release, and with the latest source code from Git. The script relies on smb.lua and the `start_session_basic` function. This function tries to create a session with the "\<blank>" and "\guest" users as seen in the output:
```
# nmap -Pn -p445 --script smb-os-discovery -d a.b.c.d
[...]
NSE: [smb-os-discovery a.b.c.d] SMB: Login as \guest failed (NT_STATUS_ACCESS_DENIED)
NSE: [smb-os-discovery a.b.c.d] SMB: Login as \<blank> failed (NT_STATUS_ACCESS_DENIED)
```

However, Wireshark doesn't seem to capture it like it was intended:
![image](https://user-images.githubusercontent.com/550823/52913419-543d7680-32be-11e9-90f8-dba5d8e226c9.png)
(192.168.4.4 is my scanner's IP, 10.x.x.x is the target SMB server)

IMO the line highlighted in red is the problem. Our nmap scanner tries to send a response instead of a request!
I think I've found the problem and fix it with this patch.

At the start of `start_session_basic`, a template request `header` is prepared. Then there's a loop over all accounts to try. But, the `header` name is used to store the result of the response parsing:
https://github.com/nmap/nmap/blob/16504696a54c3cdd8aeb4ebabff8abf24e9adddd/nselib/smb.lua#L1196

So our carefully crafted request `header` is overwritten by a response header... Then at next loop iteration we send a response header instead of a request header...

After the patch, it looks better:
![image](https://user-images.githubusercontent.com/550823/52913511-2e64a180-32bf-11e9-9540-3bd78f981e30.png)
