### PR TITLE
Create searchnse

### DIFF
--- a/searchnse
+++ b/searchnse
@@ -31,7 +31,7 @@ do
   script_name=$(echo "$line" | cut -d " " -f5 | sed 's/,//g' | sed 's/"//g')
   #echo "nmap --script-help=$script_name"
   help_output=$(nmap --script-help=$script_name)
-  script_args=$(cat /usr/share/nmap/scripts/$script_name | sed -n '/@args/,/\b/p')
+  script_args=$(cat /usr/share/nmap/scripts/$script_name | sed -n -e '/-- @args/,/auth.*/ p')
   echo -n "="
   print_divs $script_name
   echo "="
@@ -40,6 +40,6 @@ do
   print_divs $script_name
   echo "="
   echo "$help_output" | sed -e '1,3d'
-  echo "Script Arguments:"
+  echo "Script Supplemental Help:"
   echo "$script_args"
 done

--- a/searchnse
+++ b/searchnse
@@ -1,0 +1,45 @@
+#!/bin/bash
+if [ "$1" = "-h" ]
+then
+  echo "SEARCH THE NMAP SCRIPTING ENGINE DATABASE
+by midnightseer
+
+  <arg1> <filter-term>
+  # arg 1 - search term
+  # arg 2 - optional: an additional filter-term / search parameter"
+  exit
+fi
+filter=$2
+function print_divs() {
+  a=$1
+  for i in $(seq ${#a})
+    do
+    echo -n "="
+  done
+}
+SAVEIFS=$IFS   # Save current IFS
+IFS=$'\n'      # Change IFS to new line
+db_output=$(grep $1 /usr/share/nmap/scripts/script.db)
+if [[ ! -z $filter ]]
+then
+  db_output=$(echo "$db_output" | grep $filter) 
+fi
+db_array=($db_output)
+IFS=$SAVEIFS
+for line in "${db_array[@]}"
+do
+  script_name=$(echo "$line" | cut -d " " -f5 | sed 's/,//g' | sed 's/"//g')
+  #echo "nmap --script-help=$script_name"
+  help_output=$(nmap --script-help=$script_name)
+  script_args=$(cat /usr/share/nmap/scripts/$script_name | sed -n '/@args/,/\b/p')
+  echo -n "="
+  print_divs $script_name
+  echo "="
+  echo " $script_name "
+  echo -n "="
+  print_divs $script_name
+  echo "="
+  echo "$help_output" | sed -e '1,3d'
+  echo "Script Arguments:"
+  echo "$script_args"
+done


### PR DESCRIPTION
This script was created with 2 thoughts in mind: (1) offline searching (2) quick and structured parsing of the NSE db.

This is a quick script to search nmap scriptdb resident on kali (/usr/share/nmap/scripts/script.db).  I wanted a search simliar to searchsploit but I realized I didn't need it to be as robust.  I created searchnse to quickly parse for a script based on an initial seed term and a possible 2nd filter term.

I have never contirbuted via git (this is my first pull request), so hopefully I am doing this right and hopefully this tool can make searching easier for your users.

Example: searchnse smtp vuln

```
kali@kali:~/Documents/Exercises$ searchnse smtp vuln
============================
 smtp-vuln-cve2010-4344.nse 
============================
Categories: exploit intrusive vuln
https://nmap.org/nsedoc/scripts/smtp-vuln-cve2010-4344.html
  Checks for and/or exploits a heap overflow within versions of Exim
  prior to version 4.69 (CVE-2010-4344) and a privilege escalation
  vulnerability in Exim 4.72 and prior (CVE-2010-4345).

  The heap overflow vulnerability allows remote attackers to execute
  arbitrary code with the privileges of the Exim daemon
  (CVE-2010-4344). If the exploit fails then the Exim smtpd child will
  be killed (heap corruption).

  The script also checks for a privilege escalation vulnerability that
  affects Exim version 4.72 and prior. The vulnerability allows the exim
  user to gain root privileges by specifying an alternate configuration
  file using the -C option (CVE-2010-4345).

  The <code>smtp-vuln-cve2010-4344.exploit</code> script argument will make
  the script try to exploit the vulnerabilities, by sending more than 50MB of
  data, it depends on the message size limit configuration option of the
  Exim server. If the exploit succeed the <code>exploit.cmd</code> or
  <code>smtp-vuln-cve2010-4344.cmd</code> script arguments can be used to
  run an arbitrary command on the remote system, under the
  <code>Exim</code> user privileges. If this script argument is set then it
  will enable the <code>smtp-vuln-cve2010-4344.exploit</code> argument.

  To get the appropriate debug messages for this script, please use -d2.

  Some of the logic of this script is based on the metasploit
  exim4_string_format exploit.
  * http://www.metasploit.com/modules/exploit/unix/smtp/exim4_string_format

  Reference:
  * http://cve.mitre.org/cgi-bin/cvename.cgi?name=2010-4344
  * http://cve.mitre.org/cgi-bin/cvename.cgi?name=2010-4345
Script Arguments:
-- @args smtp-vuln-cve2010-4344.exploit The script will force the checks,
--       and will try to exploit the Exim SMTP server.
-- @args smtp-vuln-cve2010-4344.mailfrom Define the source email address to
--       be used.
-- @args smtp-vuln-cve2010-4344.mailto Define the destination email address
--       to be used.
-- @args exploit.cmd or smtp-vuln-cve2010-4344.cmd An arbitrary command to
--       run under the <code>Exim</code> user privileges on the remote
============================
 smtp-vuln-cve2011-1720.nse 
============================
Categories: intrusive vuln
https://nmap.org/nsedoc/scripts/smtp-vuln-cve2011-1720.html
  Checks for a memory corruption in the Postfix SMTP server when it uses
  Cyrus SASL library authentication mechanisms (CVE-2011-1720).  This
  vulnerability can allow denial of service and possibly remote code
  execution.

  Reference:
  * http://www.postfix.org/CVE-2011-1720.html
Script Arguments:

============================
 smtp-vuln-cve2011-1764.nse 
============================
Categories: intrusive vuln
https://nmap.org/nsedoc/scripts/smtp-vuln-cve2011-1764.html
  Checks for a format string vulnerability in the Exim SMTP server
  (version 4.70 through 4.75) with DomainKeys Identified Mail (DKIM) support
  (CVE-2011-1764).  The DKIM logging mechanism did not use format string
  specifiers when logging some parts of the DKIM-Signature header field.
  A remote attacker who is able to send emails, can exploit this vulnerability
  and execute arbitrary code with the privileges of the Exim daemon.

  Reference:
  * http://bugs.exim.org/show_bug.cgi?id=1106
  * http://thread.gmane.org/gmane.mail.exim.devel/4946
  * https://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2011-1764
  * http://en.wikipedia.org/wiki/DomainKeys_Identified_Mail
Script Arguments:
-- @args smtp-vuln-cve2011-1764.mailfrom Define the source email address to
--       be used.
-- @args smtp-vuln-cve2011-1764.mailto Define the destination email address
--       to be used.
```
