### PR TITLE
Add a Profinet DCP device discovery script

### DIFF
--- a/scripts/broadcast-pndcp-discovery.nse
+++ b/scripts/broadcast-pndcp-discovery.nse
@@ -25,6 +25,45 @@ results in a spread of the answers the devices on the network will send out.
 The script needs to be run as a privileged user, typically root.
 ]]
 
+---
+-- @usage
+-- nmap -e <interface> --script=broadcast-pndcp-discovery 
+--
+-- @output
+-- Pre-scan script results:
+-- | broadcast-pndcp-discovery: 
+-- |   00:30:de:40:29:c7 (Wago Kontakttechnik Gmbh): 
+-- |     Interface: enp8s0
+-- |     IP: 
+-- |       IP Info: IP set
+-- |       IP: 192.168.1.8
+-- |       Netmask: 255.255.255.0
+-- |       Gateway: 192.168.1.1
+-- |     Device: 
+-- |       Name of Station: wago-750-375
+-- |       Device manufacturer: WAGO-I/O-SYSTEM 750/753
+-- |       Vendor ID: 0x011d
+-- |       Device ID: 0x0005
+-- |       Device Role: 0x01 (IO-Device)
+-- |   00:01:05:2d:82:5f (Beckhoff Automation GmbH): 
+-- |     Interface: enp8s0
+-- |     IP: 
+-- |       IP Info: IP set
+-- |       IP: 192.168.1.1
+-- |       Netmask: 255.255.255.0
+-- |       Gateway: 192.168.1.1
+-- |     Device: 
+-- |       Device manufacturer: TwinCAT PNIO Controller
+-- |       Name of Station: tc-pncontroller
+-- |       Vendor ID: 0x0120
+-- |       Device ID: 0x0005
+-- |_      Device Role: 0x02 (IO-Controller)
+--
+
+author = "Andreas Galauner"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"discovery", "safe", "broadcast"}
+
 prerule = function()
   if ( not(nmap.is_privileged()) ) then
     stdnse.verbose1("not running due to lack of privileges.")
@@ -32,10 +71,6 @@ prerule = function()
   end
   return true
 end
-
-author = "Andreas Galauner"
-license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
-categories = {"discovery", "safe", "broadcast"}
 
 ETHER_TYPE_8021Q = 0x8100
 

--- a/scripts/broadcast-pndcp-discovery.nse
+++ b/scripts/broadcast-pndcp-discovery.nse
@@ -17,7 +17,7 @@ can contain the station name, vendor information and IP address configuration.
 Please note that this script is not 100% feature complete as not all my
 devices in my lab support all of the possible options.
 
-In order to prevent flodding of you production network, you can set the timeout
+In order to prevent flooding of your production network, you can set the timeout
 value of this script to a higher value. The responseDelay field in the DCP
 identify request frame will be calculated according to the specification. This
 results in a spread of the answers the devices on the network will send out.

--- a/scripts/broadcast-pndcp-discovery.nse
+++ b/scripts/broadcast-pndcp-discovery.nse
@@ -33,31 +33,50 @@ The script needs to be run as a privileged user, typically root.
 -- Pre-scan script results:
 -- | broadcast-pndcp-discovery:
 -- |   00:30:de:40:29:c7 (Wago Kontakttechnik Gmbh):
--- |     Interface: enp8s0
+-- |     Interface: enp11s0f0.20
 -- |     IP:
 -- |       IP Info: IP set
--- |       IP: 192.168.1.8
+-- |       IP: 192.168.20.101
 -- |       Netmask: 255.255.255.0
--- |       Gateway: 192.168.1.1
+-- |       Gateway: 192.168.20.101
 -- |     Device:
 -- |       Name of Station: wago-750-375
--- |       Device manufacturer: WAGO-I/O-SYSTEM 750/753
 -- |       Vendor ID: 0x011d
--- |       Device ID: 0x0005
+-- |       Device ID: 0x02ee
+-- |       Device manufacturer: WAGO-I/O-SYSTEM 750/753
 -- |       Device Role: 0x01 (IO-Device)
--- |   00:01:05:2d:82:5f (Beckhoff Automation GmbH):
--- |     Interface: enp8s0
+-- |   e0:dc:a0:62:57:83 (Siemens Industrial Automation Products Chengdu):
+-- |     Interface: enp11s0f0.20
 -- |     IP:
 -- |       IP Info: IP set
--- |       IP: 192.168.1.1
+-- |       IP: 192.168.20.100
 -- |       Netmask: 255.255.255.0
--- |       Gateway: 192.168.1.1
+-- |       Gateway: 0.0.0.0
 -- |     Device:
