### PR TITLE
Support for maximum body size and Content-Encoding

### DIFF
--- a/nselib/http.lua
+++ b/nselib/http.lua
@@ -159,7 +159,7 @@ USER_AGENT = stdnse.get_script_args('http.useragent') or "Mozilla/5.0 (compatibl
 local host_header = stdnse.get_script_args('http.host')
 local MAX_REDIRECT_COUNT = 5
 local MAX_BODY_SIZE = tonumber(stdnse.get_script_args('http.max-body-size')) or 2*1024*1024
-local TRUNCATED_OK = (stdnse.get_script_args('http.truncated-ok') or ""):lower() == "true"
+local TRUNCATED_OK = string.lower(stdnse.get_script_args('http.truncated-ok') or "false") ~= "false"
 local ERR_OVERSIZED_BODY = "response body too large"
 
 --- Recursively copy into a table any elements from another table whose key it

--- a/nselib/http.lua
+++ b/nselib/http.lua
@@ -1129,6 +1129,12 @@ local function response_is_cacheable(response)
     return false
   end
 
+  -- It is not desirable to cache a truncated response because it could poison
+  -- subsequent requests with different options max-body-size or truncated_ok.
+  if response.truncated then
+    return false
+  end
+
   return true
 end
 

--- a/nselib/http.lua
+++ b/nselib/http.lua
@@ -988,7 +988,7 @@ local function get_pipeline_limit(response)
     local opts = stringaux.strsplit("[,%s]+", (hdr.connection or ""):lower())
     if tableaux.contains(opts, "close") then return 1 end
     if response.version >= "1.1" or tableaux.contains(opts, "keep-alive") then
-      return 1 + tonumber((hdr["keep-alive"] or ""):match("max=(%d+)")) or 40
+      return 1 + (tonumber((hdr["keep-alive"] or ""):match("max=(%d+)")) or 39)
     end
   end
   return 1

--- a/nselib/http.lua
+++ b/nselib/http.lua
@@ -132,6 +132,7 @@
 local base64 = require "base64"
 local comm = require "comm"
 local coroutine = require "coroutine"
+local math = require "math"
 local nmap = require "nmap"
 local os = require "os"
 local sasl = require "sasl"


### PR DESCRIPTION
This patch combines the implementation for both #473 and #1493. Due to circumstances, it was not practical to break the two features apart (but it can be done if absolutely necessary).

### Content-Encoding

* The library now transparently handles the `Content-Encoding` header, recognizing encodings `identity` and `gzip`.
* The `body` member of the HTTP response object now contains the processed (decoded) body.
* The original body, as received from the server, is preserved in a new member, `rawbody`.
* Corrupted encoded body is treated like any other response error, including the response `status` being `nil`.
* Unsupported encoding is not triggering an error, instead simply resulting in undecoded body. Note that this body might not be the same as `rawbody` because other encodings might have been already processed.
* New response member `decoded` contains a list of content encodings that were successfully processed.
* New response member `undecoded` contains a list of encodings that could not be processed, either because they are not currently supported or the body is corrupt. In other words, a body was successfully decoded if this list is empty (or `nil`, if no encodings were used in the first place).
* Returned `content-encoding` and `content-length` headers are adjusted to remain consistent with body. (If all encodings got processed then the `content-encoding` header is removed altogether, which can serve an alternate test for decoding problems.)

### Body Size Limit

* Newly implemented library parameter `http.max-body-size` defines the maximum response body size (in bytes) the library is willing to receive. The default value is 2 MB. The limit can be completely disabled by setting the value to `-1`. *Note that the limit is enforced by default.*
* This behavior can be overridden case-by-case with request option `max_body_size`, with its values having the same meaning.
* This enforcement applies to raw bodies as they are received, regardless of method (`Content-Length`, `Transfer-Encoding`, or connection termination)
* This enforcement also applies when bodies are getting decoded according to `Content-Encoding`. This provides protection against the so-called zip bomb.
* Bodies that exceed the limit are still made available in truncated form through the returned response object. (See below for details.) The truncated body is guaranteed to match the size limit *exactly*.
* The response object would have `status` member equal to `nil`. In other words, the response is composed as a *failure*, so scripts would not use it unless they explicitly want to.
* Just as with the status, member `body` would be `nil` so scripts would not accidentally use the truncated body.
* In case of any response processing errors, not just the oversize body, a newly implemented member `incomplete` contains the partially built response object. This way scripts can for example inspect response status code (preserved as `response.incomplete.status`) even if the header or body parsing failed.
* In summary, the truncated body would be available as `response.incomplete.body` and scripts that do not care about the truncation could obtain the body by sourcing expression `response.body or response.incomplete.body`.
* By setting a newly implemented library parameter `http.truncated-ok` to `true`, it is possible to suppress the oversized body error, treating the response object as a *success*, and return the truncated body in the `body` member as usual. In other words, member `incomplete` becomes the response itself and a newly implemented response member `truncated` is set to `true`.
* Library parameter `http.truncated-ok` can be overridden case-by-case with request option `truncated_ok`.
* Truncated responses are never cached.
* By enforcing the body size limit, the library would stop receiving socket data when this limit is reached, leaving the open socket in a state unfit for further use. In other words, the library would not try to "suck up" and discard the remainder of the body.
* When using a pipeline, the connection is restarted, beginning with the next request. This means that one or more requests following a truncated response could be submitted more than once. To compensate for this behavior, either do not use pipeline for state-changing requests or set parameter `http.max-pipeline` to `1`, which still uses persistent connections but processes only one request at at time.

Please review and comment.