### PR TITLE
Truncate rlim_cur/rlim_max if greater than INT_MAX

### DIFF
--- a/nsock/src/netutils.c
+++ b/nsock/src/netutils.c
@@ -55,6 +55,8 @@
 
 /* $Id$ */
 
+#include <limits.h>
+
 #include "netutils.h"
 #include "error.h"
 
@@ -116,7 +118,7 @@ int maximize_fdlimit(void) {
         perror("setrlimit RLIMIT_NOFILE failed");
 
     if (!getrlimit(RLIMIT_NOFILE, &r)) {
-      maxfds = r.rlim_cur;
+      maxfds = (int)(r.rlim_cur > INT_MAX ? INT_MAX : r.rlim_cur);
       return maxfds;
     } else {
       return 0;


### PR DESCRIPTION
On macOS, the `rlim_t` type used by `rlimit` is 64 bits wide.
For me, `getrlimit` actually returns `LONG_MAX` as `rlim_max`, which makes `maximize_fdlimit` return -1 due to integer truncation.

For the purposes of the `maximize_fdlimit` function, it should be sufficient to just truncate the value and keep the return type of `int` because no one needs that many files in practice.

Fixing this issue solves #2079 and will make nmap work on macOS 10.16/11.0 Big Sur.