--- |       Device manufacturer: TwinCAT PNIO Controller
--- |       Name of Station: tc-pncontroller
+-- |       Device manufacturer: S7-1200
+-- |       Name of Station: plc
+-- |       Vendor ID: 0x002a
+-- |       Device ID: 0x010d
+-- |       Device Role: 0x02 (IO-Controller)
+-- |       Device Instance High: 0x00
+-- |       Device Instance Low: 0x64
+-- |   00:01:05:3c:94:16 (Beckhoff Automation GmbH):
+-- |     Interface: enp11s0f0.20
+-- |     IP:
+-- |       IP Info: IP set
+-- |       IP: 192.168.20.102
+-- |       Netmask: 255.255.255.0
+-- |       Gateway: 192.168.20.102
+-- |     Device:
 -- |       Vendor ID: 0x0120
--- |       Device ID: 0x0005
--- |_      Device Role: 0x02 (IO-Controller)
+-- |       Device ID: 0x0021
+-- |       Device manufacturer: TwinCAT Profinet I/O
+-- |       Name of Station: cx5140
+-- |       Device Instance High: 0x00
+-- |       Device Instance Low: 0x00
+-- |       Device Role: 0x01 (IO-Device)
+-- |       OEM Vendor ID: 0x0120
+-- |_      OEM Device ID: 0x0021
 --
 
 author = "Andreas Galauner"

