### PR TITLE
scripts: ssl-enum-ciphers cap weak ciphers (2009p)

### DIFF
--- a/scripts/ssl-enum-ciphers.nse
+++ b/scripts/ssl-enum-ciphers.nse
@@ -767,11 +767,18 @@ local function find_ciphers_group(host, port, protocol, group, scores)
                 end
               end
             end
+            local letter_grade = letter_grade(score_cipher(kex_strength, info))
+            -- Cap to B if not using Forward Secrecy or AEAD (Changes in 2009p)
+            if letter_grade == "A" then
+              if not kex.pfs or info.mode == "CBC" then
+                letter_grade = "B"
+              end
+            end
             scores[name] = {
               cipher_strength=info.size,
               kex_strength = kex_strength,
               extra = extra,
-              letter_grade = letter_grade(score_cipher(kex_strength, info))
+              letter_grade = letter_grade
             }
           end
         end


### PR DESCRIPTION
From https://github.com/ssllabs/research/wiki/SSL-Server-Rating-Guide#changes-in-2009p-1-march-2018---6-september-2018

* Cap to B if Forward Secrecy is not supported.
* Cap to B if Authenticated encryption (AEAD) ciphers not supported.