### PR TITLE
Create an option to show the RTT requests for every packet

### DIFF
--- a/nping/ArgParser.cc
+++ b/nping/ArgParser.cc
@@ -306,6 +306,7 @@ int ArgParser::parseArguments(int argc, char *argv[]) {
   {"nsock-engine", required_argument, 0, 0},
   {"no-capture", no_argument, 0, 'N'},
   {"hide-sent", no_argument, 0, 'H'},
+  {"rtt", no_argument, 0, 'R'},
 
   /* Output */
   {"verbose", optional_argument, 0, 'v'},
@@ -321,7 +322,7 @@ int ArgParser::parseArguments(int argc, char *argv[]) {
   }
 
   /* Let's get this parsing party started */
-  while((arg = getopt_long_only(argc,argv,"46c:d::e:fg:hHK:NP:q::p:S:Vv::", long_options, &option_index)) != EOF) {
+  while((arg = getopt_long_only(argc,argv,"46c:d::e:fg:hHRK:NP:q::p:S:Vv::", long_options, &option_index)) != EOF) {
 
    aux8=aux16=aux32=aux_ip4.s_addr=0;
 
@@ -1089,6 +1090,10 @@ int ArgParser::parseArguments(int argc, char *argv[]) {
         o.setShowSentPackets(false);
     break; /* case 'H': */
 
+    case 'R': /* Display RTT for every request */
+        o.setShowRTT(true);
+    break;
+
     case 'd': /* Debug mode */
       if (optarg){
         if (isdigit(optarg[0]) || optarg[0]=='-'){
@@ -1293,6 +1298,7 @@ void ArgParser::printUsage(void){
 "  -c, --count <n>                  : Stop after <n> rounds.\n"
 "  -e, --interface <name>           : Use supplied network interface.\n"
 "  -H, --hide-sent                  : Do not display sent packets.\n"
+"  -R, --rtt                        : Show RTT for every request.\n"
 "  -N, --no-capture                 : Do not try to capture replies.\n"
 "  --privileged                     : Assume user is fully privileged.\n"
 "  --unprivileged                   : Assume user lacks raw socket privileges.\n"

--- a/nping/NpingOps.cc
+++ b/nping/NpingOps.cc
@@ -194,6 +194,8 @@ NpingOps::NpingOps() {
     disable_packet_capture=false;
     disable_packet_capture_set=false;
 
+    show_rtt=false;
+
     /* Privileges */
 /* If user did not specify --privileged or --unprivileged explicitly, try to
  * determine if has root privileges. */
@@ -647,7 +649,17 @@ bool NpingOps::issetShowSentPackets(){
   return this->show_sent_pkts_set;
 } /* End of issetShowSentPackets() */
 
+/** Sets ShowRTT.
+ *  @return OP_SUCCESS on success and OP_FAILURE in case of error.           */
+int NpingOps::setShowRTT(bool val){
+  this->show_rtt=true;
+  return OP_SUCCESS;
+} /* End of setShowRTT() */
 
+/** Returns value of attribute show_rtt */
+bool NpingOps::issetShowRTT(){
+  return this->show_rtt;
+} /* End of issetShowRTT() */
 
 /******************************************************************************
  *  Operation and Performance                                                 *

--- a/nping/NpingOps.h
+++ b/nping/NpingOps.h
@@ -222,6 +222,7 @@ class NpingOps {
     bool have_pcap;           /* True if we have access to libpcap     */
     bool disable_packet_capture; /* If false, no packets are captured  */
     bool disable_packet_capture_set;
+    bool show_rtt;                 /* Display RTT for every request          */
 
     /* Privileges */
     bool isr00t;              /* True if current user has root privs   */
@@ -393,6 +394,9 @@ class NpingOps {
     int setShowSentPackets(bool val);
     bool showSentPackets();
     bool issetShowSentPackets();
+
+    int setShowRTT(bool val);
+    bool issetShowRTT();
 
     /* Operation and Performance */
     int setHostTimeout(long t);

--- a/nping/NpingTarget.cc
+++ b/nping/NpingTarget.cc
@@ -1054,6 +1054,7 @@ int NpingTarget::updateRTTs(unsigned long int diff){
     min_rtt=diff;
     min_rtt_set=true;
   }
+  curr_rtt=diff;
 
   /* Update average round trip time */
   if(!avg_rtt_set || recv_total<=1)
@@ -1075,6 +1076,11 @@ int NpingTarget::printStats(){
   return OP_SUCCESS;
 } /* End of printStats() */
 
+void NpingTarget::getCurrentRTT(bool show_curr_rtt)
+{
+    if (show_curr_rtt)
+        nping_print(VB_0|NO_NEWLINE, "rtt=%.3lfms ", curr_rtt/1000.0);
+}
 
 /* Print packet counts */
 void NpingTarget::printCounts(){

--- a/nping/NpingTarget.h
+++ b/nping/NpingTarget.h
@@ -310,6 +310,7 @@ unsigned long int min_rtt;
 bool min_rtt_set;
 unsigned long int avg_rtt;
 bool avg_rtt_set;
+unsigned long int curr_rtt;
 
 
 int setProbeRecvTCP(u16 sport, u16 dport);
@@ -321,6 +322,7 @@ int setProbeRecvICMP(u16 id, u16 seq);
 int setProbeSentARP();
 int setProbeRecvARP();
 int updateRTTs(unsigned long int diff);
+void getCurrentRTT(bool show_curr_rtt);
 int printStats();
 void printCounts();
 void printRTTs();

--- a/nping/ProbeMode.cc
+++ b/nping/ProbeMode.cc
@@ -1973,12 +1973,13 @@ void ProbeMode::probe_tcpconnect_event_handler(nsock_pool nsp, nsock_event nse, 
          * to look up the target by its IP address. */
         trg=o.targets.findTarget( &peer );
         if(trg!=NULL){
+            trg->setProbeRecvTCP( peerport , 0);
+            trg->getCurrentRTT(o.issetShowRTT());
             if ( trg->getSuppliedHostName() )
                 nping_print(VB_0,"RCVD (%.4fs) Handshake with %s:%d (%s:%d) completed",
                          o.stats.elapsedRuntime(t), trg->getSuppliedHostName(), peerport, ipstring, peerport );
             else
                 nping_print(VB_0,"RCVD (%.4fs) Handshake with %s:%d completed", o.stats.elapsedRuntime(t), ipstring, peerport );
-            trg->setProbeRecvTCP( peerport , 0);
         }else{
             nping_print(VB_0,"RCVD (%.4fs) Handshake with %s:%d completed", o.stats.elapsedRuntime(t), ipstring, peerport );
         }


### PR DESCRIPTION
Create "-R" (--rtt) to show round trip time for each RCVD line.
Currently it is enabled only for unprivileged TCP packets. Extending to
other protocols could be feasible.

This is supposed to be one of the nping todo items:

> * Consider adding the possibility to see the RTT in the RECV line. Something
  similar to the way the traditional ping tool prints the RTT (time=XXX ms)
It was originated from this discussion: https://seclists.org/nmap-dev/2013/q3/594

I tried to adopt a minimalist version, i.e.: supporting only unprivileged TCP packets, exactly as the example described in the URL above. Extending (or fixing) to other (privileged?) protocols could be possible, AFAIK.