### PR TITLE
Change default pos to 0 for parse function

### DIFF
--- a/nselib/mqtt.lua
+++ b/nselib/mqtt.lua
@@ -295,7 +295,7 @@ Comm = {
     assert(type(buf) == "string")
 
     if not pos then
-      pos = 0
+      pos = 1
     end
     assert(type(pos) == "number")
     assert(pos < #buf)


### PR DESCRIPTION
The first character of a string has position 1, not 0.