### PR TITLE
http.lua: fix handling of responses with "content-encoding" but empty body

### DIFF
--- a/nselib/http.lua
+++ b/nselib/http.lua
@@ -940,7 +940,7 @@ local function next_response(s, method, partial, options)
     end
   end
 
-  if response.header["content-encoding"] then
+  if response.header["content-encoding"] and #body > 0 then
     local dcd, undcd
     body, dcd, undcd, err, fragment = decode_body(body, response.header["content-encoding"], maxlen)
     response.body = body or fragment


### PR DESCRIPTION
### Observation
I had an error when running the http-default-accounts script against a web server:
```
NSE: http-default-accounts M:55971b79c158 against redacted:80 threw an error!
/root/tools/nmap/nselib/http.lua:866: attempt to get length of a nil value (local 'newbody')
stack traceback:
	/root/tools/nmap/nselib/http.lua:866: in upvalue 'decode_body'
	/root/tools/nmap/nselib/http.lua:945: in upvalue 'next_response'
	/root/tools/nmap/nselib/http.lua:1355: in function </root/tools/nmap/nselib/http.lua:1328>
	(...tail calls...)
	/root/tools/nmap/nselib/http.lua:1762: in function 'http.get'
	/root/tools/nmap/nselib/http.lua:2604: in function 'http.identify_404'
	/root/tools/nmap/scripts/http-default-accounts.nse:368: in function </root/tools/nmap/scripts/http-default-accounts.nse:359>
	(...tail calls...)

```

### Explanation
The script calls `http.identify_404` and ultimately `http.decode_body` is called.
The HTTP exchange I have (with a legitimate DELL iDRAC...) is:
```
GET /nmaplowercheck1563440512 HTTP/1.1
Connection: close
User-Agent: Mozilla/5.0 (compatible; Nmap Scripting Engine; https://nmap.org/book/nse.html)
Host: redacted

HTTP/1.1 302 Found
Content-Encoding: gzip
Content-Type: text/html
Location: https://redacted:443/Applications/dellUI/login.htm
Content-Length: 0
Connection: close
Date: Thu, 18 Jul 2019 11:01:54 GMT
Server: lighttpd/1.4.23


```

The issue is that the response body is empty while there is `Content-Encoding: gzip`.  `http.decode_body` does not properly handle this.
I could have fixed it in this function but I do not think it makes sense to add a "decoded" body to the HTTP response where the body is empty. Therefore I chose here to skip the decoding part when the body is empty.