--- a/scripts/broadcast-pndcp-discovery.nse
+++ b/scripts/broadcast-pndcp-discovery.nse
@@ -1,0 +1,410 @@
+local nmap = require "nmap"
+local stdnse = require "stdnse"
+local table = require "table"
+local packet = require "packet"
+local datafiles = require "datafiles"
+local coroutine = require "coroutine"
+local string = require "string"
+local ipOps = require "ipOps"
+local target = require "target"
+
+description = [[
+Sends a DCP identify request to the Profinet DCP identification MAC address
+01:0e:cf:00:00:00 and reports the resulsts.
+The script displays information about the responding Profinet devices which
+can contain the station name, vendor information and IP address configuration.
+
+Please note that this script is not 100% feature complete as not all my
+devices in my lab support all of the possible options.
+
+In order to prevent flodding of you production network, you can set the timeout
+value of this script to a higher value. The responseDelay field in the DCP
+identify request frame will be calculated according to the specification. This
+results in a spread of the answers the devices on the network will send out.
+
+The script needs to be run as a privileged user, typically root.
+]]
+
+prerule = function()
+  if ( not(nmap.is_privileged()) ) then
+    stdnse.verbose1("not running due to lack of privileges.")
+    return false
+  end
+  return true
+end
+
+author = "Andreas Galauner"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"discovery", "safe", "broadcast"}
+
+ETHER_TYPE_8021Q = 0x8100
+
+PNDCP_OPTION_IP                         = 0x01
+PNDCP_OPTION_DEVICE                     = 0x02
+PNDCP_OPTION_DHCP                       = 0x03
+-- NOTE: The following two options are used to perform actions in
+-- the device using a Set request, we don't do that
+-- PNDCP_OPTION_CONTROL                    = 0x05
+-- PNDCP_OPTION_DEVICEINITIATIVE           = 0x06
+
+PNDCP_SUBOPTION_IP_MAC                  = 0x01
+PNDCP_SUBOPTION_IP_IP                   = 0x02
+
+-- DIN/EN 61158-5-10 6.3.1.3.1 (IP Info)
+PNDCP_SUBOPTION_IP_IP_IPINFO_NOTSET           = 0x00
+PNDCP_SUBOPTION_IP_IP_IPINFO_SET              = 0x01
+PNDCP_SUBOPTION_IP_IP_IPINFO_SETDHCP          = 0x02
+PNDCP_SUBOPTION_IP_IP_IPINFO_NOTSET_CONFLICT  = 0x80
+PNDCP_SUBOPTION_IP_IP_IPINFO_SET_CONFLICT     = 0x81
+PNDCP_SUBOPTION_IP_IP_IPINFO_SETDHCP_CONFLICT = 0x82
+
+PNDCP_SUBOPTION_DEVICE_MANUF            = 0x01
+PNDCP_SUBOPTION_DEVICE_NAMEOFSTATION    = 0x02
+PNDCP_SUBOPTION_DEVICE_DEV_ID           = 0x03
+PNDCP_SUBOPTION_DEVICE_DEV_ROLE         = 0x04
+PNDCP_SUBOPTION_DEVICE_DEV_OPTIONS      = 0x05
+PNDCP_SUBOPTION_DEVICE_ALIAS_NAME       = 0x06
+PNDCP_SUBOPTION_DEVICE_DEV_INSTANCE     = 0x07
+PNDCP_SUBOPTION_DEVICE_OEM_DEV_ID       = 0x08
+
+PNDCP_DEVICE_ROLES = {
+  [0x01] = "IO-Device",
+  [0x02] = "IO-Controller",
+  [0x04] = "IO-Multidevice",
+  [0x08] = "PN-Supervisor",
+}
+
+PNDCP_IP_INFO = {
+  [0x00] = "No IP set",
+  [0x01] = "IP set",
+  [0x02] = "IP set via DHCP",
+  [0x80] = "No IP set (address conflict detected)",
+  [0x81] = "IP set (address conflict detected)",
+  [0x82] = "IP set via DHCP (address conflict detected)",
+}
+
+-- Converts a 6 byte string into the familiar MAC address formatting
+--
+-- @param mac string containing the MAC address
+-- @return formatted string suitable for printing
+function get_mac_addr(mac)
+  local catch = function() return end
+  local try = nmap.new_try(catch)
+  local mac_prefixes = try(datafiles.parse_mac_prefixes())
+
+  if mac:len() ~= 6 then
+    return "Unknown"
+  else
+    local prefix = string.upper(string.format("%02x%02x%02x", mac:byte(1), mac:byte(2), mac:byte(3)))
+    local manuf = mac_prefixes[prefix] or "Unknown"
+    return string.format("%s (%s)", stdnse.format_mac(mac:sub(1,6)), manuf )
+  end
+end
+
+-- Parses a DCP block in a DCP identify response
+-- This function parses a single DCP block and returns the option, suboption, block length, data and position where the next block should be parsed
+--
+-- @param suboption message the raw message to be parsed
+-- @param suboption the position in the message where the parsing should start
+-- @return the option, suboption, block length, data of the parsed block and position where the next block should be parsed
+local parseBlock = function(message, pos)
+  local dcp_block_format = ">B B I2"
+
+  if #message - pos + 1 < string.packsize(dcp_block_format) then
+    return nil, "Message too short for DCP block"
+  end
+
+  local option, suboption, blocklen, pos = string.unpack(dcp_block_format, message, pos)
+  local blockdata = string.sub(message, pos, pos + blocklen - 1)
+  pos = pos + blocklen
+
+  -- skip padding byte - blocks always need to be aligned to 2 bytes
+  -- minus 1 because lua 1-indexes arrays and strings
+  if ((pos - 1) & 1) == 1 then
+    pos = pos + 1
+  end
+
+  return option, suboption, blocklen, blockdata, pos
+end
+
+-- Parses a DCP IP block suboption in a DCP identify response
+--
+-- @param suboption type of the suboption
+-- @param block the raw block data to parse
+-- @param results A resulsts table to be filled with the parsed data
+local pndcpParseIpBlock = function(suboption, block, results)
+  stdnse.debug1("Parsing IP block: Suboption: %u, Data: %s", suboption, stdnse.tohex(blockdata))
+
+  -- FIXME: PNDCP_SUBOPTION_IP_MAC parsing is untested, none of my devices report this
+  if suboption == PNDCP_SUBOPTION_IP_MAC then
+    local dcp_suboption_ip_mac_format = ">xx c6"
+    if #block >= string.packsize(dcp_suboption_ip_mac_format) then
+      macaddr = string.unpack(dcp_suboption_ip_mac_format, block)
+      results["MAC address"] = get_mac_addr(macaddr)
+    end
+
+  elseif suboption == PNDCP_SUBOPTION_IP_IP then
+    local dcp_suboption_ip_ip_format = ">I2 I4 I4 I4"
+    if #block >= string.packsize(dcp_suboption_ip_ip_format) then
+      block_info, ip, netmask, gateway = string.unpack(dcp_suboption_ip_ip_format, block)
+      ip = ipOps.fromdword(ip)
+
+      results["IP Info"] = PNDCP_IP_INFO[block_info]
+      results["IP"] = ip
+      results["Netmask"] = ipOps.fromdword(netmask)
+      results["Gateway"] = ipOps.fromdword(gateway)
+
+      -- Add new target if desired and if IP address looks valid
+      if target.ALLOW_NEW_TARGETS and ip ~= "0.0.0.0" then
+        target.add(ip)
+      end
+    end
+  end
+end
+
+-- Parses a DCP Device block suboption in a DCP identify response
+--
+-- @param suboption type of the suboption
+-- @param block the raw block data to parse
+-- @param results A resulsts table to be filled with the parsed data
+local pndcpParseDeviceBlock = function(suboption, block, results)
+  stdnse.debug1("Parsing device block: Suboption: %u, Data: %s", suboption, stdnse.tohex(blockdata))
+
+  if suboption == PNDCP_SUBOPTION_DEVICE_MANUF then
+    results["Device manufacturer"] = string.sub(block, 3)
+
+  elseif suboption == PNDCP_SUBOPTION_DEVICE_NAMEOFSTATION then
+    results["Name of Station"] = string.sub(block, 3)
+
+  elseif suboption == PNDCP_SUBOPTION_DEVICE_DEV_ID then
+    local dcp_suboption_device_id_format = ">x x I2"
+    if #block >= string.packsize(dcp_suboption_device_id_format) then
+      vendor_id, device_id = string.unpack(dcp_suboption_device_id_format, block)
+      results["Vendor ID"] = ("0x%04x"):format(vendor_id)
+      results["Device ID"] = ("0x%04x"):format(device_id)
+    end
+
+  elseif suboption == PNDCP_SUBOPTION_DEVICE_DEV_ROLE then
+    local dcp_suboption_device_role_format = ">x x B x"
+    if #block >= string.packsize(dcp_suboption_device_role_format) then
+      device_role = string.unpack(dcp_suboption_device_role_format, block)
+
+      device_role_strings = {}
+      if device_role == 0x00 then
+        table.insert(device_role_strings, "None")
+      end
+
+      for flag, name in pairs(PNDCP_DEVICE_ROLES) do
+        if device_role & flag ~= 0 then
+          table.insert(device_role_strings, name)
+        end
+      end
+
+      results["Device Role"] = ("0x%02x (%s)"):format(device_role, table.concat(device_role_strings, ", "))
+    end
+
+  -- NOTE: Contains a list what options/suboptions the device supports,
+  -- no need to parse this explicitly, I think
+  elseif suboption == PNDCP_SUBOPTION_DEVICE_DEV_OPTIONS then
+
+  -- FIXME: I didn't see the following suboptions on any of my devices,
+  -- so I'm not parsing them here as I can't test it
+  elseif suboption == PNDCP_SUBOPTION_DEVICE_ALIAS_NAME then
+  elseif suboption == PNDCP_SUBOPTION_DEVICE_DEV_INSTANCE then
+  elseif suboption == PNDCP_SUBOPTION_DEVICE_OEM_DEV_ID then
+  end
+end
+
+-- FIXME: believe it or not, but none of my devices support DHCP, so I can't test this
+-- -- Parses a DCP DHCP block suboption in a DCP identify response
+-- --
+-- -- @param suboption type of the suboption
+-- -- @param block the raw block data to parse
+-- -- @param results A resulsts table to be filled with the parsed data
+-- local pndcpParseDhcpBlock = function(suboption, block, results)
+-- end
+
+-- Listens for Profinet DCP Identify response packets.
+-- @param interface Interface to listen on.
+-- @param timeout Amount of time to listen for.
+-- @param responses table to put valid responses into.
+local pndcpListener = function(interface, timeout, responses)
+  local condvar = nmap.condvar(responses)
+  local start = nmap.clock_ms()
+  local listener = nmap.new_socket()
+  local status, len, l2data, l3data, _
+  listener:set_timeout(100)
+  listener:pcap_open(interface.device, 1500, false, 'ether proto 0x8892 or (vlan and ether proto 0x8892)')
+
+  stdnse.debug1("Listener started")
+
+  while (nmap.clock_ms() - start) < timeout do
+    status, len, l2data, l3data = listener:pcap_receive()
+    if status then
+      local f = packet.Frame:new(l2data)
+
+      -- check ethertype in l2data to see if the DCP frame is VLAN tagged
+      -- if that's the case, drop the VLAN header from the l3data
+      local dcp_frame = ""
+      if f.ether_type == ETHER_TYPE_8021Q then
+        dcp_frame = string.sub(l3data, 5)
+      else
+        dcp_frame = l3data
+      end
+
+      -- parse the DCP frame
+      local dcp_header_format = ">I2 B B I4 x x I2"
+      if #dcp_frame >= string.packsize(dcp_header_format) then
+        frame_id, service_id, service_type, xid, dcp_datalen, pos = string.unpack(dcp_header_format, dcp_frame)
+
+        -- Profinet DCP frames need to have an appropriate Frame ID
+        if frame_id >= 0xfefc and frame_id <= 0xfeff then
+          stdnse.debug1("Received DCP frame - Service ID: %u, Service Type: %u, XID: %u, Datalen: %u", service_id, service_type, xid, dcp_datalen)
+
+          -- check if the Profinet Frame ID is 0xfeff = PN DCP Identify response
+          -- Service ID needs to be 5 = Identify
+          -- Service Type needs to be 1 = Response Success
+          if frame_id == 0xfeff and service_id == 5 and service_type == 1 then
+            stdnse.debug1("DCP Frame seems to be an Identify Response Success")
+
+            local identify_response = stdnse.output_table()
+            identify_response.Interface = interface.device
+
+            identify_response.IP = stdnse.output_table()
+            identify_response.Device = stdnse.output_table()
+            -- FIXME: believe it or not, but none of my devices support DHCP, so I can't test this
+            --identify_response.DHCP = stdnse.output_table()
+
+            while pos < #dcp_frame do
+              local block_pos = pos
+              option, suboption, blocklen, blockdata, pos = parseBlock(dcp_frame, block_pos)
+
+              if not option then
+                stdnse.debug1("Error while parsing DCP blocks: %s", suboption)
+                break
+              end
+
+              stdnse.debug1("Parsed DCP block info: Postion: %u, Option: %u, Suboption: %u, Blocklen: %u, Data: %s, Next position: %u", block_pos, option, suboption, blocklen, stdnse.tohex(blockdata), pos)
+
+              if option == PNDCP_OPTION_IP then
+                pndcpParseIpBlock(suboption, blockdata, identify_response.IP)
+
+              elseif option == PNDCP_OPTION_DEVICE then
+                pndcpParseDeviceBlock(suboption, blockdata, identify_response.Device)
+
+              -- FIXME: believe it or not, but none of my devices support DHCP, so I can't test this
+              -- elseif option == PNDCP_OPTION_DHCP then
+              --   pndcpParseDhcpBlock(suboption, blockdata, identify_response.DHCP)
+
+              else
+                stdnse.debug1("Encountered unknown DCP block: Postion: %u, Option: %u, Suboption: %u, Blocklen: %u, Data: %s, Next position: %u", block_pos, option, suboption, blocklen, stdnse.tohex(blockdata), pos)
+              end
+
+            end
+
+            responses[get_mac_addr(f.mac_src)] = identify_response
+          end
+        end
+      end
+    end
+  end
+  condvar("signal")
+end
+
+-- Sends a Profinet DCP identify request.
+-- @param interface Network interface to send on.
+local pndcpIdentify = function(interface, responseDelay)
+  local sock = nmap.new_dnet()
+  sock:ethernet_open(interface.device)
+
+  -- Wait for the listener threads to start up and open the receiving socket
+  stdnse.sleep(0.1)
+
+  -- Build DCP probe
+  local pn_dcp_identify = string.pack(">I2 B B I4 I2 I2 B B I2",
+    0xfefe,     -- Frame ID
+    0x05,       -- Service ID: 5 = Identify
+    0x00,       -- Service Type: 0 = Request
+    0x00000001, -- Xid (transaction ID): 1
+    responseDelay, -- Response delay
+    0x0004,     -- DCP Data length (length of following data)
+
+    0xff,       -- Option: 0xff = all
+    0xff,       -- Suboption: 0xff = all
+    0x0000      -- Length of following block data: 0
+  )
+
+  -- Build probe ethernet frame
+  local probe = packet.Frame:new()
+  probe.mac_src = interface.mac
+  probe.mac_dst = packet.mactobin("01:0e:cf:00:00:00")
+  probe.ether_type = string.pack(">I2", 0x8892)
+  probe.buf = tostring(pn_dcp_identify)
+  probe:build_ether_frame()
+
+  sock:ethernet_send(probe.frame_buf)
+  sock:ethernet_close()
+end
+
+
+action = function(host, port)
+  local responses, interfaces, lthreads = {}, {}, {}
+
+  local timeout = stdnse.parse_timespec(stdnse.get_script_args(SCRIPT_NAME .. ".timeout"))
+  local interface = stdnse.get_script_args(SCRIPT_NAME .. ".interface")
+
+  -- Calculate response delay values as per spec
+  -- See DIN/EN 61158-6-10 chapter 4.3.1.3.5
+  timeout = (timeout or 1)
+  responseDelay = (timeout - 1) * 100
+
+  -- clamp the response delay to allowed values per spec
+  if responseDelay <= 0 then
+    responseDelay = 1
+  elseif responseDelay > 6400 then
+    responseDelay = 6400
+  end
+
+  -- Check the interface
+  interface = interface or nmap.get_interface()
+  if interface then
+    -- Get the interface information
+    interface = nmap.get_interface_info(interface)
+    if not interface then
+      return stdnse.format_output(false, ("Failed to retrieve %s interface information."):format(interface))
+    end
+    interfaces = {interface}
+    stdnse.debug1("Will use %s interface.", interface.shortname)
+  else
+    local ifacelist = nmap.list_interfaces()
+    for _, iface in ipairs(ifacelist) do
+      -- Match all ethernet interfaces
+      if iface.address and iface.link == "ethernet" and
+        iface.address:match("%d+%.%d+%.%d+%.%d+") then
+
+        stdnse.debug1("Will use %s interface.", iface.shortname)
+        table.insert(interfaces, iface)
+      end
+    end
+  end
+
+  -- We should iterate over interfaces
+  for _, interface in pairs(interfaces) do
+    local co = stdnse.new_thread(pndcpListener, interface, timeout * 1000, responses)
+    pndcpIdentify(interface, responseDelay)
+    lthreads[co] = true
+  end
+
+  local condvar = nmap.condvar(responses)
+  -- Wait for the listening threads to finish
+  repeat
+    for thread in pairs(lthreads) do
+      if coroutine.status(thread) == "dead" then lthreads[thread] = nil end
+    end
+    if ( next(lthreads) ) then
+      condvar("wait")
+    end
+  until next(lthreads) == nil;
+
+  return responses
+end

