### PR TITLE
[WIP do not merge] smb.lua: deal with servers that enable Extended Security through one flag only

### DIFF
--- a/nselib/smb.lua
+++ b/nselib/smb.lua
@@ -968,11 +968,6 @@ function negotiate_v1(smb, overrides)
     return false, "SMB: Server returned a SMBv2 packet, don't know how to handle"
   end
 
-  -- Since this is the first response seen, check any necessary flags here
-  if((flags2 & 0x0800) ~= 0x0800) then
-    smb['extended_security'] = false
-  end
-
   -- Parse the parameter section
   local dialect_format = "<I2"
   local parameters_format = "<BI2 I2 I4 I4 I4 I4"
@@ -1016,6 +1011,16 @@ function negotiate_v1(smb, overrides)
     smb['timezone_str'] = "UTC-" .. math.abs(smb['timezone'])
   else
     smb['timezone_str'] = "UTC+" .. smb['timezone']
+  end
+
+  -- Since this is the first response seen, check any necessary flags here
+  -- To enable Extended Security, servers are supposed to set
+  -- both SMB_FLAGS2_EXTENDED_SECURITY and CAP_EXTENDED_SECURITY but some only enable one of the two,
+  -- so we assume that Extended Security is enabled if at least one is
+  if((flags2 & 0x0800) == 0x0800 or (smb.capabilities & 0x80000000) == 0x80000000) then
+    smb['extended_security'] = true
+  else
+    smb['extended_security'] = false
   end
 
   -- Data section


### PR DESCRIPTION
[WIP please ignore]

In the wild I've observed SMB servers (from NetApp based on other info I have) that enable Extended Security by setting to 1 the `CAP_EXTENDED_SECURITY` capability, while setting to 0 the `SMB_FLAGS2_EXTENDED_SECURITY` flag.
This doesn't seem to be compliant with [[MS-SMB]](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/d883d0a5-5a0a-4626-8e3e-87b0b66b79aa) but still it happens...

Before the patch:
```
NSE: smb-os-discovery against a.b.c.d threw an error!
/root/tools/nmap/nselib/unicode.lua:202: bad argument #2 to 'unpack' (data string too short)
stack traceback:
	[C]: in function 'string.unpack'
	/root/tools/nmap/nselib/unicode.lua:202: in function 'unicode.utf16_dec'
	/root/tools/nmap/nselib/unicode.lua:71: in function 'unicode.transcode'
	(...tail calls...)
	/root/tools/nmap/nselib/smb.lua:1042: in function 'smb.negotiate_v1'
	/root/tools/nmap/nselib/smb.lua:1074: in function 'smb.negotiate_protocol'
	/root/tools/nmap/nselib/smb.lua:372: in function 'smb.start_ex'
	/root/tools/nmap/nselib/smb.lua:3363: in function 'smb.get_os'
	/root/tools/nmap/scripts/smb-os-discovery.nse:152: in function </root/tools/nmap/scripts/smb-os-discovery.nse:149>
	(...tail calls...)
```
By adding a few `print()` to debug, I've confirmed that `smb['extended_security']` was `false` so it tries to decode the security blob as UTF-16 which fails. This is another problem, see PR #1477 

After the patch:
```
# nmap -Pn -p445 --script smb-os-discovery -d 10.228.186.44
Starting Nmap 7.70SVN ( https://nmap.org ) at ...
[...]
Host script results:
| smb-os-discovery: 
|   OS: Windows 2000 (Windows 2000 LAN Manager)
|   OS CPE: cpe:/o:microsoft:windows_2000::-
|   Computer name: REDACTED
|   NetBIOS computer name: 
|   Domain name: REDACTED
|   FQDN: REDACTED
|_  System time: 2019-02-17T16:31:14+01:00
```

Here are a few Wireshark screenshots for these strange servers:
* SMB_FLAGS2_EXTENDED_SECURITY = 0
![image](https://user-images.githubusercontent.com/550823/52915326-e64f7a00-32d2-11e9-993a-148b7eec243c.png)
* CAP_EXTENDED_SECURITY = 1
![image](https://user-images.githubusercontent.com/550823/52915328-f404ff80-32d2-11e9-9b88-b85483809adb.png)
* Confirmation that a security blob is present:
![image](https://user-images.githubusercontent.com/550823/52915331-fff0c180-32d2-11e9-99bf-bd351ec5d870.png)


I had to move this code a lower below in the function to have access to `smb.capabilities`. I changed the logic of the `if` from a negative ("if not... then false") to a positive statement ("if... then true") so it's easier to read.
I've also added `smb['extended_security'] = true` which wasn't present because I prefer when it's explicit, instead of relying on a default value set somewhere else.