### PR TITLE
Skip pointless SSL retries when SSL_OP_NO_SSLv2 is a no-op

### DIFF
--- a/nsock/src/nsock_core.c
+++ b/nsock/src/nsock_core.c
@@ -459,6 +459,7 @@ void handle_connect_result(struct npool *ms, struct nevent *nse, enum nse_status
         nse->sslinfo.ssl_desire = sslerr;
         socket_count_write_inc(iod);
         update_events(iod, ms, nse, EV_WRITE, EV_NONE);
+#if SSL_OP_NO_SSLv2 != 0
       } else if (iod->lastproto != IPPROTO_UDP && !(options & SSL_OP_NO_SSLv2)) {
         /* SSLv2 does not apply to DTLS, so ensure lastproto was not UDP. */
         int saved_ev;
@@ -490,6 +491,7 @@ void handle_connect_result(struct npool *ms, struct nevent *nse, enum nse_status
         socket_count_write_inc(nse->iod);
         update_events(iod, ms, nse, EV_READ|EV_WRITE, EV_NONE);
         nse->sslinfo.ssl_desire = SSL_ERROR_WANT_CONNECT;
+#endif
       } else {
         nsock_log_info("EID %li %s",
                        nse->id, ERR_error_string(ERR_get_error(), NULL));


### PR DESCRIPTION
When an initial SSL handshake fails, nmap performs several additional retries with option `SSL_OP_NO_SSLv2` enabled. Since the option is ignored in all currently supported versions of OpenSSL<sup>1</sup> then the retries are largely pointless.

At some point in the future it would be prudent to remove all code related to `SSL_OP_NO_SSLv2` from the code base. This minimal patch is instead intentionally preserving all the logic but skips the retries if nmap is compiled against newer OpenSSL, keeping them with older versions. 

<sup>1</sup> OpenSSL option `SSL_OP_NO_SSLv2` became a no-op with version 1.1.0. Version 1.0.2 is expected to reach end-of-life status on December 31, 2019.
https://www.openssl.org/policies/releasestrat.html