### PR TITLE
ncat: Added --ssl-servername option to specify hostname to request

### DIFF
--- a/ncat/docs/ncat.1
+++ b/ncat/docs/ncat.1
@@ -96,6 +96,7 @@ Options taking a time assume seconds\&. Append \*(Aqms\*(Aq for milliseconds,
       \-\-ssl\-trustfile        PEM file containing trusted SSL certificates
       \-\-ssl\-ciphers          Cipherlist containing SSL ciphers to use
       \-\-ssl\-alpn             ALPN protocol list to use\&.
+      \-\-ssl\-servername <servername>  Specify remote name for SNI negotiation
       \-\-version              Display Ncat\*(Aqs version information and exit
 
 See the ncat(1) manpage for full options, descriptions and usage examples
@@ -289,6 +290,11 @@ ALL:!aNULL:!eNULL:!LOW:!EXP:!RC4:!MD5:@STRENGTH
 \fB\-\-ssl\-alpn \fR\fB\fIALPN list\fR\fR (Specify ALPN protocol list)
 .RS 4
 This option allows you to specify a comma\-separated list of protocols to send via the Application\-Layer Protocol Negotiation (ALPN) TLS extension\&. Not supported by all versions of OpenSSL\&.
+.RE
+.PP
+\fB\-\-ssl\-servername \fR\fB\fIservername\fR\fR (Specify remote name)
+.RS 4
+This option sets the server name to request during SNI negotiation, if different from the target name\&.
 .RE
 .SH "PROXY OPTIONS"
 .PP

--- a/ncat/docs/ncat.usage.txt
+++ b/ncat/docs/ncat.usage.txt
@@ -51,6 +51,7 @@ Options taking a time assume seconds. Append 'ms' for milliseconds,
       --ssl-trustfile        PEM file containing trusted SSL certificates
       --ssl-ciphers          Cipherlist containing SSL ciphers to use
       --ssl-alpn             ALPN protocol list to use.
+      --ssl-servername       Server name to request during SNI negotiation
       --version              Display Ncat's version information and exit
 
 See the ncat(1) manpage for full options, descriptions and usage examples

--- a/ncat/docs/ncat.xml
+++ b/ncat/docs/ncat.xml
@@ -424,6 +424,17 @@
         </listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term>
+          <option>--ssl-servername <replaceable>servername</replaceable></option> (Specify remote name)
+          <indexterm><primary><option>--ssl-servername</option> (Ncat option)</primary></indexterm>
+        </term>
+        <listitem>
+	  <para>This option sets the server name to request during
+	  SNI negotiation, if different from the target name.</para>
+        </listitem>
+      </varlistentry>
+
     </variablelist>
 
   </refsect1>

--- a/ncat/ncat_connect.c
+++ b/ncat/ncat_connect.c
@@ -970,9 +970,13 @@ static nsock_iod new_iod(nsock_pool mypool) {
    nsock_iod nsi = nsock_iod_new(mypool, NULL);
    if (nsi == NULL)
      bye("Failed to create nsock_iod.");
-   if (nsock_iod_set_hostname(nsi, o.target) == -1)
-     bye("Failed to set hostname on iod.");
-
+   if (o.sslservername != NULL) {
+     if (nsock_iod_set_hostname(nsi, o.sslservername) == -1)
+       bye("Failed to set specified hostname on iod.");
+   } else {
+     if (nsock_iod_set_hostname(nsi, o.target) == -1)
+       bye("Failed to set hostname on iod.");
+   }
    switch (srcaddr.storage.ss_family) {
      case AF_UNSPEC:
        break;

--- a/ncat/ncat_core.c
+++ b/ncat/ncat_core.c
@@ -215,6 +215,7 @@ void options_init(void)
     o.sslcert = NULL;
     o.sslkey = NULL;
     o.sslverify = 0;
+    o.sslservername = NULL;
     o.ssltrustfile = NULL;
     o.sslciphers = NULL;
     o.sslalpn = NULL;

--- a/ncat/ncat_core.h
+++ b/ncat/ncat_core.h
@@ -220,6 +220,7 @@ struct options {
     int ssl;
     char *sslcert;
     char *sslkey;
+    char *sslservername;
     int sslverify;
     char *ssltrustfile;
     char *sslciphers;

--- a/ncat/ncat_main.c
+++ b/ncat/ncat_main.c
@@ -356,6 +356,7 @@ int main(int argc, char *argv[])
         {"ssl-cert",        required_argument,  NULL,         0},
         {"ssl-key",         required_argument,  NULL,         0},
         {"ssl-verify",      no_argument,        NULL,         0},
+        {"ssl-servername",  required_argument,  NULL,         0},
         {"ssl-trustfile",   required_argument,  NULL,         0},
         {"ssl-ciphers",     required_argument,  NULL,         0},
         {"ssl-alpn",        required_argument,  NULL,         0},
@@ -559,6 +560,9 @@ int main(int argc, char *argv[])
             } else if (strcmp(long_options[option_index].name, "ssl-key") == 0) {
                 o.ssl = 1;
                 o.sslkey = Strdup(optarg);
+            } else if (strcmp(long_options[option_index].name, "ssl-servername") == 0) {
+                o.ssl = 1;
+                o.sslservername = Strdup(optarg);
             } else if (strcmp(long_options[option_index].name, "ssl-verify") == 0) {
                 o.sslverify = 1;
                 o.ssl = 1;
@@ -693,6 +697,7 @@ int main(int argc, char *argv[])
 "      --ssl-cert             Specify SSL certificate file (PEM) for listening\n"
 "      --ssl-key              Specify SSL private key (PEM) for listening\n"
 "      --ssl-verify           Verify trust and domain name of certificates\n"
+"      --ssl-servername       Server name to request during SNI negotiation\n"
 "      --ssl-trustfile        PEM file containing trusted SSL certificates\n"
 "      --ssl-ciphers          Cipherlist containing SSL ciphers to use\n"
 "      --ssl-alpn             ALPN protocol list to use.\n"


### PR DESCRIPTION
nsock_iod_set_hostname is accessible in nse code, but I could not find a
knob to use it with ncat.  This patch adds --ssl-servername to ncat.

With this patch, using the example from issue #1927:

```
  $ echo -n -e 'GET / HTTP/1.0\r\nHost: servername\r\n\r\n' | \
      ncat -n -v --ssl --ssl-servername servername 10.1.2.3 443
  HTTP/1.1 200 OK
```

Signed-off-by: Hank Leininger <hlein@korelogic.com>
Closes: https://github.com/nmap/nmap/issues/1927