### PR TITLE
Modify Apache ActiveMQ Stomp service probe

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -6290,8 +6290,9 @@ match am-pdp m|^setreply=450 4\.5\.0 Failure:%20Missing%20'request'%20field%20at
 match am-pdp m|^setreply=450 4\.5\.0 Failure:%20Missing%20'request'%20field%20at%20\(eval%20\d+\)%20line%20(?:196),%20<GEN\d+>%20line%20\d\.\r\n| p/amavisd-new AM.PDP/ v/2.9.0 - 2.10.1/ cpe:/a:ijs:amavisd_new:2/
 match am-pdp m|^setreply=450 4\.5\.0 Failure:%20Missing%20'request'%20field%20at%20\(eval%20\d+\)%20line%20(?:197),%20<GEN\d+>%20line%20\d\.\r\n| p/amavisd-new AM.PDP/ v/2.11.0 - 2.11.1/ cpe:/a:ijs:amavisd_new:2.11/
 
-match amqp m|^AMQP\x00\x00\x09\x01$| p/Advanced Message Queue Protocol/
-match amqp m|^AMQP\x01\x01\x00\x0a$| p/Advanced Message Queue Protocol/
+match amqp m|^AMQP.\x00\x09\x01$| p/Advanced Message Queue Protocol (0-9)/
+match amqp m|^AMQP.\x01\x00\x0a$| p/Advanced Message Queue Protocol (0-10)/
+match amqp m|^AMQP.\x01\x00\x00$| p/Advanced Message Queue Protocol (1.0.0)/
 
 match as2 m|^HTTP/1\.1 404 Not Found\r\nServer: Cleo LexiCom/([\w._-]+) \(([^)]+)\)\r\n| p/Cleo LexiCom AS2/ v/$1/ o/$2/
 

--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -15259,7 +15259,7 @@ match ms-sql-s m|^\x04\x01\x00\x2b\x00\x00\x00\x00\x00\x00\x1a\x00\x06\x01\x00\x
 Probe TCP HELP4STOMP q|HELP\n\n\0|
 rarity 8
 ports 6163,61613
-match stomp m|^ERROR\nmessage:Unknown STOMP action:.+ org\.apache\.activemq\.|s p/Apache ActiveMQ/ cpe:/a:apache:activemq/
+match stomp m|^ERROR\n.+message:Unknown STOMP action:.+ org\.apache\.activemq\.|s p/Apache ActiveMQ Stomp/ cpe:/a:apache:activemq/
 match stomp m|^ERROR\nmessage:Illegal command\ncontent-type:text/plain\nversion:([\d.,]+)\ncontent-length:\d+\n\nYou must log in using CONNECT first\0\n| p/RabbitMQ/ i/versions: $1/ cpe:/a:pivotal_software:rabbitmq/
 
 # The following line matches IPDS (IBM's Intelligent Printer Data Stream) on port 9600

--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -15259,7 +15259,7 @@ match ms-sql-s m|^\x04\x01\x00\x2b\x00\x00\x00\x00\x00\x00\x1a\x00\x06\x01\x00\x
 Probe TCP HELP4STOMP q|HELP\n\n\0|
 rarity 8
 ports 6163,61613
-match stomp m|^ERROR\n.+message:Unknown STOMP action:.+ org\.apache\.activemq\.|s p/Apache ActiveMQ Stomp/ cpe:/a:apache:activemq/
+match stomp m|^ERROR\nmessage:Unknown STOMP action:.+ org\.apache\.activemq\.|s p/Apache ActiveMQ/ cpe:/a:apache:activemq/
 match stomp m|^ERROR\nmessage:Illegal command\ncontent-type:text/plain\nversion:([\d.,]+)\ncontent-length:\d+\n\nYou must log in using CONNECT first\0\n| p/RabbitMQ/ i/versions: $1/ cpe:/a:pivotal_software:rabbitmq/
 
 # The following line matches IPDS (IBM's Intelligent Printer Data Stream) on port 9600


### PR DESCRIPTION
This pull request changes the service probes for the STOMP protocol of "Apache ActiveMQ" to achieve better matches.

My ActiveMQ service returned the message "ERROR\ncontent-type:text/plain\nmessage:Unknown STOMP action: HELP" which was not covered by the original probe because this message contained an additional content-type header.

I also changed the service name from "Apache ActiveMQ" to "Apache ActiveMQ Stomp" to reflect that this service is using the STOMP protocol.