### PR TITLE
Allow the user to specify the source port to be used is the comm libr…

### DIFF
--- a/nselib/comm.lua
+++ b/nselib/comm.lua
@@ -64,6 +64,9 @@ local setup_connect = function(host, port, opts)
 
   local connect_timeout, request_timeout = get_timeouts(host, opts)
 
+  if opts.srcport then
+    sock:bind(nil, opts.srcport)
+  end
   sock:set_timeout(connect_timeout)
 
   if type(host) == "string" and opts.any_af then


### PR DESCRIPTION
It would we very useful to be able to set a specific source port to be used in the comm library.  This is trivial to do, as far as I can see, so I think this would be a good feature.