### PR TITLE
preserve ar flags when cross-compiling

### DIFF
--- a/liblua/Makefile
+++ b/liblua/Makefile
@@ -11,13 +11,15 @@ CFLAGS= -O2 -Wall -Wextra -DLUA_COMPAT_5_2 $(SYSCFLAGS) $(MYCFLAGS)
 LDFLAGS= $(SYSLDFLAGS) $(MYLDFLAGS)
 LIBS= -lm $(SYSLIBS) $(MYLIBS)
 
-AR= ar rcu
+AR= ar
 RANLIB= ranlib
 RM= rm -f
 
 SYSCFLAGS=
 SYSLDFLAGS=
 SYSLIBS=
+
+ARFLAGS= rcu
 
 MYCFLAGS=
 MYLDFLAGS=
@@ -56,7 +58,7 @@ o:	$(ALL_O)
 a:	$(ALL_A)
 
 $(LUA_A): $(BASE_O)
-	$(AR) $@ $(BASE_O)
+	$(AR) $(ARFLAGS) $@ $(BASE_O)
 	$(RANLIB) $@
 
 $(LUA_T): $(LUA_O) $(LUA_A)


### PR DESCRIPTION
Modelled on ARFLAGS use in libpcre, libssh2, libz.