--- a/scripts/broadcast-pndcp-discovery.nse
+++ b/scripts/broadcast-pndcp-discovery.nse
@@ -27,32 +27,32 @@ The script needs to be run as a privileged user, typically root.
 
 ---
 -- @usage
--- nmap -e <interface> --script=broadcast-pndcp-discovery 
+-- nmap -e <interface> --script=broadcast-pndcp-discovery
 --
 -- @output
 -- Pre-scan script results:
--- | broadcast-pndcp-discovery: 
--- |   00:30:de:40:29:c7 (Wago Kontakttechnik Gmbh): 
+-- | broadcast-pndcp-discovery:
+-- |   00:30:de:40:29:c7 (Wago Kontakttechnik Gmbh):
 -- |     Interface: enp8s0
--- |     IP: 
+-- |     IP:
 -- |       IP Info: IP set
 -- |       IP: 192.168.1.8
 -- |       Netmask: 255.255.255.0
 -- |       Gateway: 192.168.1.1
--- |     Device: 
+-- |     Device:
 -- |       Name of Station: wago-750-375
 -- |       Device manufacturer: WAGO-I/O-SYSTEM 750/753
 -- |       Vendor ID: 0x011d
 -- |       Device ID: 0x0005
 -- |       Device Role: 0x01 (IO-Device)
