### PR TITLE
http-enum: Add support for Atlassian products

### DIFF
--- a/nselib/data/http-fingerprints.lua
+++ b/nselib/data/http-fingerprints.lua
@@ -12562,6 +12562,148 @@ table.insert(fingerprints, {
     },
   });
 
+-- Atlassian Jira
+table.insert(fingerprints, {
+  category = 'atlassian',
+  probes = {
+    {
+      path = '/rest/applinks/1.0/manifest',
+      method = 'GET'
+    },
+    {
+      path = '/jira/rest/applinks/1.0/manifest',
+      method = 'GET'
+    },
+    {
+      path = '/secure/rest/applinks/1.0/manifest',
+      method = 'GET'
+    },
+  },
+  matches = {
+    {
+      match = '<typeId>jira</typeId>.*<version>([^<]+)</version>',
+      output = 'Atlassian Jira \\1'
+    }
+  },
+});
+
+-- Atlassian Jira Service Desk
+table.insert(fingerprints, {
+  category = 'atlassian',
+  probes = {
+    {
+      path = '/rest/servicedeskapi/info',
+      method = 'GET'
+    },
+    {
+      path = '/jira/rest/servicedeskapi/info',
+      method = 'GET'
+    },
+    {
+      path = '/secure/rest/servicedeskapi/info',
+      method = 'GET'
+    },
+  },
+  matches = {
+    {
+      match = '"version":%s*"([^-"]+)',
+      output = 'Atlassian Jira Service Desk \\1'
+    }
+  },
+});
+
+-- Atlassian Confluence
+table.insert(fingerprints, {
+  category = 'atlassian',
+  probes = {
+    {
+      path = '/rest/applinks/1.0/manifest',
+      method = 'GET'
+    },
+    {
+      path = '/confluence/rest/applinks/1.0/manifest',
+      method = 'GET'
+    },
+    {
+      path = '/wiki/rest/applinks/1.0/manifest',
+      method = 'GET'
+    },
+  },
+  matches = {
+    {
+      match = '<typeId>confluence</typeId>.*<version>([^<]+)</version>',
+      output = 'Atlassian Confluence \\1'
+    }
+  },
+});
+
+-- Atlassian Bitbucket Server
+table.insert(fingerprints, {
+  category = 'atlassian',
+  probes = {
+    {
+      path = '/rest/applinks/1.0/manifest',
+      method = 'GET'
+    },
+    {
+      path = '/bitbucket/rest/applinks/1.0/manifest',
+      method = 'GET'
+    },
+  },
+  matches = {
+    {
+      match = '<typeId>stash</typeId>.*<version>([^<]+)</version>',
+      output = 'Atlassian Bitbucket Server \\1'
+    },
+    {
+      match = '<typeId>bitbucket</typeId>.*<version>([^<]+)</version>',
+      output = 'Atlassian Bitbucket Server \\1'
+    }
+  },
+});
+
+-- Atlassian Bamboo
+table.insert(fingerprints, {
+  category = 'atlassian',
+  probes = {
+    {
+      path = '/rest/applinks/1.0/manifest',
+      method = 'GET'
+    },
+    {
+      path = '/bamboo/rest/applinks/1.0/manifest',
+      method = 'GET'
+    },
+  },
+  matches = {
+    {
+      match = '<typeId>bamboo</typeId>.*<version>([^<]+)</version>',
+      output = 'Atlassian Bamboo \\1'
+    }
+  },
+});
+
+-- Atlassian Crowd
+table.insert(fingerprints, {
+  category = 'atlassian',
+  probes = {
+    {
+      path = '/rest/applinks/1.0/manifest',
+      method = 'GET'
+    },
+    {
+      path = '/crowd/rest/applinks/1.0/manifest',
+      method = 'GET'
+    },
+  },
+  matches = {
+    {
+      match = '<typeId>crowd</typeId>.*<version>([^<]+)</version>',
+      output = 'Atlassian Crowd \\1'
+    }
+  },
+});
+
 local stdnse = require "stdnse"
 local nmap = require "nmap"
 


### PR DESCRIPTION
Atlassian products have an unauthenticated endpoint used to help set up
cross-product linking capabilities that exposes both the product and
version information. The application is often hosted at a server's root
directory or one of several common subdirectories.

This change adds support for the following products to http-enum:

- Atlassian Jira
- Atlassian Jira Service Desk
- Atlassian Confluence
- Atlassian Bitbucket Server
- Atlassian Bamboo
- Atlassian Crowd

```
PORT    STATE SERVICE
443/tcp open  https
| http-enum: 
|   /jira/rest/applinks/1.0/manifest: Atlassian Jira 7.13.5
|_  /jira/rest/servicedeskapi/info: Atlassian Jira Service Desk 3.16.4

PORT    STATE SERVICE
443/tcp open  https
| http-enum: 
|   /rest/applinks/1.0/manifest: Atlassian Confluence 7.0.1-beta2
|_  /crowd/rest/applinks/1.0/manifest: Atlassian Crowd 3.4.4

PORT    STATE SERVICE
443/tcp open  https
| http-enum: 
|_  /rest/applinks/1.0/manifest: Atlassian Bitbucket Server 6.7.0-m6

PORT    STATE SERVICE
443/tcp open  https
| http-enum: 
|_  /crowd/rest/applinks/1.0/manifest: Atlassian Crowd 3.6.0-qr20190821060811

PORT    STATE SERVICE
443/tcp open  https
| http-enum: 
|_  /rest/applinks/1.0/manifest: Atlassian Bamboo 6.10.0-m125
```