### PR TITLE
http-default-accounts-fingerprints: status code 400 should not be an authentication success

### DIFF
--- a/nselib/data/http-default-accounts-fingerprints.lua
+++ b/nselib/data/http-default-accounts-fingerprints.lua
@@ -73,6 +73,7 @@ local function try_http_basic_login(host, port, path, user, pass, digest_auth)
   local credentials = {username = user, password = pass, digest = digest_auth}
   local resp = http_get_simple(host, port, path, {auth=credentials})
   return resp.status
+         and resp.status ~= 400
          and resp.status ~= 401
          and resp.status ~= 403
          and resp.status ~= 404


### PR DESCRIPTION
I encountered this issue while scanning a Tomcat server on its HTTPS port. I don't know why (and it's another issue in itself) but the SSL connection intermittently fails so the NSE engine re-tried with HTTP on port 443 and obviously Tomcat replied with:
```
NSE: TCP REDACTED:443 | HTTP/1.1 400 Bad Request
Date: Wed, 04 Mar 2020 16:06:32 GMT
Server: REDACTED
Content-Length: 362
Connection: close
Content-Type: text/html; charset=iso-8859-1

<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>400 Bad Request</title>
</head><body>
<h1>Bad Request</h1>
<p>Your browser sent a request that this server could not understand.<br />
Reason: You're speaking plain HTTP to an SSL-enabled server port.<br />
 Instead use the HTTPS scheme to access this URL, please.<br />
[...]
```
So it currently triggers false-positives.

Therefore I suggest adding HTTP status code 400.