--- |   00:01:05:2d:82:5f (Beckhoff Automation GmbH): 
+-- |   00:01:05:2d:82:5f (Beckhoff Automation GmbH):
 -- |     Interface: enp8s0
--- |     IP: 
+-- |     IP:
 -- |       IP Info: IP set
 -- |       IP: 192.168.1.1
 -- |       Netmask: 255.255.255.0
 -- |       Gateway: 192.168.1.1
--- |     Device: 
+-- |     Device:
 -- |       Device manufacturer: TwinCAT PNIO Controller
 -- |       Name of Station: tc-pncontroller
 -- |       Vendor ID: 0x0120
@@ -72,50 +72,50 @@ prerule = function()
   return true
 end
 
-ETHER_TYPE_8021Q = 0x8100
+local ETHER_TYPE_8021Q = 0x8100
 
-PNDCP_OPTION_IP                         = 0x01
-PNDCP_OPTION_DEVICE                     = 0x02
-PNDCP_OPTION_DHCP                       = 0x03
+local PNDCP_OPTION_IP                         = 0x01
+local PNDCP_OPTION_DEVICE                     = 0x02
+local PNDCP_OPTION_DHCP                       = 0x03
 -- NOTE: The following two options are used to perform actions in
 -- the device using a Set request, we don't do that
