### PR TITLE
adding kubernetes versioning script

### DIFF
--- a/kubernetes-version.nse
+++ b/kubernetes-version.nse
@@ -1,0 +1,43 @@
+description = [[
+  Attempts to detect the Kubernetes API version.
+]]
+
+categories = {"safe", "version"}
+
+author = "Jon Mosco"
+
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+
+---
+-- @usage
+-- nmap --script kubernetes-version <host>
+-- @output
+-- PORT     STATE SERVICE VERSION
+-- 8443/tcp open  kubernetes-api
+
+local shortport = require "shortport"
+local json = require "json"
+local http = require "http"
+local nmap = require "nmap"
+
+portrule = shortport.version_port_or_service({6443, 8443}, {"kubernetes", "kubernetes-api"}, "tcp")
+
+action = function(host, port)
+
+  local http_response = http.get(host, port, "/version")
+  if not http_response or not http_response.status or
+    http_response.status ~= 200 or not http_response.body then
+    return
+  end
+
+  local ok_json, response = json.parse(http_response.body)
+  if ok_json and response["major"] and response["minor"] then
+    ---Detected
+    port.version.name = 'kubernetes-api'
+    port.version.version = response["gitVersion"]
+    port.version.product = "Kubernetes"
+    nmap.set_port_version(host, port)
+    return response
+  end
+  return
+end


### PR DESCRIPTION
Early version of NSE script to obtain version of Kubernetes API.  Any suggestions/help would be appreciated.  This is my first NSE script.

Sample output:
```
$ nmap --script ./kubernetes-version.nse 192.168.39.225
Starting Nmap 7.70 ( https://nmap.org ) at 2019-04-20 08:20 EDT
Nmap scan report for 192.168.39.225             
Host is up (0.00012s latency).                                         
Not shown: 994 closed ports                                         
PORT     STATE SERVICE                         
22/tcp   open  ssh                        
80/tcp   open  http                                 
111/tcp  open  rpcbind                             
443/tcp  open  https                                  
2049/tcp open  nfs                                 
8443/tcp open  kubernetes-api                  
| kubernetes-version:                      
|   goVersion: go1.12.1                                     
|   buildDate: 2019-03-25T15:45:25Z            
|   gitVersion: v1.14.0                                             
|   compiler: gc                               
|   major: 1                                                               
|   gitCommit: 641856db18352033a0d96dbc99153fa3b27298e5                
|   gitTreeState: clean                        
|   minor: 14                                  
|_  platform: linux/amd64                                    
                                               
Nmap done: 1 IP address (1 host up) scanned in 0.23 seconds
```