### PR TITLE
Increase buffer for nmap arguments when "--resume" a scan

### DIFF
--- a/nmap.cc
+++ b/nmap.cc
@@ -2336,7 +2336,7 @@ int nmap_main(int argc, char *argv[]) {
 int gather_logfile_resumption_state(char *fname, int *myargc, char ***myargv) {
   char *filestr;
   int filelen;
-  char nmap_arg_buffer[1024];
+  char nmap_arg_buffer[1024*128];
   struct in_addr lastip;
   char *p, *q, *found, *lastipstr; /* I love C! */
   /* We mmap it read/write since we will change the last char to a newline if it is not already */


### PR DESCRIPTION
I have a complicated nmap scan with a long list of ports (used both for "-PS", SYN ping, and "-p", SYN port scan).
Here is what happens when I try to resume this scan (using the .nmap or .gnmap files):

> nmap --resume myscan.nmap 
> Unable to parse supposed log file myscan.nmap.  Perhaps the Nmap execution had not finished at least one host?  In that case there is no use "resuming"
> QUITTING!

I found that the issue is that the arguments string length is higher than 1024 which is currently not supported:
https://github.com/nmap/nmap/blob/23ee017b951b299e874f2079103e27e98bcac867/nmap.cc#L2339
https://github.com/nmap/nmap/blob/23ee017b951b299e874f2079103e27e98bcac867/nmap.cc#L2392-L2393

I chose arbitrarily the new value of "1024*128" but it seems large enough while being a reasonable size (131ko). Also based on this, but it is not a definite answer:
https://serverfault.com/a/163390
With the patch I can confirm that my scan can properly resume.

As a side note, I think that the displayed error message has no relation with the issue here.