--- PNDCP_OPTION_CONTROL                    = 0x05
--- PNDCP_OPTION_DEVICEINITIATIVE           = 0x06
+-- local PNDCP_OPTION_CONTROL                    = 0x05
+-- local PNDCP_OPTION_DEVICEINITIATIVE           = 0x06
 
-PNDCP_SUBOPTION_IP_MAC                  = 0x01
-PNDCP_SUBOPTION_IP_IP                   = 0x02
+local PNDCP_SUBOPTION_IP_MAC                  = 0x01
+local PNDCP_SUBOPTION_IP_IP                   = 0x02
 
 -- DIN/EN 61158-5-10 6.3.1.3.1 (IP Info)
-PNDCP_SUBOPTION_IP_IP_IPINFO_NOTSET           = 0x00
-PNDCP_SUBOPTION_IP_IP_IPINFO_SET              = 0x01
-PNDCP_SUBOPTION_IP_IP_IPINFO_SETDHCP          = 0x02
-PNDCP_SUBOPTION_IP_IP_IPINFO_NOTSET_CONFLICT  = 0x80
-PNDCP_SUBOPTION_IP_IP_IPINFO_SET_CONFLICT     = 0x81
-PNDCP_SUBOPTION_IP_IP_IPINFO_SETDHCP_CONFLICT = 0x82
+local PNDCP_SUBOPTION_IP_IP_IPINFO_NOTSET           = 0x00
+local PNDCP_SUBOPTION_IP_IP_IPINFO_SET              = 0x01
+local PNDCP_SUBOPTION_IP_IP_IPINFO_SETDHCP          = 0x02
+local PNDCP_SUBOPTION_IP_IP_IPINFO_NOTSET_CONFLICT  = 0x80
+local PNDCP_SUBOPTION_IP_IP_IPINFO_SET_CONFLICT     = 0x81
+local PNDCP_SUBOPTION_IP_IP_IPINFO_SETDHCP_CONFLICT = 0x82
 
