### PR TITLE
ipmi-brute fixes

### DIFF
--- a/nselib/ipmi.lua
+++ b/nselib/ipmi.lua
@@ -174,7 +174,7 @@ least-significant byte first.
 
 parse_channel_auth_reply = function(reply)
   local data = {}
-  local pos = 0
+  local pos = 1
   local value
 
   data.rmcp_version,
@@ -231,7 +231,7 @@ end
 
 parse_open_session_reply = function(reply)
   local data = {}
-  local pos = 0
+  local pos = 1
   local value
 
   -- 4 bytes Header
@@ -267,7 +267,7 @@ end
 
 parse_rakp_1_reply = function(reply)
   local data = {}
-  local pos = 0
+  local pos = 1
   local value
 
   -- 4 bytes Header

--- a/scripts/ipmi-brute.nse
+++ b/scripts/ipmi-brute.nse
@@ -104,7 +104,7 @@ Driver = {
       hmac_salt, rakp2_message["hmac_sha1"], password)
 
     if found then
-      return true, brute.Account:new(username, password, creds.State.VALID)
+      return true, creds.Account:new(username, password, creds.State.VALID)
     else
       return false, brute.Error:new("Incorrect password")
     end


### PR DESCRIPTION
Needed to do ipmi default credential scanning but hit a bunch of errors on 7.80 nmap. Seems like the default behavior of bin.unpack was to treat the position argument as 1 even if the value was zero. string.unpack does not seem to do this (at least now). These fixes resolve the problem and I am now able to do ipmi-version and ipmi-brute. 