### PR TITLE
nping: Add unnumbered interface support for nping.

### DIFF
--- a/libnetutil/netutil.cc
+++ b/libnetutil/netutil.cc
@@ -214,6 +214,8 @@ typedef unsigned __int8 u_int8_t;
 #define PCAP_NETMASK_UNKNOWN 0
 #endif
 
+static int deviceUnnumbered;
+
 /** Print fatal error messages to stderr and then exits. A newline
     character is printed automatically after the supplied text.
  * @warning This function does not return because it calls exit() */
@@ -1532,7 +1534,7 @@ struct interface_info *getInterfaceByName(const char *iname, int af) {
   for (ifnum = 0; ifnum < numifaces; ifnum++) {
     if ((strcmp(ifaces[ifnum].devfullname, iname) == 0 ||
         strcmp(ifaces[ifnum].devname, iname) == 0) &&
-        ifaces[ifnum].addr.ss_family == af)
+        (deviceUnnumbered || ifaces[ifnum].addr.ss_family == af))
       return &ifaces[ifnum];
   }
 
@@ -3520,6 +3522,10 @@ int route_dst(const struct sockaddr_storage *dst, struct route_nfo *rnfo,
 #endif
 }
 
+void set_device_unnumbered(int val)
+{
+    deviceUnnumbered = val;
+}
 /* Wrapper for system function sendto(), which retries a few times when
  * the call fails. It also prints informational messages about the
  * errors encountered. It returns the number of bytes sent or -1 in

--- a/libnetutil/netutil.h
+++ b/libnetutil/netutil.h
@@ -493,6 +493,9 @@ const char *ippackethdrinfo(const u8 *packet, u32 len, int detail);
 int route_dst(const struct sockaddr_storage *dst, struct route_nfo *rnfo,
               const char *device, const struct sockaddr_storage *spoofss);
 
+/* Set device as unnumbered */
+void set_device_unnumbered(int val);
+
 /* Send an IP packet over a raw socket. */
 int send_ip_packet_sd(int sd, const struct sockaddr_in *dst, const u8 *packet, unsigned int packetlen);
 

