### PR TITLE
Remove $LANG debug output from macOS zenmap launcher script

### DIFF
--- a/zenmap/install_scripts/macosx/launcher.sh
+++ b/zenmap/install_scripts/macosx/launcher.sh
@@ -41,10 +41,6 @@ if [ -z ${lang+x} ]; then
   export LANG="`echo $lang`.UTF-8"
 fi
 
-echo $LANG > ~/Desktop/tmp.txt
-echo " | " >> ~/Desktop/tmp.txt
-echo $lang >> ~/Desktop/tmp.txt
-
 if test -f "$bundle_lib/charset.alias"; then
     export CHARSETALIASDIR="$bundle_lib"
 fi


### PR DESCRIPTION
I've noticed a `tmp.txt` file appearing on my desktop when running `zenmap`.