### PR TITLE
smb.lua: fix parameter_length check in smb_read

### DIFF
--- a/nselib/smb.lua
+++ b/nselib/smb.lua
@@ -884,7 +884,7 @@ function smb_read(smb, read_data)
   header, parameter_length, pos = string.unpack("<c32 B", result, pos)
 
   -- Double the length parameter, since parameters are two-byte values.
-  if (length - pos + 1) < (parameter_length * 2) then
+  if (length - pos + 1) <= (parameter_length * 2) then
     return false, "SMB: ERROR: parameter_length greater than response length"
   end
   parameters, pos = string.unpack(("<c%d"):format(parameter_length*2), result, pos)


### PR DESCRIPTION
I've noticed a problem when running the smb-os-discovery script against a server with a buggy SMB implementation. The stacktrace shows that the problem is in `smb.smb_read` when called by `smb.logoff` to parse the SMB "Session Setup AndX Response".

Indeed the logoff response from the server has a problem:
![image](https://user-images.githubusercontent.com/550823/52916712-3a625a80-32e3-11e9-9895-8eb7b67f6827.png)

WCT=3 so there should be 3 parameters and a length of 3*2=6 bytes, but we only have space for 2 parameters.

In this case, what we observe is (based on `print()` added for debug):
```
length - pos + 1: 6
parameter_length * 2: 6
```
So, to catch this case we need to use '<=' instead of '<'.

For compliant servers, we observe:
![image](https://user-images.githubusercontent.com/550823/52916818-7813b300-32e4-11e9-93b9-e94b2761db4f.png)

Which gives:
```
length - pos + 1: 6
parameter_length * 2: 4
```

FYI this check was introduced by https://github.com/nmap/nmap/commit/fd86015cde070f3e6a767deaf957940b0758c987#diff-745cc71d4fb73c80aa992887e27f84ceR909