### PR TITLE
Add cve-2020-0796 nse script to base scripts

### DIFF
--- a/scripts/smb-vuln-cve-2020-0796.nse
+++ b/scripts/smb-vuln-cve-2020-0796.nse
@@ -1,0 +1,157 @@
+local smb = require "smb"
+local stdnse = require "stdnse"
+local nmap = require "nmap"
+local vulns = require "vulns"
+local string = require "string"
+local smb2 = require "smb2"
+
+description = [[
+Checks for the SMB version and if it is vulnerable to cve-2020-0796 (SMBv3 only)
+
+The script attempts to initiate a connection using the dialects:
+* NT LM 0.12 (SMBv1)
+* 2.02       (SMBv2)
+* 2.10       (SMBv2)
+* 3.00       (SMBv3)
+* 3.02       (SMBv3)
+* 3.11       (SMBv3)
+
+This script is a child script of the smb-protocols script that will
+be used until the corresponding packet of the exploits are released
+as a poc, so it won't expose the activation packet.
+]]
+
+---
+-- example usage:
+-- @usage nmap -p445 --script smb-vuln-cve-2020-0796 <target>
+-- @usage nmap -p139 --script smb-vuln-cve-2020-0796 <target>
+-- @usage nmap -p445 --script vuln <target>
+--
+-- @output
+-- Host script results:
+-- | smb-vuln-cve-2020-0796:
+-- |   VULNERABLE:
+-- |   Wormable Remote Code Execution vulnerability in Microsoft SMBv3
+-- |     State: VULNERABLE
+-- |     IDs:  CVE:CVE-2020-0796
+-- |     Risk factor: HIGH
+-- |       A critical remote code execution vulnerability exists in Microsoft SMBv3, that can act as a worm.
+-- |
+-- |     Disclosure date: 2020-03-10
+-- |     References:
+-- |       'https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-0796'
+-- |       'https://www.tenable.com/blog/cve-2020-0796-wormable-remote-code-execution-vulnerability-in-microsoft-server-message-block'
+--
+-- @xmloutput
+-- <table key="CVE-2020-0796">
+-- <elem key="title">Wormable Remote Code Execution vulnerability in Microsoft SMBv3</elem>
+-- <elem key="state">VULNERABLE</elem>
+-- <table key="ids">
+-- <elem>CVE:CVE-2020-0796</elem>
+-- </table>
+-- <table key="description">
+-- <elem>A critical remote code execution vulnerability exists in Microsoft SMBv3.&#xa;</elem>
+-- </table>
+-- <table key="dates">
+-- <table key="disclosure">
+-- <elem key="month">03</elem>
+-- <elem key="year">2020</elem>
+-- <elem key="day">10</elem>
+-- </table>
+-- </table>
+-- <elem key="disclosure">2020-03-10</elem>
+-- <table key="refs">
+-- <elem>https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-0796</elem>
+-- <elem>https://www.tenable.com/blog/cve-2020-0796-wormable-remote-code-execution-vulnerability-in-microsoft-server-message-block/</elem>
+-- </table>
+-- </table>
+---
+
+author = "Yoav Dagan & Idan Gur"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"vuln", "safe"}
+
+hostrule = function(host)
+  return smb.get_port(host) ~= nil
+end
+
+local function check_cve20200796(host, port)
+  local smb2_dialects = {0x0300, 0x0302, 0x0311}
+  local supported_dialects = {}
+  local status
+  local smbstate
+
+  -- Check SMB2 and SMB3 dialects
+  for i, dialect in pairs(smb2_dialects) do
+    local dialect_human = stdnse.tohex(dialect, {separator = ".", group = 2})
+    -- we need a clean connection for each negotiate request
+    status, smbstate = smb.start(host)
+    if(status == false) then
+      return false, smbstate
+    end
+    stdnse.debug2("Checking if dialect '%s' is supported", dialect_human)
+    local overrides = {}
+    status, dialect = smb2.negotiate_v2(smbstate, overrides)
+    if status then
+      stdnse.debug2("SMB2: Dialect '%s' is supported", dialect_human)
+      table.insert(supported_dialects, dialect_human)
+    end
+    --clean smb connection
+    smb.stop(smbstate)
+  end
+
+
+  local vuln_bool = false
+  if status then
+    for i, v in pairs(supported_dialects) do
+      if v == "3.11" then -- currently only smbv3 3.11 is known to be vulnerable, if more info about versions will come this will be changed
+        vuln_bool = true
+      end
+    end
+
+    if vuln_bool then
+      stdnse.debug1("SMBv3 (3.11) version found on the remote system, Vulnerable!")
+      return true
+    else
+      stdnse.debug1("No compatible dialects found on the remote system, Unvulnerable!")
+      return false, "Uncompatible dialects, Unvulnerable"
+    end
+  end
+
+  stdnse.debug1("No dialects were accepted, Unkown state of vulnerability")
+  return false, "No dialects accepted"
+end
+
+
+action = function(host,port)
+  local vuln_status, err
+  local vuln = {
+    title = "Wormable Remote Code Execution vulnerability in Microsoft SMBv3",
+    IDS = {CVE = 'CVE-2020-0796'},
+    risk_factor = "HIGH",
+    description = [[
+A critical remote code execution vulnerability exists in Microsoft SMBv3.
+    ]],
+    references = {
+      'https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-0796',
+      'https://www.tenable.com/blog/cve-2020-0796-wormable-remote-code-execution-vulnerability-in-microsoft-server-message-block'
+    },
+    dates = {
+      disclosure = {year = '2020', month = '03', day = '10'},
+    }
+  }
+
+  local report = vulns.Report:new(SCRIPT_NAME, host, port)
+  vuln.state = vulns.STATE.NOT_VULN
+
+  vuln_status, err = check_cve20200796(host, port)
+
+  if vuln_status then
+    stdnse.debug1("This host is vulnerable for cve-2020-0796!")
+    vuln.state = vulns.STATE.VULN
+  else
+    vuln.state = vulns.STATE.NOT_VULN
+    vuln.check_results = err
+  end
+  return report:make_output(vuln)
+end

