### PR TITLE
Add a Beckhoff TwinCAT service port and UDP probe

### DIFF
--- a/nmap-payloads
+++ b/nmap-payloads
@@ -322,3 +322,8 @@ udp 9987
 # https://github.com/memcached/memcached/blob/master/doc/protocol.txt
 udp 11211
 "\0\x01\0\0\0\x01\0\0version\r\n"
+
+# Beckhoff ADS discovery request
+# https://github.com/ONE75/adsclient/blob/master/src/AdsClient.Finder/DeviceFinder.cs#L49-L64
+udp 48899
+"\x03\x66\x14\x71\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01\x01\x10\x27\x00\x00\x00\x00"

--- a/nmap-services
+++ b/nmap-services
@@ -23453,7 +23453,7 @@ unknown	48883/udp	0.000518
 unknown	48887/udp	0.001036
 unknown	48890/udp	0.000518
 unknown	48898/udp	0.001036
-unknown	48899/udp	0.000518
+tc_ads_discovery	48899/udp	0.000518
 unknown	48901/udp	0.001036
 unknown	48903/udp	0.000518
 unknown	48906/udp	0.001036


### PR DESCRIPTION
This PR adds a service name for TwinCAT's UDP discovery service and a UDP probe for it.

The probe prevents hosts vulnerable to [CVE-2019-5636](https://blog.rapid7.com/2019/10/08/r7-2019-32-denial-of-service-vulnerabilities-in-beckhoff-twincat-plc-environment-fixed/) from terminating the probed service.

nmap output:
```
$ sudo ./nmap -sU -p48899 CX-140BB6
Starting Nmap 7.80SVN ( https://nmap.org ) at 2019-12-16 18:20 CET
Nmap scan report for CX-140BB6 (192.168.178.80)
Host is up (0.0012s latency).
rDNS record for 192.168.178.80: CX-140BB6.fritz.box

PORT      STATE SERVICE
48899/udp open  tc_ads_discovery
MAC Address: 00:01:05:2D:82:5E (Beckhoff Automation GmbH)

Nmap done: 1 IP address (1 host up) scanned in 0.33 seconds
```