### PR TITLE
Replacing hard linked icon of zenmap with icon theme compatible name

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -381,6 +381,7 @@ install-zenmap: $(ZENMAPDIR)/setup.py
 	$(INSTALL) -d $(DESTDIR)$(bindir) $(DESTDIR)$(mandir)/man1
 	cd $(ZENMAPDIR) && $(PYTHON) setup.py --quiet install --prefix "$(prefix)" --force $(if $(DESTDIR),--root "$(DESTDIR)")
 	$(INSTALL) -c -m 644 docs/zenmap.1 $(DESTDIR)$(mandir)/man1/
+	$(INSTALL) -c -m 644 zenmap/share/zenmap/pixmaps/zenmap.png /usr/share/pixmaps/
 # Create a symlink from nmapfe to zenmap if nmapfe doesn't exist or is
 # already a link.
 	if [ ! -f $(DESTDIR)$(bindir)/nmapfe -o -L $(DESTDIR)$(bindir)/nmapfe ]; then \
@@ -438,6 +439,7 @@ uninstall-nmap:
 uninstall-zenmap:
 	cd $(ZENMAPDIR) && $(PYTHON) setup.py uninstall
 	rm -f $(DESTDIR)$(mandir)/man1/zenmap.1
+	rm -f /usr/share/pixmaps/zenmap.png
 # Uninstall nmapfe only if it's a symlink.
 	if [ -L $(DESTDIR)$(bindir)/nmapfe ]; then \
 		rm -f $(DESTDIR)$(bindir)/nmapfe; \

--- a/zenmap/setup.py
+++ b/zenmap/setup.py
@@ -437,13 +437,10 @@ for dir in dirs:
         pf.write(pcontent)
         pf.close()
 
-        # Rewrite the zenmap.desktop and zenmap-root.desktop files to point to
-        # the installed locations of the su-to-zenmap.sh script and application
-        # icon.
+        # Rewrite the zenmap-root.desktop file to point to the
+        # installed location of the su-to-zenmap.sh script.
         su_filename = os.path.join(
                 self.saved_prefix, data_dir, "su-to-zenmap.sh")
-        icon_filename = os.path.join(
-                self.saved_prefix, pixmaps_dir, "zenmap.png")
 
         desktop_filename = None
         root_desktop_filename = None
@@ -453,16 +450,6 @@ for dir in dirs:
             elif re.search("%s$" % re.escape("zenmap.desktop"), f):
                 desktop_filename = f
 
-        if desktop_filename is not None:
-            df = open(desktop_filename, "r")
-            dcontent = df.read()
-            df.close()
-            regex = re.compile("^(Icon *= *).*$", re.MULTILINE)
-            dcontent = regex.sub("\\1%s" % icon_filename, dcontent)
-            df = open(desktop_filename, "w")
-            df.write(dcontent)
-            df.close()
-
         if root_desktop_filename is not None:
             df = open(root_desktop_filename, "r")
             dcontent = df.read()
@@ -471,8 +458,6 @@ for dir in dirs:
                     "^((?:Exec|TryExec) *= *).*su-to-zenmap.sh(.*)$",
                     re.MULTILINE)
             dcontent = regex.sub("\\1%s\\2" % su_filename, dcontent)
-            regex = re.compile("^(Icon *= *).*$", re.MULTILINE)
-            dcontent = regex.sub("\\1%s" % icon_filename, dcontent)
             df = open(root_desktop_filename, "w")
             df.write(dcontent)
             df.close()


### PR DESCRIPTION
In the current state the .desktop files are modified during the installation process so that the icon points to a static location leading to the impossibility for icon themes to display a custom icon for zenmap. This patch removes the modification of the .desktop files (in setup.py) and also placing the zenmap.png in a standard conform location (cf. https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html).