### PR TITLE
Fixed undefined behavior in netmask generation #1717

### DIFF
--- a/nbase/nbase_addrset.c
+++ b/nbase/nbase_addrset.c
@@ -500,7 +500,7 @@ static int sockaddr_to_mask (const struct sockaddr *sa, int bits, u32 *mask)
       mask[i] = 0;
     }
     else {
-      mask[i] = ~((1 << (unmasked_bits - (32 * (4 - i)))) - 1);
+      mask[i] = ~(0xffffffff % (1 << unmasked_bits));
     }
   }
   return 1;


### PR DESCRIPTION
Tested this change on x86_64, i586, ppc, ppc64, ppc64le, aarch64 and s390x. Unit tests passed successfully on these architectures.

Also played around with the test binary (addrset) a bit and could not find any obvious problems with the change.