### PR TITLE
smb.lua: fix bug in start_session_basic while parsing status

### DIFF
--- a/nselib/smb.lua
+++ b/nselib/smb.lua
@@ -1193,8 +1193,9 @@ local function start_session_basic(smb, log_errors, overrides)
     end
 
     -- Read the result
-    status, header, parameters, data = smb_read(smb)
-    if(status ~= true) then
+    local smb_read_status
+    smb_read_status, header, parameters, data = smb_read(smb)
+    if(smb_read_status ~= true) then
       return false, header
     end
 


### PR DESCRIPTION
When using the "smb-os-discovery" script against a host which refuses connection with anonymous and guest accounts, and with the latest Nmap version from Git, we have an error:
```
# nmap -Pn -p445 --script smb-os-discovery -d a.b.c.d
Starting Nmap 7.70SVN ( https://nmap.org ) at ....
[...]
NSE: Starting smb-os-discovery against a.b.c.d.
NSE: [smb-os-discovery a.b.c.d] SMB: Added account '' to account list
NSE: [smb-os-discovery a.b.c.d] SMB: Added account 'guest' to account list
NSE: [smb-os-discovery a.b.c.d] SMB: Login as \guest failed (NT_STATUS_ACCESS_DENIED)
NSE: [smb-os-discovery a.b.c.d] SMB: Login as \<blank> failed (NT_STATUS_ACCESS_DENIED)
NSE: [smb-os-discovery a.b.c.d] SMB: ERROR: No accounts left to try
NSE: smb-os-discovery against a.b.c.d threw an error!
/root/tools/nmap/nselib/smb.lua:202: bad argument #2 to 'format' (number expected, got boolean)
stack traceback:
	[C]: in function 'string.format'
	/root/tools/nmap/nselib/smb.lua:202: in function 'smb.get_status_name'
	/root/tools/nmap/nselib/smb.lua:1285: in upvalue 'start_session_basic'
	/root/tools/nmap/nselib/smb.lua:1567: in function 'smb.start_session'
	/root/tools/nmap/nselib/smb.lua:380: in function 'smb.start_ex'
	/root/tools/nmap/nselib/smb.lua:3337: in function 'smb.get_os'
	/root/tools/nmap/scripts/smb-os-discovery.nse:152: in function </root/tools/nmap/scripts/smb-os-discovery.nse:149>
	(...tail calls...)
```
After adding a few `print`, I understood that there was a confusion around `status` since in the same function it's used for two purposes:
* getting the status result after calling `smb_read`, as a boolean:
https://github.com/nmap/nmap/blob/16504696a54c3cdd8aeb4ebabff8abf24e9adddd/nselib/smb.lua#L1196-L1199
* getting the status from the SMB header of the received responses, as an integer (and meant to be mapped to common codes such as NT_ACCESS_DENIED later by `smb.get_status_name`):
https://github.com/nmap/nmap/blob/16504696a54c3cdd8aeb4ebabff8abf24e9adddd/nselib/smb.lua#L1206

After the patch, we have:
```
NSE: Starting smb-os-discovery against a.b.c.d.
NSE: [smb-os-discovery a.b.c.d] SMB: Added account '' to account list
NSE: [smb-os-discovery a.b.c.d] SMB: Added account 'guest' to account list
NSE: [smb-os-discovery a.b.c.d] SMB: Login as \guest failed (NT_STATUS_ACCESS_DENIED)
NSE: [smb-os-discovery a.b.c.d] SMB: Login as \<blank> failed (NT_STATUS_ACCESS_DENIED)
NSE: [smb-os-discovery a.b.c.d] SMB: ERROR: No accounts left to try
NSE: Finished smb-os-discovery against a.b.c.d.
[...]

Host script results:
| smb-os-discovery: 
|_  ERROR: No accounts left to try
```
("No accounts left to try" comes from the smbauth lib)

The error displayed is different from what we see with the latest 7.70 release:
```
Starting Nmap 7.70 ( https://nmap.org ) at 
[...]
NSE: Starting smb-os-discovery against a.b.c.d.
NSE: [smb-os-discovery a.b.c.d] SMB: Added account '' to account list
NSE: [smb-os-discovery a.b.c.d] SMB: Added account 'guest' to account list
NSE: [smb-os-discovery a.b.c.d] LM Password: 
NSE: [smb-os-discovery a.b.c.d] SMB: Login as \guest failed (NT_STATUS_ACCESS_DENIED)
NSE: [smb-os-discovery a.b.c.d] SMB: Login as \<blank> failed (NT_STATUS_ACCESS_DENIED)
NSE: [smb-os-discovery a.b.c.d] SMB: ERROR: No accounts left to try
NSE: Finished smb-os-discovery against a.b.c.d.
[...]

Host script results:
| smb-os-discovery: 
|_  ERROR: NT_STATUS_ACCESS_DENIED
```

This error was better but I'm wondering if it was intended or if it is thanks to a lucky bug. We have a loop which tries to connect with two accounts, here the status is the same for both (NT_STATUS_ACCESS_DENIED) but it could have been different. And with this code, we only would see the status code for the last try, not the previous.

FYI, git bisect tells me that the difference between the latest version from source and the latest 7.70 release, comes from https://github.com/nmap/nmap/commit/fd86015cde070f3e6a767deaf957940b0758c987