### PR TITLE
[NSE] Add rdp-ntlm-info.nse

### DIFF
--- a/nselib/rdp.lua
+++ b/nselib/rdp.lua
@@ -47,6 +47,13 @@ CONNECT_RESPONSE_RESULT = {
   [15] = "rt-user-rejected",
 }
 
+-- requestedProtocols - flag - RDP_NEG_REQ - MS-RDPBCGR 2.2.1.1.1
+PROTOCOL_RDP = 0         -- Standard RDP Security
+PROTOCOL_SSL = 1         -- TLS 1.0, 1.1, 1.2
+PROTOCOL_HYBRID = 2      -- CredSSP (NLA). TLS flag should be set as well
+PROTOCOL_RDSTLS = 4      -- RDSTLS
+PROTOCOL_HYBRID_EX = 8   -- CredSSP (NLA) with Early User Auth PDU
+
 Packet = {
 
   TPKT = {

--- a/scripts/rdp-ntlm-info.nse
+++ b/scripts/rdp-ntlm-info.nse
@@ -1,0 +1,168 @@
+local datetime = require "datetime"
+local os = require "os"
+local shortport = require "shortport"
+local stdnse = require "stdnse"
+local smbauth = require "smbauth"
+local string = require "string"
+local rdp = require "rdp"
+
+description = [[
+This script enumerates information from remote RDP services with CredSSP
+(NLA) authentication enabled.
+
+Sending an incomplete CredSSP (NTLM) authentication request with null credentials
+will cause the remote service to respond with a NTLMSSP message disclosing
+information to include NetBIOS, DNS, and OS build version.
+]]
+
+---
+-- @usage
+-- nmap -p 3389 --script rdp-ntlm-info <target>
+--
+-- @output
+-- 3389/tcp open     ms-wbt-server syn-ack ttl 128 Microsoft Terminal Services
+-- | rdp-ntlm-info:
+-- |   Target_Name: W2016
+-- |   NetBIOS_Domain_Name: W2016
+-- |   NetBIOS_Computer_Name: W16GA-SRV01
+-- |   DNS_Domain_Name: W2016.lab
+-- |   DNS_Computer_Name: W16GA-SRV01.W2016.lab
+-- |   DNS_Tree_Name: W2016.lab
+-- |   Product_Version: 10.0.14393
+-- |_  System_Time: 2019-06-13T10:38:35+00:00
+--
+--@xmloutput
+-- <elem key="Target_Name">W2016</elem>
+-- <elem key="NetBIOS_Domain_Name">W2016</elem>
+-- <elem key="NetBIOS_Computer_Name">W16GA-SRV01</elem>
+-- <elem key="DNS_Domain_Name">W2016.lab</elem>
+-- <elem key="DNS_Computer_Name">W16GA-SRV01.W2016.lab</elem>
+-- <elem key="DNS_Tree_Name">W2016.lab</elem>
+-- <elem key="Product_Version">10.0.14393</elem>
+-- <elem key="System_Time">2019-06-13T10:38:35+00:00</elem>
+
+
+
+author = "Tom Sellers"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"default", "discovery", "safe"}
+
+portrule = shortport.port_or_service(3389, "ms-wbt-server")
+
+action = function(host, port)
+
+  local comm = rdp.Comm:new(host, port)
+  if ( not(comm:connect()) ) then
+    return false, fail("Failed to connect to server")
+  end
+
+  -- Request CredSSP protocol = 3
+  local cr = rdp.Request.ConnectionRequest:new(11)
+  local status, _ = comm:exch(cr)
+  if ( not(status) ) then
+    comm:close()
+    return
+  end
+
+  -- This script could include code to detect which security protocols the
+  -- target claims that it accepts however that's less than useful because
+  -- 1. Windows XP doesn't provide that layer of the packet
+  -- 2. Even when configured for RDP Security only, Windows Server 2008
+  --    will still let you connect over TLS and start the CredSSP nego.
+
+  local _, response, recvtime
+  status, _ = comm.socket:reconnect_ssl()
+  if status then
+    stdnse.debug1("Sending NTLM NEGOTIATE..")
+
+    -- NTLMSSP Negotiate request mimicking a Windows 10 client
+    local NTLM_NEGOTIATE_BLOB = stdnse.fromhex(
+      "30 37 A0 03 02 01 60 A1 30 30 2E 30 2C A0 2A 04 28" ..
+      "4e 54 4c 4d 53 53 50 00" .. -- Identifier - NTLMSSP
+      "01 00 00 00" ..  -- Type: NTLMSSP Negotiate - 01
+      "B7 82 08 E2 " .. -- Flags (NEGOTIATE_SIGN_ALWAYS | NEGOTIATE_NTLM | NEGOTIATE_SIGN | REQUEST_TARGET | NEGOTIATE_UNICODE)
+      "00 00 " ..       -- DomainNameLen
+      "00 00" ..        -- DomainNameMaxLen
+      "00 00 00 00" ..  -- DomainNameBufferOffset
+      "00 00 " ..       -- WorkstationLen
+      "00 00" ..        -- WorkstationMaxLen
+      "00 00 00 00" ..  -- WorkstationBufferOffset
+      "0A" ..           -- ProductMajorVersion = 10
+      "00 " ..          -- ProductMinorVersion = 0
+      "63 45 " ..       -- ProductBuild = 0x4563 = 17763
+      "00 00 00" ..     -- Reserved
+      "0F"              -- NTLMRevision = 5 = NTLMSSP_REVISION_W2K3
+    )
+
+    -- Not using comm:exch here since that performs some processing on the
+    -- packet that isn't appropriate in this case.
+    status, response = comm:send(NTLM_NEGOTIATE_BLOB)
+    if ( not(status) ) then
+      return false, response
+    end
+
+    status, response = comm:recv()
+    if status then
+      recvtime = os.time()
+    end
+  else
+    comm:close()
+    stdnse.debug1("Unable to establish a TLS connection which is required to negotiation CredSSP.")
+    return
+  end
+
+  if response == nil then
+    return
+  end
+
+  -- Continue only if NTLMSSP response is returned
+  local start = response:find("NTLMSSP")
+  response = response:sub(start)
+  if not string.match(response, "^NTLMSSP") then
+    return nil
+  end
+
+  local ntlm_decoded = smbauth.get_host_info_from_security_blob(response)
+
+  local output = stdnse.output_table()
+
+  -- Target Name will always be returned under any implementation
+  output.Target_Name = ntlm_decoded.target_realm
+
+  -- Display information returned & ignore responses with null values
+  if ntlm_decoded.netbios_domain_name and #ntlm_decoded.netbios_domain_name > 0 then
+    output.NetBIOS_Domain_Name = ntlm_decoded.netbios_domain_name
+  end
+
+  if ntlm_decoded.netbios_computer_name and #ntlm_decoded.netbios_computer_name > 0 then
+    output.NetBIOS_Computer_Name = ntlm_decoded.netbios_computer_name
+  end
+
+  if ntlm_decoded.dns_domain_name and #ntlm_decoded.dns_domain_name > 0 then
+    output.DNS_Domain_Name = ntlm_decoded.dns_domain_name
+  end
+
+  if ntlm_decoded.fqdn and #ntlm_decoded.fqdn > 0 then
+    output.DNS_Computer_Name = ntlm_decoded.fqdn
+  end
+
+  if ntlm_decoded.dns_forest_name and #ntlm_decoded.dns_forest_name > 0 then
+    output.DNS_Tree_Name = ntlm_decoded.dns_forest_name
+  end
+
+  if ntlm_decoded.os_major_version then
+    local product_ver = string.format("%d.%d.%d",
+    ntlm_decoded.os_major_version, ntlm_decoded.os_minor_version, ntlm_decoded.os_build)
+    output.Product_Version = product_ver
+  end
+
+  if ntlm_decoded.timestamp and ntlm_decoded.timestamp > 0 then
+    -- 64-bit number of 100ns clicks since 1/1/1601
+    local unixstamp = ntlm_decoded.timestamp // 10000000 - 11644473600
+    datetime.record_skew(host, unixstamp, recvtime)
+    local sys_time =  datetime.format_timestamp( unixstamp, 0)
+    output.System_Time = sys_time
+  end
+
+  return output
+end

--- a/scripts/rdp-ntlm-info.nse
+++ b/scripts/rdp-ntlm-info.nse
@@ -53,11 +53,11 @@ action = function(host, port)
 
   local comm = rdp.Comm:new(host, port)
   if ( not(comm:connect()) ) then
-    return false, fail("Failed to connect to server")
+    return nil
   end
 
-  -- Request CredSSP protocol = 3
-  local cr = rdp.Request.ConnectionRequest:new(11)
+  local requested_protocol = rdp.PROTOCOL_SSL | rdp.PROTOCOL_HYBRID | rdp.PROTOCOL_HYBRID_EX
+  local cr = rdp.Request.ConnectionRequest:new(requested_protocol)
   local status, _ = comm:exch(cr)
   if ( not(status) ) then
     comm:close()
@@ -117,10 +117,10 @@ action = function(host, port)
 
   -- Continue only if NTLMSSP response is returned
   local start = response:find("NTLMSSP")
-  response = response:sub(start)
-  if not string.match(response, "^NTLMSSP") then
+  if not start then
     return nil
   end
+  response = response:sub(start)
 
   local ntlm_decoded = smbauth.get_host_info_from_security_blob(response)
 


### PR DESCRIPTION
This PR adds an NSE script, `rdp-ntlm-info.nse`,  which enumerates information from remote RDP services  that have CredSSP (NLA) authentication enabled. It is modeled after Justin Cacak's `*-ntlm-info.nse` scripts. I'm not a fan of the output format and using `ntlm` in the script name isn't intuitive here but I've kept them in this case in order to be consistent with his existing scripts and to enable someone to run them all using `--script *-ntlm-info`.

**Note:** No authentication is required and no logon attempts were made.

#### Example output

Run against a Windows 2019 server with NLA ( CredSSP ) enabled.
```shell
3389/tcp open  ms-wbt-server
| rdp-ntlm-info: 
|   Target_Name: W19GA-SRV01
|   NetBIOS_Domain_Name: W19GA-SRV01
|   NetBIOS_Computer_Name: W19GA-SRV01
|   DNS_Domain_Name: W19GA-SRV01
|   DNS_Computer_Name: W19GA-SRV01
|   Product_Version: 10.0.17763
|_  System_Time: 2019-06-13T11:20:33+00:00
```

Here is output that also includes output from `htlm-ntlm-info.nse` so that you can compare the results.

`sudo nmap -sSCV --script=*-ntlm-info -p 80,3389  <target>`

```shell
80/tcp   open     http          syn-ack ttl 128 Microsoft IIS httpd 10.0
| http-ntlm-info: 
|   Target_Name: W2016
|   NetBIOS_Domain_Name: W2016
|   NetBIOS_Computer_Name: W16GA-SRV01
|   DNS_Domain_Name: W2016.lab
|   DNS_Computer_Name: W16GA-SRV01.W2016.lab
|   DNS_Tree_Name: W2016.lab
|_  Product_Version: 10.0.14393
|_http-server-header: Microsoft-IIS/10.0
3389/tcp open     ms-wbt-server syn-ack ttl 128 Microsoft Terminal Services
| rdp-ntlm-info: 
|   Target_Name: W2016
|   NetBIOS_Domain_Name: W2016
|   NetBIOS_Computer_Name: W16GA-SRV01
|   DNS_Domain_Name: W2016.lab
|   DNS_Computer_Name: W16GA-SRV01.W2016.lab
|   DNS_Tree_Name: W2016.lab
|   Product_Version: 10.0.14393
|_  System_Time: 2019-06-13T10:38:35+00:00
```

Against Windows 2008 with a few more services configured to use NTLM
`sudo nmap -sSC --script=*-ntlm-info -p 23,25,80,3389 <target>`

```shell
PORT     STATE SERVICE
23/tcp   open  telnet
| telnet-ntlm-info: 
|   Target_Name: W008GA-DC01
|   NetBIOS_Domain_Name: W008GA-DC01
|   NetBIOS_Computer_Name: W008GA-DC01
|   DNS_Domain_Name: W008GA-DC01.difflab.lab
|   DNS_Computer_Name: W008GA-DC01.difflab.lab
|_  Product_Version: 6.0.6002
25/tcp   open  smtp
| smtp-ntlm-info: 
|   Target_Name: W008GA-DC01
|   NetBIOS_Domain_Name: W008GA-DC01
|   NetBIOS_Computer_Name: W008GA-DC01
|   DNS_Domain_Name: W008GA-DC01.difflab.lab
|   DNS_Computer_Name: W008GA-DC01.difflab.lab
|_  Product_Version: 6.0.6002
80/tcp   open  http
| http-ntlm-info: 
|   Target_Name: W008GA-DC01
|   NetBIOS_Domain_Name: W008GA-DC01
|   NetBIOS_Computer_Name: W008GA-DC01
|   DNS_Domain_Name: W008GA-DC01.difflab.lab
|   DNS_Computer_Name: W008GA-DC01.difflab.lab
|_  Product_Version: 6.0.6002
3389/tcp open  ms-wbt-server
| rdp-ntlm-info: 
|   Target_Name: W008GA-DC01
|   NetBIOS_Domain_Name: W008GA-DC01
|   NetBIOS_Computer_Name: W008GA-DC01
|   DNS_Domain_Name: W008GA-DC01.difflab.lab
|   DNS_Computer_Name: W008GA-DC01.difflab.lab
|   Product_Version: 6.0.6002
|_  System_Time: 2019-06-13T11:50:50+00:00
```