--- a/nping/ArgParser.cc
+++ b/nping/ArgParser.cc
@@ -299,6 +299,7 @@ int ArgParser::parseArguments(int argc, char *argv[]) {
   {"interface", required_argument, 0, 'e'},
   {"privileged", no_argument, 0, 0},
   {"unprivileged", no_argument, 0, 0},
+  {"unnumbered", no_argument, 0, 0},
   {"send-eth", no_argument, 0, 0},
   {"send-ip", no_argument, 0, 0},
   {"bpf-filter", required_argument, 0, 0},
@@ -951,6 +952,8 @@ int ArgParser::parseArguments(int argc, char *argv[]) {
         o.setIsRoot();
     } else if (strcmp(long_options[option_index].name, "unprivileged") == 0 ){
         o.setIsRoot(0);
+    } else if (strcmp(long_options[option_index].name, "unnumbered") == 0 ){
+        o.setIsUnnumbered(1);
     } else if (strcmp(long_options[option_index].name, "send-eth") == 0 ){
         o.setSendPreference(PACKET_SEND_ETH_STRONG);
     } else if (strcmp(long_options[option_index].name, "send-ip") == 0 ){
@@ -1296,6 +1299,7 @@ void ArgParser::printUsage(void){
 "  -N, --no-capture                 : Do not try to capture replies.\n"
 "  --privileged                     : Assume user is fully privileged.\n"
 "  --unprivileged                   : Assume user lacks raw socket privileges.\n"
+"  --unnumbered                     : Allow unnumbered interface.\n"
 "  --send-eth                       : Send packets at the raw Ethernet layer.\n"
 "  --send-ip                        : Send packets using raw IP sockets.\n"
 "  --bpf-filter <filter spec>       : Specify custom BPF filter.\n"

--- a/nping/NpingOps.cc
+++ b/nping/NpingOps.cc
@@ -1013,6 +1013,33 @@ int NpingOps::setPayloadType(int t){
   return OP_SUCCESS;
 } /* End of setPayloadType() */
 
+/******************************************************************************
+ *  Unnumbered interface                                                      *
+ ******************************************************************************/
+
+/** Sets value of attribute isunnum.
+ *  @returns previous isunnum value */
+int NpingOps::setIsUnnumbered(int v) {
+  int prev=this->isunnum;
+  this->isunnum = (v==0) ? 0 : 1;
+  return prev;
+} /* End of setIsUnnumbered() */
+
+
+/** Sets attribute isunnum to value 0.
+ *  @returns previous isunnum value */
+int NpingOps::setIsUnnumbered() {
+  int prev=this->isunnum;
+  this->isunnum=0;
+ return prev;
+} /* End of setIsUnnumbered() */
+
+
+/* Returns the state of attribute isunnum */
+bool NpingOps::isUnnumbered() {
+  return (this->isunnum);
+} /* End of isUnnumbered() */
+
 
 /** Returns value of attribute payload_type */
 int NpingOps::getPayloadType(){

--- a/nping/NpingOps.h
+++ b/nping/NpingOps.h
@@ -226,6 +226,9 @@ class NpingOps {
     /* Privileges */
     bool isr00t;              /* True if current user has root privs   */
 
+    /* Unnumbered */
+    bool isunnum;             /* True if interface is unumbered        */
+
     /* Payloads */
     int payload_type;         /* Type of payload (RAND,HEX,FILE)       */
     bool payload_type_set;
@@ -453,6 +456,11 @@ class NpingOps {
     int setIsRoot(int v);
     int setIsRoot();
     bool isRoot();
+
+    /* Unnumbered */
+    int setIsUnnumbered(int v);
+    int setIsUnnumbered();
+    bool isUnnumbered();
 
     /* Payloads */
     int setPayloadType(int t);

--- a/nping/NpingTargets.cc
+++ b/nping/NpingTargets.cc
@@ -313,6 +313,9 @@ int NpingTargets::processSpecs(){
       /* Get all the information needed to send packets to this target.
 	   * (Only in case we are not in unprivileged modes) */
 		if(o.getMode()!=TCP_CONNECT && o.getMode()!=UDP_UNPRIV){
+                  /* allow unnumbered device lookup for --unnumbered option*/
+                  if(o.isUnnumbered())
+                      set_device_unnumbered(1);
 		  result=route_dst( &ss, &rnfo, o.getDevice(), NULL );
 		  if(result==false){
 			nping_warning(QT_2, "Failed to determine route to host %s. Skipping it...", mytarget->getTargetIPstr() );

--- a/nping/docs/nping-usage.txt
+++ b/nping/docs/nping-usage.txt
@@ -96,6 +96,7 @@ MISC:
   -N, --no-capture                 : Do not try to capture replies.
   --privileged                     : Assume user is fully privileged.
   --unprivileged                   : Assume user lacks raw socket privileges.
+  --unnumbered                     : Allow unnumbered interface.
   --send-eth                       : Send packets at the raw ethernet layer.
   --send-ip                        : Send packets using raw IP sockets.
   --bpf-filter <filter spec>       : Specify custom BPF filter.


### PR DESCRIPTION
https://github.com/nmap/nmap/issues/1792

This is done via a new option called --unnumbered.
This will bypass address-family check in libnetutil.

The source address is obtained by user level program hooked to kernel.

[vm5:/]$ ip netns exec vrf.1 nping 172.16.255.112

Starting Nping 0.7.12 ( https://nmap.org/nping ) at 2019-10-31 11:04 UTC
Could not find interface lfts which was specified by -e

[vm5:/]$ ip netns exec vrf.1 nping --unnumbered 172.16.255.112

Starting Nping 0.7.12 ( https://nmap.org/nping ) at 2019-10-31 11:04 UTC
SENT (0.0207s) ICMP [10.20.24.15 > 172.16.255.112 Echo request (type=8/code=0) id=57351 seq=1] IP [ttl=64 id=54572 iplen=28 ]
RCVD (0.2162s) ICMP [172.16.255.112 > 10.20.24.15 Echo reply (type=0/code=0) id=57351 seq=1] IP [ttl=254 id=54572 iplen=28 ]
SENT (1.0210s) ICMP [10.20.24.15 > 172.16.255.112 Echo request (type=8/code=0) id=57351 seq=3] IP [ttl=64 id=54572 iplen=28 ]
RCVD (1.0482s) ICMP [172.16.255.112 > 10.20.24.15 Echo reply (type=0/code=0) id=57351 seq=3] IP [ttl=254 id=54572 iplen=28 ]
^C
Max rtt: 195.331ms | Min rtt: 27.200ms | Avg rtt: 111.265ms
Raw packets sent: 2 (56B) | Rcvd: 2 (56B) | Lost: 0 (0.00%)
Nping done: 1 IP address pinged in 1.39 seconds

[vm5:/]$ ip netns exec vrf.1 nping -help | grep unnumbered
  --unnumbered                     : Allow unnumbered interface.

[vm5:/]$ ip netns exec vrf.1 ifconfig
lfts      Link encap:Ethernet  HWaddr 00:00:00:00:00:00
          inet6 addr: fe80::200:ff:fe00:0/64 Scope:Link
          UP BROADCAST RUNNING NOARP MULTICAST  MTU:1500  Metric:1
          RX packets:22 errors:0 dropped:0 overruns:0 frame:0
          TX packets:45 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000
          RX bytes:756 (756.0 B)  TX bytes:2700 (2.6 KiB)