### PR TITLE
Avoid using sensitive information on the command line (#2060)

### DIFF
--- a/ncat/docs/ncat.xml
+++ b/ncat/docs/ncat.xml
@@ -481,6 +481,9 @@
           <option>--proxy-type socks5</option>, the form should be
           username:password.  For
           <option>--proxy-type socks4</option>, it should be a username only.</para>
+          <para>These credentials can be alternatively passed onto Ncat by setting environment variable
+          <envar>NCAT_PROXY_AUTH</envar><indexterm><primary><envar>NCAT_PROXY_AUTH</envar> environment variable</primary></indexterm>,
+          which reduces the risk of the credentials being captured in process logs. (Option <option>--proxy-auth</option>takes precedence.)</para>
         </listitem>
       </varlistentry>
 

--- a/ncat/ncat_main.c
+++ b/ncat/ncat_main.c
@@ -823,6 +823,12 @@ int main(int argc, char *argv[])
         }
     }
 
+    /* proxy credentials can be alternatively passed by setting environment variable
+     * which reduces the risk of sensitive information being captured in process logs */
+    if (!o.proxy_auth) {
+      o.proxy_auth = getenv("NCAT_PROXY_AUTH");
+    }
+
     if (o.zerobyte) {
       if (o.listen)
         bye("Services designed for LISTENING can't be used with -z");


### PR DESCRIPTION
Optionally can use environment variable NCAT_PROXY_AUTH to specify SOCKS5 proxy credentials.
This reduces the risk of the credentials being captured in process logs.
Note that pption --proxy-auth takes precedence.