--- a/scripts/smb-vuln-cve-2020-0796.nse
+++ b/scripts/smb-vuln-cve-2020-0796.nse
@@ -9,15 +9,12 @@ description = [[
 Checks for the SMB version and if it is vulnerable to cve-2020-0796 (SMBv3 only)
 
 The script attempts to initiate a connection using the dialects:
-* NT LM 0.12 (SMBv1)
-* 2.02       (SMBv2)
-* 2.10       (SMBv2)
 * 3.00       (SMBv3)
 * 3.02       (SMBv3)
 * 3.11       (SMBv3)
 
-This script is a child script of the smb-protocols script that will
-be used until the corresponding packet of the exploits are released
+This script is a child script of the smb-protocols and ms17-10 scripts
+that will be used until the corresponding packet of the exploits are released
 as a poc, so it won't expose the activation packet.
 ]]
 
@@ -76,13 +73,13 @@ hostrule = function(host)
 end
 
 local function check_cve20200796(host, port)
-  local smb2_dialects = {0x0300, 0x0302, 0x0311}
+  local smb3_dialects = {0x0300, 0x0302, 0x0311}
   local supported_dialects = {}
   local status
   local smbstate
 
-  -- Check SMB2 and SMB3 dialects
-  for i, dialect in pairs(smb2_dialects) do
+  -- Check SMB3 dialects
+  for i, dialect in pairs(smb3_dialects) do
     local dialect_human = stdnse.tohex(dialect, {separator = ".", group = 2})
     -- we need a clean connection for each negotiate request
     status, smbstate = smb.start(host)

--- a/scripts/smb-vuln-cve-2020-0796.nse
+++ b/scripts/smb-vuln-cve-2020-0796.nse
@@ -9,12 +9,15 @@ description = [[
 Checks for the SMB version and if it is vulnerable to cve-2020-0796 (SMBv3 only)
 
 The script attempts to initiate a connection using the dialects:
+* NT LM 0.12 (SMBv1)
+* 2.02       (SMBv2)
+* 2.10       (SMBv2)
 * 3.00       (SMBv3)
 * 3.02       (SMBv3)
 * 3.11       (SMBv3)
 
-This script is a child script of the smb-protocols and ms17-10 scripts
-that will be used until the corresponding packet of the exploits are released
+This script is a child script of the smb-protocols script that will
+be used until the corresponding packet of the exploits are released
 as a poc, so it won't expose the activation packet.
 ]]
 
@@ -73,13 +76,13 @@ hostrule = function(host)
 end
 
 local function check_cve20200796(host, port)
-  local smb3_dialects = {0x0300, 0x0302, 0x0311}
+  local smb2_dialects = {0x0300, 0x0302, 0x0311}
   local supported_dialects = {}
   local status
   local smbstate
 
-  -- Check SMB3 dialects
-  for i, dialect in pairs(smb3_dialects) do
+  -- Check SMB2 and SMB3 dialects
+  for i, dialect in pairs(smb2_dialects) do
     local dialect_human = stdnse.tohex(dialect, {separator = ".", group = 2})
     -- we need a clean connection for each negotiate request
     status, smbstate = smb.start(host)


### PR DESCRIPTION
New remote code execution (RCE) exploit in SMBv3, that can be wormable and thus is extremely dangerous, I've used some example scripts and currently, this just checks for the affected SMB version (3.11) , using the `smb2.negotiate_v2` to check if it can be accessed and negotiated.

In later updates when a proper POC of the exploit is released I will update the scripts so it will send the exact exploit packet to check if the remote system is truly vulnerable (and not only has the vulnerable SMB version), but until then this will do for now.