### PR TITLE
Host Discovery: Ignore TCP RST

### DIFF
--- a/NmapOps.cc
+++ b/NmapOps.cc
@@ -398,6 +398,7 @@ void NmapOps::Initialize() {
   exclude_portlist = NULL;
   proxy_chain = NULL;
   resuming = false;
+  host_discovery_ignore_tcp_reset = false;
 }
 
 bool NmapOps::SCTPScan() {

--- a/NmapOps.h
+++ b/NmapOps.h
@@ -395,6 +395,7 @@ class NmapOps {
   char *exclude_portlist; /* exclude-ports list specified by user */
 
   nsock_proxychain proxy_chain;
+  bool host_discovery_ignore_tcp_reset; /* host discovery should not consider TCP RST packet responses as a live asset */
 
 #ifndef NOLUA
   bool script;

--- a/nmap.cc
+++ b/nmap.cc
@@ -271,6 +271,7 @@ static void printusage() {
          "  -PS/PA/PU/PY[portlist]: TCP SYN/ACK, UDP or SCTP discovery to given ports\n"
          "  -PE/PP/PM: ICMP echo, timestamp, and netmask request discovery probes\n"
          "  -PO[protocol list]: IP Protocol Ping\n"
+         "  --host-discovery-ignore-tcp-reset: Ignore reset during host discovery\n"
          "  -n/-R: Never do DNS resolution/Always resolve [default: sometimes]\n"
          "  --dns-servers <serv1[,serv2],...>: Specify custom DNS servers\n"
          "  --system-dns: Use OS's DNS resolver\n"
@@ -622,6 +623,7 @@ void parse_options(int argc, char **argv) {
     {"nsock-engine", required_argument, 0, 0},
     {"proxies", required_argument, 0, 0},
     {"proxy", required_argument, 0, 0},
+    {"host-discovery-ignore-tcp-reset", no_argument, 0, 0},
     {"osscan-limit", no_argument, 0, 0}, /* skip OSScan if no open ports */
     {"osscan-guess", no_argument, 0, 0}, /* More guessing flexibility */
     {"fuzzy", no_argument, 0, 0}, /* Alias for osscan_guess */
@@ -841,6 +843,8 @@ void parse_options(int argc, char **argv) {
         } else if ((strcmp(long_options[option_index].name, "proxies") == 0) || (strcmp(long_options[option_index].name, "proxy") == 0)) {
           if (nsock_proxychain_new(optarg, &o.proxy_chain, NULL) < 0)
             fatal("Invalid proxy chain specification");
+        } else if (strcmp(long_options[option_index].name, "host-discovery-ignore-tcp-reset") == 0) {
+            o.host_discovery_ignore_tcp_reset = true;
         } else if (strcmp(long_options[option_index].name, "osscan-limit")  == 0) {
           o.osscan_limit = true;
         } else if (strcmp(long_options[option_index].name, "osscan-guess")  == 0

--- a/scan_engine_raw.cc
+++ b/scan_engine_raw.cc
@@ -747,9 +747,13 @@ int get_ping_pcap_result(UltraScanInfo *USI, struct timeval *stime) {
     } else if (hdr.proto == IPPROTO_TCP && USI->ptech.rawtcpscan) {
       struct tcp_hdr *tcp = (struct tcp_hdr *) data;
       /* Check that the packet has useful flags. */
-      if (!(tcp->th_flags & TH_RST)
-          && ((tcp->th_flags & (TH_SYN | TH_ACK)) != (TH_SYN | TH_ACK)))
-        continue;
+      if (o.host_discovery_ignore_tcp_reset
+        && (tcp->th_flags & TH_RST))
+          continue;
+      else if (!(tcp->th_flags & TH_RST)
+        && ((tcp->th_flags & (TH_SYN | TH_ACK)) != (TH_SYN | TH_ACK)))
+          continue;
+
       /* Now ensure this host is even in the incomplete list */
       hss = USI->findHost(&hdr.src);
       if (!hss)


### PR DESCRIPTION
This PR adds a new option, `--host-discovery-ignore-tcp-reset`, that tells Nmap to ignore TCP reset packets for the purpose host discovery. Firewalls can sometimes be configured to send resets instead of dropping packets when an ACL is triggered. This can cause hosts to be flagged as up when they are not. The intent of the patch is to provide an option to ignore these RST packets.

*Note*: This patch was originally written by Paul Miseiko at Rapid7 (my employer). I'm submitting this upstream with permission and by request. Any errors with the PR are likely mine.


I can't point to a device on the Internet that is doing this but we can simulate the behavior with a closed port on `scanme.nmap.org` and using TCP SYN discovery.

### Without the option

Note the host is up due to a RST response: `Host is up, received reset ttl 50 (0.074s latency).`

```shell
$ sudo ./nmap -d -p 8080 -PS8080 -n --packet-trace  scanme.nmap.org

Starting Nmap 7.70SVN ( https://nmap.org ) at 2019-05-30 18:16 CDT
--------------- Timing report ---------------
  hostgroups: min 1, max 100000
  rtt-timeouts: init 1000, min 100, max 10000
  max-scan-delay: TCP 1000, UDP 1000, SCTP 1000
  parallelism: min 0, max 0
  max-retries: 10, host-timeout: 0
  min-rate: 0, max-rate: 0
---------------------------------------------
Initiating Ping Scan at 18:16
Scanning scanme.nmap.org (45.33.32.156) [1 port]
Packet capture filter (device en4): dst host 172.16.1.192 and (icmp or icmp6 or ((tcp or udp or sctp) and (src host 45.33.32.156)))
SENT (0.0361s) TCP 172.16.1.192:45225 > 45.33.32.156:8080 S ttl=59 id=48831 iplen=44  seq=1143953030 win=1024 <mss 1460>
RCVD (0.1101s) TCP 45.33.32.156:8080 > 172.16.1.192:45225 RA ttl=50 id=0 iplen=40  seq=0 win=0 
We got a TCP ping packet back from 45.33.32.156 port 8080 (trynum = 0)
Completed Ping Scan at 18:16, 0.07s elapsed (1 total hosts)
Overall sending rates: 13.35 packets / s, 587.33 bytes / s.
Initiating SYN Stealth Scan at 18:16
Scanning scanme.nmap.org (45.33.32.156) [1 port]
Packet capture filter (device en4): dst host 172.16.1.192 and (icmp or icmp6 or ((tcp or udp or sctp) and (src host 45.33.32.156)))
SENT (0.1114s) TCP 172.16.1.192:45481 > 45.33.32.156:8080 S ttl=59 id=15252 iplen=44  seq=1065690232 win=1024 <mss 1460>
RCVD (0.1857s) TCP 45.33.32.156:8080 > 172.16.1.192:45481 RA ttl=50 id=0 iplen=40  seq=0 win=0 
Completed SYN Stealth Scan at 18:16, 0.07s elapsed (1 total ports)
Overall sending rates: 13.31 packets / s, 585.80 bytes / s.
Nmap scan report for scanme.nmap.org (45.33.32.156)
Host is up, received reset ttl 50 (0.074s latency).
Other addresses for scanme.nmap.org (not scanned): 2600:3c01::f03c:91ff:fe18:bb2f
Scanned at 2019-05-30 18:16:26 CDT for 0s

PORT     STATE  SERVICE    REASON
8080/tcp closed http-proxy reset ttl 50
Final times for host: srtt: 74133 rttvar: 55632  to: 296661

Nmap done: 1 IP address (1 host up) scanned in 0.19 seconds
           Raw packets sent: 2 (88B) | Rcvd: 2 (80B)
```

### With the option

Nmap thinks the host is down: `Note: Host seems down. If it is really up,..`

```shell
$ sudo ./nmap -d -p 8080 -PS8080 -n --packet-trace --host-discovery-ignore-tcp-reset scanme.nmap.org

Starting Nmap 7.70SVN ( https://nmap.org ) at 2019-05-30 18:15 CDT
--------------- Timing report ---------------
  hostgroups: min 1, max 100000
  rtt-timeouts: init 1000, min 100, max 10000
  max-scan-delay: TCP 1000, UDP 1000, SCTP 1000
  parallelism: min 0, max 0
  max-retries: 10, host-timeout: 0
  min-rate: 0, max-rate: 0
---------------------------------------------
Initiating Ping Scan at 18:15
Scanning scanme.nmap.org (45.33.32.156) [1 port]
Packet capture filter (device en4): dst host 172.16.1.192 and (icmp or icmp6 or ((tcp or udp or sctp) and (src host 45.33.32.156)))
SENT (0.0410s) TCP 172.16.1.192:54985 > 45.33.32.156:8080 S ttl=46 id=42332 iplen=44  seq=4020378568 win=1024 <mss 1460>
RCVD (0.1167s) TCP 45.33.32.156:8080 > 172.16.1.192:54985 RA ttl=50 id=0 iplen=40  seq=0 win=0 
SENT (1.0467s) TCP 172.16.1.192:54986 > 45.33.32.156:8080 S ttl=57 id=10575 iplen=44  seq=4020444105 win=1024 <mss 1460>
RCVD (1.1216s) TCP 45.33.32.156:8080 > 172.16.1.192:54986 RA ttl=47 id=0 iplen=40  seq=0 win=0 
Completed Ping Scan at 18:15, 2.02s elapsed (1 total hosts)
Overall sending rates: 0.99 packets / s, 43.44 bytes / s.
Nmap scan report for scanme.nmap.org (45.33.32.156) [host down, received no-response]
Other addresses for scanme.nmap.org (not scanned): 2600:3c01::f03c:91ff:fe18:bb2f
Note: Host seems down. If it is really up, but blocking our ping probes, try -Pn
Nmap done: 1 IP address (0 hosts up) scanned in 2.07 seconds
           Raw packets sent: 2 (88B) | Rcvd: 2 (80B)
```

### With the option and using a port that responds with a SYN/ACK

In the example below I'm using  SYN discovery  against 80 (open) and 8080 (closed). We see a RST/ACK on 8080 which we ignore and a SYN/ACK on 80 which indicates that the host is up and that the new option didn't break the expected behavior. Note that I'm not actually scanning port 80 in order to reduce the potential impact on the results.

`Host is up, received syn-ack ttl 47 (0.073s latency).` 

```shell
$ sudo ./nmap -d -p8080 -PS80,8080 -n --packet-trace --host-discovery-ignore-tcp-reset scanme.nmap.org

Starting Nmap 7.70SVN ( https://nmap.org ) at 2019-05-30 18:34 CDT
--------------- Timing report ---------------
  hostgroups: min 1, max 100000
  rtt-timeouts: init 1000, min 100, max 10000
  max-scan-delay: TCP 1000, UDP 1000, SCTP 1000
  parallelism: min 0, max 0
  max-retries: 10, host-timeout: 0
  min-rate: 0, max-rate: 0
---------------------------------------------
Initiating Ping Scan at 18:34
Scanning scanme.nmap.org (45.33.32.156) [2 ports]
Packet capture filter (device en4): dst host 172.16.1.192 and (icmp or icmp6 or ((tcp or udp or sctp) and (src host 45.33.32.156)))
SENT (0.0345s) TCP 172.16.1.192:62184 > 45.33.32.156:80 S ttl=57 id=64395 iplen=44  seq=2894489787 win=1024 <mss 1460>
SENT (0.0345s) TCP 172.16.1.192:62184 > 45.33.32.156:8080 S ttl=40 id=4801 iplen=44  seq=2894489787 win=1024 <mss 1460>
RCVD (0.1065s) TCP 45.33.32.156:8080 > 172.16.1.192:62184 RA ttl=47 id=0 iplen=40  seq=0 win=0 
RCVD (0.1072s) TCP 45.33.32.156:80 > 172.16.1.192:62184 SA ttl=47 id=0 iplen=44  seq=2668706749 win=29200 <mss 1460>
We got a TCP ping packet back from 45.33.32.156 port 80 (trynum = 0)
Completed Ping Scan at 18:34, 0.07s elapsed (1 total hosts)
Overall sending rates: 27.20 packets / s, 1196.86 bytes / s.
Initiating SYN Stealth Scan at 18:34
Scanning scanme.nmap.org (45.33.32.156) [1 port]
Packet capture filter (device en4): dst host 172.16.1.192 and (icmp or icmp6 or ((tcp or udp or sctp) and (src host 45.33.32.156)))
SENT (0.1086s) TCP 172.16.1.192:62440 > 45.33.32.156:8080 S ttl=46 id=51138 iplen=44  seq=2418066826 win=1024 <mss 1460>
RCVD (0.1801s) TCP 45.33.32.156:8080 > 172.16.1.192:62440 RA ttl=47 id=0 iplen=40  seq=0 win=0 
Completed SYN Stealth Scan at 18:34, 0.07s elapsed (1 total ports)
Overall sending rates: 13.78 packets / s, 606.39 bytes / s.
Nmap scan report for scanme.nmap.org (45.33.32.156)
Host is up, received syn-ack ttl 47 (0.073s latency).
Other addresses for scanme.nmap.org (not scanned): 2600:3c01::f03c:91ff:fe18:bb2f
Scanned at 2019-05-30 18:34:21 CDT for 0s

PORT     STATE  SERVICE    REASON
8080/tcp closed http-proxy reset ttl 47
Final times for host: srtt: 72606 rttvar: 54840  to: 291966

Nmap done: 1 IP address (1 host up) scanned in 0.18 seconds
           Raw packets sent: 3 (132B) | Rcvd: 3 (124B)
```
