### PR TITLE
Remove unnecessary line breaks in man pages

### DIFF
--- a/docs/nmap.1
+++ b/docs/nmap.1
@@ -615,9 +615,7 @@ Traceroute works by sending packets with a low TTL (time\-to\-live) in an attemp
 .RS 4
 Tells Nmap to
 \fInever\fR
-do reverse DNS
-
-resolution on the active IP addresses it finds\&. Since DNS can be slow even with Nmap\*(Aqs built\-in parallel stub resolver, this option can slash scanning times\&.
+do reverse DNS resolution on the active IP addresses it finds\&. Since DNS can be slow even with Nmap\*(Aqs built\-in parallel stub resolver, this option can slash scanning times\&.
 .RE
 .PP
 \fB\-R\fR (DNS resolution for all targets)


### PR DESCRIPTION
There were two line breaks in the middle of a sentence in the man pages.