### PR TITLE
Mitigate nil values and change strjoin library

### DIFF
--- a/nselib/msrpc.lua
+++ b/nselib/msrpc.lua
@@ -59,6 +59,7 @@ local os = require "os"
 local smb = require "smb"
 local stdnse = require "stdnse"
 local string = require "string"
+local stringaux = require "stringaux"
 local table = require "table"
 local unicode = require "unicode"
 _ENV = stdnse.module("msrpc", stdnse.seeall)
@@ -2165,7 +2166,7 @@ function lsa_lookupnames2(smbstate, policy_handle, names)
   local result
   local pos, align
 
-  stdnse.debug2("MSRPC: Calling LsarLookupNames2(%s) [%s]", stdnse.strjoin(", ", names), smbstate['ip'])
+  stdnse.debug2("MSRPC: Calling LsarLookupNames2(%s) [%s]", stringaux.strjoin(", ", names), smbstate['ip'])
 
 
   --    [in]     policy_handle *handle,
@@ -2256,7 +2257,7 @@ function lsa_lookupsids2(smbstate, policy_handle, sids)
   local result
   local pos, align
 
-  stdnse.debug2("MSRPC: Calling LsarLookupSids2(%s) [%s]", stdnse.strjoin(", ", sids), smbstate['ip'])
+  stdnse.debug2("MSRPC: Calling LsarLookupSids2(%s) [%s]", stringaux.strjoin(", ", sids), smbstate['ip'])
 
   --    [in]     policy_handle *handle,
   arguments = msrpctypes.marshall_policy_handle(policy_handle)

--- a/nselib/msrpctypes.lua
+++ b/nselib/msrpctypes.lua
@@ -313,6 +313,10 @@ local function unmarshall_ptr(location, data, pos, func, args, result)
   end
   -- If we're unmarshalling the header, then pull off a referent_id.
   if(location == HEAD or location == ALL) then
+
+    -- Make sure pos is defined before doing arithmetics
+    if (pos == nil) then pos = 1 end
+
     if #data - pos + 1 < 4 then
       stdnse.debug1("MSRPC: ERROR: Ran off the end of a packet in unmarshall_ptr(). Please report!")
       return pos, nil
@@ -843,6 +847,9 @@ end
 --@return (pos, int32) The new position, and the value.
 function unmarshall_int32(data, pos)
   local value
+
+  -- Make sure pos is defined before doing arithmetics
+  if (pos == nil) then pos = 1 end
 
   if #data - pos + 1 < 4 then
     stdnse.debug1("MSRPC: ERROR: Ran off the end of a packet in unmarshall_int32(). Please report!")
@@ -1639,6 +1646,8 @@ function marshall_dom_sid2(sid)
   until pos_next == nil
   sid_array['num_auths'] = i - 1
 
+  -- Make sure sid_array.authority is defined before passing it to string.pack
+  if (sid_array.authority == nil) then sid_array.authority = 1 end
   result = {
     -- TODO: Is the first 32-bit integer here supposed to be num_auths, or some
     -- other count value?


### PR DESCRIPTION
The `msrpc.lua` and `msrpctypes.lua` were giving off errors when running the command:
`nmap -Pn -p445 --script smb-brute domain.com -d`.

The errors in the `msrpctypes.lua` script came from the migration from bin.pack and bin.unpack to string.pack and string.unpack. The former accepted `nil` values for as arguments and we did not do any arithmetic to determine whether the data is enough to extract an object. Now, however, we need to manually check whether the data is enough and can no longer pass `nil` values as arguments. The fix just initializes uninitialized variables to 1 which is the default for Lua.

The errros in the `msrpc.lua` script came from the wrong library referencing for the strjoin method used in some internal methods. I managed to find it in the `stringaux` library, not in the `stdnse`.