### PR TITLE
Added new --overwrite-output option

### DIFF
--- a/NmapOps.cc
+++ b/NmapOps.cc
@@ -347,6 +347,7 @@ void NmapOps::Initialize() {
   sctpinitscan = 0;
   sctpcookieechoscan = 0;
   append_output = false;
+  overwrite_output = false;
   memset(logfd, 0, sizeof(FILE *) * LOG_NUM_FILES);
   ttl = -1;
   badsum = false;

--- a/NmapOps.h
+++ b/NmapOps.h
@@ -355,7 +355,8 @@ class NmapOps {
   int xmasscan;
   bool noresolve;
   bool noportscan;
-  bool append_output; /* Append to any output files rather than overwrite */
+  bool append_output; /* Append to any output files*/
+  bool overwrite_output; /* Allow overwriting output files rather than quitting */
   FILE *logfd[LOG_NUM_FILES];
   FILE *nmap_stdout; /* Nmap standard output */
   int ttl; // Time to live

--- a/docs/man-xlate/nmap-de.1
+++ b/docs/man-xlate/nmap-de.1
@@ -206,7 +206,8 @@ OUTPUT:
   \-\-packet\-trace: Show all packets sent and received
   \-\-iflist: Print host interfaces and routes (for debugging)
   \-\-log\-errors: Log errors/warnings to the normal\-format output file
-  \-\-append\-output: Append to rather than clobber specified output files
+  \-\-append\-output: Append to specified output files
+  \-\-overwrite\-output: Overwrite the specified output files without a warning
   \-\-resume <filename>: Resume an aborted scan
   \-\-stylesheet <path/URL>: XSL stylesheet to transform XML output to HTML
   \-\-webxml: Reference stylesheet from Nmap\&.Org for more portable XML
@@ -1827,14 +1828,24 @@ ist die Umleitung der interaktiven Ausgabe (inklusive des Standardfehlerstroms) 
 .PP
 \fBWeitere Ausgabeoptionen\fR
 .PP
-\fB\-\-append\-output\fR (an Ausgabedateien hinzufügen, statt sie zu überschreiben)
+\fB\-\-append\-output\fR (an Ausgabedateien anfügen)
 .RS 4
-Wenn Sie einen Dateinamen für ein Ausgabeformat wie z\&.B\&.
+Wenn Sie einen Dateinamen, der bereits vergeben wurde, für ein Ausgabeformat wie z\&.B\&.
 \fB\-oX\fR
 oder
 \fB\-oN\fR
-angeben, wird diese Datei standardmäßig überschrieben\&. Wenn Sie deren Inhalt lieber behalten und die neuen Ergebnisse anhängen möchten, benutzen Sie die Option
-\fB\-\-append\-output\fR\&. Dann wird bei allen angegebenen Ausgabedateinamen dieses Nmap\-Aufrufs an die Dateien angehängt, statt sie zu überschreiben\&. Mit XML\-Scandaten (\fB\-oX\fR) funktioniert das nicht so gut, da die erzeugte Datei im Allgemeinen nicht mehr sauber geparst wird, es sei denn, Sie reparieren sie von Hand\&.
+angeben, bricht Nmap standardmäßig mit einer Fehlermeldung ab\&. Wenn die neuen Ergebnisse anhängen möchten, benutzen Sie die Option
+\fB\-\-append\-output\fR\&. Dann wird bei allen angegebenen Ausgabedateinamen dieses Nmap\-Aufrufs an die Dateien angehängt\&. Mit XML\-Scandaten (\fB\-oX\fR) funktioniert das nicht so gut, da die erzeugte Datei im Allgemeinen nicht mehr sauber geparst wird, es sei denn, Sie reparieren sie von Hand\&.
+.RE
+.PP
+\fB\-\-overwrite\-output\fR (Ausgabedateien ohne Warnung überschreiben)
+.RS 4
+Wenn Sie einen Dateinamen, der bereits vergeben wurde, für ein Ausgabeformat wie z\&.B\&.
+\fB\-oX\fR
+oder
+\fB\-oN\fR
+angeben, bricht Nmap standardmäßig mit einer Fehlermeldung ab\&. Wenn die Ausgabedateien ohne Warnung überschreiben möchten, benutzen Sie die Option
+\fB\-\-append\-output\fR\&. Dann werden alle angegebenen Ausgabedatein dieses Nmap\-Aufrufs überschrieben\&.
 .RE
 .PP
 \fB\-\-resume \fR\fB\fIfilename\fR\fR (abgebrochenen Scan fortsetzen)

--- a/docs/man-xlate/nmap-man-de.xml
+++ b/docs/man-xlate/nmap-man-de.xml
@@ -237,7 +237,8 @@ OUTPUT:
   --packet-trace: Show all packets sent and received
   --iflist: Print host interfaces and routes (for debugging)
   --log-errors: Log errors/warnings to the normal-format output file
-  --append-output: Append to rather than clobber specified output files
+  --append-output: Append to specified output files
+  --overwrite-output: Overwrite the specified output files without a warning
   --resume &lt;filename&gt;: Resume an aborted scan
   --stylesheet &lt;path/URL&gt;: XSL stylesheet to transform XML output to HTML
   --webxml: Reference stylesheet from Nmap.Org for more portable XML
@@ -3753,21 +3754,37 @@ auf Windows kann er schwierig sein.</para>
 
       <varlistentry>
         <term>
-          <option>--append-output</option> (an Ausgabedateien hinzufügen, statt sie zu überschreiben)
+          <option>--append-output</option> (an Ausgabedateien anfügen)
            <indexterm><primary><option>--append-output</option></primary></indexterm>
         </term>
         <listitem>
 
-<para>Wenn Sie einen Dateinamen für ein Ausgabeformat wie z.B. 
-<option>-oX</option> oder <option>-oN</option> angeben, wird diese 
-Datei standardmäßig überschrieben. 
-Wenn Sie deren Inhalt lieber behalten und die neuen Ergebnisse anhängen 
-möchten, benutzen Sie die Option <option>--append-output</option>. 
-Dann wird bei allen angegebenen Ausgabedateinamen dieses Nmap-Aufrufs 
-an die Dateien angehängt, statt sie zu überschreiben. Mit XML-Scandaten 
+<para>Wenn Sie einen Dateinamen, der bereits vergeben wurde, für ein 
+Ausgabeformat wie  z.B. <option>-oX</option> oder <option>-oN</option> 
+angeben, bricht Nmap standardmäßig mit einer Fehlermeldung ab. 
+Wenn die neuen Ergebnisse anhängen möchten, benutzen Sie die Option 
+<option>--append-output</option>. Dann wird bei allen angegebenen 
+Ausgabedateinamen dieses Nmap-Aufrufs an die Dateien angehängt. Mit XML-Scandaten 
 (<option>-oX</option>) funktioniert das nicht so gut, da die erzeugte Datei 
 im Allgemeinen nicht mehr sauber geparst wird, es sei denn, Sie reparieren sie 
 von Hand.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>
+          <option>--overwrite-output</option> (Ausgabedateien ohne Warnung überschreiben)
+           <indexterm><primary><option>--overwrite-output</option></primary></indexterm>
+        </term>
+        <listitem>
+
+<para>Wenn Sie einen Dateinamen, der bereits vergeben wurde, für ein 
+Ausgabeformat wie z.B. <option>-oX</option> oder <option>-oN</option> 
+angeben, bricht Nmap standardmäßig mit einer Fehlermeldung ab. 
+Wenn die Ausgabedateien ohne Warnung überschreiben möchten, benutzen Sie 
+die Option <option>--overwrite-output</option>. 
+Dann werden alle angegebenen Ausgabedateinamen dieses Nmap-Aufrufs 
+überschrieben.</para>
         </listitem>
       </varlistentry>
 

--- a/docs/nmap.1
+++ b/docs/nmap.1
@@ -214,7 +214,8 @@ OUTPUT:
   \-\-open: Only show open (or possibly open) ports
   \-\-packet\-trace: Show all packets sent and received
   \-\-iflist: Print host interfaces and routes (for debugging)
-  \-\-append\-output: Append to rather than clobber specified output files
+  \-\-append\-output: Append to specified output files
+  \-\-overwrite\-output: Overwrite the specified output files without a warning
   \-\-resume <filename>: Resume an aborted scan
   \-\-stylesheet <path/URL>: XSL stylesheet to transform XML output to HTML
   \-\-webxml: Reference stylesheet from Nmap\&.Org for more portable XML
@@ -2155,14 +2156,24 @@ Prints the interface list and system routes as detected by Nmap\&. This is usefu
 .PP
 \fBMiscellaneous output options\fR
 .PP
-\fB\-\-append\-output\fR (Append to rather than clobber output files)
+\fB\-\-append\-output\fR (Append to specified output files)
 .RS 4
-When you specify a filename to an output format flag such as
+When you specify a filename, which already exists, to an output format flag such as
 \fB\-oX\fR
 or
-\fB\-oN\fR, that file is overwritten by default\&. If you prefer to keep the existing content of the file and append the new results, specify the
+\fB\-oN\fR, Nmap quits by default\&. If you prefer to keep the existing content of the file and append the new results, specify the
 \fB\-\-append\-output\fR
-option\&. All output filenames specified in that Nmap execution will then be appended to rather than clobbered\&. This doesn\*(Aqt work well for XML (\fB\-oX\fR) scan data as the resultant file generally won\*(Aqt parse properly until you fix it up by hand\&.
+option\&. All output filenames specified in that Nmap execution will then be appended to\&. This doesn\*(Aqt work well for XML (\fB\-oX\fR) scan data as the resultant file generally won\*(Aqt parse properly until you fix it up by hand\&.
+.RE
+.PP
+\fB\-\-overwrite\-output\fR (Overwrite the specified output files without a warning)
+.RS 4
+When you specify a filename, which already exists, to an output format flag such as
+\fB\-oX\fR
+or
+\fB\-oN\fR, Nmap quits by default\&. If you prefer to overwrite the existing content of the file, specify the
+\fB\-\-overwrite\-output\fR
+option\&. All output filenames specified in that Nmap execution will then be overwritten without a warning\&.
 .RE
 .PP
 \fB\-\-resume \fR\fB\fIfilename\fR\fR (Resume aborted scan)

--- a/docs/nmap.usage.txt
+++ b/docs/nmap.usage.txt
@@ -93,7 +93,8 @@ OUTPUT:
   --open: Only show open (or possibly open) ports
   --packet-trace: Show all packets sent and received
   --iflist: Print host interfaces and routes (for debugging)
-  --append-output: Append to rather than clobber specified output files
+  --append-output: Append to specified output files
+  --overwrite-output: Overwrite the specified output files without a warning
   --resume <filename>: Resume an aborted scan
   --stylesheet <path/URL>: XSL stylesheet to transform XML output to HTML
   --webxml: Reference stylesheet from Nmap.Org for more portable XML

--- a/docs/refguide.xml
+++ b/docs/refguide.xml
@@ -4046,21 +4046,37 @@ hosts with at least one
 
       <varlistentry>
         <term>
-          <option>--append-output</option> (Append to rather than clobber output files)
+          <option>--append-output</option> (Append to specified output files)
            <indexterm><primary><option>--append-output</option></primary></indexterm>
         </term>
         <listitem>
 
-           <para>When you specify a filename to an output format flag
-           such as <option>-oX</option> or <option>-oN</option>, that
-           file is overwritten by default.  If you prefer to keep the
-           existing content of the file and append the new results,
-           specify the <option>--append-output</option> option.  All
-           output filenames specified in that Nmap execution will then
-           be appended to rather than clobbered.  This doesn't work
-           well for XML (<option>-oX</option>) scan data as the
-           resultant file generally won't parse properly until you fix
-           it up by hand.</para>
+           <para>When you specify a filename, which already exists,
+           to an output format flag such as <option>-oX</option> or
+           <option>-oN</option>, Nmap quits by default. If you prefer
+           to keep the existing content of the file and append the 
+           new results, specify the <option>--append-output</option> 
+           option.  All output filenames specified in that Nmap execution 
+           will then be appended.  This doesn't work well for XML 
+           (<option>-oX</option>) scan data as the resultant file generally 
+           won't parse properly until you fix it up by hand.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>
+          <option>--overwrite-output</option> (Overwrite the specified output files without a warning)
+           <indexterm><primary><option>--overwrite-output</option></primary></indexterm>
+        </term>
+        <listitem>
+
+           <para>When you specify a filename, which already exists, to 
+           an output format flag such as <option>-oX</option> or 
+           <option>-oN</option>, Nmap quits by default. If you prefer to
+           overwrite the existing content of the file, specify the 
+           <option>--overwrite-output</option> option. All output 
+           filenames specified in that Nmap execution will then be 
+           overwritten without a warning.</para>
         </listitem>
       </varlistentry>
 

--- a/nmap.cc
+++ b/nmap.cc
@@ -357,7 +357,8 @@ static void printusage() {
          "  --open: Only show open (or possibly open) ports\n"
          "  --packet-trace: Show all packets sent and received\n"
          "  --iflist: Print host interfaces and routes (for debugging)\n"
-         "  --append-output: Append to rather than clobber specified output files\n"
+         "  --append-output: Append to specified output files\n"
+         "  --overwrite-output: Overwrite the specified output files without a warning\n"
          "  --resume <filename>: Resume an aborted scan\n"
          "  --stylesheet <path/URL>: XSL stylesheet to transform XML output to HTML\n"
          "  --webxml: Reference stylesheet from Nmap.Org for more portable XML\n"
@@ -647,6 +648,7 @@ void parse_options(int argc, char **argv) {
     {"unprivileged", no_argument, 0, 0},
     {"mtu", required_argument, 0, 0},
     {"append-output", no_argument, 0, 0},
+    {"overwrite-output", no_argument, 0, 0},
     {"noninteractive", no_argument, 0, 0},
     {"spoof-mac", required_argument, 0, 0},
     {"thc", no_argument, 0, 0},
@@ -797,6 +799,8 @@ void parse_options(int argc, char **argv) {
           o.requested_data_files["nmap-service-probes"] = optarg;
         } else if (strcmp(long_options[option_index].name, "append-output") == 0) {
           o.append_output = true;
+        } else if (strcmp(long_options[option_index].name, "overwrite-output") == 0) {
+          o.overwrite_output = true;
         } else if (strcmp(long_options[option_index].name, "noninteractive") == 0) {
           o.noninteractive = true;
         } else if (strcmp(long_options[option_index].name, "spoof-mac") == 0) {
@@ -1540,19 +1544,19 @@ void  apply_delayed_options() {
   /* Open the log files, now that we know whether the user wants them appended
      or overwritten */
   if (delayed_options.normalfilename) {
-    log_open(LOG_NORMAL, o.append_output, delayed_options.normalfilename);
+    log_open(LOG_NORMAL, o.append_output, o.overwrite_output, delayed_options.normalfilename);
     free(delayed_options.normalfilename);
   }
   if (delayed_options.machinefilename) {
-    log_open(LOG_MACHINE, o.append_output, delayed_options.machinefilename);
+    log_open(LOG_MACHINE, o.append_output, o.overwrite_output, delayed_options.machinefilename);
     free(delayed_options.machinefilename);
   }
   if (delayed_options.kiddiefilename) {
-    log_open(LOG_SKID, o.append_output, delayed_options.kiddiefilename);
+    log_open(LOG_SKID, o.append_output, o.overwrite_output, delayed_options.kiddiefilename);
     free(delayed_options.kiddiefilename);
   }
   if (delayed_options.xmlfilename) {
-    log_open(LOG_XML, o.append_output, delayed_options.xmlfilename);
+    log_open(LOG_XML, o.append_output, o.overwrite_output, delayed_options.xmlfilename);
     free(delayed_options.xmlfilename);
   }
 

--- a/output.cc
+++ b/output.cc
@@ -1147,7 +1147,7 @@ void log_flush_all() {
 /* Open a log descriptor of the type given to the filename given.  If
    append is true, the file will be appended instead of clobbered if
    it already exists.  If the file does not exist, it will be created */
-int log_open(int logt, bool append, char *filename) {
+int log_open(int logt, bool append, bool overwrite, char *filename) {
   int i = 0;
   if (logt <= 0 || logt > LOG_FILE_MASK)
     return -1;
@@ -1165,8 +1165,15 @@ int log_open(int logt, bool append, char *filename) {
   } else {
     if (append)
       o.logfd[i] = fopen(filename, "a");
-    else
+    else {
+      FILE *file;
+      if (!overwrite && (file = fopen(filename, "r"))) {
+        fclose(file);
+        fatal("Failed to overwrite %s output file %s. Use option --overwrite-output.", logtypes[i],
+            filename);
+      }
       o.logfd[i] = fopen(filename, "w");
+    }
     if (!o.logfd[i])
       fatal("Failed to open %s output file %s for writing", logtypes[i],
             filename);

--- a/output.h
+++ b/output.h
@@ -238,7 +238,7 @@ void log_flush_all();
 /* Open a log descriptor of the type given to the filename given.  If
    append is nonzero, the file will be appended instead of clobbered if
    it already exists.  If the file does not exist, it will be created */
-int log_open(int logt, bool append, char *filename);
+int log_open(int logt, bool append, bool overwrite, char *filename);
 
 /* Output the list of ports scanned to the top of machine parseable
    logs (in a comment, unfortunately).  The items in ports should be


### PR DESCRIPTION
Nmap will no longer overwrite output files, unless the option
--overwrite-output is used.

The docs for english and german have been updated to the new behavior.