### PR TITLE
Added workaround to prevent RDP enum script from getting stuck

### DIFF
--- a/nselib/rdp.lua
+++ b/nselib/rdp.lua
@@ -179,6 +179,10 @@ Packet = {
       local block_type, block_len
       while userdata:len() > pos do
         block_type, block_len  = string.unpack("<I2I2", userdata, pos)
+        if block_len == 0 then
+          -- Workaround to prevent getting stuck (https://github.com/nmap/nmap/issues/1737)
+          block_len = 1
+        end
         if block_type == 0x0c01 then
           -- 2.2.1.42 Server Core Data - TS_UD_SC_CORE
           local proto_ver = string.unpack("<I4",userdata, pos + 4)


### PR DESCRIPTION
This workaround prevents `scripts/rdp-enum-encryption.nse` from getting stuck when a block length of zero occurs in `nselib/rdp.lua` (#1737).

I spent some time debugging but did not fully understand when and why the issue occurs. As mentioned in #1737, it is related to ASN1 decoding.

As I specifically check for block length 0, the workaround only triggers when the script would get stuck otherwise and does not change the behaviour of the script when it would work fine.

As this is only a workaround, in my view the respective issue should stay open.