### PR TITLE
Address exception and decoding issue in rdp-enum-encryption

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 #Nmap Changelog ($Id$); -*-text-*-
 
+o [NSE][GH#1611] Address two protocol parsing issues in rdp-enum-encryption and
+  the RDP nse library which broke scanning of Windows XP. Clarify protocol
+  types [Tom Sellers]
+
 o [NSE][GH#1608] Script http-fileupload-exploiter failed to locate its resource
   file unless executed from a specific working directory. [nnposter]
 

--- a/nselib/rdp.lua
+++ b/nselib/rdp.lua
@@ -372,7 +372,6 @@ Comm = {
     end
 
     local data
-
     status, data = self:recv()
     if ( #data< 5 ) then
       return false, "Packet too short"

--- a/scripts/rdp-enum-encryption.nse
+++ b/scripts/rdp-enum-encryption.nse
@@ -72,7 +72,6 @@ local function enum_protocols(host, port)
     end
     local cr = rdp.Request.ConnectionRequest:new(v)
     local status, response = comm:exch(cr)
-
     comm:close()
     if ( not(status) ) then
       return false, response
@@ -148,7 +147,6 @@ local function enum_ciphers(host, port)
     local msc = rdp.Request.MCSConnectInitial:new(v)
     local status, response = comm:exch(msc)
     comm:close()
-
     if ( status ) then
       if ( response.ccr and response.ccr.enc_cipher == v ) then
         table.insert(res_ciphers, ("%s: SUCCESS"):format(k))

--- a/scripts/rdp-enum-encryption.nse
+++ b/scripts/rdp-enum-encryption.nse
@@ -15,14 +15,18 @@ http://labs.mwrinfosecurity.com/tools/2009/01/12/rdp-cipher-checker/
 -- @output
 -- PORT     STATE SERVICE
 -- 3389/tcp open  ms-wbt-server
--- | rdp-enum-encryption:
 -- |   Security layer
--- |     CredSSP: SUCCESS
+-- |     CredSSP (NLA): SUCCESS
+-- |     CredSSP with Early User Auth: SUCCESS
 -- |     Native RDP: SUCCESS
+-- |     RDSTLS: SUCCESS
 -- |     SSL: SUCCESS
 -- |   RDP Encryption level: High
+-- |     40-bit RC4: SUCCESS
+-- |     56-bit RC4: SUCCESS
 -- |     128-bit RC4: SUCCESS
--- |_    FIPS 140-1: SUCCESS
+-- |     FIPS 140-1: SUCCESS
+-- |_  RDP Protocol Version:  RDP 5.x, 6.x, 7.x, or 8.x server
 --
 
 author = "Patrik Karlsson"
@@ -46,7 +50,9 @@ local function enum_protocols(host, port)
   local PROTOCOLS = {
     ["Native RDP"] = 0,
     ["SSL"] = 1,
-    ["CredSSP"] = 3
+    ["CredSSP (NLA)"] = 3,
+    ["RDSTLS"] = 4,
+    ["CredSSP with Early User Auth"] = 8
   }
 
   local ERRORS = {
@@ -66,6 +72,7 @@ local function enum_protocols(host, port)
     end
     local cr = rdp.Request.ConnectionRequest:new(v)
     local status, response = comm:exch(cr)
+
     comm:close()
     if ( not(status) ) then
       return false, response
@@ -85,7 +92,10 @@ local function enum_protocols(host, port)
         end
       end
     else
-      table.insert(res_proto, ("%s: FAILED"):format(k))
+      -- rdpNegData, which contains the negotiaion response or failure,
+      -- is optional. WinXP SP3 does not return this section which means
+      -- we can't tell if the protocol is accepted or not.
+      table.insert(res_proto, ("%s: Unknown"):format(k))
     end
   end
   table.sort(res_proto)
@@ -110,6 +120,7 @@ local function enum_ciphers(host, port)
   }
 
   local res_ciphers = {}
+  local proto_version
 
   local function get_ordered_ciphers()
     local i = 0
@@ -137,18 +148,21 @@ local function enum_ciphers(host, port)
     local msc = rdp.Request.MCSConnectInitial:new(v)
     local status, response = comm:exch(msc)
     comm:close()
+
     if ( status ) then
-      local enc_level = string.unpack("B", response.itut.data, 95 + 8)
-      local enc_cipher= string.unpack("B", response.itut.data, 95 + 4)
-      if ( enc_cipher == v ) then
+      if ( response.ccr and response.ccr.enc_cipher == v ) then
         table.insert(res_ciphers, ("%s: SUCCESS"):format(k))
       end
-      res_ciphers.name = ("RDP Encryption level: %s"):format(ENC_LEVELS[enc_level] or "Unknown")
+      res_ciphers.name = ("RDP Encryption level: %s"):format(ENC_LEVELS[response.ccr.enc_level] or "Unknown")
+
+      if response.ccr.proto_version then
+        proto_version = response.ccr.proto_version
+      end
     elseif ( nmap.debugging() > 0 ) then
       table.insert(res_ciphers, ("%s: FAILURE"):format(k))
     end
   end
-  return true, res_ciphers
+  return true, res_ciphers, proto_version
 end
 
 action = function(host, port)
@@ -159,12 +173,15 @@ action = function(host, port)
     return res_proto
   end
 
-  local status, res_ciphers = enum_ciphers(host, port)
+  local status, res_ciphers, proto_version = enum_ciphers(host, port)
   if ( not(status) ) then
     return res_ciphers
   end
 
   table.insert(result, res_proto)
   table.insert(result, res_ciphers)
+  if proto_version then
+    table.insert(result, proto_version)
+  end
   return stdnse.format_output(true, result)
 end

--- a/scripts/rdp-enum-encryption.nse
+++ b/scripts/rdp-enum-encryption.nse
@@ -71,16 +71,21 @@ local function enum_protocols(host, port)
       return false, response
     end
 
-    local success = string.unpack("B", response.itut.data)
-    if ( success == 2 ) then
-      table.insert(res_proto, ("%s: SUCCESS"):format(k))
-    elseif ( nmap.debugging() > 0 ) then
-      local err = string.unpack("B", response.itut.data, 5)
-      if ( err > 0 ) then
-        table.insert(res_proto, ("%s: FAILED (%s)"):format(k, ERRORS[err] or "Unknown"))
-      else
-        table.insert(res_proto, ("%s: FAILED"):format(k))
+    if response.itut.data ~= "" then
+      local success = string.unpack("B", response.itut.data)
+
+      if ( success == 2 ) then
+        table.insert(res_proto, ("%s: SUCCESS"):format(k))
+      elseif ( nmap.debugging() > 0 ) then
+        local err = string.unpack("B", response.itut.data, 5)
+        if ( err > 0 ) then
+          table.insert(res_proto, ("%s: FAILED (%s)"):format(k, ERRORS[err] or "Unknown"))
+        else
+          table.insert(res_proto, ("%s: FAILED"):format(k))
+        end
       end
+    else
+      table.insert(res_proto, ("%s: FAILED"):format(k))
     end
   end
   table.sort(res_proto)


### PR DESCRIPTION
This PR addresses a few bugs in RDP protocol parsing in `scripts/rdp-enum-encryption.nse` and `nselib/rdp.lua`.

It should also address the following issue:

Feature Request: rdp-enum-encryption should check if NLA is required #174
 - [https://github.com/nmap/nmap/issues/174](https://github.com/nmap/nmap/issues/174)

## Exception vs Windows XP
There was an exception caused by `rdp-enum-encryption.nse` attempting to unpack data that doesn't exist. This was noticed when running the script against Windows XP SP3 which doesn't return a certain layer in the protocol during the initial negotiation packet exchange.

Testing
```shell
sudo nmap -sSVC -p 3389 --script=rdp-enum-encryption -vvvv  -d2 <target>
````

### Before fix
```shell
<snip>

NSE: rdp-enum-encryption M:559f23dc78f8 against 192.168.200.196:3389 threw an error!
.../local/bin/../share/nmap/scripts/rdp-enum-encryption.nse:74: bad argument #2 to 'unpack' (data string too short)
stack traceback:
	[C]: in function 'string.unpack'
	.../local/bin/../share/nmap/scripts/rdp-enum-encryption.nse:74: in upvalue 'enum_protocols'
	.../local/bin/../share/nmap/scripts/rdp-enum-encryption.nse:152: in function <.../local/bin/../share/nmap/scripts/rdp-enum-encryption.nse:149>
	(...tail calls...)

<snip>
PORT     STATE SERVICE       REASON          VERSION
3389/tcp open  ms-wbt-server syn-ack ttl 128 Microsoft Terminal Services
```

### After fix
```
PORT     STATE SERVICE       REASON          VERSION
3389/tcp open  ms-wbt-server syn-ack ttl 128 Microsoft Terminal Services
| rdp-enum-encryption: 
|   Security layer
|     CredSSP: Unknown
|     Native RDP: Unknown
|     SSL: Unknown
|   RDP Encryption level: Unknown
|     128-bit RC4: SUCCESS
|_    FIPS 140-1: FAILURE
```

## Incorrectly decoding ServerData

The existing code was incorrectly decoding the ServerData section of the ConferenceCreateResponse packet.  This was due to assuming a certain block was a fixed size. This broke when certain optional fields were included.  The impact was that certain encryption level options were not being detected. This primarily impacted Windows XP.

The fix was adding decoding of the type and lengths for the sections in ServerData.

### Before fix
Technically, before the fix this section was empty due to the first bug fixed above. But after fixing that bug here is what the output looked like.
```shell
3389/tcp open  ms-wbt-server syn-ack ttl 128
| rdp-enum-encryption: 
|   RDP Encryption level: Unknown
|     128-bit RC4: SUCCESS
|_    FIPS 140-1: FAILURE

```


### After fix
```shell
PORT     STATE SERVICE       REASON
3389/tcp open  ms-wbt-server syn-ack ttl 128
| rdp-enum-encryption: 
|   Security layer
|     CredSSP: Unknown
|     Native RDP: Unknown
|     SSL: Unknown
|   RDP Encryption level: Client Compatible
|     40-bit RC4: SUCCESS
|     56-bit RC4: SUCCESS
|     128-bit RC4: SUCCESS
|_    FIPS 140-1: FAILURE
```

## Added output

- Now that ServerData is being decoded we can determine which RDP protocol is being advertised. When detected this will now show up in the `RDP Protocol Version:  ` section. Since the library doesn't currently support TLS negotiation this will be missing for hosts that require TLS until this feature is added. The same applies for CredSSP.

- In the Security layer section of the output
   -  `CredSSP` has been changed to `CredSSP (NLA)` to clarify that this is NLA for those who are using the script to audit networks for things like CVE-2019-0708.
  - `CredSSP with Early User Auth` and `RDSTLS` have been added.

### Output

Windows XP SP3
```shell
3389/tcp open  ms-wbt-server syn-ack ttl 128
| rdp-enum-encryption: 
|   Security layer
|     CredSSP (NLA): Unknown
|     CredSSP with Early User Auth: Unknown
|     Native RDP: Unknown
|     RDSTLS: Unknown
|     SSL: Unknown
|   RDP Encryption level: Client Compatible
|     40-bit RC4: SUCCESS
|     56-bit RC4: SUCCESS
|     128-bit RC4: SUCCESS
|     FIPS 140-1: FAILURE
|_  RDP Protocol Version:  RDP 5.x, 6.x, 7.x, or 8.x server
```
Windows 2008 with NLA optional and configured for client compatible ciphers
```shell
3389/tcp open  ms-wbt-server syn-ack ttl 128
| rdp-enum-encryption: 
|   Security layer
|     CredSSP (NLA): SUCCESS
|     CredSSP with Early User Auth: SUCCESS
|     Native RDP: SUCCESS
|     RDSTLS: SUCCESS
|     SSL: SUCCESS
|   RDP Encryption level: Client Compatible
|     40-bit RC4: SUCCESS
|     56-bit RC4: SUCCESS
|     128-bit RC4: SUCCESS
|     FIPS 140-1: SUCCESS
|_  RDP Protocol Version:  RDP 5.x, 6.x, 7.x, or 8.x server
```

Windows 2019
```shell
3389/tcp open  ms-wbt-server syn-ack ttl 128
| rdp-enum-encryption: 
|   Security layer
|     CredSSP (NLA): SUCCESS
|     CredSSP with Early User Auth: SUCCESS
|     Native RDP: FAILED (HYBRID_REQUIRED_BY_SERVER)
|     RDSTLS: SUCCESS
|_    SSL: FAILED (HYBRID_REQUIRED_BY_SERVER)
```