-PNDCP_SUBOPTION_DEVICE_MANUF            = 0x01
-PNDCP_SUBOPTION_DEVICE_NAMEOFSTATION    = 0x02
-PNDCP_SUBOPTION_DEVICE_DEV_ID           = 0x03
-PNDCP_SUBOPTION_DEVICE_DEV_ROLE         = 0x04
-PNDCP_SUBOPTION_DEVICE_DEV_OPTIONS      = 0x05
-PNDCP_SUBOPTION_DEVICE_ALIAS_NAME       = 0x06
-PNDCP_SUBOPTION_DEVICE_DEV_INSTANCE     = 0x07
-PNDCP_SUBOPTION_DEVICE_OEM_DEV_ID       = 0x08
+local PNDCP_SUBOPTION_DEVICE_MANUF            = 0x01
+local PNDCP_SUBOPTION_DEVICE_NAMEOFSTATION    = 0x02
+local PNDCP_SUBOPTION_DEVICE_DEV_ID           = 0x03
+local PNDCP_SUBOPTION_DEVICE_DEV_ROLE         = 0x04
+local PNDCP_SUBOPTION_DEVICE_DEV_OPTIONS      = 0x05
+local PNDCP_SUBOPTION_DEVICE_ALIAS_NAME       = 0x06
+local PNDCP_SUBOPTION_DEVICE_DEV_INSTANCE     = 0x07
+local PNDCP_SUBOPTION_DEVICE_OEM_DEV_ID       = 0x08
 
