### PR TITLE
Print statistics @ signal SIGQUIT without stopping.

### DIFF
--- a/nping/nping.cc
+++ b/nping/nping.cc
@@ -192,7 +192,8 @@ int main(int argc, char *argv[] ){
   /* Register the SIGINT signal so when the users presses CTRL-C we print stats
    * before quitting. */
   #if HAVE_SIGNAL
-    signal(SIGINT, signal_handler); 
+    signal(SIGINT, signal_handler);
+    signal(SIGQUIT, signal_handler);
   #endif
 
   /* Let's parse and validate user supplied args */
@@ -287,10 +288,13 @@ void test_stuff(){
 } /* End of test_stuff() */
 
 
-/** This function is called whenever user presses CTRL-C. Basically what we
-  * do here is stop Tx and Rx clocks, stop global clock, display statistics,
-  * do a bit of cleanup and exit the program. The exit() call makes the
-  * program return EXIT_FAILURE instead of the usual EXIT_SUCCESS.
+/** This function is called whenever user presses CTRL-C (SIGINT). Basically
+  * what we  do here is stop Tx and Rx clocks, stop global clock, display
+  * statistics, do a bit of cleanup and exit the program. The exit() call
+  * makes the program return EXIT_FAILURE instead of the usual EXIT_SUCCESS.
+  *
+  * If we just receive a SIGQUIT signal, we only print the current statistics,
+  * and continue.
   *
   * TODO: Many of the things done in this function may not be safe due to
   * reentrancy issues. Check http://seclists.org/nmap-dev/2009/q3/0596.html
@@ -310,10 +314,15 @@ void signal_handler(int signo){
         exit(EXIT_FAILURE);
       break;
 
+      case SIGQUIT:
+        o.displayStatistics();
+        nping_print(VB_0," "); /* Print newline */
+      break;
+
       default:
         nping_warning(QT_2, "signal_handler(): Unexpected signal received (%d). Please report a bug.", signo);
+        fflush(stderr);
+        exit(EXIT_FAILURE);
       break;
   }
-  fflush(stderr);
-  exit(EXIT_FAILURE);
 } /* End of signal_handler() */


### PR DESCRIPTION
To have the same option, for showing the current statistics without stopping, I request to pull the attached commit. We simply catch the SIGQUIT signal, like on ping (see [1]), to print the current statistics without stopping nping.

This provides the ability to check without interrupting a endless test (-c0) itself (only by a short signal interrupt).


Thanks.

[1]:
https://unix.stackexchange.com/questions/143845/check-ping-statistics-without-stopping

[2]:
…
ecv=2166083 trans=2166083] IP [ttl=64 id=55539 iplen=40 ]
SENT (98.2646s) ICMP [127.0.0.1 > 127.0.0.1 Timestamp request (type=13/code=0) id=14835 seq=99 orig=0
 recv=0 trans=0] IP [ttl=64 id=19268 iplen=40 ]
RCVD (98.3102s) ICMP [127.0.0.1 > 127.0.0.1 Timestamp reply (type=14/code=0) id=14835 seq=99 orig=0 r
ecv=2167086 trans=2167086] IP [ttl=64 id=55603 iplen=40 ]
 
Max rtt: 210.089ms | Min rtt: 3.266ms | Avg rtt: 107.773ms
Raw packets sent: 99 (3.960KB) | Rcvd: 99 (3.960KB) | Lost: 0 (0.00%)
 
SENT (99.2674s) ICMP [127.0.0.1 > 127.0.0.1 Timestamp request (type=13/code=0) id=14835 seq=100 orig=
0 recv=0 trans=0] IP [ttl=64 id=19268 iplen=40 ]
RCVD (99.3603s) ICMP [127.0.0.1 > 127.0.0.1 Timestamp reply (type=14/code=0) id=14835 seq=100 orig=0 
recv=2168089 trans=2168089] IP [ttl=64 id=55675 iplen=40 ]
SENT (100.2699s) ICMP [127.0.0.1 > 127.0.0.1 Timestamp request (type=13/code=0) id=14835 seq=101 orig
=0 recv=0 trans=0] IP [ttl=64 id=19268 iplen=40 ]
RCVD (100.4102s) ICMP [127.0.0.1 > 127.0.0.1 Timestamp reply (type=14/code=0) id=14835 seq=101 orig=0
 recv=2169091 trans=2169091] IP [ttl=64 id=55753 iplen=40 ]
…