### PR TITLE
Check if the result is nil before taking its length

### DIFF
--- a/scripts/smb-protocols.nse
+++ b/scripts/smb-protocols.nse
@@ -64,7 +64,7 @@ action = function(host,port)
     output.dialects = supported_dialects
   end
 
-  if #output.dialects>0 then
+  if output.dialects and #output.dialects>0 then
     return output
   else
     stdnse.debug1("No dialects were accepted")


### PR DESCRIPTION
Very minor bug fix to avoid throwing an error at the end of the script if no connections were found.

Mitigates
```
NSE: [smb-protocols 127.0.0.1] SMB: None of the NetBIOS names worked!
NSE: smb-protocols against 127.0.0.1 threw an error!
/usr/bin/../share/nmap/scripts/smb-protocols.nse:67: attempt to get length of a nil value (field 'dialects')
stack traceback:
        /usr/bin/../share/nmap/scripts/smb-protocols.nse:67: in function </usr/bin/../share/nmap/scripts/smb-protocols.nse:53>
```