-PNDCP_DEVICE_ROLES = {
+local PNDCP_DEVICE_ROLES = {
   [0x01] = "IO-Device",
   [0x02] = "IO-Controller",
   [0x04] = "IO-Multidevice",
   [0x08] = "PN-Supervisor",
 }
 
-PNDCP_IP_INFO = {
-  [0x00] = "No IP set",
-  [0x01] = "IP set",
-  [0x02] = "IP set via DHCP",
-  [0x80] = "No IP set (address conflict detected)",
-  [0x81] = "IP set (address conflict detected)",
-  [0x82] = "IP set via DHCP (address conflict detected)",
+local PNDCP_IP_INFO = {
+  [PNDCP_SUBOPTION_IP_IP_IPINFO_NOTSET] = "No IP set",
+  [PNDCP_SUBOPTION_IP_IP_IPINFO_SET] = "IP set",
+  [PNDCP_SUBOPTION_IP_IP_IPINFO_SETDHCP] = "IP set via DHCP",
+  [PNDCP_SUBOPTION_IP_IP_IPINFO_NOTSET_CONFLICT] = "No IP set (address conflict detected)",
+  [PNDCP_SUBOPTION_IP_IP_IPINFO_SET_CONFLICT] = "IP set (address conflict detected)",
+  [PNDCP_SUBOPTION_IP_IP_IPINFO_SETDHCP_CONFLICT] = "IP set via DHCP (address conflict detected)",
 }
 
 -- Converts a 6 byte string into the familiar MAC address formatting
@@ -137,19 +137,21 @@ local get_mac_addr = function(mac)
 end
 
 -- Parses a DCP block in a DCP identify response
--- This function parses a single DCP block and returns the option, suboption, block length, data and position where the next block should be parsed
+-- This function parses a single DCP block and returns the option, suboption, block length,
+-- data and position where the next block should be parsed
 --
 -- @param suboption message the raw message to be parsed
 -- @param suboption the position in the message where the parsing should start
 -- @return the option, suboption, block length, data of the parsed block and position where the next block should be parsed
 local parseBlock = function(message, pos)
+  local option, suboption, blocklen
   local dcp_block_format = ">B B I2"
 
   if #message - pos + 1 < string.packsize(dcp_block_format) then
     return nil, "Message too short for DCP block"
   end
 
-  local option, suboption, blocklen, pos = string.unpack(dcp_block_format, message, pos)
+  option, suboption, blocklen, pos = string.unpack(dcp_block_format, message, pos)
   local blockdata = string.sub(message, pos, pos + blocklen - 1)
   pos = pos + blocklen
 
@@ -267,20 +269,20 @@ local pndcpListener = function(interface, timeout, responses)
   local condvar = nmap.condvar(responses)
   local start = nmap.clock_ms()
   local listener = nmap.new_socket()
-  local status, len, l2data, l3data
+  local status, l2data, l3data, _
   listener:set_timeout(100)
   listener:pcap_open(interface.device, 1500, false, 'ether proto 0x8892 or (vlan and ether proto 0x8892)')
 
   stdnse.debug1("Listener started")
 
   while (nmap.clock_ms() - start) < timeout do
-    status, len, l2data, l3data = listener:pcap_receive()
+    status, _, l2data, l3data = listener:pcap_receive()
     if status then
       local f = packet.Frame:new(l2data)
 
       -- check ethertype in l2data to see if the DCP frame is VLAN tagged
       -- if that's the case, drop the VLAN header from the l3data
-      local dcp_frame = ""
+      local dcp_frame
       if f.ether_type == ETHER_TYPE_8021Q then
         dcp_frame = string.sub(l3data, 5)
       else


### PR DESCRIPTION
This patch adds an NSE script which allows device discovery of Profinet DCP devices on a network.

Profinet is an industrial Ethernet fieldbus protocol suite. DCP is a subprotocol of Profinet which is used for device discovery and configuration. This script sends a standard DCP Identify request and parses all the responses it gets back from the devices on the network.

Sample output:
```
$ sudo ./nmap -e enp8s0 --script broadcast-pndcp-discovery
Starting Nmap 7.80SVN ( https://nmap.org ) at 2019-11-25 21:15 CET
Pre-scan script results:
| broadcast-pndcp-discovery: 
|   08:00:27:2d:c2:02 (Oracle VirtualBox virtual NIC): 
|     Interface: enp8s0
|     IP: 
|       IP Info: IP set
|       IP: 192.168.178.36
|       Netmask: 255.255.255.0
|       Gateway: 192.168.178.1
|     Device: 
|       Device manufacturer: SIMATIC-PC
|       Name of Station: plcdev
|       Vendor ID: 0x002a
|       Device ID: 0x0005
|       Device Role: 0x00 (None)
|   00:30:de:40:29:c7 (Wago Kontakttechnik Gmbh): 
|     Interface: enp8s0
|     IP: 
|       IP Info: IP set
|       IP: 192.168.1.8
|       Netmask: 255.255.255.0
|       Gateway: 192.168.1.1
|     Device: 
|       Name of Station: wago-750-375
|       Device manufacturer: WAGO-I/O-SYSTEM 750/753
|       Vendor ID: 0x011d
|       Device ID: 0x0005
|       Device Role: 0x01 (IO-Device)
|   00:01:05:2d:82:5f (Beckhoff Automation GmbH): 
|     Interface: enp8s0
|     IP: 
|       IP Info: IP set
|       IP: 192.168.1.1
|       Netmask: 255.255.255.0
|       Gateway: 192.168.1.1
|     Device: 
|       Device manufacturer: TwinCAT PNIO Controller
|       Name of Station: tc-pncontroller
|       Vendor ID: 0x0120
|       Device ID: 0x0005
|       Device Role: 0x02 (IO-Controller)
|   00:01:05:3c:94:17 (Beckhoff Automation GmbH): 
|     Interface: enp8s0
|     IP: 
|       IP Info: IP set
|       IP: 192.168.1.7
|       Netmask: 255.255.255.0
|       Gateway: 192.168.1.1
|     Device: 
|       Device manufacturer: TwinCAT Profinet I/O
|       Name of Station: cx5140
|       Vendor ID: 0x0120
|       Device ID: 0x0005
|_      Device Role: 0x01 (IO-Device)
```