### PR TITLE
Python 3 and pygobject port of Zenmap

### DIFF
--- a/zenmap/install_scripts/utils/version_update.py
+++ b/zenmap/install_scripts/utils/version_update.py
@@ -143,7 +143,7 @@ NAME_PY = os.path.join("zenmapCore", "Name.py")
 
 def update_date(base_dir):
     name_file = os.path.join(base_dir, NAME_PY)
-    print ">>> Updating %s" % name_file
+    print(">>> Updating %s" % name_file)
     nf = open(name_file, "r")
     ncontent = nf.read()
     nf.close()
@@ -157,22 +157,22 @@ def update_date(base_dir):
 
 
 def update_version(base_dir, version):
-    print ">>> Updating %s" % os.path.join(base_dir, VERSION)
+    print(">>> Updating %s" % os.path.join(base_dir, VERSION))
     vf = open(os.path.join(base_dir, VERSION), "wb")
-    print >> vf, version
+    print(version, file=vf)
     vf.close()
-    print ">>> Updating %s" % os.path.join(base_dir, VERSION_PY)
+    print(">>> Updating %s" % os.path.join(base_dir, VERSION_PY))
     vf = open(os.path.join(base_dir, VERSION_PY), "w")
-    print >> vf, "VERSION = \"%s\"" % version
+    print("VERSION = \"%s\"" % version, file=vf)
     vf.close()
 
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print >> sys.stderr, "Usage: %s <version>" % sys.argv[0]
+        print("Usage: %s <version>" % sys.argv[0], file=sys.stderr)
         sys.exit(1)
 
     version = sys.argv[1]
-    print ">>> Updating version number to \"%s\"" % version
+    print(">>> Updating version number to \"%s\"" % version)
     update_version(".", version)
     update_date(".")

--- a/zenmap/radialnet/bestwidgets/__init__.py
+++ b/zenmap/radialnet/bestwidgets/__init__.py
@@ -125,9 +125,12 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
 
-gtk_version_major, gtk_version_minor, gtk_version_release = gtk.gtk_version
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
+gtk_version_major, gtk_version_minor, gtk_version_release = gi.version_info
 
 #from boxes import BWHBox, BWVBox, BWTable, BWStatusbar, BWScrolledWindow
 #from buttons import BWStockButton, BWToggleStockButton

--- a/zenmap/radialnet/bestwidgets/boxes.py
+++ b/zenmap/radialnet/bestwidgets/boxes.py
@@ -125,13 +125,16 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+ 
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 __all__ = ('BWBox', 'BWHBox', 'BWVBox',
         'BWStatusbar', 'BWTable', 'BWScrolledWindow')
 
 
-class BWBox(gtk.Box):
+class BWBox(Gtk.Box):
     """
     """
     def bw_pack_start_expand_fill(self, widget, padding=0):
@@ -165,40 +168,40 @@ class BWBox(gtk.Box):
         self.pack_end(widget, False, False, padding)
 
 
-class BWHBox(gtk.HBox, BWBox):
+class BWHBox(Gtk.HBox, BWBox):
     """
     """
     def __init__(self, homogeneous=False, spacing=12):
         """
         """
-        gtk.HBox.__init__(self, homogeneous, spacing)
+        Gtk.HBox.__init__(self, homogeneous, spacing)
 
 
-class BWVBox(gtk.VBox, BWBox):
+class BWVBox(Gtk.VBox, BWBox):
     """
     """
     def __init__(self, homogeneous=False, spacing=12):
         """
         """
-        gtk.VBox.__init__(self, homogeneous, spacing)
+        Gtk.VBox.__init__(self, homogeneous, spacing)
 
 
-class BWStatusbar(gtk.Statusbar, BWBox):
+class BWStatusbar(Gtk.Statusbar, BWBox):
     """
     """
     def __init__(self, homogeneous=False, spacing=12):
         """
         """
-        gtk.HBox.__init__(self, homogeneous, spacing)
+        Gtk.HBox.__init__(self, homogeneous, spacing)
 
 
-class BWTable(gtk.Table, BWBox):
+class BWTable(Gtk.Table, BWBox):
     """
     """
     def __init__(self, rows=1, columns=1, homogeneous=False):
         """
         """
-        gtk.Table.__init__(self, rows, columns, homogeneous)
+        Gtk.Table.__init__(self, rows, columns, homogeneous)
         self.bw_set_spacing(12)
 
         self.__rows = rows
@@ -222,8 +225,8 @@ class BWTable(gtk.Table, BWBox):
 
     def bw_attach_next(self,
                        child,
-                       xoptions=gtk.EXPAND | gtk.FILL,
-                       yoptions=gtk.EXPAND | gtk.FILL,
+                       xoptions=Gtk.AttachOptions.EXPAND | Gtk.AttachOptions.FILL,
+                       yoptions=Gtk.AttachOptions.EXPAND | Gtk.AttachOptions.FILL,
                        xpadding=0,
                        ypadding=0):
         """
@@ -253,13 +256,13 @@ class BWTable(gtk.Table, BWBox):
             self.__last_point = (row, column)
 
 
-class BWScrolledWindow(gtk.ScrolledWindow):
+class BWScrolledWindow(Gtk.ScrolledWindow):
     """
     """
     def __init__(self):
         """
         """
-        gtk.ScrolledWindow.__init__(self)
-        self.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
-        self.set_shadow_type(gtk.SHADOW_NONE)
+        Gtk.ScrolledWindow.__init__(self)
+        self.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        self.set_shadow_type(Gtk.ShadowType.NONE)
         self.set_border_width(6)

--- a/zenmap/radialnet/bestwidgets/buttons.py
+++ b/zenmap/radialnet/bestwidgets/buttons.py
@@ -125,34 +125,37 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 
-class BWStockButton(gtk.Button):
+class BWStockButton(Gtk.Button):
     """
     """
-    def __init__(self, stock, text=None, size=gtk.ICON_SIZE_BUTTON):
+    def __init__(self, stock, text=None, size=Gtk.IconSize.BUTTON):
         """
         """
-        gtk.Button.__init__(self, text)
+        Gtk.Button.__init__(self, text)
 
         self.__size = size
 
-        self.__image = gtk.Image()
+        self.__image = Gtk.Image()
         self.__image.set_from_stock(stock, self.__size)
         self.set_image(self.__image)
 
 
-class BWToggleStockButton(gtk.ToggleButton):
+class BWToggleStockButton(Gtk.ToggleButton):
     """
     """
-    def __init__(self, stock, text=None, size=gtk.ICON_SIZE_BUTTON):
+    def __init__(self, stock, text=None, size=Gtk.IconSize.BUTTON):
         """
         """
-        gtk.ToggleButton.__init__(self, text)
+        Gtk.ToggleButton.__init__(self, text)
 
         self.__size = size
 
-        self.__image = gtk.Image()
+        self.__image = Gtk.Image()
         self.__image.set_from_stock(stock, self.__size)
         self.set_image(self.__image)

--- a/zenmap/radialnet/bestwidgets/comboboxes.py
+++ b/zenmap/radialnet/bestwidgets/comboboxes.py
@@ -125,19 +125,21 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
-import gobject
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GObject
 
 
-class BWChangeableComboBoxEntry(gtk.ComboBoxEntry):
+class BWChangeableComboBoxEntry(Gtk.ComboBox):
     """
     """
     def __init__(self):
         """
         """
-        self.__liststore = gtk.ListStore(gobject.TYPE_STRING)
+        self.__liststore = Gtk.ListStore(GObject.TYPE_STRING)
 
-        gtk.ComboBoxEntry.__init__(self, self.__liststore, 0)
+        Gtk.ComboBox.__init__(self, self.__liststore, 0, has_entry=True)
 
         self.connect("changed", self.__changed)
         self.get_child().connect("changed", self.__entry_changed)
@@ -182,16 +184,16 @@ if __name__ == "__main__":
         """
         combo.append_text('New')
 
-    window = gtk.Window()
-    window.connect("destroy", lambda w: gtk.main_quit())
+    window = Gtk.Window()
+    window.connect("destroy", lambda w: Gtk.main_quit())
 
-    box = gtk.HBox()
+    box = Gtk.HBox()
 
     combo = BWChangeableComboBoxEntry()
     combo.append_text('New')
     combo.set_active(0)
 
-    button = gtk.Button('More')
+    button = Gtk.Button('More')
     button.connect("clicked", button_clicked, combo)
 
     box.pack_start(button, False, False)
@@ -200,4 +202,4 @@ if __name__ == "__main__":
     window.add(box)
     window.show_all()
 
-    gtk.main()
+    Gtk.main()

--- a/zenmap/radialnet/bestwidgets/comboboxes.py
+++ b/zenmap/radialnet/bestwidgets/comboboxes.py
@@ -196,8 +196,8 @@ if __name__ == "__main__":
     button = Gtk.Button('More')
     button.connect("clicked", button_clicked, combo)
 
-    box.pack_start(button, False, False)
-    box.pack_start(combo, True, True)
+    box.pack_start(button, False, False, 0)
+    box.pack_start(combo, True, True, 0)
 
     window.add(box)
     window.show_all()

--- a/zenmap/radialnet/bestwidgets/comboboxes.py
+++ b/zenmap/radialnet/bestwidgets/comboboxes.py
@@ -131,7 +131,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject
 
 
-class BWChangeableComboBoxEntry(Gtk.ComboBox):
+class BWChangeableComboBoxEntry(Gtk.ComboBoxText):
     """
     """
     def __init__(self):
@@ -139,7 +139,7 @@ class BWChangeableComboBoxEntry(Gtk.ComboBox):
         """
         self.__liststore = Gtk.ListStore(GObject.TYPE_STRING)
 
-        Gtk.ComboBox.__init__(self, self.__liststore, 0, has_entry=True)
+        Gtk.ComboBoxText.__init__(self, model=self.__liststore, has_entry=True)
 
         self.connect("changed", self.__changed)
         self.get_child().connect("changed", self.__entry_changed)
@@ -193,7 +193,7 @@ if __name__ == "__main__":
     combo.append_text('New')
     combo.set_active(0)
 
-    button = Gtk.Button('More')
+    button = Gtk.Button(label='More')
     button.connect("clicked", button_clicked, combo)
 
     box.pack_start(button, False, False, 0)

--- a/zenmap/radialnet/bestwidgets/expanders.py
+++ b/zenmap/radialnet/bestwidgets/expanders.py
@@ -143,7 +143,7 @@ class BWExpander(Gtk.Expander):
         self.__label = BWSectionLabel(label)
         self.set_label_widget(self.__label)
 
-        self.__alignment = Gtk.Alignment(0, 0, 1, 1)
+        self.__alignment = Gtk.Alignment.new(0, 0, 1, 1)
         self.__alignment.set_padding(12, 0, 24, 0)
 
         self.add(self.__alignment)

--- a/zenmap/radialnet/bestwidgets/expanders.py
+++ b/zenmap/radialnet/bestwidgets/expanders.py
@@ -125,22 +125,25 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+ 
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 from radialnet.bestwidgets.labels import BWSectionLabel
 
 
-class BWExpander(gtk.Expander):
+class BWExpander(Gtk.Expander):
     """
     """
     def __init__(self, label=''):
         """
         """
-        gtk.Expander.__init__(self)
+        Gtk.Expander.__init__(self)
 
         self.__label = BWSectionLabel(label)
         self.set_label_widget(self.__label)
 
-        self.__alignment = gtk.Alignment(0, 0, 1, 1)
+        self.__alignment = Gtk.Alignment(0, 0, 1, 1)
         self.__alignment.set_padding(12, 0, 24, 0)
 
         self.add(self.__alignment)

--- a/zenmap/radialnet/bestwidgets/frames.py
+++ b/zenmap/radialnet/bestwidgets/frames.py
@@ -125,21 +125,24 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+ 
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Gdk
 
 
-class BWFrame(gtk.Frame):
+class BWFrame(Gtk.Frame):
     """
     """
     def __init__(self, label=''):
         """
         """
-        gtk.Frame.__init__(self)
+        Gtk.Frame.__init__(self)
 
         self.set_border_width(3)
-        self.set_shadow_type(gtk.SHADOW_NONE)
+        self.set_shadow_type(Gtk.ShadowType.NONE)
 
-        self.__alignment = gtk.Alignment(0, 0, 1, 1)
+        self.__alignment = Gtk.Alignment(0, 0, 1, 1)
         self.__alignment.set_padding(12, 0, 24, 0)
 
         self.add(self.__alignment)

--- a/zenmap/radialnet/bestwidgets/labels.py
+++ b/zenmap/radialnet/bestwidgets/labels.py
@@ -125,33 +125,36 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+ 
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 
-class BWLabel(gtk.Label):
+class BWLabel(Gtk.Label):
     """
     """
     def __init__(self, text=''):
         """
         """
-        gtk.Label.__init__(self)
+        Gtk.Label.__init__(self)
 
         self.set_text(text)
-        self.set_justify(gtk.JUSTIFY_LEFT)
+        self.set_justify(Gtk.Justification.LEFT)
         self.set_alignment(0, 0.50)
         self.set_line_wrap(True)
 
 
-class BWSectionLabel(gtk.Label):
+class BWSectionLabel(Gtk.Label):
     """
     """
     def __init__(self, text=''):
         """
         """
-        gtk.Label.__init__(self)
+        Gtk.Label.__init__(self)
 
         self.set_markup('<b>' + text + '</b>')
-        self.set_justify(gtk.JUSTIFY_LEFT)
+        self.set_justify(Gtk.Justification.LEFT)
         self.set_alignment(0, 0.50)
         self.set_line_wrap(True)
 

--- a/zenmap/radialnet/bestwidgets/textview.py
+++ b/zenmap/radialnet/bestwidgets/textview.py
@@ -199,7 +199,7 @@ class BWTextEditor(BWScrolledWindow):
         """
         """
         BWScrolledWindow.__init__(self)
-        self.connect('expose_event', self.__expose)
+        self.connect('draw', self.__draw)
 
         self.__auto_scroll = False
 
@@ -224,7 +224,7 @@ class BWTextEditor(BWScrolledWindow):
 
         self.add_with_viewport(self.__hbox)
 
-    def __expose(self, widget, event):
+    def __draw(self, widget, event):
         """
         """
         # code to fix a gtk issue that don't show text correctly

--- a/zenmap/radialnet/bestwidgets/textview.py
+++ b/zenmap/radialnet/bestwidgets/textview.py
@@ -125,7 +125,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+ 
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 from radialnet.bestwidgets.boxes import *
 
 
@@ -144,8 +147,8 @@ class BWTextView(BWScrolledWindow):
     def __create_widgets(self):
         """
         """
-        self.__textbuffer = gtk.TextBuffer()
-        self.__textview = gtk.TextView(self.__textbuffer)
+        self.__textbuffer = Gtk.TextBuffer()
+        self.__textview = Gtk.TextView(self.__textbuffer)
 
         self.add_with_viewport(self.__textview)
 
@@ -207,12 +210,12 @@ class BWTextEditor(BWScrolledWindow):
         """
         self.__hbox = BWHBox(spacing=6)
 
-        self.__textbuffer = gtk.TextBuffer()
-        self.__textview = gtk.TextView(self.__textbuffer)
+        self.__textbuffer = Gtk.TextBuffer()
+        self.__textview = Gtk.TextView(self.__textbuffer)
 
-        self.__linebuffer = gtk.TextBuffer()
-        self.__lineview = gtk.TextView(self.__linebuffer)
-        self.__lineview.set_justification(gtk.JUSTIFY_RIGHT)
+        self.__linebuffer = Gtk.TextBuffer()
+        self.__lineview = Gtk.TextView(self.__linebuffer)
+        self.__lineview.set_justification(Gtk.Justification.RIGHT)
         self.__lineview.set_editable(False)
         self.__lineview.set_sensitive(False)
 

--- a/zenmap/radialnet/bestwidgets/windows.py
+++ b/zenmap/radialnet/bestwidgets/windows.py
@@ -125,21 +125,23 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
-from radialnet.bestwidgets import gtk_version_minor
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 PRIMARY_TEXT_MARKUP = '<span weight="bold" size="larger">%s</span>'
 
 
-class BWAlertDialog(gtk.MessageDialog):
+class BWAlertDialog(Gtk.MessageDialog):
     """
     """
-    def __init__(self, parent=None, flags=0, type=gtk.MESSAGE_INFO,
-                 buttons=gtk.BUTTONS_OK,
+    def __init__(self, parent=None, flags=0, type=Gtk.MessageType.INFO,
+                 buttons=Gtk.ButtonsType.OK,
                  primary_text=None,
                  secondary_text=None):
 
-        gtk.MessageDialog.__init__(self, parent, flags, type, buttons)
+        Gtk.MessageDialog.__init__(self, parent, flags, type, buttons)
 
         self.connect('response', self.__destroy)
 
@@ -149,10 +151,7 @@ class BWAlertDialog(gtk.MessageDialog):
         self.set_markup(PRIMARY_TEXT_MARKUP % primary_text)
 
         if secondary_text:
-
-            # GTK up to version 2.4 does not have secondary_text
-            if gtk_version_minor > 4:
-                self.format_secondary_text(secondary_text)
+            self.format_secondary_text(secondary_text)
 
     def __destroy(self, dialog, id):
         """
@@ -160,14 +159,14 @@ class BWAlertDialog(gtk.MessageDialog):
         self.destroy()
 
 
-class BWWindow(gtk.Window):
+class BWWindow(Gtk.Window):
     """
     """
-    def __init__(self, type=gtk.WINDOW_TOPLEVEL):
+    def __init__(self, type=Gtk.WindowType.TOPLEVEL):
         """
         """
-        gtk.Window.__init__(self, type)
+        Gtk.Window.__init__(self, type)
         self.set_border_width(5)
 
 
-BWMainWindow = gtk.Window
+BWMainWindow = Gtk.Window

--- a/zenmap/radialnet/core/ArgvHandle.py
+++ b/zenmap/radialnet/core/ArgvHandle.py
@@ -165,4 +165,4 @@ if __name__ == '__main__':
 
     h = ArgvHandle(sys.argv)
 
-    print h.get_last_value()
+    print(h.get_last_value())

--- a/zenmap/radialnet/core/Coordinate.py
+++ b/zenmap/radialnet/core/Coordinate.py
@@ -274,5 +274,5 @@ if __name__ == "__main__":
     polar = PolarCoordinate(1, math.pi)
     cartesian = CartesianCoordinate(-1, 0)
 
-    print polar.to_cartesian()
-    print cartesian.to_polar()
+    print(polar.to_cartesian())
+    print(cartesian.to_polar())

--- a/zenmap/radialnet/core/Interpolation.py
+++ b/zenmap/radialnet/core/Interpolation.py
@@ -224,4 +224,4 @@ if __name__ == "__main__":
     i.set_start_point(0, 0)
     i.set_final_point(1, 1)
 
-    print len(i.get_points(10)), i.get_points(10)
+    print(len(i.get_points(10)), i.get_points(10))

--- a/zenmap/radialnet/core/Interpolation.py
+++ b/zenmap/radialnet/core/Interpolation.py
@@ -181,7 +181,7 @@ class Linear2DInterpolator:
         a_pass = 0
         b_pass = 0
 
-        self.__interpolated_points = range(number_of_pass)
+        self.__interpolated_points = list(range(number_of_pass))
 
         for i in range(0, number_of_pass):
 
@@ -206,7 +206,7 @@ class Linear2DInterpolator:
         a_pass = float(af - ai) / number_of_pass
         b_pass = float(bf - bi) / number_of_pass
 
-        self.__interpolated_points = range(number_of_pass)
+        self.__interpolated_points = list(range(number_of_pass))
 
         for i in range(1, number_of_pass + 1):
             self.__interpolated_points[i - 1] = (ai + a_pass * i,

--- a/zenmap/radialnet/gui/Application.py
+++ b/zenmap/radialnet/gui/Application.py
@@ -125,7 +125,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 from radialnet.util.integration import make_graph_from_nmap_parser
 from radialnet.core.Info import INFO
@@ -179,9 +182,9 @@ class Application(BWMainWindow):
 
         self.add(self.__vbox)
         self.set_title(" ".join([INFO['name'], INFO['version']]))
-        self.set_position(gtk.WIN_POS_CENTER)
+        self.set_position(Gtk.WindowPosition.CENTER)
         self.show_all()
-        self.connect('destroy', gtk.main_quit)
+        self.connect('destroy', Gtk.main_quit)
 
         self.__radialnet.set_no_show_all(True)
         self.__control.set_no_show_all(True)
@@ -223,4 +226,4 @@ class Application(BWMainWindow):
     def start(self):
         """
         """
-        gtk.main()
+        Gtk.main()

--- a/zenmap/radialnet/gui/ControlWidget.py
+++ b/zenmap/radialnet/gui/ControlWidget.py
@@ -125,9 +125,12 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GLib, Gdk, GObject
+
 import math
-import gobject
 
 import radialnet.util.geometry as geometry
 
@@ -203,39 +206,39 @@ class ControlAction(BWExpander):
         self.__tbox.bw_set_spacing(0)
         self.__vbox = BWVBox()
 
-        self.__jump_to = gtk.RadioToolButton(None, gtk.STOCK_JUMP_TO)
+        self.__jump_to = Gtk.RadioToolButton(None, Gtk.STOCK_JUMP_TO)
         try_set_tooltip_text(self.__jump_to, 'Change focus')
         self.__jump_to.connect('toggled',
                                self.__change_pointer,
                                RadialNet.POINTER_JUMP_TO)
 
         try:
-            # gtk.STOCK_INFO is available only in PyGTK 2.8 and later.
-            info_icon = gtk.STOCK_INFO
+            # Gtk.STOCK_INFO is available only in PyGTK 2.8 and later.
+            info_icon = Gtk.STOCK_INFO
         except AttributeError:
-            self.__info = gtk.RadioToolButton(self.__jump_to, None)
+            self.__info = Gtk.RadioToolButton(self.__jump_to, None)
             self.__info.set_label(_("Info"))
         else:
-            self.__info = gtk.RadioToolButton(self.__jump_to, info_icon)
+            self.__info = Gtk.RadioToolButton(self.__jump_to, info_icon)
         try_set_tooltip_text(self.__info, 'Show information')
         self.__info.connect('toggled',
                             self.__change_pointer,
                             RadialNet.POINTER_INFO)
 
-        self.__group = gtk.RadioToolButton(self.__jump_to, gtk.STOCK_ADD)
+        self.__group = Gtk.RadioToolButton(self.__jump_to, Gtk.STOCK_ADD)
         try_set_tooltip_text(self.__group, 'Group children')
         self.__group.connect('toggled',
                              self.__change_pointer,
                              RadialNet.POINTER_GROUP)
 
-        self.__region = gtk.RadioToolButton(self.__jump_to,
-                                            gtk.STOCK_SELECT_COLOR)
+        self.__region = Gtk.RadioToolButton(self.__jump_to,
+                                            Gtk.STOCK_SELECT_COLOR)
         try_set_tooltip_text(self.__region, 'Fill region')
         self.__region.connect('toggled',
                               self.__change_pointer,
                               RadialNet.POINTER_FILL)
 
-        self.__region_color = gtk.combo_box_new_text()
+        self.__region_color = Gtk.ComboBoxText.new()
         self.__region_color.append_text(_('Red'))
         self.__region_color.append_text(_('Yellow'))
         self.__region_color.append_text(_('Green'))
@@ -273,13 +276,13 @@ class ControlAction(BWExpander):
         self.radialnet.set_region_color(self.__region_color.get_active())
 
 
-class ControlVariableWidget(gtk.DrawingArea):
+class ControlVariableWidget(Gtk.DrawingArea):
     """
     """
     def __init__(self, name, value, update, increment=1):
         """
         """
-        gtk.DrawingArea.__init__(self)
+        Gtk.DrawingArea.__init__(self)
 
         self.__variable_name = name
         self.__value = value
@@ -299,13 +302,12 @@ class ControlVariableWidget(gtk.DrawingArea):
         self.connect('button_release_event', self.button_release)
         self.connect('motion_notify_event', self.motion_notify)
 
-        self.add_events(gtk.gdk.BUTTON_PRESS_MASK |
-                        gtk.gdk.BUTTON_RELEASE_MASK |
-                        gtk.gdk.MOTION_NOTIFY |
-                        gtk.gdk.POINTER_MOTION_HINT_MASK |
-                        gtk.gdk.POINTER_MOTION_MASK)
+        self.add_events(Gdk.EventMask.BUTTON_PRESS_MASK |
+                        Gdk.EventMask.BUTTON_RELEASE_MASK |
+                        Gdk.EventMask.POINTER_MOTION_HINT_MASK |
+                        Gdk.EventMask.POINTER_MOTION_MASK)
 
-        gobject.timeout_add(REFRESH_RATE, self.verify_value)
+        GLib.timeout_add(REFRESH_RATE, self.verify_value)
 
     def verify_value(self):
         """
@@ -325,14 +327,14 @@ class ControlVariableWidget(gtk.DrawingArea):
 
         if self.__button_is_clicked(pointer) and event.button == 1:
 
-            event.window.set_cursor(gtk.gdk.Cursor(gtk.gdk.HAND2))
+            event.window.set_cursor(Gdk.Cursor(Gdk.CursorType.HAND2))
             self.__active_increment = True
             self.__increment_value()
 
     def button_release(self, widget, event):
         """
         """
-        event.window.set_cursor(gtk.gdk.Cursor(gtk.gdk.LEFT_PTR))
+        event.window.set_cursor(Gdk.Cursor(Gdk.CursorType.LEFT_PTR))
 
         self.__active_increment = False
         self.__pointer_position = 0
@@ -438,7 +440,7 @@ class ControlVariableWidget(gtk.DrawingArea):
 
         if self.__active_increment:
 
-            gobject.timeout_add(self.__increment_time,
+            GLib.timeout_add(self.__increment_time,
                                 self.__increment_value)
 
     def set_value_function(self, value):
@@ -478,18 +480,18 @@ class ControlVariable(BWHBox):
                                                self.__set_function,
                                                self.__increment_pass)
 
-        self.__left_button = gtk.Button()
+        self.__left_button = Gtk.Button()
         self.__left_button.set_size_request(20, 20)
-        self.__left_arrow = gtk.Arrow(gtk.ARROW_LEFT, gtk.SHADOW_NONE)
+        self.__left_arrow = Gtk.Arrow(Gtk.ArrowType.LEFT, Gtk.ShadowType.NONE)
         self.__left_button.add(self.__left_arrow)
         self.__left_button.connect('pressed',
                                    self.__pressed,
                                    -self.__increment_pass)
         self.__left_button.connect('released', self.__released)
 
-        self.__right_button = gtk.Button()
+        self.__right_button = Gtk.Button()
         self.__right_button.set_size_request(20, 20)
-        self.__right_arrow = gtk.Arrow(gtk.ARROW_RIGHT, gtk.SHADOW_NONE)
+        self.__right_arrow = Gtk.Arrow(Gtk.ArrowType.RIGHT, Gtk.ShadowType.NONE)
         self.__right_button.add(self.__right_arrow)
         self.__right_button.connect('pressed',
                                     self.__pressed,
@@ -514,7 +516,7 @@ class ControlVariable(BWHBox):
             self.__set_function(self.__get_function() + increment)
             self.__control.verify_value()
 
-            gobject.timeout_add(self.__increment_time,
+            GLib.timeout_add(self.__increment_time,
                                 self.__increment_function,
                                 increment)
 
@@ -543,29 +545,28 @@ class ControlFisheye(BWVBox):
         """
         self.__params = BWHBox()
 
-        self.__fisheye_label = gtk.Label(_('<b>Fisheye</b> on ring'))
+        self.__fisheye_label = Gtk.Label(_('<b>Fisheye</b> on ring'))
         self.__fisheye_label.set_use_markup(True)
 
-        self.__ring = gtk.Adjustment(0, 0, self.__ring_max_value, 0.01, 0.01)
+        self.__ring = Gtk.Adjustment(0, 0, self.__ring_max_value, 0.01, 0.01)
 
-        self.__ring_spin = gtk.SpinButton(self.__ring)
+        self.__ring_spin = Gtk.SpinButton(self.__ring)
         self.__ring_spin.set_digits(2)
 
-        self.__ring_scale = gtk.HScale(self.__ring)
+        self.__ring_scale = Gtk.Scale(Gtk.Orientation.HORIZONTAL, self.__ring)
         self.__ring_scale.set_size_request(100, -1)
         self.__ring_scale.set_digits(2)
-        self.__ring_scale.set_value_pos(gtk.POS_LEFT)
+        self.__ring_scale.set_value_pos(Gtk.PositionType.LEFT)
         self.__ring_scale.set_draw_value(False)
-        self.__ring_scale.set_update_policy(gtk.UPDATE_CONTINUOUS)
 
-        self.__interest_label = gtk.Label(_('with interest factor'))
-        self.__interest = gtk.Adjustment(0, 0, 10, 0.01)
-        self.__interest_spin = gtk.SpinButton(self.__interest)
+        self.__interest_label = Gtk.Label(_('with interest factor'))
+        self.__interest = Gtk.Adjustment(0, 0, 10, 0.01)
+        self.__interest_spin = Gtk.SpinButton(self.__interest)
         self.__interest_spin.set_digits(2)
 
-        self.__spread_label = gtk.Label(_('and spread factor'))
-        self.__spread = gtk.Adjustment(0, -1.0, 1.0, 0.01, 0.01)
-        self.__spread_spin = gtk.SpinButton(self.__spread)
+        self.__spread_label = Gtk.Label(_('and spread factor'))
+        self.__spread = Gtk.Adjustment(0, -1.0, 1.0, 0.01, 0.01)
+        self.__spread_spin = Gtk.SpinButton(self.__spread)
         self.__spread_spin.set_digits(2)
 
         self.__params.bw_pack_start_noexpand_nofill(self.__fisheye_label)
@@ -582,7 +583,7 @@ class ControlFisheye(BWVBox):
         self.__interest.connect('value_changed', self.__change_interest)
         self.__spread.connect('value_changed', self.__change_spread)
 
-        gobject.timeout_add(REFRESH_RATE, self.__update_fisheye)
+        GLib.timeout_add(REFRESH_RATE, self.__update_fisheye)
 
     def __update_fisheye(self):
         """
@@ -679,8 +680,8 @@ class ControlInterpolation(BWExpander):
         """
         self.__vbox = BWVBox()
 
-        self.__cartesian_radio = gtk.RadioButton(None, _('Cartesian'))
-        self.__polar_radio = gtk.RadioButton(
+        self.__cartesian_radio = Gtk.RadioButton(None, _('Cartesian'))
+        self.__polar_radio = Gtk.RadioButton(
                 self.__cartesian_radio, _('Polar'))
         self.__cartesian_radio.connect('toggled',
                                        self.__change_system,
@@ -694,14 +695,14 @@ class ControlInterpolation(BWExpander):
         self.__system_box.bw_pack_start_noexpand_nofill(self.__cartesian_radio)
 
         self.__frames_box = BWHBox()
-        self.__frames_label = gtk.Label(_('Frames'))
+        self.__frames_label = Gtk.Label(_('Frames'))
         self.__frames_label.set_alignment(0.0, 0.5)
-        self.__frames = gtk.Adjustment(self.radialnet.get_number_of_frames(),
+        self.__frames = Gtk.Adjustment(self.radialnet.get_number_of_frames(),
                                        1,
                                        1000,
                                        1)
         self.__frames.connect('value_changed', self.__change_frames)
-        self.__frames_spin = gtk.SpinButton(self.__frames)
+        self.__frames_spin = Gtk.SpinButton(self.__frames)
         self.__frames_box.bw_pack_start_expand_fill(self.__frames_label)
         self.__frames_box.bw_pack_start_noexpand_nofill(self.__frames_spin)
 
@@ -710,7 +711,7 @@ class ControlInterpolation(BWExpander):
 
         self.bw_add(self.__vbox)
 
-        gobject.timeout_add(REFRESH_RATE, self.__update_animation)
+        GLib.timeout_add(REFRESH_RATE, self.__update_animation)
 
     def __update_animation(self):
         """
@@ -762,12 +763,12 @@ class ControlLayout(BWExpander):
         """
         self.__hbox = BWHBox()
 
-        self.__layout = gtk.combo_box_new_text()
+        self.__layout = Gtk.combo_box_new_text()
         self.__layout.append_text(_('Symmetric'))
         self.__layout.append_text(_('Weighted'))
         self.__layout.set_active(self.radialnet.get_layout())
         self.__layout.connect('changed', self.__change_layout)
-        self.__force = gtk.ToolButton(gtk.STOCK_REFRESH)
+        self.__force = Gtk.ToolButton(Gtk.STOCK_REFRESH)
         self.__force.connect('clicked', self.__force_update)
 
         self.__hbox.bw_pack_start_expand_fill(self.__layout)
@@ -823,13 +824,13 @@ class ControlRingGap(BWVBox):
                                         self.radialnet.get_ring_gap,
                                         self.radialnet.set_ring_gap)
 
-        self.__label = gtk.Label(_('Lower ring gap'))
+        self.__label = Gtk.Label(_('Lower ring gap'))
         self.__label.set_alignment(0.0, 0.5)
-        self.__adjustment = gtk.Adjustment(self.radialnet.get_min_ring_gap(),
+        self.__adjustment = Gtk.Adjustment(self.radialnet.get_min_ring_gap(),
                                            0,
                                            50,
                                            1)
-        self.__spin = gtk.SpinButton(self.__adjustment)
+        self.__spin = Gtk.SpinButton(self.__adjustment)
         self.__spin.connect('value_changed', self.__change_lower)
 
         self.__lower_hbox = BWHBox()
@@ -854,8 +855,8 @@ class ControlOptions(BWScrolledWindow):
         """
         BWScrolledWindow.__init__(self)
 
-        self.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_ALWAYS)
-        self.set_shadow_type(gtk.SHADOW_NONE)
+        self.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.ALWAYS)
+        self.set_shadow_type(Gtk.ShadowType.NONE)
 
         self.radialnet = radialnet
 
@@ -866,8 +867,8 @@ class ControlOptions(BWScrolledWindow):
     def __create_widgets(self):
         """
         """
-        self.__liststore = gtk.ListStore(gobject.TYPE_BOOLEAN,
-                                         gobject.TYPE_STRING)
+        self.__liststore = Gtk.ListStore(GObject.TYPE_BOOLEAN,
+                                         GObject.TYPE_STRING)
 
         self.__liststore.append([None, OPTIONS[0]])
         self.__liststore.append([None, OPTIONS[1]])
@@ -877,24 +878,24 @@ class ControlOptions(BWScrolledWindow):
         self.__liststore.append([None, OPTIONS[5]])
         self.__liststore.append([None, OPTIONS[6]])
 
-        self.__cell_toggle = gtk.CellRendererToggle()
+        self.__cell_toggle = Gtk.CellRendererToggle()
         self.__cell_toggle.set_property('activatable', True)
         self.__cell_toggle.connect('toggled',
                                    self.__change_option,
                                    self.__liststore)
 
-        self.__column_toggle = gtk.TreeViewColumn('', self.__cell_toggle)
+        self.__column_toggle = Gtk.TreeViewColumn('', self.__cell_toggle)
         self.__column_toggle.add_attribute(self.__cell_toggle, 'active', 0)
         self.__column_toggle.set_cell_data_func(self.__cell_toggle, self.__cell_toggle_data_method)
 
-        self.__cell_text = gtk.CellRendererText()
+        self.__cell_text = Gtk.CellRendererText()
 
-        self.__column_text = gtk.TreeViewColumn(None,
+        self.__column_text = Gtk.TreeViewColumn(None,
                                                 self.__cell_text,
                                                 text=1)
         self.__column_text.set_cell_data_func(self.__cell_text, self.__cell_text_data_method)
 
-        self.__treeview = gtk.TreeView(self.__liststore)
+        self.__treeview = Gtk.TreeView(self.__liststore)
         self.__treeview.set_enable_search(True)
         self.__treeview.set_search_column(1)
         self.__treeview.set_headers_visible(False)
@@ -903,7 +904,7 @@ class ControlOptions(BWScrolledWindow):
 
         self.add_with_viewport(self.__treeview)
 
-        gobject.timeout_add(REFRESH_RATE, self.__update_options)
+        GObject.timeout_add(REFRESH_RATE, self.__update_options)
 
     def __cell_toggle_data_method(self, column, cell, model, it):
         if not self.enable_labels and model.get_value(it, 1) == 'hostname':
@@ -1003,13 +1004,13 @@ class ControlView(BWExpander):
         self.bw_add(self.__vbox)
 
 
-class ControlNavigation(gtk.DrawingArea):
+class ControlNavigation(Gtk.DrawingArea):
     """
     """
     def __init__(self, radialnet):
         """
         """
-        gtk.DrawingArea.__init__(self)
+        Gtk.DrawingArea.__init__(self)
 
         self.radialnet = radialnet
 
@@ -1049,23 +1050,21 @@ class ControlNavigation(gtk.DrawingArea):
         self.connect('key_press_event', self.key_press)
         self.connect('key_release_event', self.key_release)
 
-        self.add_events(gtk.gdk.BUTTON_PRESS_MASK |
-                        gtk.gdk.BUTTON_RELEASE_MASK |
-                        gtk.gdk.ENTER_NOTIFY |
-                        gtk.gdk.LEAVE_NOTIFY |
-                        gtk.gdk.MOTION_NOTIFY |
-                        gtk.gdk.NOTHING |
-                        gtk.gdk.KEY_PRESS_MASK |
-                        gtk.gdk.KEY_RELEASE_MASK |
-                        gtk.gdk.POINTER_MOTION_HINT_MASK |
-                        gtk.gdk.POINTER_MOTION_MASK)
+        self.add_events(Gdk.EventMask.BUTTON_PRESS_MASK |
+                        Gdk.EventMask.BUTTON_RELEASE_MASK |
+                        Gdk.EventMask.ENTER_NOTIFY_MASK |
+                        Gdk.EventMask.LEAVE_NOTIFY_MASK  |
+                        Gdk.EventMask.KEY_PRESS_MASK |
+                        Gdk.EventMask.KEY_RELEASE_MASK |
+                        Gdk.EventMask.POINTER_MOTION_HINT_MASK |
+                        Gdk.EventMask.POINTER_MOTION_MASK)
 
         self.__rotate_node.set_coordinate(40, self.radialnet.get_rotation())
 
     def key_press(self, widget, event):
         """
         """
-        # key = gtk.gdk.keyval_name(event.keyval)
+        # key = Gdk.keyval_name(event.keyval)
 
         self.queue_draw()
 
@@ -1074,7 +1073,7 @@ class ControlNavigation(gtk.DrawingArea):
     def key_release(self, widget, event):
         """
         """
-        # key = gtk.gdk.keyval_name(event.keyval)
+        # key = Gdk.keyval_name(event.keyval)
 
         self.queue_draw()
 
@@ -1108,20 +1107,20 @@ class ControlNavigation(gtk.DrawingArea):
 
         if self.__rotate_is_clicked(pointer):
 
-            event.window.set_cursor(gtk.gdk.Cursor(gtk.gdk.HAND2))
+            event.window.set_cursor(Gdk.Cursor(Gdk.CursorType.HAND2))
             self.__rotating = True
 
         direction = self.__move_is_clicked(pointer)
 
         if direction is not None and self.__moving is None:
 
-            event.window.set_cursor(gtk.gdk.Cursor(gtk.gdk.HAND2))
+            event.window.set_cursor(Gdk.Cursor(Gdk.CursorType.HAND2))
             self.__moving = direction
             self.__move_in_direction(direction)
 
         if self.__center_is_clicked(pointer):
 
-            event.window.set_cursor(gtk.gdk.Cursor(gtk.gdk.HAND2))
+            event.window.set_cursor(Gdk.Cursor(Gdk.CursorType.HAND2))
             self.__centering = True
             self.__move_position = (0, 0)
             self.radialnet.set_translation(self.__move_position)
@@ -1145,7 +1144,7 @@ class ControlNavigation(gtk.DrawingArea):
         self.__rotating = False     # stop rotate
         self.__move_factor = 1
 
-        event.window.set_cursor(gtk.gdk.Cursor(gtk.gdk.LEFT_PTR))
+        event.window.set_cursor(Gdk.Cursor(Gdk.CursorType.LEFT_PTR))
 
         self.queue_draw()
 
@@ -1319,7 +1318,7 @@ class ControlNavigation(gtk.DrawingArea):
             if self.__move_factor < self.__move_factor_limit:
                 self.__move_factor += 1
 
-            gobject.timeout_add(self.__move_pass,
+            GObject.timeout_add(self.__move_pass,
                                 self.__move_in_direction,
                                 direction)
 

--- a/zenmap/radialnet/gui/ControlWidget.py
+++ b/zenmap/radialnet/gui/ControlWidget.py
@@ -361,7 +361,7 @@ class ControlVariableWidget(Gtk.DrawingArea):
 
         self.queue_draw()
 
-    def expose(self, widget, event):
+    def expose(self, widget, context):
         """
         Drawing callback
         @type  widget: GtkWidget
@@ -373,7 +373,7 @@ class ControlVariableWidget(Gtk.DrawingArea):
         """
         self.set_size_request(100, 30)
 
-        self.context = widget.window.cairo_create()
+        self.context = context
         self.__draw()
 
         return True
@@ -1181,7 +1181,7 @@ class ControlNavigation(Gtk.DrawingArea):
 
         return False
 
-    def expose(self, widget, event):
+    def expose(self, widget, context):
         """
         Drawing callback
         @type  widget: GtkWidget
@@ -1193,7 +1193,7 @@ class ControlNavigation(Gtk.DrawingArea):
         """
         self.set_size_request(120, 130)
 
-        self.context = widget.window.cairo_create()
+        self.context = context
         self.__draw()
 
         return False

--- a/zenmap/radialnet/gui/ControlWidget.py
+++ b/zenmap/radialnet/gui/ControlWidget.py
@@ -206,33 +206,29 @@ class ControlAction(BWExpander):
         self.__tbox.bw_set_spacing(0)
         self.__vbox = BWVBox()
 
-        self.__jump_to = Gtk.RadioToolButton(None, Gtk.STOCK_JUMP_TO)
+        self.__jump_to = Gtk.RadioToolButton(group=None,
+                                             stock_id=Gtk.STOCK_JUMP_TO)
         try_set_tooltip_text(self.__jump_to, 'Change focus')
         self.__jump_to.connect('toggled',
                                self.__change_pointer,
                                RadialNet.POINTER_JUMP_TO)
 
-        try:
-            # Gtk.STOCK_INFO is available only in PyGTK 2.8 and later.
-            info_icon = Gtk.STOCK_INFO
-        except AttributeError:
-            self.__info = Gtk.RadioToolButton(self.__jump_to, None)
-            self.__info.set_label(_("Info"))
-        else:
-            self.__info = Gtk.RadioToolButton(self.__jump_to, info_icon)
+        self.__info = Gtk.RadioToolButton(group=self.__jump_to,
+                                          stock_id=Gtk.STOCK_INFO)
         try_set_tooltip_text(self.__info, 'Show information')
         self.__info.connect('toggled',
                             self.__change_pointer,
                             RadialNet.POINTER_INFO)
 
-        self.__group = Gtk.RadioToolButton(self.__jump_to, Gtk.STOCK_ADD)
+        self.__group = Gtk.RadioToolButton(group=self.__jump_to,
+                                           stock_id=Gtk.STOCK_ADD)
         try_set_tooltip_text(self.__group, 'Group children')
         self.__group.connect('toggled',
                              self.__change_pointer,
                              RadialNet.POINTER_GROUP)
 
-        self.__region = Gtk.RadioToolButton(self.__jump_to,
-                                            Gtk.STOCK_SELECT_COLOR)
+        self.__region = Gtk.RadioToolButton(group=self.__jump_to,
+                                            stock_id=Gtk.STOCK_SELECT_COLOR)
         try_set_tooltip_text(self.__region, 'Fill region')
         self.__region.connect('toggled',
                               self.__change_pointer,
@@ -680,9 +676,10 @@ class ControlInterpolation(BWExpander):
         """
         self.__vbox = BWVBox()
 
-        self.__cartesian_radio = Gtk.RadioButton(None, _('Cartesian'))
-        self.__polar_radio = Gtk.RadioButton(
-                self.__cartesian_radio, _('Polar'))
+        self.__cartesian_radio = Gtk.RadioButton(group=None,
+                                                 label=_('Cartesian'))
+        self.__polar_radio = Gtk.RadioButton(group=self.__cartesian_radio,
+                                             label=_('Polar'))
         self.__cartesian_radio.connect('toggled',
                                        self.__change_system,
                                        RadialNet.INTERPOLATION_CARTESIAN)
@@ -695,12 +692,12 @@ class ControlInterpolation(BWExpander):
         self.__system_box.bw_pack_start_noexpand_nofill(self.__cartesian_radio)
 
         self.__frames_box = BWHBox()
-        self.__frames_label = Gtk.Label(_('Frames'))
+        self.__frames_label = Gtk.Label(label=_('Frames'))
         self.__frames_label.set_alignment(0.0, 0.5)
-        self.__frames = Gtk.Adjustment(self.radialnet.get_number_of_frames(),
-                                       1,
-                                       1000,
-                                       1)
+        self.__frames = Gtk.Adjustment(value=self.radialnet.get_number_of_frames(),
+                                       lower=1,
+                                       upper=1000,
+                                       step_increment=1)
         self.__frames.connect('value_changed', self.__change_frames)
         self.__frames_spin = Gtk.SpinButton(adjustment=self.__frames)
         self.__frames_box.bw_pack_start_expand_fill(self.__frames_label)

--- a/zenmap/radialnet/gui/ControlWidget.py
+++ b/zenmap/radialnet/gui/ControlWidget.py
@@ -383,8 +383,8 @@ class ControlVariableWidget(Gtk.DrawingArea):
         """
         allocation = self.get_allocation()
 
-        self.__center_of_widget = (allocation.width / 2,
-                                   allocation.height / 2)
+        self.__center_of_widget = (allocation.width // 2,
+                                   allocation.height // 2)
 
         xc, yc = self.__center_of_widget
 
@@ -1295,8 +1295,8 @@ class ControlNavigation(Gtk.DrawingArea):
         # Getting allocation reference
         allocation = self.get_allocation()
 
-        self.__center_of_widget = (allocation.width / 2,
-                                   allocation.height / 2)
+        self.__center_of_widget = (allocation.width // 2,
+                                   allocation.height // 2)
 
         self.__draw_rotate_control()
         self.__draw_move_control()

--- a/zenmap/radialnet/gui/ControlWidget.py
+++ b/zenmap/radialnet/gui/ControlWidget.py
@@ -601,7 +601,7 @@ class ControlFisheye(BWVBox):
             elif value > ring_max_value:
                 value = ring_max_value
 
-            self.__ring.set_all(value, 1, ring_max_value, 0.01, 0.01, 0)
+            self.__ring.configure(value, 1, ring_max_value, 0.01, 0.01, 0)
             self.__ring_max_value = ring_max_value
 
             self.__ring_scale.queue_draw()
@@ -906,13 +906,13 @@ class ControlOptions(BWScrolledWindow):
 
         GObject.timeout_add(REFRESH_RATE, self.__update_options)
 
-    def __cell_toggle_data_method(self, column, cell, model, it):
+    def __cell_toggle_data_method(self, column, cell, model, it, data):
         if not self.enable_labels and model.get_value(it, 1) == 'hostname':
             cell.set_property('activatable', False)
         else:
             cell.set_property('activatable', True)
 
-    def __cell_text_data_method(self, column, cell, model, it):
+    def __cell_text_data_method(self, column, cell, model, it, data):
         if not self.enable_labels and model.get_value(it, 1) == 'hostname':
             cell.set_property('strikethrough', True)
         else:

--- a/zenmap/radialnet/gui/ControlWidget.py
+++ b/zenmap/radialnet/gui/ControlWidget.py
@@ -297,7 +297,7 @@ class ControlVariableWidget(Gtk.DrawingArea):
 
         self.__last_value = self.__value()
 
-        self.connect('expose_event', self.expose)
+        self.connect('draw', self.expose)
         self.connect('button_press_event', self.button_press)
         self.connect('button_release_event', self.button_release)
         self.connect('motion_notify_event', self.motion_notify)
@@ -550,10 +550,10 @@ class ControlFisheye(BWVBox):
 
         self.__ring = Gtk.Adjustment(0, 0, self.__ring_max_value, 0.01, 0.01)
 
-        self.__ring_spin = Gtk.SpinButton(self.__ring)
+        self.__ring_spin = Gtk.SpinButton(adjustment=self.__ring)
         self.__ring_spin.set_digits(2)
 
-        self.__ring_scale = Gtk.Scale(Gtk.Orientation.HORIZONTAL, self.__ring)
+        self.__ring_scale = Gtk.Scale(orientation=Gtk.Orientation.HORIZONTAL, adjustment=self.__ring)
         self.__ring_scale.set_size_request(100, -1)
         self.__ring_scale.set_digits(2)
         self.__ring_scale.set_value_pos(Gtk.PositionType.LEFT)
@@ -561,12 +561,12 @@ class ControlFisheye(BWVBox):
 
         self.__interest_label = Gtk.Label(_('with interest factor'))
         self.__interest = Gtk.Adjustment(0, 0, 10, 0.01)
-        self.__interest_spin = Gtk.SpinButton(self.__interest)
+        self.__interest_spin = Gtk.SpinButton(adjustment=self.__interest)
         self.__interest_spin.set_digits(2)
 
         self.__spread_label = Gtk.Label(_('and spread factor'))
         self.__spread = Gtk.Adjustment(0, -1.0, 1.0, 0.01, 0.01)
-        self.__spread_spin = Gtk.SpinButton(self.__spread)
+        self.__spread_spin = Gtk.SpinButton(adjustment=self.__spread)
         self.__spread_spin.set_digits(2)
 
         self.__params.bw_pack_start_noexpand_nofill(self.__fisheye_label)
@@ -702,7 +702,7 @@ class ControlInterpolation(BWExpander):
                                        1000,
                                        1)
         self.__frames.connect('value_changed', self.__change_frames)
-        self.__frames_spin = Gtk.SpinButton(self.__frames)
+        self.__frames_spin = Gtk.SpinButton(adjustment=self.__frames)
         self.__frames_box.bw_pack_start_expand_fill(self.__frames_label)
         self.__frames_box.bw_pack_start_noexpand_nofill(self.__frames_spin)
 
@@ -763,7 +763,7 @@ class ControlLayout(BWExpander):
         """
         self.__hbox = BWHBox()
 
-        self.__layout = Gtk.combo_box_new_text()
+        self.__layout = Gtk.ComboBoxText()
         self.__layout.append_text(_('Symmetric'))
         self.__layout.append_text(_('Weighted'))
         self.__layout.set_active(self.radialnet.get_layout())
@@ -830,7 +830,7 @@ class ControlRingGap(BWVBox):
                                            0,
                                            50,
                                            1)
-        self.__spin = Gtk.SpinButton(self.__adjustment)
+        self.__spin = Gtk.SpinButton(adjustment=self.__adjustment)
         self.__spin.connect('value_changed', self.__change_lower)
 
         self.__lower_hbox = BWHBox()
@@ -1041,7 +1041,7 @@ class ControlNavigation(Gtk.DrawingArea):
         self.__rotate_clicked = False
         self.__move_clicked = None
 
-        self.connect('expose_event', self.expose)
+        self.connect('draw', self.expose)
         self.connect('button_press_event', self.button_press)
         self.connect('button_release_event', self.button_release)
         self.connect('motion_notify_event', self.motion_notify)

--- a/zenmap/radialnet/gui/Dialogs.py
+++ b/zenmap/radialnet/gui/Dialogs.py
@@ -125,19 +125,22 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+ 
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 from radialnet.core.Info import INFO
 from radialnet.gui.Image import Pixmaps
 
 
-class AboutDialog(gtk.AboutDialog):
+class AboutDialog(Gtk.AboutDialog):
     """
     """
     def __init__(self):
         """
         """
-        gtk.AboutDialog.__init__(self)
+        Gtk.AboutDialog.__init__(self)
 
         self.set_name(INFO['name'])
         self.set_version(INFO['version'])

--- a/zenmap/radialnet/gui/HostsViewer.py
+++ b/zenmap/radialnet/gui/HostsViewer.py
@@ -125,9 +125,12 @@
 # *                                                                         *
 # ***************************************************************************/
 
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GObject
+
 import re
-import gtk
-import gobject
 
 from radialnet.bestwidgets.windows import BWMainWindow
 
@@ -141,7 +144,7 @@ HOSTS_HEADER = ['ID', '#', 'Hosts']
 
 DIMENSION = (700, 400)
 
-IP_RE = re.compile('^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$')
+IP_RE = re.compile(r'^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$')
 
 
 class HostsViewer(BWMainWindow):
@@ -155,7 +158,7 @@ class HostsViewer(BWMainWindow):
         self.set_default_size(DIMENSION[0], DIMENSION[1])
 
         self.__nodes = nodes
-        self.__default_view = gtk.Label(_("No node selected"))
+        self.__default_view = Gtk.Label(_("No node selected"))
         self.__view = self.__default_view
 
         self.__create_widgets()
@@ -163,7 +166,7 @@ class HostsViewer(BWMainWindow):
     def __create_widgets(self):
         """
         """
-        self.__panel = gtk.HPaned()
+        self.__panel = Gtk.HPaned()
         self.__panel.set_border_width(6)
 
         self.__list = HostsList(self, self.__nodes)
@@ -189,15 +192,15 @@ class HostsViewer(BWMainWindow):
         self.__panel.add2(self.__view)
 
 
-class HostsList(gtk.ScrolledWindow):
+class HostsList(Gtk.ScrolledWindow):
     """
     """
     def __init__(self, parent, nodes):
         """
         """
         super(HostsList, self).__init__()
-        self.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
-        self.set_shadow_type(gtk.SHADOW_NONE)
+        self.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        self.set_shadow_type(Gtk.ShadowType.NONE)
 
         self.__parent = parent
         self.__nodes = nodes
@@ -207,15 +210,15 @@ class HostsList(gtk.ScrolledWindow):
     def __create_widgets(self):
         """
         """
-        self.__cell = gtk.CellRendererText()
+        self.__cell = Gtk.CellRendererText()
 
-        self.__hosts_store = gtk.ListStore(gobject.TYPE_INT,
-                                           gobject.TYPE_INT,
-                                           gobject.TYPE_STRING,
-                                           gobject.TYPE_STRING,
-                                           gobject.TYPE_BOOLEAN)
+        self.__hosts_store = Gtk.ListStore(GObject.TYPE_INT,
+                                           GObject.TYPE_INT,
+                                           GObject.TYPE_STRING,
+                                           GObject.TYPE_STRING,
+                                           GObject.TYPE_BOOLEAN)
 
-        self.__hosts_treeview = gtk.TreeView(self.__hosts_store)
+        self.__hosts_treeview = Gtk.TreeView(self.__hosts_store)
         self.__hosts_treeview.connect('cursor-changed', self.__cursor_callback)
 
         for i in range(len(self.__nodes)):
@@ -237,7 +240,7 @@ class HostsList(gtk.ScrolledWindow):
 
         for i in range(0, len(HOSTS_HEADER)):
 
-            column = gtk.TreeViewColumn(HOSTS_HEADER[i],
+            column = Gtk.TreeViewColumn(HOSTS_HEADER[i],
                                         self.__cell,
                                         text=i)
 

--- a/zenmap/radialnet/gui/HostsViewer.py
+++ b/zenmap/radialnet/gui/HostsViewer.py
@@ -278,7 +278,7 @@ class HostsList(Gtk.ScrolledWindow):
 
         self.__parent.change_notebook(node)
 
-    def __host_sort(self, treemodel, iter1, iter2):
+    def __host_sort(self, treemodel, iter1, iter2, *_):
         """
         """
         value1 = treemodel.get_value(iter1, 2)

--- a/zenmap/radialnet/gui/Image.py
+++ b/zenmap/radialnet/gui/Image.py
@@ -125,8 +125,12 @@
 # *                                                                         *
 # ***************************************************************************/
 
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import GdkPixbuf
+
 import os
-import gtk
 import array
 
 from zenmapCore.Paths import Path
@@ -190,7 +194,7 @@ class Image:
 
             file = self.get_icon(icon, image_type)
             self.__cache[icon + image_type] = \
-                    gtk.gdk.pixbuf_new_from_file(file)
+                    GdkPixbuf.Pixbuf.new_from_file(file)
 
         return self.__cache[icon + image_type]
 

--- a/zenmap/radialnet/gui/Image.py
+++ b/zenmap/radialnet/gui/Image.py
@@ -146,8 +146,8 @@ def get_pixels_for_cairo_image_surface(pixbuf):
     containing the icon pixels of a gtk.gdk.Pixbuf that can be used by
     cairo.ImageSurface.create_for_data() method.
     """
-    data = array.ArrayType('c')
-    format = pixbuf.get_rowstride() / pixbuf.get_width()
+    data = array.array('B')
+    image_format = pixbuf.get_rowstride() // pixbuf.get_width()
 
     i = 0
     j = 0
@@ -155,16 +155,16 @@ def get_pixels_for_cairo_image_surface(pixbuf):
 
         b, g, r = pixbuf.get_pixels()[i:i + FORMAT_RGB]
 
-        if format == FORMAT_RGBA:
+        if image_format == FORMAT_RGBA:
             a = pixbuf.get_pixels()[i + FORMAT_RGBA - 1]
-        elif format == FORMAT_RGB:
+        elif image_format == FORMAT_RGB:
             a = '\xff'
         else:
             raise TypeError('unknown image format')
 
-        data[j:j + FORMAT_RGBA] = array.ArrayType('c', [r, g, b, a])
+        data[j:j + FORMAT_RGBA] = array.array('B', [r, g, b, a])
 
-        i += format
+        i += image_format
         j += FORMAT_RGBA
 
     return (FORMAT_RGBA * pixbuf.get_width(), data)

--- a/zenmap/radialnet/gui/LegendWindow.py
+++ b/zenmap/radialnet/gui/LegendWindow.py
@@ -125,8 +125,11 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
-import pango
+import gi
+ 
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Pango
+
 import math
 import cairo
 
@@ -192,24 +195,24 @@ def draw_line(context, x, y, dash, color, label):
     context.show_text(label)
 
 
-class LegendWindow(gtk.Window):
+class LegendWindow(Gtk.Window):
     """
     """
     def __init__(self):
         """
         """
-        gtk.Window.__init__(self, gtk.WINDOW_TOPLEVEL)
+        Gtk.Window.__init__(self, Gtk.WindowType.TOPLEVEL)
         self.set_default_size(DIMENSION_NORMAL[0], DIMENSION_NORMAL[1])
-        self.__title_font = pango.FontDescription("Monospace Bold")
+        self.__title_font = Pango.FontDescription("Monospace Bold")
         self.set_title(_("Topology Legend"))
 
-        self.vbox = gtk.VBox()
+        self.vbox = Gtk.VBox()
         self.add(self.vbox)
 
-        self.drawing_area = gtk.DrawingArea()
+        self.drawing_area = Gtk.DrawingArea()
         self.vbox.pack_start(self.drawing_area)
         self.drawing_area.connect("expose-event", self.expose_event_handler)
-        self.more_uri = gtk.LinkButton(
+        self.more_uri = Gtk.LinkButton(
                 "https://nmap.org/book/zenmap-topology.html#zenmap-topology-legend",
                 label=_("View full legend online"))
         self.vbox.pack_start(self.more_uri, False, False)

--- a/zenmap/radialnet/gui/LegendWindow.py
+++ b/zenmap/radialnet/gui/LegendWindow.py
@@ -210,12 +210,12 @@ class LegendWindow(Gtk.Window):
         self.add(self.vbox)
 
         self.drawing_area = Gtk.DrawingArea()
-        self.vbox.pack_start(self.drawing_area)
+        self.vbox.pack_start(self.drawing_area, True, True, 0)
         self.drawing_area.connect("expose-event", self.expose_event_handler)
         self.more_uri = Gtk.LinkButton(
                 "https://nmap.org/book/zenmap-topology.html#zenmap-topology-legend",
                 label=_("View full legend online"))
-        self.vbox.pack_start(self.more_uri, False, False)
+        self.vbox.pack_start(self.more_uri, False, False, 0)
 
     def expose_event_handler(self, widget, event):
         """

--- a/zenmap/radialnet/gui/LegendWindow.py
+++ b/zenmap/radialnet/gui/LegendWindow.py
@@ -128,7 +128,7 @@
 import gi
  
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, Pango
+from gi.repository import Gtk, Gdk, Pango
 
 import math
 import cairo
@@ -140,7 +140,9 @@ DIMENSION_NORMAL = (350, 450)
 
 
 def draw_pixmap(context, x, y, name, label):
-    context.set_source_pixbuf(Pixmaps().get_pixbuf(name), x, y)
+    # This is pretty hideous workaround
+    Gdk.cairo_set_source_pixbuf(context, Pixmaps().get_pixbuf(name), x, y)
+    #context.set_source_pixbuf()
     context.paint()
     context.move_to(x + 50, y + 10)
     context.set_source_rgb(0, 0, 0)
@@ -211,101 +213,100 @@ class LegendWindow(Gtk.Window):
 
         self.drawing_area = Gtk.DrawingArea()
         self.vbox.pack_start(self.drawing_area, True, True, 0)
-        self.drawing_area.connect("expose-event", self.expose_event_handler)
+        self.drawing_area.connect("draw", self.draw_event_handler)
         self.more_uri = Gtk.LinkButton(
                 "https://nmap.org/book/zenmap-topology.html#zenmap-topology-legend",
                 label=_("View full legend online"))
         self.vbox.pack_start(self.more_uri, False, False, 0)
 
-    def expose_event_handler(self, widget, event):
+    def draw_event_handler(self, widget, graphic_context):
         """
         """
-        self.graphic_context = widget.window.cairo_create()
         x, y = 45, 20
-        draw_heading(self.graphic_context, x, y, _("Hosts"))
+        draw_heading(graphic_context, x, y, _("Hosts"))
 
         # white circle
         y += 20
-        draw_circle(self.graphic_context, x, y, 3, (1, 1, 1),
+        draw_circle(graphic_context, x, y, 3, (1, 1, 1),
                 _("host was not port scanned"))
         # green circle
         y += 20
-        draw_circle(self.graphic_context, x, y, 4, (0, 1, 0),
+        draw_circle(graphic_context, x, y, 4, (0, 1, 0),
                 _("host with fewer than 3 open ports"))
         # yellow circle
         y += 20
-        draw_circle(self.graphic_context, x, y, 5, (1, 1, 0),
+        draw_circle(graphic_context, x, y, 5, (1, 1, 0),
                 _("host with 3 to 6 open ports"))
         # red circle
         y += 20
-        draw_circle(self.graphic_context, x, y, 6, (1, 0, 0),
+        draw_circle(graphic_context, x, y, 6, (1, 0, 0),
                 _("host with more than 6 open ports"))
 
         # green square
         y += 20
         rx = x - 20
-        draw_square(self.graphic_context, rx, y, 10, (0, 1, 0))
+        draw_square(graphic_context, rx, y, 10, (0, 1, 0))
         rx += 10 + 5
         # yellow square
-        draw_square(self.graphic_context, rx, y, 12, (1, 1, 0))
+        draw_square(graphic_context, rx, y, 12, (1, 1, 0))
         rx += 12 + 5
         # red square
-        draw_square(self.graphic_context, rx, y, 14, (1, 0, 0))
+        draw_square(graphic_context, rx, y, 14, (1, 0, 0))
 
-        self.graphic_context.move_to(x + 50, y + 5)
-        self.graphic_context.set_source_rgb(0, 0, 0)
-        self.graphic_context.show_text(_("host is a router, switch, or WAP"))
+        graphic_context.move_to(x + 50, y + 5)
+        graphic_context.set_source_rgb(0, 0, 0)
+        graphic_context.show_text(_("host is a router, switch, or WAP"))
 
         # connections between hosts
         y += 30
-        draw_heading(self.graphic_context, x, y, _("Traceroute connections"))
+        draw_heading(graphic_context, x, y, _("Traceroute connections"))
 
         y += 20
-        self.graphic_context.move_to(x, y)
-        self.graphic_context.show_text(_("Thicker line means higher round-trip time"))
+        graphic_context.move_to(x, y)
+        graphic_context.show_text(_("Thicker line means higher round-trip time"))
         # primary traceroute (blue line)
         y += 20
-        draw_line(self.graphic_context, x, y, [], (0, 0, 1),
+        draw_line(graphic_context, x, y, [], (0, 0, 1),
                 _("primary traceroute connection"))
         # Alternate route (orange line)
         y += 20
-        draw_line(self.graphic_context, x, y, [], (1, 0.5, 0),
+        draw_line(graphic_context, x, y, [], (1, 0.5, 0),
                 _("alternate path"))
         # no traceroute
         y += 20
-        draw_line(self.graphic_context, x, y, [4.0, 2.0], (0, 0, 0),
+        draw_line(graphic_context, x, y, [4.0, 2.0], (0, 0, 0),
                 _("no traceroute information"))
         # missing traceroute
         y += 20
-        self.graphic_context.set_source_rgb(0.5, 0.7, 0.95)
-        self.graphic_context.move_to(x - 15, y)
-        self.graphic_context.arc(x - 25, y, 5, 0, 2 * math.pi)
-        self.graphic_context.stroke_preserve()
-        draw_line(self.graphic_context, x, y, [4.0, 2.0], (0.5, 0.7, 0.95),
+        graphic_context.set_source_rgb(0.5, 0.7, 0.95)
+        graphic_context.move_to(x - 15, y)
+        graphic_context.arc(x - 25, y, 5, 0, 2 * math.pi)
+        graphic_context.stroke_preserve()
+        draw_line(graphic_context, x, y, [4.0, 2.0], (0.5, 0.7, 0.95),
                 _("missing traceroute hop"))
 
         # special purpose hosts
         y += 30
-        draw_heading(self.graphic_context, x, y, _("Additional host icons"))
+        draw_heading(graphic_context, x, y, _("Additional host icons"))
 
         # router image
         y += 20
-        draw_pixmap(self.graphic_context, x, y, "router", _("router"))
+        draw_pixmap(graphic_context, x, y, "router", _("router"))
 
         # switch image
         y += 20
-        draw_pixmap(self.graphic_context, x, y, "switch", _("switch"))
+        draw_pixmap(graphic_context, x, y, "switch", _("switch"))
 
         # wap image
         y += 20
-        draw_pixmap(self.graphic_context, x, y, "wireless",
+        draw_pixmap(graphic_context, x, y, "wireless",
                 _("wireless access point"))
 
         # firewall image
         y += 20
-        draw_pixmap(self.graphic_context, x, y, "firewall", _("firewall"))
+        draw_pixmap(graphic_context, x, y, "firewall", _("firewall"))
 
         # host with filtered ports
         y += 20
-        draw_pixmap(self.graphic_context, x, y, "padlock",
+        draw_pixmap(graphic_context, x, y, "padlock",
                 _("host with some filtered ports"))

--- a/zenmap/radialnet/gui/NodeNotebook.py
+++ b/zenmap/radialnet/gui/NodeNotebook.py
@@ -447,7 +447,7 @@ class SystemPage(BWScrolledWindow):
 
         self.__address_label = BWSectionLabel(_('Address:'))
         self.__address_list = Gtk.ComboBoxText.new_with_entry()
-        self.__address_list.child.set_editable(False)
+        self.__address_list.get_child().set_editable(False)
 
         for address in self.__node.get_info('addresses'):
 
@@ -470,7 +470,7 @@ class SystemPage(BWScrolledWindow):
 
             self.__hostname_label = BWSectionLabel(_('Hostname:'))
             self.__hostname_list = Gtk.ComboBoxText.new_with_entry()
-            self.__hostname_list.child.set_editable(False)
+            self.__hostname_list.get_child().set_editable(False)
 
             for hostname in self.__node.get_info('hostnames'):
 
@@ -617,7 +617,7 @@ class SystemPage(BWScrolledWindow):
             self.__fp_label = BWSectionLabel(_('Used ports:'))
 
             self.__fp_ports_list = Gtk.ComboBoxText.new_with_entry()
-            self.__fp_ports_list.child.set_editable(False)
+            self.__fp_ports_list.get_child().set_editable(False)
 
             self.__fp_vbox = BWVBox()
 

--- a/zenmap/radialnet/gui/NodeNotebook.py
+++ b/zenmap/radialnet/gui/NodeNotebook.py
@@ -125,9 +125,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
-import pango
-import gobject
+import gi
+ 
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GObject, Pango
 
 from radialnet.bestwidgets.boxes import BWVBox, BWHBox, BWScrolledWindow, BWTable
 from radialnet.bestwidgets.expanders import BWExpander
@@ -177,14 +178,14 @@ def get_service_color(state):
     return color
 
 
-class NodeNotebook(gtk.Notebook):
+class NodeNotebook(Gtk.Notebook):
     """
     """
     def __init__(self, node):
         """
         """
-        gtk.Notebook.__init__(self)
-        self.set_tab_pos(gtk.POS_TOP)
+        Gtk.Notebook.__init__(self)
+        self.set_tab_pos(Gtk.PositionType.TOP)
 
         self.__node = node
 
@@ -204,25 +205,25 @@ class NodeNotebook(gtk.Notebook):
         self.append_page(self.__trace_page, BWLabel(_('Traceroute')))
 
 
-class ServicesPage(gtk.Notebook):
+class ServicesPage(Gtk.Notebook):
     """
     """
     def __init__(self, node):
         """
         """
-        gtk.Notebook.__init__(self)
+        Gtk.Notebook.__init__(self)
         self.set_border_width(6)
-        self.set_tab_pos(gtk.POS_TOP)
+        self.set_tab_pos(Gtk.PositionType.TOP)
 
         self.__node = node
-        self.__font = pango.FontDescription('Monospace')
+        self.__font = Pango.FontDescription('Monospace')
 
         self.__create_widgets()
 
     def __create_widgets(self):
         """
         """
-        self.__cell = gtk.CellRendererText()
+        self.__cell = Gtk.CellRendererText()
 
         # texteditor widgets
         self.__texteditor = BWTextEditor()
@@ -230,7 +231,7 @@ class ServicesPage(gtk.Notebook):
         self.__texteditor.bw_set_editable(False)
         self.__texteditor.set_border_width(0)
 
-        self.__select_combobox = gtk.combo_box_new_text()
+        self.__select_combobox = Gtk.ComboBoxText()
         self.__select_combobox.connect('changed', self.__change_text_value)
 
         self.__viewer = BWVBox(spacing=6)
@@ -247,15 +248,15 @@ class ServicesPage(gtk.Notebook):
 
         self.__ports_scroll = BWScrolledWindow()
 
-        self.__ports_store = gtk.TreeStore(gobject.TYPE_INT,
-                                           gobject.TYPE_STRING,
-                                           gobject.TYPE_STRING,
-                                           gobject.TYPE_STRING,
-                                           gobject.TYPE_STRING,
-                                           gobject.TYPE_STRING,
-                                           gobject.TYPE_BOOLEAN)
+        self.__ports_store = Gtk.TreeStore(GObject.TYPE_INT,
+                                           GObject.TYPE_STRING,
+                                           GObject.TYPE_STRING,
+                                           GObject.TYPE_STRING,
+                                           GObject.TYPE_STRING,
+                                           GObject.TYPE_STRING,
+                                           GObject.TYPE_BOOLEAN)
 
-        self.__ports_treeview = gtk.TreeView(self.__ports_store)
+        self.__ports_treeview = Gtk.TreeView(self.__ports_store)
 
         for port in self.__node.get_info('ports'):
 
@@ -325,7 +326,7 @@ class ServicesPage(gtk.Notebook):
 
         for i in range(len(PORTS_HEADER)):
 
-            column = gtk.TreeViewColumn(PORTS_HEADER[i],
+            column = Gtk.TreeViewColumn(PORTS_HEADER[i],
                                         self.__cell,
                                         text=i)
 
@@ -348,13 +349,13 @@ class ServicesPage(gtk.Notebook):
 
         self.__xports_scroll = BWScrolledWindow()
 
-        self.__xports_store = gtk.TreeStore(gobject.TYPE_INT,
-                                            gobject.TYPE_STRING,
-                                            gobject.TYPE_STRING,
-                                            gobject.TYPE_STRING,
-                                            gobject.TYPE_BOOLEAN)
+        self.__xports_store = Gtk.TreeStore(GObject.TYPE_INT,
+                                            GObject.TYPE_STRING,
+                                            GObject.TYPE_STRING,
+                                            GObject.TYPE_STRING,
+                                            GObject.TYPE_BOOLEAN)
 
-        self.__xports_treeview = gtk.TreeView(self.__xports_store)
+        self.__xports_treeview = Gtk.TreeView(self.__xports_store)
 
         for xports in self.__node.get_info('extraports'):
 
@@ -377,7 +378,7 @@ class ServicesPage(gtk.Notebook):
 
         for i in range(len(EXTRAPORTS_HEADER)):
 
-            column = gtk.TreeViewColumn(EXTRAPORTS_HEADER[i],
+            column = Gtk.TreeViewColumn(EXTRAPORTS_HEADER[i],
                                         self.__cell,
                                         text=i)
 
@@ -422,7 +423,7 @@ class SystemPage(BWScrolledWindow):
         BWScrolledWindow.__init__(self)
 
         self.__node = node
-        self.__font = pango.FontDescription('Monospace')
+        self.__font = Pango.FontDescription('Monospace')
 
         self.__create_widgets()
 
@@ -432,20 +433,20 @@ class SystemPage(BWScrolledWindow):
         self.__vbox = BWVBox()
         self.__vbox.set_border_width(6)
 
-        self.__cell = gtk.CellRendererText()
+        self.__cell = Gtk.CellRendererText()
 
         self.__general_frame = BWExpander(_('General information'))
         self.__sequences_frame = BWExpander(_('Sequences'))
         self.__os_frame = BWExpander(_('Operating System'))
 
-        self.__sequences_frame.bw_add(gtk.Label(_('No sequence information.')))
-        self.__os_frame.bw_add(gtk.Label(_('No OS information.')))
+        self.__sequences_frame.bw_add(Gtk.Label(_('No sequence information.')))
+        self.__os_frame.bw_add(Gtk.Label(_('No OS information.')))
 
         # general information widgets
         self.__general = BWTable(3, 2)
 
         self.__address_label = BWSectionLabel(_('Address:'))
-        self.__address_list = gtk.combo_box_entry_new_text()
+        self.__address_list = Gtk.ComboBoxText.new_with_entry()
         self.__address_list.child.set_editable(False)
 
         for address in self.__node.get_info('addresses'):
@@ -461,14 +462,14 @@ class SystemPage(BWScrolledWindow):
         self.__address_list.set_active(0)
 
         self.__general.bw_attach_next(self.__address_label,
-                                      yoptions=gtk.FILL,
-                                      xoptions=gtk.FILL)
-        self.__general.bw_attach_next(self.__address_list, yoptions=gtk.FILL)
+                                      yoptions=Gtk.AttachOptions.FILL,
+                                      xoptions=Gtk.AttachOptions.FILL)
+        self.__general.bw_attach_next(self.__address_list, yoptions=Gtk.AttachOptions.FILL)
 
         if self.__node.get_info('hostnames') is not None:
 
             self.__hostname_label = BWSectionLabel(_('Hostname:'))
-            self.__hostname_list = gtk.combo_box_entry_new_text()
+            self.__hostname_list = Gtk.ComboBoxText.new_with_entry()
             self.__hostname_list.child.set_editable(False)
 
             for hostname in self.__node.get_info('hostnames'):
@@ -479,10 +480,10 @@ class SystemPage(BWScrolledWindow):
             self.__hostname_list.set_active(0)
 
             self.__general.bw_attach_next(self.__hostname_label,
-                                          yoptions=gtk.FILL,
-                                          xoptions=gtk.FILL)
+                                          yoptions=Gtk.AttachOptions.FILL,
+                                          xoptions=Gtk.AttachOptions.FILL)
             self.__general.bw_attach_next(self.__hostname_list,
-                                          yoptions=gtk.FILL)
+                                          yoptions=Gtk.AttachOptions.FILL)
 
         if self.__node.get_info('uptime') is not None:
 
@@ -498,10 +499,10 @@ class SystemPage(BWScrolledWindow):
             self.__uptime_value.set_line_wrap(False)
 
             self.__general.bw_attach_next(self.__uptime_label,
-                                          yoptions=gtk.FILL,
-                                          xoptions=gtk.FILL)
+                                          yoptions=Gtk.AttachOptions.FILL,
+                                          xoptions=Gtk.AttachOptions.FILL)
             self.__general.bw_attach_next(self.__uptime_value,
-                                          yoptions=gtk.FILL)
+                                          yoptions=Gtk.AttachOptions.FILL)
 
         self.__general_frame.bw_add(self.__general)
         self.__general_frame.set_expanded(True)
@@ -512,7 +513,7 @@ class SystemPage(BWScrolledWindow):
                     self.__create_sequences_widget(sequences))
 
         # operating system information widgets
-        self.__os = gtk.Notebook()
+        self.__os = Gtk.Notebook()
 
         os = self.__node.get_info('os')
 
@@ -522,12 +523,12 @@ class SystemPage(BWScrolledWindow):
 
                 self.__match_scroll = BWScrolledWindow()
 
-                self.__match_store = gtk.ListStore(gobject.TYPE_STRING,
-                                                   gobject.TYPE_STRING,
-                                                   gobject.TYPE_INT,
-                                                   gobject.TYPE_BOOLEAN)
+                self.__match_store = Gtk.ListStore(GObject.TYPE_STRING,
+                                                   GObject.TYPE_STRING,
+                                                   GObject.TYPE_INT,
+                                                   GObject.TYPE_BOOLEAN)
 
-                self.__match_treeview = gtk.TreeView(self.__match_store)
+                self.__match_treeview = Gtk.TreeView(self.__match_store)
 
                 for os_match in os['matches']:
 
@@ -541,7 +542,7 @@ class SystemPage(BWScrolledWindow):
 
                 for i in range(len(OSMATCH_HEADER)):
 
-                    column = gtk.TreeViewColumn(OSMATCH_HEADER[i],
+                    column = Gtk.TreeViewColumn(OSMATCH_HEADER[i],
                                                 self.__cell,
                                                 text=i)
 
@@ -564,14 +565,14 @@ class SystemPage(BWScrolledWindow):
 
                 self.__class_scroll = BWScrolledWindow()
 
-                self.__class_store = gtk.ListStore(gobject.TYPE_STRING,
-                                                   gobject.TYPE_STRING,
-                                                   gobject.TYPE_STRING,
-                                                   gobject.TYPE_STRING,
-                                                   gobject.TYPE_STRING,
-                                                   gobject.TYPE_BOOLEAN)
+                self.__class_store = Gtk.ListStore(GObject.TYPE_STRING,
+                                                   GObject.TYPE_STRING,
+                                                   GObject.TYPE_STRING,
+                                                   GObject.TYPE_STRING,
+                                                   GObject.TYPE_STRING,
+                                                   GObject.TYPE_BOOLEAN)
 
-                self.__class_treeview = gtk.TreeView(self.__class_store)
+                self.__class_treeview = Gtk.TreeView(self.__class_store)
 
                 for os_class in os['classes']:
 
@@ -588,7 +589,7 @@ class SystemPage(BWScrolledWindow):
 
                 for i in range(len(OSCLASS_HEADER)):
 
-                    column = gtk.TreeViewColumn(OSCLASS_HEADER[i],
+                    column = Gtk.TreeViewColumn(OSCLASS_HEADER[i],
                                                 self.__cell,
                                                 text=i)
 
@@ -615,7 +616,7 @@ class SystemPage(BWScrolledWindow):
             self.__fp_ports = BWHBox()
             self.__fp_label = BWSectionLabel(_('Used ports:'))
 
-            self.__fp_ports_list = gtk.combo_box_entry_new_text()
+            self.__fp_ports_list = Gtk.ComboBoxText.new_with_entry()
             self.__fp_ports_list.child.set_editable(False)
 
             self.__fp_vbox = BWVBox()
@@ -669,7 +670,7 @@ class SystemPage(BWScrolledWindow):
 
             table.attach(tcp_class, 1, 2, 1, 2)
 
-            tcp_values = gtk.combo_box_entry_new_text()
+            tcp_values = Gtk.ComboBoxText.new_with_entry()
 
             for value in tcp['values']:
                 tcp_values.append_text(value)
@@ -694,7 +695,7 @@ class SystemPage(BWScrolledWindow):
 
             table.attach(ip_id_class, 1, 2, 2, 3)
 
-            ip_id_values = gtk.combo_box_entry_new_text()
+            ip_id_values = Gtk.ComboBoxText.new_with_entry()
 
             for value in ip_id['values']:
                 ip_id_values.append_text(value)
@@ -712,7 +713,7 @@ class SystemPage(BWScrolledWindow):
 
             if tcp_ts['values'] is not None:
 
-                tcp_ts_values = gtk.combo_box_entry_new_text()
+                tcp_ts_values = Gtk.ComboBoxText.new_with_entry()
 
                 for value in tcp_ts['values']:
                     tcp_ts_values.append_text(value)
@@ -746,7 +747,7 @@ class TraceroutePage(BWVBox):
             hops = trace.get("hops")
         if hops is None or len(hops) == 0:
 
-            self.__trace_label = gtk.Label(NO_TRACE_TEXT)
+            self.__trace_label = Gtk.Label(NO_TRACE_TEXT)
             self.pack_start(self.__trace_label, True, True)
 
         else:
@@ -755,19 +756,19 @@ class TraceroutePage(BWVBox):
             hops = self.__node.get_info('trace')['hops']
             ttls = [int(i['ttl']) for i in hops]
 
-            self.__cell = gtk.CellRendererText()
+            self.__cell = Gtk.CellRendererText()
 
             self.__trace_scroll = BWScrolledWindow()
             self.__trace_scroll.set_border_width(0)
 
-            self.__trace_store = gtk.ListStore(gobject.TYPE_INT,
-                                               gobject.TYPE_STRING,
-                                               gobject.TYPE_STRING,
-                                               gobject.TYPE_STRING,
-                                               gobject.TYPE_STRING,
-                                               gobject.TYPE_BOOLEAN)
+            self.__trace_store = Gtk.ListStore(GObject.TYPE_INT,
+                                               GObject.TYPE_STRING,
+                                               GObject.TYPE_STRING,
+                                               GObject.TYPE_STRING,
+                                               GObject.TYPE_STRING,
+                                               GObject.TYPE_BOOLEAN)
 
-            self.__trace_treeview = gtk.TreeView(self.__trace_store)
+            self.__trace_treeview = Gtk.TreeView(self.__trace_store)
 
             count = 0
 
@@ -797,7 +798,7 @@ class TraceroutePage(BWVBox):
 
             for i in range(len(TRACE_HEADER)):
 
-                column = gtk.TreeViewColumn(TRACE_HEADER[i],
+                column = Gtk.TreeViewColumn(TRACE_HEADER[i],
                                             self.__cell,
                                             text=i)
 

--- a/zenmap/radialnet/gui/NodeNotebook.py
+++ b/zenmap/radialnet/gui/NodeNotebook.py
@@ -748,7 +748,7 @@ class TraceroutePage(BWVBox):
         if hops is None or len(hops) == 0:
 
             self.__trace_label = Gtk.Label(NO_TRACE_TEXT)
-            self.pack_start(self.__trace_label, True, True)
+            self.pack_start(self.__trace_label, True, True, 0)
 
         else:
 

--- a/zenmap/radialnet/gui/NodeWindow.py
+++ b/zenmap/radialnet/gui/NodeWindow.py
@@ -125,8 +125,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
-import pango
+import gi
+ 
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Gdk, Pango
 
 import radialnet.util.drawing as drawing
 
@@ -146,13 +148,13 @@ class NodeWindow(BWWindow):
     def __init__(self, node, position):
         """
         """
-        BWWindow.__init__(self, gtk.WINDOW_TOPLEVEL)
+        BWWindow.__init__(self, Gtk.WindowType.TOPLEVEL)
         self.move(position[0], position[1])
         self.set_default_size(DIMENSION_NORMAL[0], DIMENSION_NORMAL[1])
 
         self.__node = node
 
-        self.__title_font = pango.FontDescription('Monospace Bold')
+        self.__title_font = Pango.FontDescription('Monospace Bold')
 
         self.__icon = Application()
         self.__create_widgets()
@@ -168,14 +170,14 @@ class NodeWindow(BWWindow):
         # create head elements
 
         # icon with node's score color
-        self.__color_box = gtk.EventBox()
-        self.__color_image = gtk.Image()
+        self.__color_box = Gtk.EventBox()
+        self.__color_image = Gtk.Image()
         self.__color_image.set_from_file(self.__icon.get_icon('border'))
         self.__color_box.add(self.__color_image)
         self.__color_box.set_size_request(15, 15)
         r, g, b = drawing.cairo_to_gdk_color(
                 self.__node.get_draw_info('color'))
-        self.__color_box.modify_bg(gtk.STATE_NORMAL, gtk.gdk.Color(r, g, b))
+        self.__color_box.modify_bg(Gtk.StateType.NORMAL, Gdk.Color(r, g, b))
 
         # title with the node ip and hostname
         self.__title = self.__node.get_host().get_hostname()

--- a/zenmap/radialnet/gui/RadialNet.py
+++ b/zenmap/radialnet/gui/RadialNet.py
@@ -1055,7 +1055,7 @@ class RadialNet(Gtk.DrawingArea):
             max = self.__graph.get_max_edge_mean_weight()
 
             if max != min:
-                thickness = (latency - min) * 4 // (max - min) + 1
+                thickness = (latency - min) * 4 / (max - min) + 1
 
             else:
                 thickness = 1
@@ -1079,8 +1079,8 @@ class RadialNet(Gtk.DrawingArea):
 
                 context.set_font_size(8)
                 context.set_line_width(1)
-                context.move_to(xc + (xa + xb) // 2 + 1,
-                                     yc - (ya + yb) // 2 + 4)
+                context.move_to(xc + (xa + xb) / 2 + 1,
+                                     yc - (ya + yb) / 2 + 4)
                 context.show_text(str(round(latency, 2)))
                 context.stroke()
 

--- a/zenmap/radialnet/gui/RadialNet.py
+++ b/zenmap/radialnet/gui/RadialNet.py
@@ -863,19 +863,16 @@ class RadialNet(Gtk.DrawingArea):
 
         return False
 
-    def expose(self, widget, event):
+    def expose(self, widget, context):
         """
         Drawing callback
         @type  widget: GtkWidget
         @param widget: Gtk widget superclass
-        @type  event: GtkEvent
-        @param event: Gtk event of widget
+        @type  context: cairo.Context
+        @param context: cairo context class
         @rtype: boolean
         @return: Indicator of the event propagation
         """
-        context = widget.window.cairo_create()
-
-        context.rectangle(*event.area)
         context.set_source_rgb(1.0, 1.0, 1.0)
         context.fill()
 

--- a/zenmap/radialnet/gui/RadialNet.py
+++ b/zenmap/radialnet/gui/RadialNet.py
@@ -781,7 +781,8 @@ class RadialNet(Gtk.DrawingArea):
 
             if result is not None:
 
-                xw, yw = self.window.get_origin()
+                # first returned value is not meaningful and should be ignored
+                _, xw, yw = self.get_window().get_origin()
                 node, point = result
                 x, y = point
 

--- a/zenmap/radialnet/gui/RadialNet.py
+++ b/zenmap/radialnet/gui/RadialNet.py
@@ -125,10 +125,15 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GLib
+
 import math
 import cairo
-import gobject
+
+from functools import reduce
 
 import radialnet.util.geometry as geometry
 import radialnet.util.misc as misc
@@ -170,7 +175,7 @@ FILE_TYPE_PS = 3
 FILE_TYPE_SVG = 4
 
 
-class RadialNet(gtk.DrawingArea):
+class RadialNet(Gtk.DrawingArea):
     """
     Radial network visualization widget
     """
@@ -240,19 +245,17 @@ class RadialNet(gtk.DrawingArea):
         self.connect('key_release_event', self.key_release)
         self.connect('scroll_event', self.scroll_event)
 
-        self.add_events(gtk.gdk.BUTTON_PRESS_MASK |
-                        gtk.gdk.BUTTON_RELEASE_MASK |
-                        gtk.gdk.ENTER_NOTIFY |
-                        gtk.gdk.LEAVE_NOTIFY |
-                        gtk.gdk.MOTION_NOTIFY |
-                        gtk.gdk.NOTHING |
-                        gtk.gdk.KEY_PRESS_MASK |
-                        gtk.gdk.KEY_RELEASE_MASK |
-                        gtk.gdk.POINTER_MOTION_HINT_MASK |
-                        gtk.gdk.POINTER_MOTION_MASK |
-                        gtk.gdk.SCROLL_MASK)
+        self.add_events(Gdk.EventMask.BUTTON_PRESS_MASK |
+                        Gdk.EventMask.BUTTON_RELEASE_MASK |
+                        Gdk.EventMask.ENTER_NOTIFY_MASK |
+                        Gdk.EventMask.LEAVE_NOTIFY_MASK |
+                        Gdk.EventMask.KEY_PRESS_MASK |
+                        Gdk.EventMask.KEY_RELEASE_MASK |
+                        Gdk.EventMask.POINTER_MOTION_HINT_MASK |
+                        Gdk.EventMask.POINTER_MOTION_MASK |
+                        Gdk.EventMask.SCROLL_MASK)
 
-        self.set_flags(gtk.CAN_FOCUS)
+        self.set_can_focus(True)
         self.grab_focus()
 
     def graph_is_not_empty(function):
@@ -604,10 +607,10 @@ class RadialNet(gtk.DrawingArea):
     def scroll_event(self, widget, event):
         """
         """
-        if event.direction == gtk.gdk.SCROLL_UP:
+        if event.direction == Gdk.ScrollDirection.UP:
             self.set_scale(self.__scale + 0.01)
 
-        if event.direction == gtk.gdk.SCROLL_DOWN:
+        if event.direction == Gdk.ScrollDirection.DOWN:
             self.set_scale(self.__scale - 0.01)
 
         self.queue_draw()
@@ -617,7 +620,7 @@ class RadialNet(gtk.DrawingArea):
     def key_press(self, widget, event):
         """
         """
-        key = gtk.gdk.keyval_name(event.keyval)
+        key = Gdk.keyval_name(event.keyval)
 
         if key == 'KP_Add':
             self.set_ring_gap(self.__ring_gap + 1)
@@ -639,7 +642,7 @@ class RadialNet(gtk.DrawingArea):
     def key_release(self, widget, event):
         """
         """
-        key = gtk.gdk.keyval_name(event.keyval)
+        key = Gdk.keyval_name(event.keyval)
 
         if key == 'c':
             self.__translation = (0, 0)
@@ -1640,7 +1643,7 @@ class RadialNet(gtk.DrawingArea):
 
         # animation continue condition
         if index < self.__number_of_frames - 1:
-            gobject.timeout_add(self.__animation_rate,  # time to recall
+            GLib.timeout_add(self.__animation_rate,  # time to recall
                                 self.__livens_up,       # recursive call
                                 index + 1)              # next iteration
         else:

--- a/zenmap/radialnet/gui/RadialNet.py
+++ b/zenmap/radialnet/gui/RadialNet.py
@@ -128,7 +128,7 @@
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, GLib
+from gi.repository import Gtk, GLib, Gdk
 
 import math
 import cairo
@@ -235,7 +235,7 @@ class RadialNet(Gtk.DrawingArea):
 
         super(RadialNet, self).__init__()
 
-        self.connect('expose_event', self.expose)
+        self.connect('draw', self.expose)
         self.connect('button_press_event', self.button_press)
         self.connect('button_release_event', self.button_release)
         self.connect('motion_notify_event', self.motion_notify)

--- a/zenmap/radialnet/gui/RadialNet.py
+++ b/zenmap/radialnet/gui/RadialNet.py
@@ -197,7 +197,7 @@ class RadialNet(Gtk.DrawingArea):
         self.__interpolation_slow_in_out = True
 
         self.__animating = False
-        self.__animation_rate = 1000 / 60  # 60Hz (human perception factor)
+        self.__animation_rate = 1000 // 60  # 60Hz (human perception factor)
         self.__number_of_frames = 60
 
         self.__scale = 1.0
@@ -888,8 +888,8 @@ class RadialNet(Gtk.DrawingArea):
         # getting allocation reference
         allocation = self.get_allocation()
 
-        self.__center_of_widget = (allocation.width / 2,
-                                   allocation.height / 2)
+        self.__center_of_widget = (allocation.width // 2,
+                                   allocation.height // 2)
 
         xc, yc = self.__center_of_widget
 
@@ -1055,7 +1055,7 @@ class RadialNet(Gtk.DrawingArea):
             max = self.__graph.get_max_edge_mean_weight()
 
             if max != min:
-                thickness = (latency - min) * 4 / (max - min) + 1
+                thickness = (latency - min) * 4 // (max - min) + 1
 
             else:
                 thickness = 1
@@ -1079,8 +1079,8 @@ class RadialNet(Gtk.DrawingArea):
 
                 context.set_font_size(8)
                 context.set_line_width(1)
-                context.move_to(xc + (xa + xb) / 2 + 1,
-                                     yc - (ya + yb) / 2 + 4)
+                context.move_to(xc + (xa + xb) // 2 + 1,
+                                     yc - (ya + yb) // 2 + 4)
                 context.show_text(str(round(latency, 2)))
                 context.stroke()
 
@@ -1521,9 +1521,9 @@ class RadialNet(Gtk.DrawingArea):
             self.__calc_node_positions()
 
         # steps for slow-in/slow-out animation
-        steps = range(self.__number_of_frames)
+        steps = list(range(self.__number_of_frames))
 
-        for i in range(len(steps) / 2):
+        for i in range(len(steps) // 2):
             steps[self.__number_of_frames - 1 - i] = steps[i]
 
         # normalize angles and calculate interpolated points

--- a/zenmap/radialnet/gui/SaveDialog.py
+++ b/zenmap/radialnet/gui/SaveDialog.py
@@ -164,7 +164,7 @@ class SaveDialog(zenmapGUI.FileChoosers.UnicodeFileChooserDialog):
         for type in TYPES:
             types_store.append(type)
 
-        self.__combo = Gtk.ComboBox(types_store)
+        self.__combo = Gtk.ComboBox(model=types_store)
         cell = Gtk.CellRendererText()
         self.__combo.pack_start(cell, True)
         self.__combo.add_attribute(cell, "text", 0)

--- a/zenmap/radialnet/gui/SaveDialog.py
+++ b/zenmap/radialnet/gui/SaveDialog.py
@@ -125,7 +125,11 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
 import os.path
 import radialnet.gui.RadialNet as RadialNet
 import zenmapGUI.FileChoosers
@@ -152,16 +156,16 @@ class SaveDialog(zenmapGUI.FileChoosers.UnicodeFileChooserDialog):
         """
         """
         super(SaveDialog, self).__init__(title=_("Save Topology"),
-                action=gtk.FILE_CHOOSER_ACTION_SAVE,
-                buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL,
-                    gtk.STOCK_SAVE, gtk.RESPONSE_OK))
+                action=Gtk.FileChooserAction.SAVE,
+                buttons=(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                    Gtk.STOCK_SAVE, Gtk.ResponseType.OK))
 
-        types_store = gtk.ListStore(str, object, str)
+        types_store = Gtk.ListStore(str, object, str)
         for type in TYPES:
             types_store.append(type)
 
-        self.__combo = gtk.ComboBox(types_store)
-        cell = gtk.CellRendererText()
+        self.__combo = Gtk.ComboBox(types_store)
+        cell = Gtk.CellRendererText()
         self.__combo.pack_start(cell, True)
         self.__combo.add_attribute(cell, "text", 0)
 
@@ -171,7 +175,7 @@ class SaveDialog(zenmapGUI.FileChoosers.UnicodeFileChooserDialog):
         self.connect("response", self.__response_cb)
 
         hbox = HIGHBox()
-        label = gtk.Label(_("Select File Type:"))
+        label = Gtk.Label(_("Select File Type:"))
         hbox.pack_end(self.__combo, False)
         hbox.pack_end(label, False)
 
@@ -199,7 +203,7 @@ class SaveDialog(zenmapGUI.FileChoosers.UnicodeFileChooserDialog):
     def __response_cb(self, widget, response_id):
         """Intercept the "response" signal to check if someone used the "By
         extension" file type with an unknown extension."""
-        if response_id == gtk.RESPONSE_OK and self.get_filetype() is None:
+        if response_id == Gtk.ResponseType.OK and self.get_filetype() is None:
             ext = self.__get_extension()
             if ext == "":
                 filename = self.get_filename() or ""

--- a/zenmap/radialnet/gui/SaveDialog.py
+++ b/zenmap/radialnet/gui/SaveDialog.py
@@ -176,8 +176,8 @@ class SaveDialog(zenmapGUI.FileChoosers.UnicodeFileChooserDialog):
 
         hbox = HIGHBox()
         label = Gtk.Label(_("Select File Type:"))
-        hbox.pack_end(self.__combo, False)
-        hbox.pack_end(label, False)
+        hbox.pack_end(self.__combo, False, True, 0)
+        hbox.pack_end(label, False, True, 0)
 
         self.set_extra_widget(hbox)
         self.set_do_overwrite_confirmation(True)

--- a/zenmap/radialnet/gui/Toolbar.py
+++ b/zenmap/radialnet/gui/Toolbar.py
@@ -125,7 +125,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 from radialnet.bestwidgets.buttons import BWStockButton, BWToggleStockButton
 from radialnet.gui.SaveDialog import SaveDialog
@@ -141,13 +144,13 @@ HIDE = False
 REFRESH_RATE = 500
 
 
-class ToolsMenu(gtk.Menu):
+class ToolsMenu(Gtk.Menu):
     """
     """
     def __init__(self, radialnet):
         """
         """
-        gtk.Menu.__init__(self)
+        Gtk.Menu.__init__(self)
 
         self.radialnet = radialnet
 
@@ -156,10 +159,10 @@ class ToolsMenu(gtk.Menu):
     def __create_items(self):
         """
         """
-        self.__hosts = gtk.ImageMenuItem(_('Hosts viewer'))
+        self.__hosts = Gtk.ImageMenuItem(_('Hosts viewer'))
         self.__hosts.connect("activate", self.__hosts_viewer_callback)
-        self.__hosts_image = gtk.Image()
-        self.__hosts_image.set_from_stock(gtk.STOCK_INDEX, gtk.ICON_SIZE_MENU)
+        self.__hosts_image = Gtk.Image()
+        self.__hosts_image.set_from_stock(Gtk.STOCK_INDEX, Gtk.IconSize.MENU)
         self.__hosts.set_image(self.__hosts_image)
 
         self.append(self.__hosts)
@@ -184,13 +187,13 @@ class ToolsMenu(gtk.Menu):
         self.__hosts.set_sensitive(False)
 
 
-class Toolbar(gtk.HBox):
+class Toolbar(Gtk.HBox):
     """
     """
     def __init__(self, radialnet, window, control, fisheye):
         """
         """
-        gtk.HBox.__init__(self)
+        Gtk.HBox.__init__(self)
         #self.set_style(gtk.TOOLBAR_BOTH_HORIZ)
         #self.set_tooltips(True)
 
@@ -225,22 +228,22 @@ class Toolbar(gtk.HBox):
         #self.__tools_button.set_menu(self.__tools_menu)
         #self.__tools_button.connect('clicked', self.__tools_callback)
 
-        self.__save_button = BWStockButton(gtk.STOCK_SAVE, _("Save Graphic"))
+        self.__save_button = BWStockButton(Gtk.STOCK_SAVE, _("Save Graphic"))
         self.__save_button.connect("clicked", self.__save_image_callback)
 
-        self.__hosts_button = BWStockButton(gtk.STOCK_INDEX, _("Hosts Viewer"))
+        self.__hosts_button = BWStockButton(Gtk.STOCK_INDEX, _("Hosts Viewer"))
         self.__hosts_button.connect("clicked", self.__hosts_viewer_callback)
 
         self.__control = BWToggleStockButton(
-                gtk.STOCK_PROPERTIES, _("Controls"))
+                Gtk.STOCK_PROPERTIES, _("Controls"))
         self.__control.connect('clicked', self.__control_callback)
         self.__control.set_active(False)
 
-        self.__fisheye = BWToggleStockButton(gtk.STOCK_ZOOM_FIT, _("Fisheye"))
+        self.__fisheye = BWToggleStockButton(Gtk.STOCK_ZOOM_FIT, _("Fisheye"))
         self.__fisheye.connect('clicked', self.__fisheye_callback)
         self.__fisheye.set_active(False)
 
-        self.__legend_button = BWStockButton(gtk.STOCK_INDEX, _("Legend"))
+        self.__legend_button = BWStockButton(Gtk.STOCK_INDEX, _("Legend"))
         self.__legend_button.connect('clicked', self.__legend_callback)
 
         #self.__fullscreen = gtk.ToggleToolButton(gtk.STOCK_FULLSCREEN)
@@ -255,8 +258,8 @@ class Toolbar(gtk.HBox):
         #self.__about.connect('clicked', self.__about_callback)
         #self.__about.set_tooltip(self.__tooltips, _('About RadialNet'))
 
-        self.__separator = gtk.SeparatorToolItem()
-        self.__expander = gtk.SeparatorToolItem()
+        self.__separator = Gtk.SeparatorToolItem()
+        self.__expander = Gtk.SeparatorToolItem()
         self.__expander.set_expand(True)
         self.__expander.set_draw(False)
 
@@ -314,17 +317,17 @@ class Toolbar(gtk.HBox):
 
         response = self.__save_chooser.run()
 
-        if response == gtk.RESPONSE_OK:
+        if response == Gtk.ResponseType.OK:
             filename = self.__save_chooser.get_filename()
             filetype = self.__save_chooser.get_filetype()
 
             try:
                 self.radialnet.save_drawing_to_file(filename, filetype)
-            except Exception, e:
+            except Exception as e:
                 alert = HIGAlertDialog(parent=self.__save_chooser,
-                        type=gtk.MESSAGE_ERROR,
+                        type=Gtk.MessageType.ERROR,
                         message_format=_("Error saving snapshot"),
-                        secondary_text=unicode(e))
+                        secondary_text=str(e))
                 alert.run()
                 alert.destroy()
 

--- a/zenmap/radialnet/gui/Toolbar.py
+++ b/zenmap/radialnet/gui/Toolbar.py
@@ -273,11 +273,11 @@ class Toolbar(Gtk.HBox):
         #self.insert(self.__about,        7)
 
         #self.pack_start(self.__tools_button, False)
-        self.pack_start(self.__hosts_button, False)
-        self.pack_start(self.__fisheye, False)
-        self.pack_start(self.__control, False)
-        self.pack_end(self.__save_button, False)
-        self.pack_end(self.__legend_button, False)
+        self.pack_start(self.__hosts_button, False, True, 0)
+        self.pack_start(self.__fisheye, False, True, 0)
+        self.pack_start(self.__control, False, True, 0)
+        self.pack_end(self.__save_button, False, True, 0)
+        self.pack_end(self.__legend_button, False, True, 0)
 
     def disable_controls(self):
         """

--- a/zenmap/radialnet/util/drawing.py
+++ b/zenmap/radialnet/util/drawing.py
@@ -129,7 +129,7 @@
 def cairo_to_gdk_color(color):
     """
     """
-    new_color = range(len(color))
+    new_color = list(range(len(color)))
 
     for i in range(len(color)):
         new_color[i] = int(color[i] * 65535)

--- a/zenmap/setup.py
+++ b/zenmap/setup.py
@@ -127,8 +127,8 @@
 # ***************************************************************************/
 import sys
 
-if sys.version_info[0] != 2:
-    sys.exit("Sorry, Zenmap requires Python 2")
+if sys.version_info[0] != 3:
+    sys.exit("Sorry, Zenmap requires Python 3")
 
 import errno
 import os
@@ -195,7 +195,7 @@ data_files = [
         ]
 
 # Add i18n files to data_files list
-os.path.walk(locale_dir, mo_find, data_files)
+os.walk(locale_dir, mo_find, data_files)
 
 
 # path_startswith and path_strip_prefix are used to deal with the installation
@@ -356,7 +356,7 @@ for dir in dirs:
         uninstaller_file.close()
 
         # Set exec bit for uninstaller
-        mode = ((os.stat(uninstaller_filename)[ST_MODE]) | 0555) & 07777
+        mode = ((os.stat(uninstaller_filename)[ST_MODE]) | 0o555) & 0o7777
         os.chmod(uninstaller_filename, mode)
 
     def set_modules_path(self):
@@ -488,7 +488,7 @@ for dir in dirs:
         with open(INSTALLED_FILES_NAME, "w") as f:
             for output in self.get_installed_files():
                 assert "\n" not in output
-                print >> f, output
+                print(output, file=f)
 
 
 class my_uninstall(Command):
@@ -510,7 +510,7 @@ class my_uninstall(Command):
         # Read the list of installed files.
         try:
             f = open(INSTALLED_FILES_NAME, "r")
-        except IOError, e:
+        except IOError as e:
             if e.errno == errno.ENOENT:
                 log.error("Couldn't open the installation record '%s'. "
                         "Have you installed yet?" % INSTALLED_FILES_NAME)
@@ -533,7 +533,7 @@ class my_uninstall(Command):
             try:
                 if not self.dry_run:
                     os.remove(file)
-            except OSError, e:
+            except OSError as e:
                 log.error(str(e))
         # Delete the directories. First reverse-sort the normalized paths by
         # length so that child directories are deleted before their parents.
@@ -544,7 +544,7 @@ class my_uninstall(Command):
                 log.info("Removing the directory '%s'." % dir)
                 if not self.dry_run:
                     os.rmdir(dir)
-            except OSError, e:
+            except OSError as e:
                 if e.errno == errno.ENOTEMPTY:
                     log.info("Directory '%s' not empty; not removing." % dir)
                 else:

--- a/zenmap/share/zenmap/locale/xgettext-profile_editor.py
+++ b/zenmap/share/zenmap/locale/xgettext-profile_editor.py
@@ -21,10 +21,10 @@ def escape(s):
 
 
 def output_msgid(msgid, locator):
-    print
-    print u"#: %s:%d" % (locator.getSystemId(), locator.getLineNumber())
-    print u"msgid", escape(msgid)
-    print u"msgstr", escape(u"")
+    print()
+    print("#: %s:%d" % (locator.getSystemId(), locator.getLineNumber()))
+    print("msgid", escape(msgid))
+    print("msgstr", escape(""))
 
 
 class Handler (xml.sax.handler.ContentHandler):
@@ -32,12 +32,12 @@ class Handler (xml.sax.handler.ContentHandler):
         self.locator = locator
 
     def startElement(self, name, attrs):
-        if name == u"group":
-            output_msgid(attrs[u"name"], self.locator)
-        if attrs.get(u"short_desc"):
-            output_msgid(attrs[u"short_desc"], self.locator)
-        if attrs.get(u"label"):
-            output_msgid(attrs[u"label"], self.locator)
+        if name == "group":
+            output_msgid(attrs["name"], self.locator)
+        if attrs.get("short_desc"):
+            output_msgid(attrs["short_desc"], self.locator)
+        if attrs.get("label"):
+            output_msgid(attrs["label"], self.locator)
 
 opts, filenames = getopt.gnu_getopt(sys.argv[1:], "D:", ["directory="])
 for o, a in opts:

--- a/zenmap/zenmap
+++ b/zenmap/zenmap
@@ -179,15 +179,15 @@ if INSTALL_LIB is not None and is_secure_dir(INSTALL_LIB):
 
 try:
     import zenmapGUI.App
-except ImportError, e:
-    print >> sys.stderr, """\
+except ImportError as e:
+    print("""\
 Could not import the zenmapGUI.App module: %s.
-I checked in these directories:""" % repr(e.message)
+I checked in these directories:""" % repr(e.message), file=sys.stderr)
     for dir in sys.path:
-        print >> sys.stderr, "    %s" % dir
-    print >> sys.stderr, """\
+        print("    %s" % dir, file=sys.stderr)
+    print("""\
 If you installed Zenmap in another directory, you may have to add the
-modules directory to the PYTHONPATH environment variable."""
+modules directory to the PYTHONPATH environment variable.""", file=sys.stderr)
     sys.exit(1)
 
 if __name__ == '__main__':

--- a/zenmap/zenmapCore/BasePaths.py
+++ b/zenmap/zenmapCore/BasePaths.py
@@ -133,7 +133,7 @@ import sys
 from zenmapCore.Name import APP_NAME
 
 
-def fs_dec(s):
+def fs_dec(s):  # This is unused now
     """Decode s from the filesystem decoding, handling various possible
     errors."""
     enc = sys.getfilesystemencoding()
@@ -156,7 +156,7 @@ def fs_enc(u):
 # systems like Windows where the file system encoding is different from the
 # result of sys.getdefaultencoding(). So we call os.path.expanduser with a
 # plain string and decode it from the filesystem encoding.
-HOME = fs_dec(os.path.expanduser("~"))
+HOME = os.path.expanduser("~")
 
 # The base_paths dict in this file gives symbolic names to various files. For
 # example, use base_paths.target_list instead of 'target_list.txt'.

--- a/zenmap/zenmapCore/I18N.py
+++ b/zenmap/zenmapCore/I18N.py
@@ -171,10 +171,10 @@ def install_gettext(locale_dir):
     else:
         t = gettext.translation(
                 APP_NAME, locale_dir, languages=get_locales(), fallback=True)
-        t.install(unicode=True)
+        t.install(str=True)
 
 # Install a dummy _ function so modules can safely use it after importing this
 # module, even if they don't install the gettext version.
 
-import __builtin__
-__builtin__.__dict__["_"] = lambda s: s
+import builtins
+builtins.__dict__["_"] = lambda s: s

--- a/zenmap/zenmapCore/I18N.py
+++ b/zenmap/zenmapCore/I18N.py
@@ -171,7 +171,7 @@ def install_gettext(locale_dir):
     else:
         t = gettext.translation(
                 APP_NAME, locale_dir, languages=get_locales(), fallback=True)
-        t.install(str=True)
+        t.install()
 
 # Install a dummy _ function so modules can safely use it after importing this
 # module, even if they don't install the gettext version.

--- a/zenmap/zenmapCore/Name.py
+++ b/zenmap/zenmapCore/Name.py
@@ -137,7 +137,7 @@ APP_DOWNLOAD_SITE = "https://nmap.org/download.html"
 APP_DOCUMENTATION_SITE = "https://nmap.org/docs.html"
 APP_COPYRIGHT = "Copyright 2005-2020 Insecure.Com LLC"
 
-NMAP_DISPLAY_NAME = u"Nmap"
+NMAP_DISPLAY_NAME = "Nmap"
 NMAP_WEB_SITE = "https://nmap.org"
 
 UMIT_DISPLAY_NAME = "Umit"

--- a/zenmap/zenmapCore/NetworkInventory.py
+++ b/zenmap/zenmapCore/NetworkInventory.py
@@ -131,7 +131,7 @@ import unittest
 import zenmapCore
 import zenmapCore.NmapParser
 from zenmapGUI.SearchGUI import SearchParser
-from SearchResult import HostSearch
+from .SearchResult import HostSearch
 
 
 class NetworkInventory(object):
@@ -323,13 +323,13 @@ class NetworkInventory(object):
         return self.scans
 
     def get_hosts(self):
-        return self.hosts.values()
+        return list(self.hosts.values())
 
     def get_hosts_up(self):
-        return filter(lambda h: h.get_state() == 'up', self.hosts.values())
+        return [h for h in list(self.hosts.values()) if h.get_state() == 'up']
 
     def get_hosts_down(self):
-        return filter(lambda h: h.get_state() == 'down', self.hosts.values())
+        return [h for h in list(self.hosts.values()) if h.get_state() == 'down']
 
     def open_from_file(self, path):
         """Loads a scan from the given file."""
@@ -421,7 +421,7 @@ class NetworkInventory(object):
         a list of (full-path) filenames that were used to save the scans."""
         self._generate_filenames(path)
 
-        for scan, filename in self.filenames.iteritems():
+        for scan, filename in self.filenames.items():
             f = open(os.path.join(path, filename), "w")
             scan.write_xml(f)
             f.close()
@@ -435,7 +435,7 @@ class NetworkInventory(object):
         # For now, this saves each scan making up the inventory separately in
         # the database.
         from time import time
-        from cStringIO import StringIO
+        from io import StringIO
         from zenmapCore.UmitDB import Scans
 
         for parsed in self.get_scans():
@@ -492,15 +492,13 @@ class FilteredNetworkInventory(NetworkInventory):
 
     def get_hosts_up(self):
         if len(self.search_dict) > 0:
-            return filter(lambda h: h.get_state() == 'up',
-                    self.filtered_hosts)
+            return [h for h in self.filtered_hosts if h.get_state() == 'up']
         else:
             return NetworkInventory.get_hosts_up(self)
 
     def get_hosts_down(self):
         if len(self.search_dict) > 0:
-            return filter(lambda h: h.get_state() == 'down',
-                    self.filtered_hosts)
+            return [h for h in self.filtered_hosts if h.get_state() == 'down']
         else:
             return NetworkInventory.get_hosts_down(self)
 
@@ -576,10 +574,10 @@ class FilteredNetworkInventory(NetworkInventory):
         self.filter_text = filter_text.lower()
         self.search_parser.update(self.filter_text)
         self.filtered_hosts = []
-        for hostname, host in self.hosts.iteritems():
+        for hostname, host in self.hosts.items():
             # For each host in this scan
             # Test each given operator against the current host
-            for operator, args in self.search_dict.iteritems():
+            for operator, args in self.search_dict.items():
                 if not self._match_all_args(host, operator, args):
                     # No match => we discard this scan_result
                     break
@@ -650,7 +648,7 @@ class NetworkInventoryTest(unittest.TestCase):
             inv.remove_scan(scan_3)
         except Exception:
             pass
-        self.assertEqual(added_ips, inv.hosts.keys())
+        self.assertEqual(added_ips, list(inv.hosts.keys()))
         self.assertEqual(host_a.hostnames, ["a"])
         self.assertEqual(host_b.hostnames, ["b"])
 
@@ -714,7 +712,7 @@ if __name__ == "__main__":
         inventory1.add_scan(scan2)
 
         for host in inventory1.get_hosts():
-            print "%s" % host.ip["addr"],
+            print("%s" % host.ip["addr"], end=' ')
             #if len(host.hostnames) > 0:
             #    print "[%s]:" % host.hostnames[0]["hostname"]
             #else:
@@ -730,12 +728,12 @@ if __name__ == "__main__":
         inventory1.remove_scan(scan2)
         print
         for host in inventory1.get_hosts():
-            print "%s" % host.ip["addr"],
+            print("%s" % host.ip["addr"], end=' ')
 
         inventory1.add_scan(scan2)
         print
         for host in inventory1.get_hosts():
-            print "%s" % host.ip["addr"],
+            print("%s" % host.ip["addr"], end=' ')
 
         dir = "/home/ndwi/scanz/top01"
         inventory1.save_to_dir(dir)
@@ -743,6 +741,6 @@ if __name__ == "__main__":
         inventory2 = NetworkInventory()
         inventory2.open_from_dir(dir)
 
-        print
+        print()
         for host in inventory2.get_hosts():
-            print "%s" % host.ip["addr"],
+            print("%s" % host.ip["addr"], end=' ')

--- a/zenmap/zenmapCore/NmapCommand.py
+++ b/zenmap/zenmapCore/NmapCommand.py
@@ -141,7 +141,7 @@ import zenmapCore.I18N  # lgtm[py/unused-import]
 
 try:
     import subprocess
-except ImportError, e:
+except ImportError as e:
     raise ImportError(str(e) + ".\n" + _("Python 2.4 or later is required."))
 
 import zenmapCore.Paths
@@ -251,7 +251,7 @@ class NmapCommand(object):
         if self.xml_is_temp:
             try:
                 os.remove(self.xml_output_filename)
-            except OSError, e:
+            except OSError as e:
                 if e.errno != errno.ENOENT:
                     raise
 

--- a/zenmap/zenmapCore/NmapOptions.py
+++ b/zenmap/zenmapCore/NmapOptions.py
@@ -539,7 +539,7 @@ class NmapOptions(object):
         return self.d.setdefault(self.canonicalize_name(key), default)
 
     def handle_result(self, result):
-        if isinstance(result, basestring):
+        if isinstance(result, str):
             # A positional argument.
             self.target_specs.append(result)
             return
@@ -640,7 +640,7 @@ class NmapOptions(object):
                 self["-d"] = int(arg)
             except ValueError:
                 if reduce(lambda x, y: x and y,
-                        map(lambda z: z == "d", arg), True):
+                        [z == "d" for z in arg], True):
                     self.setdefault("-d", 0)
                     self["-d"] += len(arg) + 1
                 else:
@@ -720,7 +720,7 @@ class NmapOptions(object):
                     self["-v"] = -1
             except ValueError:
                 if reduce(lambda x, y: x and y,
-                        map(lambda z: z == "v", arg), True):
+                        [z == "v" for z in arg], True):
                     self.setdefault("-v", 0)
                     self["-v"] += len(arg) + 1
                 else:
@@ -763,7 +763,7 @@ class NmapOptions(object):
             opt_list.append("-T%s" % str(self["-T"]))
 
         if self["-O"] is not None:
-            if isinstance(self["-O"], basestring):
+            if isinstance(self["-O"], str):
                 opt_list.append("-O%s" % self["-O"])
             elif self["-O"]:
                 opt_list.append("-O")
@@ -815,7 +815,7 @@ class NmapOptions(object):
             if self[ping_option] is not None:
                 opt_list.append(ping_option + self[ping_option])
         if self["-PB"] is not None:
-            if isinstance(self["-PB"], basestring):
+            if isinstance(self["-PB"], str):
                 opt_list.append("-PB" + self["-PB"])
             elif self["-PB"]:
                 opt_list.append("-PB")

--- a/zenmap/zenmapCore/NmapParser.py
+++ b/zenmap/zenmapCore/NmapParser.py
@@ -622,12 +622,7 @@ in epoch format!")
         return ports
 
     def get_formatted_date(self):
-        try:
-            return time.strftime("%B %d, %Y - %H:%M", self.get_date()).decode(
-                locale.getpreferredencoding())
-        except LookupError:
-            # encoding or locale not found
-            return time.asctime(self.get_date()).decode('ascii')
+        return time.strftime("%B %d, %Y - %H:%M", self.get_date())
 
     def get_scanner(self):
         return self.nmap['nmaprun'].get('scanner', '')

--- a/zenmap/zenmapCore/NmapParser.py
+++ b/zenmap/zenmapCore/NmapParser.py
@@ -131,11 +131,7 @@ import time
 import socket
 import copy
 
-# Use the faster cStringIO if available, fallback on StringIO if not
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from StringIO import StringIO
+from io import StringIO
 
 # Prevent loading PyXML
 import xml
@@ -1400,25 +1396,25 @@ if __name__ == '__main__':
     np.parse_file(file_to_parse)
 
     for host in np.hosts:
-        print "%s:" % host.ip["addr"]
-        print "  Comment:", repr(host.comment)
-        print "  TCP sequence:", repr(host.tcpsequence)
-        print "  TCP TS sequence:", repr(host.tcptssequence)
-        print "  IP ID sequence:", repr(host.ipidsequence)
-        print "  Uptime:", repr(host.uptime)
-        print "  OS Match:", repr(host.osmatches)
-        print "  Ports:"
+        print("%s:" % host.ip["addr"])
+        print("  Comment:", repr(host.comment))
+        print("  TCP sequence:", repr(host.tcpsequence))
+        print("  TCP TS sequence:", repr(host.tcptssequence))
+        print("  IP ID sequence:", repr(host.ipidsequence))
+        print("  Uptime:", repr(host.uptime))
+        print("  OS Match:", repr(host.osmatches))
+        print("  Ports:")
         for p in host.ports:
-            print "\t%s" % repr(p)
-        print "  Ports used:", repr(host.ports_used)
-        print "  OS Matches:", repr(host.osmatches)
-        print "  Hostnames:", repr(host.hostnames)
-        print "  IP:", repr(host.ip)
-        print "  IPv6:", repr(host.ipv6)
-        print "  MAC:", repr(host.mac)
-        print "  State:", repr(host.state)
+            print("\t%s" % repr(p))
+        print("  Ports used:", repr(host.ports_used))
+        print("  OS Matches:", repr(host.osmatches))
+        print("  Hostnames:", repr(host.hostnames))
+        print("  IP:", repr(host.ip))
+        print("  IPv6:", repr(host.ipv6))
+        print("  MAC:", repr(host.mac))
+        print("  State:", repr(host.state))
         if "hops" in host.trace:
-            print "  Trace:"
+            print("  Trace:")
             for hop in host.trace["hops"]:
-                print "    ", repr(hop)
-            print
+                print("    ", repr(hop))
+            print()

--- a/zenmap/zenmapCore/Paths.py
+++ b/zenmap/zenmapCore/Paths.py
@@ -134,7 +134,7 @@ import os.path
 import sys
 import shutil
 
-from zenmapCore.BasePaths import base_paths, fs_dec
+from zenmapCore.BasePaths import base_paths
 from zenmapCore.Name import APP_NAME
 
 
@@ -147,14 +147,14 @@ def get_prefix():
     frozen = getattr(sys, "frozen", None)
     if frozen == "macosx_app" or "Zenmap.app" in sys.executable:
         # A py2app .app bundle.
-        return os.path.join(dirname(fs_dec(sys.executable)), "..", "Resources")
+        return os.path.join(dirname(sys.executable), "..", "Resources")
     elif frozen is not None:
         # Assume a py2exe executable.
-        return dirname(fs_dec(sys.executable))
+        return dirname(sys.executable)
     else:
         # Normal script execution. Look in the current directory to allow
         # running from the distribution.
-        return os.path.abspath(os.path.dirname(fs_dec(sys.argv[0])))
+        return os.path.abspath(os.path.dirname(sys.argv[0]))
 
 prefix = get_prefix()
 
@@ -250,7 +250,7 @@ def create_dir(path):
     directory already exists."""
     try:
         os.makedirs(path)
-    except OSError, e:
+    except OSError as e:
         if e.errno != errno.EEXIST:
             raise
 
@@ -292,19 +292,19 @@ def return_if_exists(path, create=False):
 Path = Paths()
 
 if __name__ == '__main__':
-    print ">>> SAVED DIRECTORIES:"
-    print ">>> LOCALE DIR:", Path.locale_dir
-    print ">>> PIXMAPS DIR:", Path.pixmaps_dir
-    print ">>> CONFIG DIR:", Path.config_dir
-    print
-    print ">>> FILES:"
-    print ">>> USER CONFIG FILE:", Path.user_config_file
-    print ">>> CONFIG FILE:", Path.user_config_file
-    print ">>> TARGET_LIST:", Path.target_list
-    print ">>> PROFILE_EDITOR:", Path.profile_editor
-    print ">>> SCAN_PROFILE:", Path.scan_profile
-    print ">>> RECENT_SCANS:", Path.recent_scans
-    print ">>> OPTIONS:", Path.options
-    print
-    print ">>> DB:", Path.db
-    print ">>> VERSION:", Path.version
+    print(">>> SAVED DIRECTORIES:")
+    print(">>> LOCALE DIR:", Path.locale_dir)
+    print(">>> PIXMAPS DIR:", Path.pixmaps_dir)
+    print(">>> CONFIG DIR:", Path.config_dir)
+    print()
+    print(">>> FILES:")
+    print(">>> USER CONFIG FILE:", Path.user_config_file)
+    print(">>> CONFIG FILE:", Path.user_config_file)
+    print(">>> TARGET_LIST:", Path.target_list)
+    print(">>> PROFILE_EDITOR:", Path.profile_editor)
+    print(">>> SCAN_PROFILE:", Path.scan_profile)
+    print(">>> RECENT_SCANS:", Path.recent_scans)
+    print(">>> OPTIONS:", Path.options)
+    print()
+    print(">>> DB:", Path.db)
+    print(">>> VERSION:", Path.version)

--- a/zenmap/zenmapCore/RecentScans.py
+++ b/zenmap/zenmapCore/RecentScans.py
@@ -181,7 +181,7 @@ recent_scans = RecentScans()
 
 if __name__ == "__main__":
     r = RecentScans()
-    print ">>> Getting empty list:", r.get_recent_scans_list()
-    print ">>> Adding recent scan bla:", r.add_recent_scan("bla")
-    print ">>> Getting recent scan list:", r.get_recent_scans_list()
+    print(">>> Getting empty list:", r.get_recent_scans_list())
+    print(">>> Adding recent scan bla:", r.add_recent_scan("bla"))
+    print(">>> Getting recent scan list:", r.get_recent_scans_list())
     del r

--- a/zenmap/zenmapCore/ScriptArgsParser.py
+++ b/zenmap/zenmapCore/ScriptArgsParser.py
@@ -256,21 +256,21 @@ if __name__ == '__main__':
 
     for test, expected in TESTS:
         args_dict = parse_script_args_dict(test)
-        print args_dict
+        print(args_dict)
         args = parse_script_args(test)
         if args == expected:
-            print "PASS", test
+            print("PASS", test)
             continue
-        print "FAIL", test
+        print("FAIL", test)
         if args is None:
-            print "Parsing error"
+            print("Parsing error")
         else:
-            print "%d args" % len(args)
+            print("%d args" % len(args))
             for a, v in args:
-                print a, "=", v
+                print(a, "=", v)
         if expected is None:
-            print "Expected parsing error"
+            print("Expected parsing error")
         else:
-            print "Expected %d args" % len(expected)
+            print("Expected %d args" % len(expected))
             for a, v in expected:
-                print a, "=", v
+                print(a, "=", v)

--- a/zenmap/zenmapCore/ScriptMetadata.py
+++ b/zenmap/zenmapCore/ScriptMetadata.py
@@ -506,16 +506,16 @@ def get_script_entries(scripts_dir, nselib_dir):
 if __name__ == '__main__':
     import sys
     for entry in get_script_entries(sys.argv[1], sys.argv[2]):
-        print "*" * 75
-        print "Filename:", entry.filename
-        print "Categories:", entry.categories
-        print "License:", entry.license
-        print "Author:", entry.author
-        print "URL:", entry.url
-        print "Description:", entry.description
-        print "Arguments:", [x[0] for x in entry.arguments]
-        print "Output:"
-        print entry.output
-        print "Usage:"
-        print entry.usage
-        print "*" * 75
+        print("*" * 75)
+        print("Filename:", entry.filename)
+        print("Categories:", entry.categories)
+        print("License:", entry.license)
+        print("Author:", entry.author)
+        print("URL:", entry.url)
+        print("Description:", entry.description)
+        print("Arguments:", [x[0] for x in entry.arguments])
+        print("Output:")
+        print(entry.output)
+        print("Usage:")
+        print(entry.usage)
+        print("*" * 75)

--- a/zenmap/zenmapCore/SearchResult.py
+++ b/zenmap/zenmapCore/SearchResult.py
@@ -129,11 +129,10 @@
 import os
 import os.path
 import re
-import StringIO
+import io
 import unittest
 
 from glob import glob
-from types import StringTypes
 
 from zenmapCore.Name import APP_NAME
 from zenmapCore.NmapOptions import NmapOptions
@@ -238,7 +237,7 @@ class SearchResult(object):
             self.parsed_scan = scan_result
 
             # Test each given operator against the current parsed result
-            for operator, args in kargs.iteritems():
+            for operator, args in kargs.items():
                 if not self._match_all_args(operator, args):
                     # No match => we discard this scan_result
                     break
@@ -387,7 +386,7 @@ class SearchResult(object):
             return True
 
         # Transform a comma-delimited string containing ports into a list
-        ports = filter(lambda not_empty: not_empty, ports.split(","))
+        ports = [not_empty for not_empty in ports.split(",") if not_empty]
 
         # Check if they're parsable, if not return False silently
         for port in ports:
@@ -424,7 +423,7 @@ class SearchResult(object):
         log.debug("Match port:%s" % ports)
 
         # Transform a comma-delimited string containing ports into a list
-        ports = filter(lambda not_empty: not_empty, ports.split(","))
+        ports = [not_empty for not_empty in ports.split(",") if not_empty]
 
         for host in self.parsed_scan.get_hosts():
             for port in ports:
@@ -510,11 +509,11 @@ class SearchDB(SearchResult, object):
             log.debug(">>> Nmap xml output: %s" % scan.nmap_xml_output)
 
             try:
-                buffer = StringIO.StringIO(scan.nmap_xml_output)
+                buffer = io.StringIO(scan.nmap_xml_output)
                 parsed = NmapParser()
                 parsed.parse(buffer)
                 buffer.close()
-            except Exception, e:
+            except Exception as e:
                 log.warning(">>> Error loading scan with ID %u from database: "
                         "%s" % (scan.scans_id, str(e)))
             else:
@@ -530,7 +529,7 @@ class SearchDir(SearchResult, object):
         log.debug(">>> SearchDir initialized")
         self.search_directory = search_directory
 
-        if isinstance(file_extensions, StringTypes):
+        if isinstance(file_extensions, str):
             self.file_extensions = file_extensions.split(";")
         elif isinstance(file_extensions, list):
             self.file_extensions = file_extensions

--- a/zenmap/zenmapCore/TargetList.py
+++ b/zenmap/zenmapCore/TargetList.py
@@ -182,7 +182,7 @@ target_list = TargetList()
 
 if __name__ == "__main__":
     t = TargetList()
-    print ">>> Getting empty list:", t.get_target_list()
-    print ">>> Adding target 127.0.0.1:", t.add_target("127.0.0.3")
-    print ">>> Getting target list:", t.get_target_list()
+    print(">>> Getting empty list:", t.get_target_list())
+    print(">>> Adding target 127.0.0.1:", t.add_target("127.0.0.3"))
+    print(">>> Getting target list:", t.get_target_list())
     del t

--- a/zenmap/zenmapCore/UmitConf.py
+++ b/zenmap/zenmapCore/UmitConf.py
@@ -128,9 +128,8 @@
 
 import re
 
-from types import StringTypes
-from ConfigParser import DuplicateSectionError, NoSectionError, NoOptionError
-from ConfigParser import Error as ConfigParser_Error
+from configparser import DuplicateSectionError, NoSectionError, NoOptionError
+from configparser import Error as ConfigParser_Error
 
 from zenmapCore.Paths import Path
 from zenmapCore.UmitLogging import log
@@ -185,10 +184,8 @@ class SearchConfig(UmitConfigParser, object):
            attr == "True" or \
            attr == "true" or \
            attr == "1":
-
-            return 1
-
-        return 0
+            return "True"
+        return "False"
 
     def get_directory(self):
         return self._get_it("directory", "")
@@ -202,7 +199,7 @@ class SearchConfig(UmitConfigParser, object):
     def set_file_extension(self, file_extension):
         if isinstance(file_extension, list):
             self._set_it("file_extension", ";".join(file_extension))
-        elif isinstance(file_extension, StringTypes):
+        elif isinstance(file_extension, str):
             self._set_it("file_extension", file_extension)
 
     def get_save_time(self):
@@ -211,7 +208,7 @@ class SearchConfig(UmitConfigParser, object):
     def set_save_time(self, save_time):
         if isinstance(save_time, list):
             self._set_it("save_time", ";".join(save_time))
-        elif isinstance(save_time, StringTypes):
+        elif isinstance(save_time, str):
             self._set_it("save_time", save_time)
 
     def get_store_results(self):
@@ -488,7 +485,7 @@ class NmapOutputHighlight(object):
         property_name = "%s_highlight" % property_name
         settings = self.sanity_settings(list(settings))
 
-        for pos in xrange(len(settings)):
+        for pos in range(len(settings)):
             config_parser.set(property_name, self.setts[pos], settings[pos])
 
     def sanity_settings(self, settings):
@@ -505,13 +502,13 @@ class NmapOutputHighlight(object):
         settings[1] = self.boolean_sanity(settings[1])
         settings[2] = self.boolean_sanity(settings[2])
 
-        tuple_regex = "[\(\[]\s?(\d+)\s?,\s?(\d+)\s?,\s?(\d+)\s?[\)\]]"
-        if isinstance(settings[3], basestring):
+        tuple_regex = r"[\(\[]\s?(\d+)\s?,\s?(\d+)\s?,\s?(\d+)\s?[\)\]]"
+        if isinstance(settings[3], str):
             settings[3] = [
                     int(t) for t in re.findall(tuple_regex, settings[3])[0]
                     ]
 
-        if isinstance(settings[4], basestring):
+        if isinstance(settings[4], str):
             settings[4] = [
                     int(h) for h in re.findall(tuple_regex, settings[4])[0]
                     ]
@@ -610,57 +607,57 @@ class NmapOutputHighlight(object):
                 "underline": str(False),
                 "text": [0, 0, 0],
                 "highlight": [65535, 65535, 65535],
-                "regex": "\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}\s.{1,4}"},
+                "regex": r"\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}\s.{1,4}"},
             "hostname": {
                 "bold": str(True),
                 "italic": str(True),
                 "underline": str(True),
                 "text": [0, 111, 65535],
                 "highlight": [65535, 65535, 65535],
-                "regex": "(\w{2,}://)*[\w-]{2,}\.[\w-]{2,}"
-                         "(\.[\w-]{2,})*(/[[\w-]{2,}]*)*"},
+                "regex": r"(\w{2,}://)*[\w-]{2,}\.[\w-]{2,}"
+                         r"(\.[\w-]{2,})*(/[[\w-]{2,}]*)*"},
             "ip": {
                 "bold": str(True),
                 "italic": str(False),
                 "underline": str(False),
                 "text": [0, 0, 0],
                 "highlight": [65535, 65535, 65535],
-                "regex": "\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"},
+                "regex": r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"},
             "port_list": {
                 "bold": str(True),
                 "italic": str(False),
                 "underline": str(False),
                 "text": [0, 1272, 28362],
                 "highlight": [65535, 65535, 65535],
-                "regex": "PORT\s+STATE\s+SERVICE(\s+VERSION)?[^\n]*"},
+                "regex": r"PORT\s+STATE\s+SERVICE(\s+VERSION)?[^\n]*"},
             "open_port": {
                 "bold": str(True),
                 "italic": str(False),
                 "underline": str(False),
                 "text": [0, 41036, 2396],
                 "highlight": [65535, 65535, 65535],
-                "regex": "\d{1,5}/.{1,5}\s+open\s+.*"},
+                "regex": r"\d{1,5}/.{1,5}\s+open\s+.*"},
             "closed_port": {
                 "bold": str(False),
                 "italic": str(False),
                 "underline": str(False),
                 "text": [65535, 0, 0],
                 "highlight": [65535, 65535, 65535],
-                "regex": "\d{1,5}/.{1,5}\s+closed\s+.*"},
+                "regex": r"\d{1,5}/.{1,5}\s+closed\s+.*"},
             "filtered_port": {
                 "bold": str(False),
                 "italic": str(False),
                 "underline": str(False),
                 "text": [38502, 39119, 0],
                 "highlight": [65535, 65535, 65535],
-                "regex": "\d{1,5}/.{1,5}\s+filtered\s+.*"},
+                "regex": r"\d{1,5}/.{1,5}\s+filtered\s+.*"},
             "details": {
                 "bold": str(True),
                 "italic": str(False),
                 "underline": str(True),
                 "text": [0, 0, 0],
                 "highlight": [65535, 65535, 65535],
-                "regex": "^(\w{2,}[\s]{,3}){,4}:"}
+                "regex": r"^(\w{2,}[\s]{,3}){,4}:"}
             }
 
 

--- a/zenmap/zenmapCore/UmitConf.py
+++ b/zenmap/zenmapCore/UmitConf.py
@@ -337,7 +337,7 @@ class WindowConfig(UmitConfigParser, object):
         self.height = self.default_height
 
     def _get_it(self, p_name, default):
-        return config_parser.get(self.section_name, p_name, default)
+        return config_parser.get(self.section_name, p_name, fallback=default)
 
     def _set_it(self, p_name, value):
         config_parser.set(self.section_name, p_name, value)

--- a/zenmap/zenmapCore/UmitConf.py
+++ b/zenmap/zenmapCore/UmitConf.py
@@ -174,7 +174,7 @@ class SearchConfig(UmitConfigParser, object):
         self.search_db = True
 
     def _get_it(self, p_name, default):
-        return config_parser.get(self.section_name, p_name, default)
+        return config_parser.get(self.section_name, p_name, fallback=default)
 
     def _set_it(self, p_name, value):
         config_parser.set(self.section_name, p_name, value)
@@ -466,7 +466,7 @@ class NmapOutputHighlight(object):
         try:
             return self.sanity_settings([
                 config_parser.get(
-                    property_name, prop, True) for prop in self.setts])
+                    property_name, prop, raw=True) for prop in self.setts])
         except Exception:
             settings = []
             prop_settings = self.default_highlights[p_name]

--- a/zenmap/zenmapCore/UmitConfigParser.py
+++ b/zenmap/zenmapCore/UmitConfigParser.py
@@ -142,7 +142,7 @@ class UmitConfigParser(ConfigParser):
         if not self.has_section(section):
             self.add_section(section)
 
-        ConfigParser.set(self, section, option, value)
+        ConfigParser.set(self, section, option, str(value))
         self.save_changes()
 
     def read(self, filename):
@@ -172,15 +172,13 @@ class UmitConfigParser(ConfigParser):
         if self._defaults:
             fp.write("[%s]\n" % DEFAULTSECT)
 
-            items = self._defaults.items()
-            items.sort()
+            items = sorted(self._defaults.items())
 
             for (key, value) in items:
                 fp.write("%s = %s\n" % (key, str(value).replace('\n', '\n\t')))
             fp.write("\n")
 
-        sects = self._sections.keys()
-        sects.sort()
+        sects = sorted(self._sections.keys())
 
         for section in sects:
             fp.write("[%s]\n" % section)

--- a/zenmap/zenmapCore/UmitDB.py
+++ b/zenmap/zenmapCore/UmitDB.py
@@ -152,7 +152,7 @@ try:
     umitdb = Path.db
 except Exception:
     import os.path
-    from BasePaths import base_paths
+    from .BasePaths import base_paths
 
     umitdb = os.path.join(Path.user_config_dir, base_paths["db"])
     Path.db = umitdb
@@ -170,15 +170,15 @@ if not exists(umitdb) or \
     umitdb = ":memory:"
     using_memory = True
 
-if isinstance(umitdb, str):
-    fs_enc = sys.getfilesystemencoding()
-    if fs_enc is None:
-        fs_enc = "UTF-8"
-    umitdb = umitdb.decode(fs_enc)
-
-# pysqlite 2.4.0 doesn't handle a unicode database name, though earlier and
-# later versions do. Encode to UTF-8 as pysqlite would do internally anyway.
-umitdb = umitdb.encode("UTF-8")
+#if isinstance(umitdb, str):
+#    fs_enc = sys.getfilesystemencoding()
+#    if fs_enc is None:
+#        fs_enc = "UTF-8"
+#    umitdb = umitdb.decode(fs_enc)
+#
+## pysqlite 2.4.0 doesn't handle a unicode database name, though earlier and
+## later versions do. Encode to UTF-8 as pysqlite would do internally anyway.
+#umitdb = umitdb.encode("UTF-8")
 
 connection = sqlite.connect(umitdb)
 
@@ -422,5 +422,5 @@ if __name__ == "__main__":
 
     sql = "SELECT * FROM scans;"
     u.cursor.execute(sql)
-    print "Scans:",
+    print("Scans:", end=' ')
     pprint(u.cursor.fetchall())

--- a/zenmap/zenmapCore/UmitDB.py
+++ b/zenmap/zenmapCore/UmitDB.py
@@ -238,7 +238,7 @@ class Table(object):
         sql = sql[:][:-2]
         sql += ") VALUES ("
 
-        for v in xrange(len(kargs.values())):
+        for v in range(len(kargs.values())):
             sql += "?, "
 
         sql = sql[:][:-2]
@@ -326,7 +326,7 @@ class Scans(Table, object):
                 raise Exception("Can't save result without xml output")
 
             if not self.verify_digest(
-                    md5(kargs["nmap_xml_output"]).hexdigest()):
+                    md5(kargs["nmap_xml_output"].encode("UTF-8")).hexdigest()):
                 raise Exception("XML output registered already!")
 
             self.scans_id = self.insert(**kargs)
@@ -370,7 +370,7 @@ class Scans(Table, object):
 
     def set_nmap_xml_output(self, nmap_xml_output):
         self.set_item("nmap_xml_output", nmap_xml_output)
-        self.set_item("digest", md5(nmap_xml_output).hexdigest())
+        self.set_item("digest", md5(nmap_xml_output.encode("UTF-8")).hexdigest())
 
     def get_date(self):
         return self.get_item("date")

--- a/zenmap/zenmapGUI/About.py
+++ b/zenmap/zenmapGUI/About.py
@@ -126,7 +126,11 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
 import webbrowser
 
 from zenmapGUI.higwidgets.higdialogs import HIGDialog
@@ -152,7 +156,7 @@ xml.__path__ = [x for x in xml.__path__ if "_xmlplus" not in x]
 from xml.sax.saxutils import escape
 
 
-class _program_entry(gtk.VBox):
+class _program_entry(Gtk.VBox):
     """A little box containing labels with a program's name and
     description and a clickable link to its web site."""
 
@@ -161,13 +165,13 @@ class _program_entry(gtk.VBox):
     NAME_WEB_SITE_SPACING = 20
 
     def __init__(self, name=None, web_site=None, description=None):
-        gtk.VBox.__init__(self)
+        Gtk.VBox.__init__(self)
 
-        self.hbox = gtk.HBox(False, self.NAME_WEB_SITE_SPACING)
+        self.hbox = Gtk.HBox(False, self.NAME_WEB_SITE_SPACING)
         self.pack_start(self.hbox)
 
         if name is not None:
-            name_label = gtk.Label()
+            name_label = Gtk.Label()
             name_label.set_markup(
                     '<span size="large" weight="bold">%s</span>' % escape(
                         name))
@@ -175,16 +179,16 @@ class _program_entry(gtk.VBox):
 
         if web_site is not None:
             try:
-                web_site_button = gtk.LinkButton(web_site)
+                web_site_button = Gtk.LinkButton(web_site)
                 web_site_button.connect("clicked", self._link_button_open)
             except AttributeError:
                 # LinkButton was only introduced in PyGTK 2.10.
-                web_site_button = gtk.Label(web_site)
+                web_site_button = Gtk.Label(web_site)
                 web_site_button.set_selectable(True)
             self.hbox.pack_start(web_site_button, False)
 
         if description is not None:
-            description_label = gtk.Label()
+            description_label = Gtk.Label()
             description_label.set_alignment(0.0, 0.0)
             description_label.set_line_wrap(True)
             description_label.set_text(description)
@@ -196,7 +200,7 @@ class _program_entry(gtk.VBox):
 
 class About(HIGDialog):
     """An about dialog showing information about the program. It is meant to
-    have roughly the same feel as gtk.AboutDialog."""
+    have roughly the same feel as Gtk.AboutDialog."""
     def __init__(self):
         HIGDialog.__init__(self)
         self.set_title(_("About %s and %s") % (
@@ -205,14 +209,14 @@ class About(HIGDialog):
         self.vbox.set_border_width(12)
         self.vbox.set_spacing(12)
 
-        label = gtk.Label()
+        label = Gtk.Label()
         label.set_markup(
                 '<span size="xx-large" weight="bold">%s %s</span>' % (
                     escape(APP_DISPLAY_NAME), escape(VERSION)))
         label.set_selectable(True)
         self.vbox.pack_start(label)
 
-        label = gtk.Label()
+        label = Gtk.Label()
         label.set_markup(
                 '<span size="small">%s</span>' % (escape(APP_COPYRIGHT)))
         self.vbox.pack_start(label)
@@ -231,15 +235,15 @@ class About(HIGDialog):
         entry = _program_entry(UMIT_DISPLAY_NAME, UMIT_WEB_SITE, _(
             "%s is an %s GUI created as part of the Nmap/Google Summer "
             "of Code program.") % (UMIT_DISPLAY_NAME, NMAP_DISPLAY_NAME))
-        button = gtk.Button(_("%s credits") % UMIT_DISPLAY_NAME)
+        button = Gtk.Button(_("%s credits") % UMIT_DISPLAY_NAME)
         button.connect("clicked", self._show_umit_credits)
         entry.hbox.pack_start(button, False)
         self.vbox.pack_start(entry)
 
         self.vbox.show_all()
 
-        close_button = self.add_button(gtk.STOCK_CLOSE, gtk.RESPONSE_CANCEL)
-        self.set_default_response(gtk.RESPONSE_CANCEL)
+        close_button = self.add_button(Gtk.STOCK_CLOSE, Gtk.ResponseType.CANCEL)
+        self.set_default_response(Gtk.ResponseType.CANCEL)
         close_button.grab_focus()
 
         self.set_has_separator(False)
@@ -276,7 +280,7 @@ class UmitCredits(HIGWindow):
         HIGWindow.__init__(self)
         self.set_title(_("%s credits") % UMIT_DISPLAY_NAME)
         self.set_size_request(-1, 250)
-        self.set_position(gtk.WIN_POS_CENTER)
+        self.set_position(Gtk.WindowPosition.CENTER)
 
         self.__create_widgets()
         self.__packing()
@@ -286,7 +290,7 @@ class UmitCredits(HIGWindow):
         self.vbox = HIGVBox()
         self.hbox = HIGHBox()
         self.notebook = HIGNotebook()
-        self.btn_close = HIGButton(stock=gtk.STOCK_CLOSE)
+        self.btn_close = HIGButton(stock=Gtk.STOCK_CLOSE)
 
         self.written_by_scroll = HIGScrolledWindow()
         self.written_by_text = HIGTextView()
@@ -316,35 +320,35 @@ class UmitCredits(HIGWindow):
         self.hbox._pack_noexpand_nofill(self.btn_close)
 
         self.notebook.append_page(
-                self.written_by_scroll, gtk.Label(_("Written by")))
+                self.written_by_scroll, Gtk.Label(_("Written by")))
         self.notebook.append_page(
-                self.design_scroll, gtk.Label(_("Design")))
+                self.design_scroll, Gtk.Label(_("Design")))
         self.notebook.append_page(
-                self.soc2007_scroll, gtk.Label(_("SoC 2007")))
+                self.soc2007_scroll, Gtk.Label(_("SoC 2007")))
         self.notebook.append_page(
-                self.contributors_scroll, gtk.Label(_("Contributors")))
+                self.contributors_scroll, Gtk.Label(_("Contributors")))
         self.notebook.append_page(
-                self.translation_scroll, gtk.Label(_("Translation")))
+                self.translation_scroll, Gtk.Label(_("Translation")))
         self.notebook.append_page(
-                self.nokia_scroll, gtk.Label(_("Maemo")))
+                self.nokia_scroll, Gtk.Label(_("Maemo")))
 
         self.written_by_scroll.add(self.written_by_text)
-        self.written_by_text.set_wrap_mode(gtk.WRAP_NONE)
+        self.written_by_text.set_wrap_mode(Gtk.WrapMode.NONE)
 
         self.design_scroll.add(self.design_text)
-        self.design_text.set_wrap_mode(gtk.WRAP_NONE)
+        self.design_text.set_wrap_mode(Gtk.WrapMode.NONE)
 
         self.soc2007_scroll.add(self.soc2007_text)
-        self.soc2007_text.set_wrap_mode(gtk.WRAP_NONE)
+        self.soc2007_text.set_wrap_mode(Gtk.WrapMode.NONE)
 
         self.contributors_scroll.add(self.contributors_text)
-        self.contributors_text.set_wrap_mode(gtk.WRAP_NONE)
+        self.contributors_text.set_wrap_mode(Gtk.WrapMode.NONE)
 
         self.translation_scroll.add(self.translation_text)
-        self.translation_text.set_wrap_mode(gtk.WRAP_NONE)
+        self.translation_text.set_wrap_mode(Gtk.WrapMode.NONE)
 
         self.nokia_scroll.add(self.nokia_text)
-        self.nokia_text.set_wrap_mode(gtk.WRAP_NONE)
+        self.nokia_text.set_wrap_mode(Gtk.WrapMode.NONE)
 
         self.btn_close.connect('clicked', lambda x, y=None: self.destroy())
 
@@ -433,6 +437,6 @@ Adriano Monteiro Marques <py.adriano@gmail.com>""")
 if __name__ == '__main__':
     about = About()
     about.show()
-    about.connect("response", lambda widget, response: gtk.main_quit())
+    about.connect("response", lambda widget, response: Gtk.main_quit())
 
-    gtk.main()
+    Gtk.main()

--- a/zenmap/zenmapGUI/About.py
+++ b/zenmap/zenmapGUI/About.py
@@ -168,14 +168,14 @@ class _program_entry(Gtk.VBox):
         Gtk.VBox.__init__(self)
 
         self.hbox = Gtk.HBox(False, self.NAME_WEB_SITE_SPACING)
-        self.pack_start(self.hbox)
+        self.pack_start(self.hbox, True, True, 0)
 
         if name is not None:
             name_label = Gtk.Label()
             name_label.set_markup(
                     '<span size="large" weight="bold">%s</span>' % escape(
                         name))
-            self.hbox.pack_start(name_label, False)
+            self.hbox.pack_start(name_label, False, True, 0)
 
         if web_site is not None:
             try:
@@ -185,14 +185,14 @@ class _program_entry(Gtk.VBox):
                 # LinkButton was only introduced in PyGTK 2.10.
                 web_site_button = Gtk.Label(web_site)
                 web_site_button.set_selectable(True)
-            self.hbox.pack_start(web_site_button, False)
+            self.hbox.pack_start(web_site_button, False, True, 0)
 
         if description is not None:
             description_label = Gtk.Label()
             description_label.set_alignment(0.0, 0.0)
             description_label.set_line_wrap(True)
             description_label.set_text(description)
-            self.pack_start(description_label)
+            self.pack_start(description_label, True, True, 0)
 
     def _link_button_open(self, widget):
         webbrowser.open(widget.get_uri())
@@ -214,31 +214,31 @@ class About(HIGDialog):
                 '<span size="xx-large" weight="bold">%s %s</span>' % (
                     escape(APP_DISPLAY_NAME), escape(VERSION)))
         label.set_selectable(True)
-        self.vbox.pack_start(label)
+        self.vbox.pack_start(label, True, True, 0)
 
         label = Gtk.Label()
         label.set_markup(
                 '<span size="small">%s</span>' % (escape(APP_COPYRIGHT)))
-        self.vbox.pack_start(label)
+        self.vbox.pack_start(label, True, True, 0)
 
         entry = _program_entry(NMAP_DISPLAY_NAME, NMAP_WEB_SITE, _(
             "%s is a free and open source utility for network exploration "
             "and security auditing.") % NMAP_DISPLAY_NAME)
-        self.vbox.pack_start(entry)
+        self.vbox.pack_start(entry, True, True, 0)
 
         entry = _program_entry(APP_DISPLAY_NAME, APP_WEB_SITE, _(
             "%s is a multi-platform graphical %s frontend and results viewer. "
             "It was originally derived from %s.") % (
                 APP_DISPLAY_NAME, NMAP_DISPLAY_NAME, UMIT_DISPLAY_NAME))
-        self.vbox.pack_start(entry)
+        self.vbox.pack_start(entry, True, True, 0)
 
         entry = _program_entry(UMIT_DISPLAY_NAME, UMIT_WEB_SITE, _(
             "%s is an %s GUI created as part of the Nmap/Google Summer "
             "of Code program.") % (UMIT_DISPLAY_NAME, NMAP_DISPLAY_NAME))
         button = Gtk.Button(_("%s credits") % UMIT_DISPLAY_NAME)
         button.connect("clicked", self._show_umit_credits)
-        entry.hbox.pack_start(button, False)
-        self.vbox.pack_start(entry)
+        entry.hbox.pack_start(button, False, True, 0)
+        self.vbox.pack_start(entry, True, True, 0)
 
         self.vbox.show_all()
 
@@ -246,7 +246,6 @@ class About(HIGDialog):
         self.set_default_response(Gtk.ResponseType.CANCEL)
         close_button.grab_focus()
 
-        self.set_has_separator(False)
         self.set_resizable(False)
 
         self._umit_credits_dialog = None

--- a/zenmap/zenmapGUI/About.py
+++ b/zenmap/zenmapGUI/About.py
@@ -167,7 +167,7 @@ class _program_entry(Gtk.VBox):
     def __init__(self, name=None, web_site=None, description=None):
         Gtk.VBox.__init__(self)
 
-        self.hbox = Gtk.HBox(False, self.NAME_WEB_SITE_SPACING)
+        self.hbox = Gtk.HBox(homogeneous=False, spacing=self.NAME_WEB_SITE_SPACING)
         self.pack_start(self.hbox, True, True, 0)
 
         if name is not None:
@@ -179,7 +179,7 @@ class _program_entry(Gtk.VBox):
 
         if web_site is not None:
             try:
-                web_site_button = Gtk.LinkButton(web_site)
+                web_site_button = Gtk.LinkButton(uri=web_site)
                 web_site_button.connect("clicked", self._link_button_open)
             except AttributeError:
                 # LinkButton was only introduced in PyGTK 2.10.
@@ -235,7 +235,7 @@ class About(HIGDialog):
         entry = _program_entry(UMIT_DISPLAY_NAME, UMIT_WEB_SITE, _(
             "%s is an %s GUI created as part of the Nmap/Google Summer "
             "of Code program.") % (UMIT_DISPLAY_NAME, NMAP_DISPLAY_NAME))
-        button = Gtk.Button(_("%s credits") % UMIT_DISPLAY_NAME)
+        button = Gtk.Button(label=_("%s credits") % UMIT_DISPLAY_NAME)
         button.connect("clicked", self._show_umit_credits)
         entry.hbox.pack_start(button, False, True, 0)
         self.vbox.pack_start(entry, True, True, 0)
@@ -319,17 +319,17 @@ class UmitCredits(HIGWindow):
         self.hbox._pack_noexpand_nofill(self.btn_close)
 
         self.notebook.append_page(
-                self.written_by_scroll, Gtk.Label(_("Written by")))
+                self.written_by_scroll, Gtk.Label(label=_("Written by")))
         self.notebook.append_page(
-                self.design_scroll, Gtk.Label(_("Design")))
+                self.design_scroll, Gtk.Label(label=_("Design")))
         self.notebook.append_page(
-                self.soc2007_scroll, Gtk.Label(_("SoC 2007")))
+                self.soc2007_scroll, Gtk.Label(label=_("SoC 2007")))
         self.notebook.append_page(
-                self.contributors_scroll, Gtk.Label(_("Contributors")))
+                self.contributors_scroll, Gtk.Label(label=_("Contributors")))
         self.notebook.append_page(
-                self.translation_scroll, Gtk.Label(_("Translation")))
+                self.translation_scroll, Gtk.Label(label=_("Translation")))
         self.notebook.append_page(
-                self.nokia_scroll, Gtk.Label(_("Maemo")))
+                self.nokia_scroll, Gtk.Label(label=_("Maemo")))
 
         self.written_by_scroll.add(self.written_by_text)
         self.written_by_text.set_wrap_mode(Gtk.WrapMode.NONE)

--- a/zenmap/zenmapGUI/App.py
+++ b/zenmap/zenmapGUI/App.py
@@ -130,7 +130,7 @@ import imp
 import os
 import signal
 import sys
-import ConfigParser
+import configparser
 import shutil
 
 # Cause an exception if PyGTK can't open a display. Normally this just
@@ -142,7 +142,9 @@ import shutil
 import warnings
 warnings.filterwarnings("error", module="gtk", append="True")
 try:
-    import gtk
+    import gi
+    gi.require_version("Gtk", "3.0")
+    from gi.repository import Gtk, Gdk
 except Exception:
     # On Mac OS X 10.5, X11 is supposed to be automatically launched on demand.
     # It works by setting the DISPLAY environment variable to something like
@@ -154,7 +156,9 @@ except Exception:
     # startup scripts, and for some reason the first connection (the one that
     # caused the launch) is rejected. But somehow subsequent connections work
     # fine! So if the import fails, try one more time.
-    import gtk
+    import gi
+    gi.require_version("Gtk", "3.0")
+    from gi.repository import Gtk, Gdk
 warnings.resetwarnings()
 
 from zenmapGUI.higwidgets.higdialogs import HIGAlertDialog
@@ -171,17 +175,17 @@ from zenmapCore.Name import APP_DISPLAY_NAME
 from zenmapGUI.higwidgets.higdialogs import HIGAlertDialog
 
 # A global list of open scan windows. When the last one is destroyed, we call
-# gtk.main_quit.
+# Gtk.main_quit.
 open_windows = []
 
 
 def _destroy_callback(window):
     open_windows.remove(window)
     if len(open_windows) == 0:
-        gtk.main_quit()
+        Gtk.main_quit()
     try:
         from zenmapCore.UmitDB import UmitDB
-    except ImportError, e:
+    except ImportError as e:
         log.debug(">>> Not cleaning up database: %s." % str(e))
     else:
         # Cleaning up data base
@@ -228,29 +232,31 @@ def install_excepthook():
         # produces a warning, but the lack of a display eventually causes a
         # segmentation fault. See http://live.gnome.org/PyGTK/WhatsNew210.
         warnings.filterwarnings("error", module="gtk")
-        import gtk
+        import gi
+        gi.require_version("Gtk", "3.0")
+        from gi.repository import Gtk, Gdk
         warnings.resetwarnings()
 
-        gtk.gdk.threads_enter()
+        Gdk.threads_enter()
 
         from zenmapGUI.higwidgets.higdialogs import HIGAlertDialog
         from zenmapGUI.CrashReport import CrashReport
         if type == ImportError:
-            d = HIGAlertDialog(type=gtk.MESSAGE_ERROR,
+            d = HIGAlertDialog(type=Gtk.MessageType.ERROR,
                 message_format=_("Import error"),
                 secondary_text=_("""A required module was not found.
 
-""" + unicode(value)))
+""" + str(value)))
             d.run()
             d.destroy()
         else:
             c = CrashReport(type, value, tb)
             c.show_all()
-            gtk.main()
+            Gtk.main()
 
-        gtk.gdk.threads_leave()
+        Gdk.threads_leave()
 
-        gtk.main_quit()
+        Gtk.main_quit()
 
     sys.excepthook = excepthook
 
@@ -283,7 +289,7 @@ def run():
         # template directory.
         create_user_config_dir(
                 Path.user_config_dir, Path.config_dir)
-    except (IOError, OSError), e:
+    except (IOError, OSError) as e:
         error_dialog = HIGAlertDialog(
                 message_format=_(
                     "Error creating the per-user configuration directory"),
@@ -307,7 +313,7 @@ scan profiles. Check for access to the directory and try again.""") % (
     try:
         # Read the ~/.zenmap/zenmap.conf configuration file.
         zenmapCore.UmitConf.config_parser.read(Path.user_config_file)
-    except ConfigParser.ParsingError, e:
+    except configparser.ParsingError as e:
         # ParsingError can leave some values as lists instead of strings. Just
         # blow it all away if we have this problem.
         zenmapCore.UmitConf.config_parser = zenmapCore.UmitConf.config_parser.__class__()
@@ -326,7 +332,7 @@ until it is repaired.""") % (Path.user_config_file, str(e), APP_DISPLAY_NAME)
         error_dialog.destroy()
         global_config_path = os.path.join(Path.config_dir, APP_NAME + '.conf')
         repair_dialog = HIGAlertDialog(
-                type=gtk.MESSAGE_QUESTION,
+                type=Gtk.MessageType.QUESTION,
                 message_format=_("Restore default configuration?"),
                 secondary_text=_("""\
 To avoid further errors parsing the configuration file %s, \
@@ -335,9 +341,9 @@ you can copy the default configuration from %s.
 Do this now? \
 """) % (Path.user_config_file, global_config_path),
                 )
-        repair_dialog.add_button(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL)
-        repair_dialog.set_default_response(gtk.RESPONSE_CANCEL)
-        if repair_dialog.run() == gtk.RESPONSE_OK:
+        repair_dialog.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
+        repair_dialog.set_default_response(Gtk.ResponseType.CANCEL)
+        if repair_dialog.run() == Gtk.ResponseType.OK:
             shutil.copyfile(global_config_path, Path.user_config_file)
             log.debug(">>> Copy %s to %s." % (global_config_path, Path.user_config_file))
         repair_dialog.destroy()
@@ -384,13 +390,13 @@ Do this now? \
 
     if main_is_frozen():
         # This is needed by py2exe
-        gtk.gdk.threads_init()
-        gtk.gdk.threads_enter()
+        Gdk.threads_init()
+        Gdk.threads_enter()
 
-    gtk.main()
+    Gtk.main()
 
     if main_is_frozen():
-        gtk.gdk.threads_leave()
+        Gdk.threads_leave()
 
 
 class NonRootWarning (HIGAlertDialog):

--- a/zenmap/zenmapGUI/BugReport.py
+++ b/zenmap/zenmapGUI/BugReport.py
@@ -126,7 +126,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 from zenmapGUI.higwidgets.higboxes import HIGVBox
 
@@ -142,11 +145,11 @@ xml.__path__ = [x for x in xml.__path__ if "_xmlplus" not in x]
 from xml.sax.saxutils import escape
 
 
-class BugReport(gtk.Window, object):
+class BugReport(Gtk.Window, object):
     def __init__(self):
-        gtk.Window.__init__(self)
+        Gtk.Window.__init__(self)
         self.set_title(_('How to Report a Bug'))
-        self.set_position(gtk.WIN_POS_CENTER_ALWAYS)
+        self.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
 
         self._create_widgets()
         self._pack_widgets()
@@ -154,11 +157,11 @@ class BugReport(gtk.Window, object):
 
     def _create_widgets(self):
         self.vbox = HIGVBox()
-        self.button_box = gtk.HButtonBox()
+        self.button_box = Gtk.HButtonBox()
 
-        self.text = gtk.Label()
+        self.text = Gtk.Label()
 
-        self.btn_ok = gtk.Button(stock=gtk.STOCK_OK)
+        self.btn_ok = Gtk.Button(stock=Gtk.STOCK_OK)
 
     def _pack_widgets(self):
         self.vbox.set_border_width(6)
@@ -192,7 +195,7 @@ https://nmap.org/data/HACKING. Patches may be sent to nmap-dev \
             })
         self.vbox.add(self.text)
 
-        self.button_box.set_layout(gtk.BUTTONBOX_END)
+        self.button_box.set_layout(Gtk.ButtonBoxStyle.END)
         self.button_box.pack_start(self.btn_ok)
 
         self.vbox._pack_noexpand_nofill(self.button_box)
@@ -208,6 +211,6 @@ https://nmap.org/data/HACKING. Patches may be sent to nmap-dev \
 if __name__ == "__main__":
     w = BugReport()
     w.show_all()
-    w.connect("delete-event", lambda x, y: gtk.main_quit())
+    w.connect("delete-event", lambda x, y: Gtk.main_quit())
 
-    gtk.main()
+    Gtk.main()

--- a/zenmap/zenmapGUI/BugReport.py
+++ b/zenmap/zenmapGUI/BugReport.py
@@ -150,6 +150,7 @@ class BugReport(Gtk.Window, object):
         Gtk.Window.__init__(self)
         self.set_title(_('How to Report a Bug'))
         self.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
+        self.set_resizable(False)
 
         self._create_widgets()
         self._pack_widgets()
@@ -167,6 +168,7 @@ class BugReport(Gtk.Window, object):
         self.vbox.set_border_width(6)
 
         self.text.set_line_wrap(True)
+        self.text.set_max_width_chars(50)
         self.text.set_markup(_("""\
 <big><b>How to report a bug</b></big>
 

--- a/zenmap/zenmapGUI/BugReport.py
+++ b/zenmap/zenmapGUI/BugReport.py
@@ -196,7 +196,7 @@ https://nmap.org/data/HACKING. Patches may be sent to nmap-dev \
         self.vbox.add(self.text)
 
         self.button_box.set_layout(Gtk.ButtonBoxStyle.END)
-        self.button_box.pack_start(self.btn_ok)
+        self.button_box.pack_start(self.btn_ok, True, True, 0)
 
         self.vbox._pack_noexpand_nofill(self.button_box)
         self.add(self.vbox)

--- a/zenmap/zenmapGUI/CrashReport.py
+++ b/zenmap/zenmapGUI/CrashReport.py
@@ -126,8 +126,12 @@
 # *                                                                         *
 # ***************************************************************************/
 
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
 import sys
-import gtk
 import traceback
 
 from zenmapGUI.higwidgets.higdialogs import HIGDialog
@@ -149,9 +153,9 @@ from xml.sax.saxutils import escape
 class CrashReport(HIGDialog):
     def __init__(self, type, value, tb):
         HIGDialog.__init__(self)
-        gtk.Window.__init__(self)
+        Gtk.Window.__init__(self)
         self.set_title(_('Crash Report'))
-        self.set_position(gtk.WIN_POS_CENTER_ALWAYS)
+        self.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
 
         self._create_widgets()
         self._pack_widgets()
@@ -162,49 +166,49 @@ class CrashReport(HIGDialog):
         self.description_text.get_buffer().set_text(text)
 
     def _create_widgets(self):
-        self.button_box = gtk.HButtonBox()
-        self.button_box_ok = gtk.HButtonBox()
+        self.button_box = Gtk.HButtonBox()
+        self.button_box_ok = Gtk.HButtonBox()
 
-        self.description_scrolled = gtk.ScrolledWindow()
-        self.description_text = gtk.TextView()
+        self.description_scrolled = Gtk.ScrolledWindow()
+        self.description_text = Gtk.TextView()
         self.description_text.set_editable(False)
 
-        self.bug_text = gtk.Label()
+        self.bug_text = Gtk.Label()
         self.bug_text.set_markup(_('An unexpected error has crashed '
             '%(app_name)s. Please copy the stack trace below and send it to '
             'the <a href="mailto:dev@nmap.org">dev@nmap.org</a> mailing list. '
             '(<a href="http://seclists.org/nmap-dev/">More about the list.</a>'
             ') The developers will see your report and try to fix the problem.'
             ) % {"app_name": escape(APP_DISPLAY_NAME)})
-        self.email_frame = gtk.Frame()
-        self.email_label = gtk.Label()
+        self.email_frame = Gtk.Frame()
+        self.email_label = Gtk.Label()
         self.email_label.set_markup(_('<b>Copy and email to '
             '<a href="mailto:dev@nmap.org">dev@nmap.org</a>:</b>'))
-        self.btn_copy = gtk.Button(stock=gtk.STOCK_COPY)
-        self.btn_ok = gtk.Button(stock=gtk.STOCK_OK)
+        self.btn_copy = Gtk.Button(stock=Gtk.STOCK_COPY)
+        self.btn_ok = Gtk.Button(stock=Gtk.STOCK_OK)
 
         self.hbox = HIGHBox()
 
     def _pack_widgets(self):
         self.description_scrolled.add(self.description_text)
         self.description_scrolled.set_policy(
-                gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
+                Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         self.description_scrolled.set_size_request(400, 150)
-        self.description_text.set_wrap_mode(gtk.WRAP_WORD)
+        self.description_text.set_wrap_mode(Gtk.WrapMode.WORD)
 
         self.bug_text.set_line_wrap(True)
         self.email_label.set_line_wrap(True)
 
         self.email_frame.set_label_widget(self.email_label)
-        self.email_frame.set_shadow_type(gtk.SHADOW_NONE)
+        self.email_frame.set_shadow_type(Gtk.ShadowType.NONE)
 
         self.hbox.set_border_width(6)
         self.vbox.set_border_width(6)
 
         self.hbox._pack_expand_fill(self.bug_text)
 
-        self.button_box.set_layout(gtk.BUTTONBOX_START)
-        self.button_box_ok.set_layout(gtk.BUTTONBOX_END)
+        self.button_box.set_layout(Gtk.ButtonBoxStyle.START)
+        self.button_box_ok.set_layout(Gtk.ButtonBoxStyle.END)
 
         self.button_box.pack_start(self.btn_copy)
         self.button_box_ok.pack_start(self.btn_ok)
@@ -225,18 +229,18 @@ class CrashReport(HIGDialog):
         return buff.get_text(buff.get_start_iter(), buff.get_end_iter())
 
     def copy(self, widget=None, event=None):
-        clipboard = gtk.clipboard_get()
+        clipboard = Gtk.clipboard_get()
         clipboard.set_text(self.get_description())
         clipboard.store()
 
     def close(self, widget=None, event=None):
         self.destroy()
-        gtk.main_quit()
+        Gtk.main_quit()
         sys.exit(0)
 
 if __name__ == "__main__":
     c = CrashReport(None, None, None)
     c.show_all()
-    c.connect("delete-event", lambda x, y: gtk.main_quit())
+    c.connect("delete-event", lambda x, y: Gtk.main_quit())
 
-    gtk.main()
+    Gtk.main()

--- a/zenmap/zenmapGUI/CrashReport.py
+++ b/zenmap/zenmapGUI/CrashReport.py
@@ -129,7 +129,7 @@
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
+from gi.repository import Gtk, Gdk
 
 import sys
 import traceback
@@ -210,14 +210,14 @@ class CrashReport(HIGDialog):
         self.button_box.set_layout(Gtk.ButtonBoxStyle.START)
         self.button_box_ok.set_layout(Gtk.ButtonBoxStyle.END)
 
-        self.button_box.pack_start(self.btn_copy)
-        self.button_box_ok.pack_start(self.btn_ok)
+        self.button_box.pack_start(self.btn_copy, True, True, 0)
+        self.button_box_ok.pack_start(self.btn_ok, True, True, 0)
 
-        self.vbox.pack_start(self.hbox)
-        self.vbox.pack_start(self.email_frame)
-        self.vbox.pack_start(self.description_scrolled)
-        self.vbox.pack_start(self.button_box)
-        self.action_area.pack_start(self.button_box_ok)
+        self.vbox.pack_start(self.hbox, True, True, 0)
+        self.vbox.pack_start(self.email_frame, True, True, 0)
+        self.vbox.pack_start(self.description_scrolled, True, True, 0)
+        self.vbox.pack_start(self.button_box, True, True, 0)
+        self.action_area.pack_start(self.button_box_ok, True, True, 0)
 
     def _connect_widgets(self):
         self.btn_ok.connect("clicked", self.close)
@@ -226,11 +226,11 @@ class CrashReport(HIGDialog):
 
     def get_description(self):
         buff = self.description_text.get_buffer()
-        return buff.get_text(buff.get_start_iter(), buff.get_end_iter())
+        return buff.get_text(buff.get_start_iter(), buff.get_end_iter(), include_hidden_chars=True)
 
     def copy(self, widget=None, event=None):
-        clipboard = Gtk.clipboard_get()
-        clipboard.set_text(self.get_description())
+        clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+        clipboard.set_text(self.get_description(), -1)
         clipboard.store()
 
     def close(self, widget=None, event=None):

--- a/zenmap/zenmapGUI/DiffCompare.py
+++ b/zenmap/zenmapGUI/DiffCompare.py
@@ -169,7 +169,8 @@ class ScanChooser(HIGVBox):
     }
 
     def __init__(self, scans, title):
-        self.__gobject_init__()
+        HIGVBox.__init__(self)
+
         self.title = title
         self.scan_dict = {}
 
@@ -197,13 +198,12 @@ class ScanChooser(HIGVBox):
         self.lbl_scan = HIGSectionLabel(self.title)
         self.hbox = HIGHBox()
         self.table = HIGTable()
-        self.list_scan = Gtk.ListStore(str)
-        self.combo_scan = Gtk.ComboBox.new_with_entry(self.list_scan, 0)
+        self.combo_scan = Gtk.ComboBoxText.new_with_entry()
         self.btn_open_scan = Gtk.Button(stock=Gtk.STOCK_OPEN)
         self.exp_scan = Gtk.Expander.new(_("Scan Output"))
         self.scrolled = Gtk.ScrolledWindow()
         self.txt_scan_result = Gtk.TextView()
-        self.txg_tag = Gtk.TextTag("scan_style")
+        self.txg_tag = Gtk.TextTag(name="scan_style")
 
     def get_buffer(self):
         return self.txt_scan_result.get_buffer()
@@ -285,7 +285,7 @@ class ScanChooser(HIGVBox):
             scan_name = os.path.split(file_chosen)[-1]
             self.add_scan(scan_name, parser)
 
-            self.combo_scan.set_active(len(self.list_scan) - 1)
+            self.combo_scan.set_active(len(self.combo_scan.get_model()) - 1)
 
     def add_scan(self, scan_name, parser):
         scan_id = 1
@@ -294,7 +294,7 @@ class ScanChooser(HIGVBox):
             new_scan_name = "%s (%s)" % (scan_name, scan_id)
             scan_id += 1
 
-        self.list_scan.append([new_scan_name])
+        self.combo_scan.append_text(new_scan_name)
         self.scan_dict[new_scan_name] = parser
 
     def _text_changed_cb(self, widget):
@@ -302,10 +302,11 @@ class ScanChooser(HIGVBox):
         buff.apply_tag(
             self.txg_tag, buff.get_start_iter(), buff.get_end_iter())
 
-    def get_parsed_scan(self):
+    @property
+    def parsed_scan(self):
         """Return the currently selected scan's parsed output as an NmapParser
         object, or None if no valid scan is selected."""
-        selected_scan = self.combo_scan.child.get_text()
+        selected_scan = self.combo_scan.get_active_text()
         return self.scan_dict.get(selected_scan)
 
     def get_nmap_output(self):
@@ -317,7 +318,6 @@ class ScanChooser(HIGVBox):
             return None
 
     nmap_output = property(get_nmap_output)
-    parsed_scan = property(get_parsed_scan)
 
 
 class DiffWindow(Gtk.Window):
@@ -433,7 +433,7 @@ class DiffWindow(Gtk.Window):
             if status == 0 or status == 1:
                 # Successful completion.
                 try:
-                    diff = self.ndiff_process.get_scan_diff()
+                    diff = self.ndiff_process.get_scan_diff().decode("utf-8")
                 except zenmapCore.Diff.NdiffParseException as e:
                     alert = HIGAlertDialog(
                         message_format=_("Error parsing ndiff output"),

--- a/zenmap/zenmapGUI/DiffCompare.py
+++ b/zenmap/zenmapGUI/DiffCompare.py
@@ -200,7 +200,7 @@ class ScanChooser(HIGVBox):
         self.list_scan = Gtk.ListStore(str)
         self.combo_scan = Gtk.ComboBox.new_with_entry(self.list_scan, 0)
         self.btn_open_scan = Gtk.Button(stock=Gtk.STOCK_OPEN)
-        self.exp_scan = Gtk.Expander(_("Scan Output"))
+        self.exp_scan = Gtk.Expander.new(_("Scan Output"))
         self.scrolled = Gtk.ScrolledWindow()
         self.txt_scan_result = Gtk.TextView()
         self.txg_tag = Gtk.TextTag("scan_style")
@@ -353,20 +353,20 @@ class DiffWindow(Gtk.Window):
     def _pack_widgets(self):
         self.main_vbox.set_border_width(6)
 
-        self.hbox_selection.pack_start(self.scan_chooser_a, True, True)
-        self.hbox_selection.pack_start(self.scan_chooser_b, True, True)
+        self.hbox_selection.pack_start(self.scan_chooser_a, True, True, 0)
+        self.hbox_selection.pack_start(self.scan_chooser_b, True, True, 0)
 
-        self.main_vbox.pack_start(self.hbox_selection, False)
+        self.main_vbox.pack_start(self.hbox_selection, False, True, 0)
 
         scroll = Gtk.ScrolledWindow()
         scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         scroll.add(self.diff_view)
-        self.main_vbox.pack_start(scroll, True, True)
+        self.main_vbox.pack_start(scroll, True, True, 0)
 
         self.progress.hide()
         self.progress.set_no_show_all(True)
-        self.hbox_buttons.pack_start(self.progress, False)
-        self.hbox_buttons.pack_end(self.btn_close, False)
+        self.hbox_buttons.pack_start(self.progress, False, True, 0)
+        self.hbox_buttons.pack_end(self.btn_close, False, True, 0)
 
         self.main_vbox._pack_noexpand_nofill(self.hbox_buttons)
 

--- a/zenmap/zenmapGUI/DiffCompare.py
+++ b/zenmap/zenmapGUI/DiffCompare.py
@@ -126,8 +126,11 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gobject
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GObject, GLib
+
 import os
 import os.path
 import sys
@@ -162,7 +165,7 @@ class ScanChooser(HIGVBox):
     has changed."""
 
     __gsignals__ = {
-        "changed": (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, ())
+        "changed": (GObject.SignalFlags.RUN_FIRST, GObject.TYPE_NONE, ())
     }
 
     def __init__(self, scans, title):
@@ -194,13 +197,13 @@ class ScanChooser(HIGVBox):
         self.lbl_scan = HIGSectionLabel(self.title)
         self.hbox = HIGHBox()
         self.table = HIGTable()
-        self.list_scan = gtk.ListStore(str)
-        self.combo_scan = gtk.ComboBoxEntry(self.list_scan, 0)
-        self.btn_open_scan = gtk.Button(stock=gtk.STOCK_OPEN)
-        self.exp_scan = gtk.Expander(_("Scan Output"))
-        self.scrolled = gtk.ScrolledWindow()
-        self.txt_scan_result = gtk.TextView()
-        self.txg_tag = gtk.TextTag("scan_style")
+        self.list_scan = Gtk.ListStore(str)
+        self.combo_scan = Gtk.ComboBox.new_with_entry(self.list_scan, 0)
+        self.btn_open_scan = Gtk.Button(stock=Gtk.STOCK_OPEN)
+        self.exp_scan = Gtk.Expander(_("Scan Output"))
+        self.scrolled = Gtk.ScrolledWindow()
+        self.txt_scan_result = Gtk.TextView()
+        self.txg_tag = Gtk.TextTag("scan_style")
 
     def get_buffer(self):
         return self.txt_scan_result.get_buffer()
@@ -234,14 +237,14 @@ class ScanChooser(HIGVBox):
         self.scrolled.add_with_viewport(self.txt_scan_result)
 
         # Setting scrolled window
-        self.scrolled.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
+        self.scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
 
     def _set_text_view(self):
         self.txg_table = self.txt_scan_result.get_buffer().get_tag_table()
         self.txg_table.add(self.txg_tag)
         self.txg_tag.set_property("family", "Monospace")
 
-        self.txt_scan_result.set_wrap_mode(gtk.WRAP_WORD)
+        self.txt_scan_result.set_wrap_mode(Gtk.WrapMode.WORD)
         self.txt_scan_result.set_editable(False)
         self.txt_scan_result.get_buffer().connect(
             "changed", self._text_changed_cb)
@@ -255,7 +258,7 @@ class ScanChooser(HIGVBox):
         response = file_chooser.run()
         file_chosen = file_chooser.get_filename()
         file_chooser.destroy()
-        if response == gtk.RESPONSE_OK:
+        if response == Gtk.ResponseType.OK:
             try:
                 parser = NmapParser()
                 parser.parse_file(file_chosen)
@@ -317,9 +320,9 @@ class ScanChooser(HIGVBox):
     parsed_scan = property(get_parsed_scan)
 
 
-class DiffWindow(gtk.Window):
+class DiffWindow(Gtk.Window):
     def __init__(self, scans):
-        gtk.Window.__init__(self)
+        Gtk.Window.__init__(self)
         self.set_title(_("Compare Results"))
         self.ndiff_process = None
         # We allow the user to start a new diff before the old one has
@@ -333,11 +336,11 @@ class DiffWindow(gtk.Window):
         self.diff_view = DiffView()
         self.diff_view.set_size_request(-1, 100)
         self.hbox_buttons = HIGHBox()
-        self.progress = gtk.ProgressBar()
-        self.btn_close = HIGButton(stock=gtk.STOCK_CLOSE)
+        self.progress = Gtk.ProgressBar()
+        self.btn_close = HIGButton(stock=Gtk.STOCK_CLOSE)
         self.hbox_selection = HIGHBox()
-        self.scan_chooser_a = ScanChooser(scans, _(u"A Scan"))
-        self.scan_chooser_b = ScanChooser(scans, _(u"B Scan"))
+        self.scan_chooser_a = ScanChooser(scans, _("A Scan"))
+        self.scan_chooser_b = ScanChooser(scans, _("B Scan"))
 
         self._pack_widgets()
         self._connect_widgets()
@@ -355,8 +358,8 @@ class DiffWindow(gtk.Window):
 
         self.main_vbox.pack_start(self.hbox_selection, False)
 
-        scroll = gtk.ScrolledWindow()
-        scroll.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         scroll.add(self.diff_view)
         self.main_vbox.pack_start(scroll, True, True)
 
@@ -405,7 +408,7 @@ class DiffWindow(gtk.Window):
             else:
                 self.progress.show()
                 if self.timer_id is None:
-                    self.timer_id = gobject.timeout_add(
+                    self.timer_id = GLib.timeout_add(
                         NDIFF_CHECK_TIMEOUT, self.check_ndiff_process)
 
     def check_ndiff_process(self):
@@ -469,13 +472,13 @@ class DiffWindow(gtk.Window):
         self.destroy()
 
 
-class DiffView(gtk.TextView):
+class DiffView(Gtk.TextView):
     REMOVE_COLOR = "#ffaaaa"
     ADD_COLOR = "#ccffcc"
 
     """A widget displaying a zenmapCore.Diff.ScanDiff."""
     def __init__(self):
-        gtk.TextView.__init__(self)
+        Gtk.TextView.__init__(self)
         self.set_editable(False)
 
         buff = self.get_buffer()
@@ -486,7 +489,7 @@ class DiffView(gtk.TextView):
         buff.create_tag("+", font="Monospace", background=self.ADD_COLOR)
 
     def clear(self):
-        self.get_buffer().set_text(u"")
+        self.get_buffer().set_text("")
 
     def show_diff(self, diff):
         self.clear()
@@ -519,6 +522,6 @@ if __name__ == "__main__":
                      "Parsed 4": parsed4})
 
     dw.show_all()
-    dw.connect("delete-event", lambda x, y: gtk.main_quit())
+    dw.connect("delete-event", lambda x, y: Gtk.main_quit())
 
-    gtk.main()
+    Gtk.main()

--- a/zenmap/zenmapGUI/FileChoosers.py
+++ b/zenmap/zenmapGUI/FileChoosers.py
@@ -126,27 +126,31 @@
 # *                                                                         *
 # ***************************************************************************/
 
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
 import os.path
 import sys
-import gtk
 
 import zenmapCore.I18N  # lgtm[py/unused-import]
 
 RESPONSE_OPEN_DIRECTORY = 1
 
 
-class AllFilesFileFilter(gtk.FileFilter):
+class AllFilesFileFilter(Gtk.FileFilter):
     def __init__(self):
-        gtk.FileFilter.__init__(self)
+        Gtk.FileFilter.__init__(self)
 
         pattern = "*"
         self.add_pattern(pattern)
         self.set_name(_("All files (%s)") % pattern)
 
 
-class ResultsFileFilter(gtk.FileFilter):
+class ResultsFileFilter(Gtk.FileFilter):
     def __init__(self):
-        gtk.FileFilter.__init__(self)
+        Gtk.FileFilter.__init__(self)
 
         patterns = ["*.xml"]
         for pattern in patterns:
@@ -154,9 +158,9 @@ class ResultsFileFilter(gtk.FileFilter):
         self.set_name(_("Nmap XML files (%s)") % ", ".join(patterns))
 
 
-class ScriptFileFilter(gtk.FileFilter):
+class ScriptFileFilter(Gtk.FileFilter):
     def __init__(self):
-        gtk.FileFilter.__init__(self)
+        Gtk.FileFilter.__init__(self)
 
         patterns = ["*.nse"]
         for pattern in patterns:
@@ -164,7 +168,7 @@ class ScriptFileFilter(gtk.FileFilter):
         self.set_name(_("NSE scripts (%s)") % ", ".join(patterns))
 
 
-class UnicodeFileChooserDialog(gtk.FileChooserDialog):
+class UnicodeFileChooserDialog(Gtk.FileChooserDialog):
     """This is a base class for file choosers. It is designed to ease the
     retrieval of Unicode file names. On most platforms, the file names returned
     are encoded in the encoding given by sys.getfilesystemencoding(). On
@@ -172,7 +176,7 @@ class UnicodeFileChooserDialog(gtk.FileChooserDialog):
     results in a file not found error. The get_filename method of this class
     handles the decoding automatically."""
     def get_filename(self):
-        filename = gtk.FileChooserDialog.get_filename(self)
+        filename = Gtk.FileChooserDialog.get_filename(self)
         if sys.platform == "win32":
             encoding = "UTF-8"
         else:
@@ -186,13 +190,13 @@ class UnicodeFileChooserDialog(gtk.FileChooserDialog):
 
 class AllFilesFileChooserDialog(UnicodeFileChooserDialog):
     def __init__(self, title="", parent=None,
-                 action=gtk.FILE_CHOOSER_ACTION_OPEN,
-                 buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL,
-                          gtk.STOCK_OPEN, gtk.RESPONSE_OK), backend=None):
+                 action=Gtk.FileChooserAction.OPEN,
+                 buttons=(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                          Gtk.STOCK_OPEN, Gtk.ResponseType.OK), backend=None):
 
-        gtk.FileChooserDialog.__init__(self, title, parent,
+        Gtk.FileChooserDialog.__init__(self, title, parent,
                                        action, buttons)
-        self.set_default_response(gtk.RESPONSE_OK)
+        self.set_default_response(Gtk.ResponseType.OK)
         self.add_filter(AllFilesFileFilter())
 
 
@@ -200,40 +204,40 @@ class ResultsFileSingleChooserDialog(UnicodeFileChooserDialog):
     """This results file choose only allows the selection of single files, not
     directories."""
     def __init__(self, title="", parent=None,
-                 action=gtk.FILE_CHOOSER_ACTION_OPEN,
-                 buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL,
-                          gtk.STOCK_OPEN, gtk.RESPONSE_OK), backend=None):
+                 action=Gtk.FileChooserAction.OPEN,
+                 buttons=(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                          Gtk.STOCK_OPEN, Gtk.ResponseType.OK), backend=None):
 
         UnicodeFileChooserDialog.__init__(self, title, parent,
                                        action, buttons)
-        self.set_default_response(gtk.RESPONSE_OK)
+        self.set_default_response(Gtk.ResponseType.OK)
         for f in (ResultsFileFilter(), AllFilesFileFilter()):
             self.add_filter(f)
 
 
 class ResultsFileChooserDialog(UnicodeFileChooserDialog):
     def __init__(self, title="", parent=None,
-                 action=gtk.FILE_CHOOSER_ACTION_OPEN,
-                 buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL,
+                 action=Gtk.FileChooserAction.OPEN,
+                 buttons=(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
                           "Open Directory", RESPONSE_OPEN_DIRECTORY,
-                          gtk.STOCK_OPEN, gtk.RESPONSE_OK), backend=None):
+                          Gtk.STOCK_OPEN, Gtk.ResponseType.OK), backend=None):
 
         UnicodeFileChooserDialog.__init__(self, title, parent,
                                        action, buttons)
-        self.set_default_response(gtk.RESPONSE_OK)
+        self.set_default_response(Gtk.ResponseType.OK)
         for f in (ResultsFileFilter(), AllFilesFileFilter()):
             self.add_filter(f)
 
 
 class ScriptFileChooserDialog(UnicodeFileChooserDialog):
     def __init__(self, title="", parent=None,
-                 action=gtk.FILE_CHOOSER_ACTION_OPEN,
-                 buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL,
-                          gtk.STOCK_OPEN, gtk.RESPONSE_OK), backend=None):
+                 action=Gtk.FileChooserAction.OPEN,
+                 buttons=(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                          Gtk.STOCK_OPEN, Gtk.ResponseType.OK), backend=None):
 
         UnicodeFileChooserDialog.__init__(self, title, parent,
                                        action, buttons)
-        self.set_default_response(gtk.RESPONSE_OK)
+        self.set_default_response(Gtk.ResponseType.OK)
         self.set_select_multiple(True)
         for f in (ScriptFileFilter(), AllFilesFileFilter()):
             self.add_filter(f)
@@ -253,32 +257,32 @@ class SaveResultsFileChooserDialog(UnicodeFileChooserDialog):
     }
 
     def __init__(self, title="", parent=None,
-                 action=gtk.FILE_CHOOSER_ACTION_SAVE,
-                 buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL,
-                          gtk.STOCK_SAVE, gtk.RESPONSE_OK), backend=None):
+                 action=Gtk.FileChooserAction.SAVE,
+                 buttons=(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                          Gtk.STOCK_SAVE, Gtk.ResponseType.OK), backend=None):
 
         UnicodeFileChooserDialog.__init__(self, title, parent, action, buttons)
 
-        types_store = gtk.ListStore(str, str, str)
+        types_store = Gtk.ListStore(str, str, str)
         for type in self.TYPES:
             types_store.append(type)
 
-        self.combo = gtk.ComboBox(types_store)
-        cell = gtk.CellRendererText()
+        self.combo = Gtk.ComboBox(types_store)
+        cell = Gtk.CellRendererText()
         self.combo.pack_start(cell, True)
         self.combo.add_attribute(cell, "text", 0)
         self.combo.connect("changed", self.combo_changed_cb)
         self.combo.set_active(1)
 
-        hbox = gtk.HBox(False, 6)
+        hbox = Gtk.HBox(False, 6)
         hbox.pack_end(self.combo, False)
-        hbox.pack_end(gtk.Label(_("Select File Type:")), False)
+        hbox.pack_end(Gtk.Label(_("Select File Type:")), False)
         hbox.show_all()
 
         self.set_extra_widget(hbox)
         self.set_do_overwrite_confirmation(True)
 
-        self.set_default_response(gtk.RESPONSE_OK)
+        self.set_default_response(Gtk.ResponseType.OK)
 
     def combo_changed_cb(self, combo):
         filename = self.get_filename() or ""
@@ -311,19 +315,19 @@ class SaveResultsFileChooserDialog(UnicodeFileChooserDialog):
 
 class DirectoryChooserDialog(UnicodeFileChooserDialog):
     def __init__(self, title="", parent=None,
-                 action=gtk.FILE_CHOOSER_ACTION_SELECT_FOLDER,
-                 buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL,
-                          gtk.STOCK_OPEN, gtk.RESPONSE_OK), backend=None):
+                 action=Gtk.FileChooserAction.SELECT_FOLDER,
+                 buttons=(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                          Gtk.STOCK_OPEN, Gtk.ResponseType.OK), backend=None):
 
         UnicodeFileChooserDialog.__init__(self, title, parent, action, buttons)
-        self.set_default_response(gtk.RESPONSE_OK)
+        self.set_default_response(Gtk.ResponseType.OK)
 
 
 class SaveToDirectoryChooserDialog(UnicodeFileChooserDialog):
     def __init__(self, title="", parent=None,
-                 action=gtk.FILE_CHOOSER_ACTION_SELECT_FOLDER,
-                 buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL,
-                          gtk.STOCK_SAVE, gtk.RESPONSE_OK), backend=None):
+                 action=Gtk.FileChooserAction.SELECT_FOLDER,
+                 buttons=(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                          Gtk.STOCK_SAVE, Gtk.ResponseType.OK), backend=None):
 
         UnicodeFileChooserDialog.__init__(self, title, parent, action, buttons)
-        self.set_default_response(gtk.RESPONSE_OK)
+        self.set_default_response(Gtk.ResponseType.OK)

--- a/zenmap/zenmapGUI/FileChoosers.py
+++ b/zenmap/zenmapGUI/FileChoosers.py
@@ -267,7 +267,7 @@ class SaveResultsFileChooserDialog(UnicodeFileChooserDialog):
         for type in self.TYPES:
             types_store.append(type)
 
-        self.combo = Gtk.ComboBox(types_store)
+        self.combo = Gtk.ComboBox(model=types_store)
         cell = Gtk.CellRendererText()
         self.combo.pack_start(cell, True)
         self.combo.add_attribute(cell, "text", 0)

--- a/zenmap/zenmapGUI/FileChoosers.py
+++ b/zenmap/zenmapGUI/FileChoosers.py
@@ -275,8 +275,8 @@ class SaveResultsFileChooserDialog(UnicodeFileChooserDialog):
         self.combo.set_active(1)
 
         hbox = Gtk.HBox(False, 6)
-        hbox.pack_end(self.combo, False)
-        hbox.pack_end(Gtk.Label(_("Select File Type:")), False)
+        hbox.pack_end(self.combo, False, True, 0)
+        hbox.pack_end(Gtk.Label(_("Select File Type:")), False, True, 0)
         hbox.show_all()
 
         self.set_extra_widget(hbox)

--- a/zenmap/zenmapGUI/FilterBar.py
+++ b/zenmap/zenmapGUI/FilterBar.py
@@ -1,5 +1,7 @@
-import gtk
-import gobject
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GObject
 
 from zenmapGUI.higwidgets.higboxes import HIGHBox
 from zenmapGUI.higwidgets.higlabels import HintWindow
@@ -10,27 +12,27 @@ class FilterBar(HIGHBox):
     entering a string that restricts the set of visible hosts."""
 
     __gsignals__ = {
-        "changed": (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, ())
+        "changed": (GObject.SignalFlags.RUN_FIRST, GObject.TYPE_NONE, ())
     }
 
     def __init__(self):
         HIGHBox.__init__(self)
-        self.information_label = gtk.Label()
-        self.entry = gtk.Entry()
+        self.information_label = Gtk.Label()
+        self.entry = Gtk.Entry()
 
         self.pack_start(self.information_label, False)
         self.information_label.show()
 
-        label = gtk.Label(_("Host Filter:"))
+        label = Gtk.Label(_("Host Filter:"))
         self.pack_start(label, False)
         label.show()
 
         self.pack_start(self.entry, True, True)
         self.entry.show()
 
-        help_button = gtk.Button()
-        icon = gtk.Image()
-        icon.set_from_stock(gtk.STOCK_INFO, gtk.ICON_SIZE_BUTTON)
+        help_button = Gtk.Button()
+        icon = Gtk.Image()
+        icon.set_from_stock(Gtk.STOCK_INFO, Gtk.IconSize.BUTTON)
         help_button.add(icon)
         help_button.connect("clicked", self._help_button_clicked)
         self.pack_start(help_button, False)

--- a/zenmap/zenmapGUI/FilterBar.py
+++ b/zenmap/zenmapGUI/FilterBar.py
@@ -44,7 +44,7 @@ class FilterBar(HIGHBox):
         self.entry.grab_focus()
 
     def get_filter_string(self):
-        return self.entry.get_text().decode("UTF-8")
+        return self.entry.get_text()
 
     def set_filter_string(self, filter_string):
         return self.entry.set_text(filter_string)

--- a/zenmap/zenmapGUI/FilterBar.py
+++ b/zenmap/zenmapGUI/FilterBar.py
@@ -20,14 +20,14 @@ class FilterBar(HIGHBox):
         self.information_label = Gtk.Label()
         self.entry = Gtk.Entry()
 
-        self.pack_start(self.information_label, False)
+        self.pack_start(self.information_label, False, True, 0)
         self.information_label.show()
 
         label = Gtk.Label(_("Host Filter:"))
-        self.pack_start(label, False)
+        self.pack_start(label, False, True, 0)
         label.show()
 
-        self.pack_start(self.entry, True, True)
+        self.pack_start(self.entry, True, True, 0)
         self.entry.show()
 
         help_button = Gtk.Button()
@@ -35,7 +35,7 @@ class FilterBar(HIGHBox):
         icon.set_from_stock(Gtk.STOCK_INFO, Gtk.IconSize.BUTTON)
         help_button.add(icon)
         help_button.connect("clicked", self._help_button_clicked)
-        self.pack_start(help_button, False)
+        self.pack_start(help_button, False, True, 0)
         help_button.show_all()
 
         self.entry.connect("changed", lambda x: self.emit("changed"))

--- a/zenmap/zenmapGUI/Icons.py
+++ b/zenmap/zenmapGUI/Icons.py
@@ -184,7 +184,7 @@ if pixmap_path:
                             ', '.join(get_pixmap_file_names(icon_name, size)),
                             pixmap_path))
                 continue
-            iconset = Gtk.IconSet(pixbuf)
+            iconset = Gtk.IconSet(pixbuf=pixbuf)
             iconfactory.add(key, iconset)
             log.debug('Register %s icon name for file %s' % (key, file_path))
     iconfactory.add_default()

--- a/zenmap/zenmapGUI/Icons.py
+++ b/zenmap/zenmapGUI/Icons.py
@@ -126,8 +126,11 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
-import gobject
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GLib, GdkPixbuf
+
 import re
 import os.path
 
@@ -161,7 +164,7 @@ if pixmap_path:
     def get_pixmap_file_names(icon_name, size):
         yield '%s_%s.png' % (icon_name, size)
 
-    iconfactory = gtk.IconFactory()
+    iconfactory = Gtk.IconFactory()
     for icon_name in icon_names:
         for type, size in (('icon', '32'), ('logo', '75')):
             key = '%s_%s' % (icon_name, type)
@@ -169,9 +172,9 @@ if pixmap_path:
             for file_name in get_pixmap_file_names(icon_name, size):
                 file_path = os.path.join(pixmap_path, file_name)
                 try:
-                    pixbuf = gtk.gdk.pixbuf_new_from_file(file_path)
+                    pixbuf = GdkPixbuf.Pixbuf.new_from_file(file_path)
                     break
-                except gobject.GError:
+                except GLib.GError:
                     # Try again.
                     pass
             else:
@@ -181,7 +184,7 @@ if pixmap_path:
                             ', '.join(get_pixmap_file_names(icon_name, size)),
                             pixmap_path))
                 continue
-            iconset = gtk.IconSet(pixbuf)
+            iconset = Gtk.IconSet(pixbuf)
             iconfactory.add(key, iconset)
             log.debug('Register %s icon name for file %s' % (key, file_path))
     iconfactory.add_default()

--- a/zenmap/zenmapGUI/MainWindow.py
+++ b/zenmap/zenmapGUI/MainWindow.py
@@ -852,7 +852,7 @@ This scan has not been run yet. Start the scan with the "Scan" button first.'))
         if self.scan_interface.changed:
             log.debug("Found changes on closing window")
             dialog = HIGDialog(
-                    buttons=(_('Close anyway').encode('utf-8'),
+                    buttons=(_('Close anyway'),
                         Gtk.ResponseType.CLOSE, Gtk.STOCK_CANCEL,
                         Gtk.ResponseType.CANCEL))
 
@@ -893,7 +893,7 @@ This scan has not been run yet. Start the scan with the "Scan" button first.'))
         elif self.scan_interface.num_scans_running() > 0:
             log.debug("Trying to close a window with a running scan")
             dialog = HIGDialog(
-                    buttons=(_('Close anyway').encode('utf-8'),
+                    buttons=(_('Close anyway'),
                         Gtk.ResponseType.CLOSE, Gtk.STOCK_CANCEL,
                         Gtk.ResponseType.CANCEL))
 

--- a/zenmap/zenmapGUI/MainWindow.py
+++ b/zenmap/zenmapGUI/MainWindow.py
@@ -126,7 +126,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 import sys
 import os
@@ -174,7 +177,7 @@ if is_maemo():
             hildon.Window.__init__(self)
             self.set_resizable(False)
             self.set_border_width(0)
-            self.vbox = gtk.VBox()
+            self.vbox = Gtk.VBox()
             self.vbox.set_border_width(0)
             self.vbox.set_spacing(0)
 
@@ -182,14 +185,14 @@ else:
     class UmitScanWindow(HIGMainWindow):
         def __init__(self):
             HIGMainWindow.__init__(self)
-            self.vbox = gtk.VBox()
+            self.vbox = Gtk.VBox()
 
 
 def can_print():
     """Return true if we have printing operations (PyGTK 2.10 or later) or
     false otherwise."""
     try:
-        gtk.PrintOperation
+        Gtk.PrintOperation
     except AttributeError:
         return False
     else:
@@ -208,7 +211,7 @@ class ScanWindow(UmitScanWindow):
 
         self.scan_interface = ScanInterface()
 
-        self.main_accel_group = gtk.AccelGroup()
+        self.main_accel_group = Gtk.AccelGroup()
 
         self.add_accel_group(self.main_accel_group)
 
@@ -226,12 +229,12 @@ class ScanWindow(UmitScanWindow):
     def _create_ui_manager(self):
         """Creates the UI Manager and a default set of actions, and builds
         the menus using those actions."""
-        self.ui_manager = gtk.UIManager()
+        self.ui_manager = Gtk.UIManager()
 
         # See info on ActionGroup at:
         # * http://www.pygtk.org/pygtk2reference/class-gtkactiongroup.html
         # * http://www.gtk.org/api/2.6/gtk/GtkActionGroup.html
-        self.main_action_group = gtk.ActionGroup('MainActionGroup')
+        self.main_action_group = Gtk.ActionGroup('MainActionGroup')
 
         # See info on Action at:
         # * http://www.pygtk.org/pygtk2reference/class-gtkaction.html
@@ -247,7 +250,7 @@ class ScanWindow(UmitScanWindow):
 
         # gtk.STOCK_ABOUT is only available in PyGTK 2.6 and later.
         try:
-            about_icon = gtk.STOCK_ABOUT
+            about_icon = Gtk.STOCK_ABOUT
         except AttributeError:
             about_icon = None
 
@@ -256,28 +259,28 @@ class ScanWindow(UmitScanWindow):
             ('Scan', None, _('Sc_an'), None),
 
             ('Save Scan',
-                gtk.STOCK_SAVE,
+                Gtk.STOCK_SAVE,
                 _('_Save Scan'),
                 None,
                 _('Save current scan results'),
                 self._save_scan_results_cb),
 
             ('Save All Scans to Directory',
-                gtk.STOCK_SAVE,
+                Gtk.STOCK_SAVE,
                 _('Save All Scans to _Directory'),
                 "<Control><Alt>s",
                 _('Save all scans into a directory'),
                 self._save_to_directory_cb),
 
             ('Open Scan',
-                gtk.STOCK_OPEN,
+                Gtk.STOCK_OPEN,
                 _('_Open Scan'),
                 None,
                 _('Open the results of a previous scan'),
                 self._load_scan_results_cb),
 
             ('Append Scan',
-                gtk.STOCK_ADD,
+                Gtk.STOCK_ADD,
                 _('_Open Scan in This Window'),
                 None,
                 _('Append a saved scan to the list of scans in this window.'),
@@ -287,56 +290,56 @@ class ScanWindow(UmitScanWindow):
             ('Tools', None, _('_Tools'), None),
 
             ('New Window',
-                gtk.STOCK_NEW,
+                Gtk.STOCK_NEW,
                 _('_New Window'),
                 "<Control>N",
                 _('Open a new scan window'),
                 self._new_scan_cb),
 
             ('Close Window',
-                gtk.STOCK_CLOSE,
+                Gtk.STOCK_CLOSE,
                 _('Close Window'),
                 "<Control>w",
                 _('Close this scan window'),
                 self._exit_cb),
 
             ('Print...',
-                gtk.STOCK_PRINT,
+                Gtk.STOCK_PRINT,
                 _('Print...'),
                 None,
                 _('Print the current scan'),
                 self._print_cb),
 
             ('Quit',
-                gtk.STOCK_QUIT,
+                Gtk.STOCK_QUIT,
                 _('Quit'),
                 "<Control>q",
                 _('Quit the application'),
                 self._quit_cb),
 
             ('New Profile',
-                gtk.STOCK_JUSTIFY_LEFT,
+                Gtk.STOCK_JUSTIFY_LEFT,
                 _('New _Profile or Command'),
                 '<Control>p',
                 _('Create a new scan profile using the current command'),
                 self._new_scan_profile_cb),
 
             ('Search Scan',
-                gtk.STOCK_FIND,
+                Gtk.STOCK_FIND,
                 _('Search Scan Results'),
                 '<Control>f',
                 _('Search for a scan result'),
                 self._search_scan_result),
 
             ('Filter Hosts',
-                gtk.STOCK_FIND,
+                Gtk.STOCK_FIND,
                 _('Filter Hosts'),
                 '<Control>l',
                 _('Search for host by criteria'),
                 self._filter_cb),
 
             ('Edit Profile',
-                gtk.STOCK_PROPERTIES,
+                Gtk.STOCK_PROPERTIES,
                 _('_Edit Selected Profile'),
                 '<Control>e',
                 _('Edit selected scan profile'),
@@ -346,7 +349,7 @@ class ScanWindow(UmitScanWindow):
             ('Profile', None, _('_Profile'), None),
 
             ('Compare Results',
-                gtk.STOCK_DND_MULTIPLE,
+                Gtk.STOCK_DND_MULTIPLE,
                 _('Compare Results'),
                 "<Control>D",
                 _('Compare Scan Results using Diffies'),
@@ -357,7 +360,7 @@ class ScanWindow(UmitScanWindow):
             ('Help', None, _('_Help'), None),
 
             ('Report a bug',
-                gtk.STOCK_DIALOG_INFO,
+                Gtk.STOCK_DIALOG_INFO,
                 _('_Report a bug'),
                 '<Control>b',
                 _("Report a bug"),
@@ -373,7 +376,7 @@ class ScanWindow(UmitScanWindow):
                 ),
 
             ('Show Help',
-                gtk.STOCK_HELP,
+                Gtk.STOCK_HELP,
                 _('_Help'),
                 None,
                 _('Shows the application help'),
@@ -478,7 +481,7 @@ class ScanWindow(UmitScanWindow):
         log.debug(">>> Saving result into database...")
         try:
             scan_interface.inventory.save_to_db()
-        except Exception, e:
+        except Exception as e:
             alert = HIGAlertDialog(
                     message_format=_("Can't save to database"),
                     secondary_text=_("Can't store unsaved scans to the "
@@ -513,7 +516,7 @@ class ScanWindow(UmitScanWindow):
         menubar = self.ui_manager.get_widget('/menubar')
 
         if is_maemo():
-            menu = gtk.Menu()
+            menu = Gtk.Menu()
             for child in menubar.get_children():
                 child.reparent(menu)
             self.set_menu(menu)
@@ -542,7 +545,7 @@ class ScanWindow(UmitScanWindow):
 
         filename = None
         response = self._results_filechooser_dialog.run()
-        if response == gtk.RESPONSE_OK:
+        if response == Gtk.ResponseType.OK:
             filename = self._results_filechooser_dialog.get_filename()
         elif response == RESPONSE_OPEN_DIRECTORY:
             filename = self._results_filechooser_dialog.get_filename()
@@ -605,7 +608,7 @@ class ScanWindow(UmitScanWindow):
             try:
                 # Parse result
                 scan_interface.load_from_file(filename)
-            except Exception, e:
+            except Exception as e:
                 alert = HIGAlertDialog(message_format=_('Error loading file'),
                                        secondary_text=str(e))
                 alert.run()
@@ -664,20 +667,20 @@ class ScanWindow(UmitScanWindow):
             dlg = HIGDialog(
                     title="Choose a scan to save",
                     parent=self,
-                    flags=gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT,
-                    buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL,
-                        gtk.STOCK_SAVE, gtk.RESPONSE_OK))
-            dlg.vbox.pack_start(gtk.Label(
+                    flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+                    buttons=(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                        Gtk.STOCK_SAVE, Gtk.ResponseType.OK))
+            dlg.vbox.pack_start(Gtk.Label(
                 "You have %u scans loaded in the current view.\n"
                 "Select the scan which you would like to save." % num_scans),
                 False)
-            scan_combo = gtk.combo_box_new_text()
+            scan_combo = Gtk.ComboBoxText()
             for scan in self.scan_interface.inventory.get_scans():
                 scan_combo.append_text(scan.nmap_command)
             scan_combo.set_active(0)
             dlg.vbox.pack_start(scan_combo, False)
             dlg.vbox.show_all()
-            if dlg.run() == gtk.RESPONSE_OK:
+            if dlg.run() == Gtk.ResponseType.OK:
                 selected = scan_combo.get_active()
                 dlg.destroy()
             else:
@@ -695,7 +698,7 @@ class ScanWindow(UmitScanWindow):
         response = self._save_results_filechooser_dialog.run()
 
         filename = None
-        if (response == gtk.RESPONSE_OK):
+        if (response == Gtk.ResponseType.OK):
             filename = self._save_results_filechooser_dialog.get_filename()
             format = self._save_results_filechooser_dialog.get_format()
             # add .xml to filename if there is no other extension
@@ -732,12 +735,12 @@ This scan has not been run yet. Start the scan with the "Scan" button first.'))
         # display a directory chooser dialog
         dir_chooser = SaveToDirectoryChooserDialog(
                 title=_("Choose a directory to save scans into"))
-        if dir_chooser.run() == gtk.RESPONSE_OK:
+        if dir_chooser.run() == Gtk.ResponseType.OK:
             self._save_all(self.scan_interface, dir_chooser.get_filename())
         dir_chooser.destroy()
 
     def _about_cb_response(self, dialog, response_id):
-        if response_id == gtk.RESPONSE_DELETE_EVENT:
+        if response_id == Gtk.ResponseType.DELETE_EVENT:
             self._about_dialog = None
         else:
             self._about_dialog.hide()
@@ -755,7 +758,7 @@ This scan has not been run yet. Start the scan with the "Scan" button first.'))
             filenames = scan_interface.inventory.save_to_dir(directory)
             for scan in scan_interface.inventory.get_scans():
                 scan.unsaved = False
-        except Exception, ex:
+        except Exception as ex:
             alert = HIGAlertDialog(message_format=_('Can\'t save file'),
                         secondary_text=str(ex))
             alert.run()
@@ -768,7 +771,7 @@ This scan has not been run yet. Start the scan with the "Scan" button first.'))
                 for filename in filenames:
                     recent_scans.add_recent_scan(filename)
                 recent_scans.save()
-            except (OSError, IOError), e:
+            except (OSError, IOError) as e:
                 alert = HIGAlertDialog(
                         message_format=_(
                             "Can't save recent scan information"),
@@ -786,7 +789,7 @@ This scan has not been run yet. Start the scan with the "Scan" button first.'))
             scan_interface.inventory.save_to_file(
                     saved_filename, selected_index, format)
             scan_interface.inventory.get_scans()[selected_index].unsaved = False  # noqa
-        except (OSError, IOError), e:
+        except (OSError, IOError) as e:
             alert = HIGAlertDialog(
                     message_format=_("Can't save file"),
                     secondary_text=_("Can't open file to write.\n%s") % str(e))
@@ -803,7 +806,7 @@ This scan has not been run yet. Start the scan with the "Scan" button first.'))
                 try:
                     recent_scans.add_recent_scan(saved_filename)
                     recent_scans.save()
-                except (OSError, IOError), e:
+                except (OSError, IOError) as e:
                     alert = HIGAlertDialog(
                             message_format=_(
                                 "Can't save recent scan information"),
@@ -850,8 +853,8 @@ This scan has not been run yet. Start the scan with the "Scan" button first.'))
             log.debug("Found changes on closing window")
             dialog = HIGDialog(
                     buttons=(_('Close anyway').encode('utf-8'),
-                        gtk.RESPONSE_CLOSE, gtk.STOCK_CANCEL,
-                        gtk.RESPONSE_CANCEL))
+                        Gtk.ResponseType.CLOSE, Gtk.STOCK_CANCEL,
+                        Gtk.ResponseType.CANCEL))
 
             alert = HIGEntryLabel('<b>%s</b>' % _("Unsaved changes"))
 
@@ -865,9 +868,9 @@ This scan has not been run yet. Start the scan with the "Scan" button first.'))
             vbox.set_border_width(5)
             vbox.set_spacing(12)
 
-            image = gtk.Image()
+            image = Gtk.Image()
             image.set_from_stock(
-                    gtk.STOCK_DIALOG_QUESTION, gtk.ICON_SIZE_DIALOG)
+                    Gtk.STOCK_DIALOG_QUESTION, Gtk.IconSize.DIALOG)
 
             vbox.pack_start(alert)
             vbox.pack_start(text)
@@ -880,7 +883,7 @@ This scan has not been run yet. Start the scan with the "Scan" button first.'))
             response = dialog.run()
             dialog.destroy()
 
-            if response == gtk.RESPONSE_CANCEL:
+            if response == Gtk.ResponseType.CANCEL:
                 return True
 
             search_config = SearchConfig()
@@ -891,8 +894,8 @@ This scan has not been run yet. Start the scan with the "Scan" button first.'))
             log.debug("Trying to close a window with a running scan")
             dialog = HIGDialog(
                     buttons=(_('Close anyway').encode('utf-8'),
-                        gtk.RESPONSE_CLOSE, gtk.STOCK_CANCEL,
-                        gtk.RESPONSE_CANCEL))
+                        Gtk.ResponseType.CLOSE, Gtk.STOCK_CANCEL,
+                        Gtk.ResponseType.CANCEL))
 
             alert = HIGEntryLabel('<b>%s</b>' % _("Trying to close"))
 
@@ -907,9 +910,9 @@ This scan has not been run yet. Start the scan with the "Scan" button first.'))
             vbox.set_border_width(5)
             vbox.set_spacing(12)
 
-            image = gtk.Image()
+            image = Gtk.Image()
             image.set_from_stock(
-                    gtk.STOCK_DIALOG_WARNING, gtk.ICON_SIZE_DIALOG)
+                    Gtk.STOCK_DIALOG_WARNING, Gtk.IconSize.DIALOG)
 
             vbox.pack_start(alert)
             vbox.pack_start(text)
@@ -922,9 +925,9 @@ This scan has not been run yet. Start the scan with the "Scan" button first.'))
             response = dialog.run()
             dialog.destroy()
 
-            if response == gtk.RESPONSE_CLOSE:
+            if response == Gtk.ResponseType.CLOSE:
                 self.scan_interface.kill_all_scans()
-            elif response == gtk.RESPONSE_CANCEL:
+            elif response == Gtk.ResponseType.CANCEL:
                 return True
 
         window = WindowConfig()
@@ -971,7 +974,7 @@ This scan has not been run yet. Start the scan with the "Scan" button first.'))
 
 
 def show_help():
-    import urllib
+    import urllib.request
     import webbrowser
 
     new = 0
@@ -979,20 +982,20 @@ def show_help():
         new = 2
 
     doc_path = abspath(join(Path.docs_dir, "help.html"))
-    url = "file:" + urllib.pathname2url(fs_enc(doc_path))
+    url = "file:" + urllib.request.pathname2url(fs_enc(doc_path))
     try:
         webbrowser.open(url, new=new)
-    except OSError, e:
+    except OSError as e:
         d = HIGAlertDialog(parent=self,
                            message_format=_("Can't find documentation files"),
                            secondary_text=_("""\
 There was an error loading the documentation file %s (%s). See the \
 online documentation at %s.\
-""") % (doc_path, unicode(e), APP_DOCUMENTATION_SITE))
+""") % (doc_path, str(e), APP_DOCUMENTATION_SITE))
         d.run()
         d.destroy()
 
 if __name__ == '__main__':
     w = ScanWindow()
     w.show_all()
-    gtk.main()
+    Gtk.main()

--- a/zenmap/zenmapGUI/MainWindow.py
+++ b/zenmap/zenmapGUI/MainWindow.py
@@ -673,12 +673,12 @@ class ScanWindow(UmitScanWindow):
             dlg.vbox.pack_start(Gtk.Label(
                 "You have %u scans loaded in the current view.\n"
                 "Select the scan which you would like to save." % num_scans),
-                False)
+                False, True, 0)
             scan_combo = Gtk.ComboBoxText()
             for scan in self.scan_interface.inventory.get_scans():
                 scan_combo.append_text(scan.nmap_command)
             scan_combo.set_active(0)
-            dlg.vbox.pack_start(scan_combo, False)
+            dlg.vbox.pack_start(scan_combo, False, True, 0)
             dlg.vbox.show_all()
             if dlg.run() == Gtk.ResponseType.OK:
                 selected = scan_combo.get_active()
@@ -872,12 +872,12 @@ This scan has not been run yet. Start the scan with the "Scan" button first.'))
             image.set_from_stock(
                     Gtk.STOCK_DIALOG_QUESTION, Gtk.IconSize.DIALOG)
 
-            vbox.pack_start(alert)
-            vbox.pack_start(text)
-            hbox.pack_start(image)
-            hbox.pack_start(vbox)
+            vbox.pack_start(alert, True, True, 0)
+            vbox.pack_start(text, True, True, 0)
+            hbox.pack_start(image, True, True, 0)
+            hbox.pack_start(vbox, True, True, 0)
 
-            dialog.vbox.pack_start(hbox)
+            dialog.vbox.pack_start(hbox, True, True, 0)
             dialog.vbox.show_all()
 
             response = dialog.run()
@@ -914,12 +914,12 @@ This scan has not been run yet. Start the scan with the "Scan" button first.'))
             image.set_from_stock(
                     Gtk.STOCK_DIALOG_WARNING, Gtk.IconSize.DIALOG)
 
-            vbox.pack_start(alert)
-            vbox.pack_start(text)
-            hbox.pack_start(image)
-            hbox.pack_start(vbox)
+            vbox.pack_start(alert, True, True, 0)
+            vbox.pack_start(text, True, True, 0)
+            hbox.pack_start(image, True, True, 0)
+            hbox.pack_start(vbox, True, True, 0)
 
-            dialog.vbox.pack_start(hbox)
+            dialog.vbox.pack_start(hbox, True, True, 0)
             dialog.vbox.show_all()
 
             response = dialog.run()

--- a/zenmap/zenmapGUI/NmapOutputProperties.py
+++ b/zenmap/zenmapGUI/NmapOutputProperties.py
@@ -126,9 +126,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
-import gtk.gdk
-import pango
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Gdk
 
 import zenmapCore.I18N  # lgtm[py/unused-import]
 from zenmapCore.UmitConf import NmapOutputHighlight
@@ -144,7 +145,7 @@ from zenmapGUI.higwidgets.higbuttons import HIGButton, HIGToggleButton
 class NmapOutputProperties(HIGDialog):
     def __init__(self, nmap_output_view):
         HIGDialog.__init__(self, _("Nmap Output Properties"),
-                           buttons=(gtk.STOCK_CLOSE, gtk.RESPONSE_CLOSE))
+                           buttons=(Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE))
 
         self.nmap_highlight = NmapOutputHighlight()
 
@@ -189,8 +190,8 @@ class NmapOutputProperties(HIGDialog):
             self.property_names[p].append(settings[0])
             self.property_names[p].append(settings[1])
             self.property_names[p].append(settings[2])
-            self.property_names[p].append(gtk.gdk.Color(*settings[3]))
-            self.property_names[p].append(gtk.gdk.Color(*settings[4]))
+            self.property_names[p].append(Gdk.Color(*settings[3]))
+            self.property_names[p].append(Gdk.Color(*settings[4]))
             self.property_names[p].append(settings[5])
 
         # Creating properties and related widgets and attaching it to main
@@ -225,7 +226,7 @@ class NmapOutputProperties(HIGDialog):
         # Adding color tab
         self.properties_notebook.append_page(
                 self.highlight_main_vbox,
-                gtk.Label(_("Highlight definitions")))
+                Gtk.Label(_("Highlight definitions")))
 
 
 class HighlightProperty(object):
@@ -248,13 +249,13 @@ class HighlightProperty(object):
     def __create_widgets(self):
         self.property_name_label = HIGEntryLabel("")
         self.example_label = HIGEntryLabel("")
-        self.bold_tg_button = HIGToggleButton("", gtk.STOCK_BOLD)
-        self.italic_tg_button = HIGToggleButton("", gtk.STOCK_ITALIC)
-        self.underline_tg_button = HIGToggleButton("", gtk.STOCK_UNDERLINE)
+        self.bold_tg_button = HIGToggleButton("", Gtk.STOCK_BOLD)
+        self.italic_tg_button = HIGToggleButton("", Gtk.STOCK_ITALIC)
+        self.underline_tg_button = HIGToggleButton("", Gtk.STOCK_UNDERLINE)
         self.text_color_button = HIGButton(
-                _("Text"), stock=gtk.STOCK_SELECT_COLOR)
+                _("Text"), stock=Gtk.STOCK_SELECT_COLOR)
         self.highlight_color_button = HIGButton(
-                _("Highlight"), stock=gtk.STOCK_SELECT_COLOR)
+                _("Highlight"), stock=Gtk.STOCK_SELECT_COLOR)
 
     def __connect_buttons(self):
         self.bold_tg_button.connect("toggled", self.update_example)
@@ -269,7 +270,7 @@ class HighlightProperty(object):
     # Text color dialog
 
     def text_color_dialog(self, widget):
-        color_dialog = gtk.ColorSelectionDialog(
+        color_dialog = Gtk.ColorSelectionDialog(
                 "%s %s" % (self.label, _("text color")))
         color_dialog.colorsel.set_current_color(self.text_color)
 
@@ -296,7 +297,7 @@ class HighlightProperty(object):
     #########################################
     # Highlight color dialog
     def highlight_color_dialog(self, widget):
-        color_dialog = gtk.ColorSelectionDialog(
+        color_dialog = Gtk.ColorSelectionDialog(
                 "%s %s" % (self.property_name, _("highlight color")))
         color_dialog.colorsel.set_current_color(self.highlight_color)
 
@@ -323,41 +324,50 @@ class HighlightProperty(object):
         color_dialog.destroy()
 
     def update_example(self, widget=None):
-        start = 0
-        end = len(self.example)
+        pass
+        # This needs to be fixed
 
-        attributes = pango.AttrList()
+        # Pango.Attribute(Pango.AttrType.FOREGROUND)
+        # https://stackoverflow.com/questions/44232223/how-do-i-use-pango-attrtype-foreground-in-python-and-gtk3
+        # https://stackoverflow.com/questions/8783670/pango-attributes-with-pygobject
+        # https://bugzilla.gnome.org/show_bug.cgi?id=646788
+        # https://gitlab.gnome.org/GNOME/pango/-/issues/189
 
-        attributes.insert(
-                pango.AttrForeground(self.text_color.red,
-                    self.text_color.green, self.text_color.blue, start, end))
-        attributes.insert(pango.AttrBackground(self.highlight_color.red,
-                                               self.highlight_color.green,
-                                               self.highlight_color.blue,
-                                               start, end))
-
-        # Bold verification
-        if self.bold_tg_button.get_active():
-            attributes.insert(pango.AttrWeight(pango.WEIGHT_HEAVY, start, end))
-        else:
-            attributes.insert(
-                    pango.AttrWeight(pango.WEIGHT_NORMAL, start, end))
-
-        # Italic verification
-        if self.italic_tg_button.get_active():
-            attributes.insert(pango.AttrStyle(pango.STYLE_ITALIC, start, end))
-        else:
-            attributes.insert(pango.AttrStyle(pango.STYLE_NORMAL, start, end))
-
-        # Underline verification
-        if self.underline_tg_button.get_active():
-            attributes.insert(
-                    pango.AttrUnderline(pango.UNDERLINE_SINGLE, start, end))
-        else:
-            attributes.insert(
-                    pango.AttrUnderline(pango.UNDERLINE_NONE, start, end))
-
-        self.example_label.set_attributes(attributes)
+#        start = 0
+#        end = len(self.example)
+#
+#        attributes = Pango.AttrList()
+#
+#        attributes.insert(
+#                pango.AttrForeground(self.text_color.red,
+#                    self.text_color.green, self.text_color.blue, start, end))
+#        attributes.insert(pango.AttrBackground(self.highlight_color.red,
+#                                               self.highlight_color.green,
+#                                               self.highlight_color.blue,
+#                                               start, end))
+#
+#        # Bold verification
+#        if self.bold_tg_button.get_active():
+#            attributes.insert(pango.AttrWeight(Pango.Weight.HEAVY, start, end))
+#        else:
+#            attributes.insert(
+#                    pango.AttrWeight(Pango.Weight.NORMAL, start, end))
+#
+#        # Italic verification
+#        if self.italic_tg_button.get_active():
+#            attributes.insert(pango.AttrStyle(Pango.Style.ITALIC, start, end))
+#        else:
+#            attributes.insert(pango.AttrStyle(Pango.Style.NORMAL, start, end))
+#
+#        # Underline verification
+#        if self.underline_tg_button.get_active():
+#            attributes.insert(
+#                    pango.AttrUnderline(Pango.Underline.SINGLE, start, end))
+#        else:
+#            attributes.insert(
+#                    pango.AttrUnderline(Pango.Underline.NONE, start, end))
+#
+#        self.example_label.set_attributes(attributes)
 
     def show_bold(self, widget):
         self.example_label.set_markup("<>")
@@ -407,4 +417,4 @@ class HighlightProperty(object):
 if __name__ == "__main__":
     n = NmapOutputProperties(None)
     n.run()
-    gtk.main()
+    Gtk.main()

--- a/zenmap/zenmapGUI/NmapOutputProperties.py
+++ b/zenmap/zenmapGUI/NmapOutputProperties.py
@@ -226,7 +226,7 @@ class NmapOutputProperties(HIGDialog):
         # Adding color tab
         self.properties_notebook.append_page(
                 self.highlight_main_vbox,
-                Gtk.Label(_("Highlight definitions")))
+                Gtk.Label(label=_("Highlight definitions")))
 
 
 class HighlightProperty(object):
@@ -270,13 +270,13 @@ class HighlightProperty(object):
     # Text color dialog
 
     def text_color_dialog(self, widget):
-        color_dialog = Gtk.ColorSelectionDialog(
+        color_dialog = Gtk.ColorSelectionDialog.new(
                 "%s %s" % (self.label, _("text color")))
-        color_dialog.colorsel.set_current_color(self.text_color)
+        color_dialog.get_color_selection().set_current_color(self.text_color)
 
-        color_dialog.ok_button.connect(
+        color_dialog.props.ok_button.connect(
                 "clicked", self.text_color_dialog_ok, color_dialog)
-        color_dialog.cancel_button.connect(
+        color_dialog.props.cancel_button.connect(
                 "clicked", self.text_color_dialog_cancel, color_dialog)
         color_dialog.connect(
                 "delete-event", self.text_color_dialog_close, color_dialog)
@@ -284,7 +284,7 @@ class HighlightProperty(object):
         color_dialog.run()
 
     def text_color_dialog_ok(self, widget, color_dialog):
-        self.text_color = color_dialog.colorsel.get_current_color()
+        self.text_color = color_dialog.get_color_selection().get_current_color()
         color_dialog.destroy()
         self.update_example()
 
@@ -297,13 +297,13 @@ class HighlightProperty(object):
     #########################################
     # Highlight color dialog
     def highlight_color_dialog(self, widget):
-        color_dialog = Gtk.ColorSelectionDialog(
+        color_dialog = Gtk.ColorSelectionDialog.new(
                 "%s %s" % (self.property_name, _("highlight color")))
-        color_dialog.colorsel.set_current_color(self.highlight_color)
+        color_dialog.get_color_selection().set_current_color(self.highlight_color)
 
-        color_dialog.ok_button.connect(
+        color_dialog.props.ok_button.connect(
                 "clicked", self.highlight_color_dialog_ok, color_dialog)
-        color_dialog.cancel_button.connect(
+        color_dialog.props.cancel_button.connect(
                 "clicked", self.highlight_color_dialog_cancel,
                 color_dialog)
         color_dialog.connect(
@@ -313,7 +313,7 @@ class HighlightProperty(object):
         color_dialog.run()
 
     def highlight_color_dialog_ok(self, widget, color_dialog):
-        self.highlight_color = color_dialog.colorsel.get_current_color()
+        self.highlight_color = color_dialog.get_color_selection().get_current_color()
         color_dialog.destroy()
         self.update_example()
 

--- a/zenmap/zenmapGUI/NmapOutputProperties.py
+++ b/zenmap/zenmapGUI/NmapOutputProperties.py
@@ -159,7 +159,7 @@ class NmapOutputProperties(HIGDialog):
         self.properties_notebook = HIGNotebook()
 
     def __pack_widgets(self):
-        self.vbox.pack_start(self.properties_notebook)
+        self.vbox.pack_start(self.properties_notebook, True, True, 0)
 
     def highlight_tab(self):
         # Creating highlight tab main box
@@ -221,7 +221,7 @@ class NmapOutputProperties(HIGDialog):
             y2 += 1
 
         # Packing main table into main vbox
-        self.highlight_main_vbox.pack_start(self.highlight_main_table)
+        self.highlight_main_vbox.pack_start(self.highlight_main_table, True, True, 0)
 
         # Adding color tab
         self.properties_notebook.append_page(

--- a/zenmap/zenmapGUI/NmapOutputViewer.py
+++ b/zenmap/zenmapGUI/NmapOutputViewer.py
@@ -126,10 +126,12 @@
 # *                                                                         *
 # ***************************************************************************/
 
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Gdk, Pango
+
 import gobject
-import gtk
-import gtk.gdk
-import pango
 import re
 
 import zenmapCore.I18N  # lgtm[py/unused-import]
@@ -139,13 +141,13 @@ from zenmapCore.UmitConf import NmapOutputHighlight
 from zenmapGUI.NmapOutputProperties import NmapOutputProperties
 
 
-class NmapOutputViewer (gtk.VBox):
+class NmapOutputViewer (Gtk.VBox):
     HIGHLIGHT_PROPERTIES = ["details", "date", "hostname", "ip", "port_list",
             "open_port", "closed_port", "filtered_port"]
 
     def __init__(self, refresh=1, stop=1):
         self.nmap_highlight = NmapOutputHighlight()
-        gtk.VBox.__init__(self)
+        Gtk.VBox.__init__(self)
 
         # Creating widgets
         self.__create_widgets()
@@ -173,17 +175,17 @@ class NmapOutputViewer (gtk.VBox):
 
     def __create_widgets(self):
         # Creating widgets
-        self.scrolled = gtk.ScrolledWindow()
-        self.text_view = gtk.TextView()
+        self.scrolled = Gtk.ScrolledWindow()
+        self.text_view = Gtk.TextView()
 
     def __set_scrolled_window(self):
         # Seting scrolled window
         self.scrolled.set_border_width(5)
         self.scrolled.add(self.text_view)
-        self.scrolled.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
+        self.scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
 
     def __set_text_view(self):
-        self.text_view.set_wrap_mode(gtk.WRAP_WORD)
+        self.text_view.set_wrap_mode(Gtk.WrapMode.WORD)
         self.text_view.set_editable(False)
 
         self.tag_font = self.text_view.get_buffer().create_tag(None)
@@ -193,29 +195,27 @@ class NmapOutputViewer (gtk.VBox):
             tag = self.text_view.get_buffer().create_tag(property)
 
             if settings[0]:
-                tag.set_property("weight", pango.WEIGHT_HEAVY)
+                tag.set_property("weight", Pango.Weight.HEAVY)
             else:
-                tag.set_property("weight", pango.WEIGHT_NORMAL)
+                tag.set_property("weight", Pango.Weight.NORMAL)
 
             if settings[1]:
-                tag.set_property("style", pango.STYLE_ITALIC)
+                tag.set_property("style", Pango.Style.ITALIC)
             else:
-                tag.set_property("style", pango.STYLE_NORMAL)
+                tag.set_property("style", Pango.Style.NORMAL)
 
             if settings[2]:
-                tag.set_property("underline", pango.UNDERLINE_SINGLE)
+                tag.set_property("underline", Pango.Underline.SINGLE)
             else:
-                tag.set_property("underline", pango.UNDERLINE_NONE)
+                tag.set_property("underline", Pango.Underline.NONE)
 
             text_color = settings[3]
             highlight_color = settings[4]
 
             tag.set_property(
-                    "foreground", gtk.color_selection_palette_to_string(
-                        [gtk.gdk.Color(*text_color), ]))
+                    "foreground", Gdk.Color(*text_color).to_string())
             tag.set_property(
-                    "background", gtk.color_selection_palette_to_string(
-                        [gtk.gdk.Color(*highlight_color), ]))
+                    "background", Gdk.Color(*highlight_color).to_string())
 
     def go_to_host(self, host):
         """Go to host line on nmap output result"""
@@ -223,7 +223,7 @@ class NmapOutputViewer (gtk.VBox):
         start_iter = buff.get_start_iter()
 
         found_tuple = start_iter.forward_search(
-                "\nNmap scan report for %s\n" % host, gtk.TEXT_SEARCH_TEXT_ONLY
+                "\nNmap scan report for %s\n" % host, Gtk.TextSearchFlags.TEXT_ONLY
                 )
         if found_tuple is None:
                 return
@@ -311,7 +311,7 @@ class NmapOutputViewer (gtk.VBox):
         The current output is extracted from the command object."""
         self.command_execution = command
         if command is not None:
-            self.text_view.get_buffer().set_text(u"")
+            self.text_view.get_buffer().set_text("")
             self.output_file_pointer = 0
         else:
             self.output_file_pointer = None

--- a/zenmap/zenmapGUI/NmapOutputViewer.py
+++ b/zenmap/zenmapGUI/NmapOutputViewer.py
@@ -141,7 +141,7 @@ from zenmapCore.UmitConf import NmapOutputHighlight
 from zenmapGUI.NmapOutputProperties import NmapOutputProperties
 
 
-class NmapOutputViewer (Gtk.VBox):
+class NmapOutputViewer(Gtk.VBox):
     HIGHLIGHT_PROPERTIES = ["details", "date", "hostname", "ip", "port_list",
             "open_port", "closed_port", "filtered_port"]
 

--- a/zenmap/zenmapGUI/NmapOutputViewer.py
+++ b/zenmap/zenmapGUI/NmapOutputViewer.py
@@ -129,7 +129,7 @@
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, Gdk, Pango, Glib
+from gi.repository import Gtk, Gdk, Pango, GLib
 
 import gobject
 import re

--- a/zenmap/zenmapGUI/NmapOutputViewer.py
+++ b/zenmap/zenmapGUI/NmapOutputViewer.py
@@ -165,7 +165,7 @@ class NmapOutputViewer (Gtk.VBox):
         self.refreshing = True
 
         # Adding widgets to the VBox
-        self.pack_start(self.scrolled, expand=True, fill=True)
+        self.pack_start(self.scrolled, True, True, 0)
 
         # The NmapCommand instance, if any, whose output is shown in this
         # display.
@@ -287,7 +287,7 @@ class NmapOutputViewer (Gtk.VBox):
         if not self.nmap_highlight.enable:
             return
 
-        text = buf.get_text(start_iter, end_iter)
+        text = buf.get_text(start_iter, end_iter, include_hidden_chars=True)
 
         for property in self.HIGHLIGHT_PROPERTIES:
             settings = self.nmap_highlight.__getattribute__(property)

--- a/zenmap/zenmapGUI/NmapOutputViewer.py
+++ b/zenmap/zenmapGUI/NmapOutputViewer.py
@@ -129,7 +129,7 @@
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, Gdk, Pango
+from gi.repository import Gtk, Gdk, Pango, Glib
 
 import gobject
 import re
@@ -365,7 +365,7 @@ class NmapOutputViewer (Gtk.VBox):
         v_adj = self.scrolled.get_vadjustment()
         if new_output and v_adj is not None:
             # Find out if the view is already scrolled to the bottom.
-            at_end = (v_adj.value >= v_adj.upper - v_adj.page_size)
+            at_end = (v_adj.get_value() >= v_adj.get_upper() - v_adj.get_page_size())
 
             buf = self.text_view.get_buffer()
             prev_end_mark = buf.create_mark(
@@ -386,6 +386,6 @@ class NmapOutputViewer (Gtk.VBox):
                 # text causes a scroll bar to appear and reflow the text,
                 # making the text a bit taller.
                 self.text_view.scroll_mark_onscreen(self.end_mark)
-                gobject.idle_add(
+                GLib.idle_add(
                         lambda: self.text_view.scroll_mark_onscreen(
                             self.end_mark))

--- a/zenmap/zenmapGUI/OptionBuilder.py
+++ b/zenmap/zenmapGUI/OptionBuilder.py
@@ -126,8 +126,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gobject
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GObject
 
 
 # Prevent loading PyXML
@@ -169,9 +171,9 @@ def get_option_check_auxiliary_widget(option, ops, check):
         assert False, "Unknown option %s" % option
 
 
-class OptionEntry(gtk.Entry):
+class OptionEntry(Gtk.Entry):
     def __init__(self, option, ops, check):
-        gtk.Entry.__init__(self)
+        Gtk.Entry.__init__(self)
         self.option = option
         self.ops = ops
         self.check = check
@@ -198,9 +200,9 @@ class OptionEntry(gtk.Entry):
         self.ops[self.option] = self.get_text().decode("UTF-8")
 
 
-class OptionExtras(gtk.Entry):
+class OptionExtras(Gtk.Entry):
     def __init__(self, option, ops, check):
-        gtk.Entry.__init__(self)
+        Gtk.Entry.__init__(self)
         self.ops = ops
         self.check = check
         self.connect("changed", self.changed_cb)
@@ -226,9 +228,9 @@ class OptionExtras(gtk.Entry):
         self.ops.extras = [self.get_text().decode("UTF-8")]
 
 
-class OptionLevel(gtk.SpinButton):
+class OptionLevel(Gtk.SpinButton):
     def __init__(self, option, ops, check):
-        gtk.SpinButton.__init__(self, gtk.Adjustment(0, 0, 10, 1), 0.0, 0)
+        Gtk.SpinButton.__init__(self, Gtk.Adjustment(0, 0, 10, 1), 0.0, 0)
         self.option = option
         self.ops = ops
         self.check = check
@@ -256,21 +258,21 @@ class OptionLevel(gtk.SpinButton):
         self.ops[self.option] = int(self.get_adjustment().get_value())
 
 
-class OptionFile(gtk.HBox):
+class OptionFile(Gtk.HBox):
     __gsignals__ = {
-        "changed": (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, ())
+        "changed": (GObject.SignalFlags.RUN_FIRST, GObject.TYPE_NONE, ())
     }
 
     def __init__(self, option, ops, check):
-        gtk.HBox.__init__(self)
+        Gtk.HBox.__init__(self)
 
         self.option = option
         self.ops = ops
         self.check = check
 
-        self.entry = gtk.Entry()
+        self.entry = Gtk.Entry()
         self.pack_start(self.entry, True, True)
-        button = HIGButton(stock=gtk.STOCK_OPEN)
+        button = HIGButton(stock=Gtk.STOCK_OPEN)
         self.pack_start(button, False)
 
         button.connect("clicked", self.clicked_cb)
@@ -300,20 +302,20 @@ class OptionFile(gtk.HBox):
 
     def clicked_cb(self, button):
         dialog = AllFilesFileChooserDialog(_("Choose file"))
-        if dialog.run() == gtk.RESPONSE_OK:
+        if dialog.run() == Gtk.ResponseType.OK:
             self.entry.set_text(dialog.get_filename())
         dialog.destroy()
 
 
-class TargetEntry(gtk.Entry):
+class TargetEntry(Gtk.Entry):
     def __init__(self, ops):
-        gtk.Entry.__init__(self)
+        Gtk.Entry.__init__(self)
         self.ops = ops
         self.connect("changed", self.changed_cb)
         self.update()
 
     def update(self):
-        self.set_text(u" ".join(self.ops.target_specs))
+        self.set_text(" ".join(self.ops.target_specs))
 
     def changed_cb(self, widget):
         self.ops.target_specs = self.get_targets()
@@ -343,29 +345,29 @@ class OptionTab(object):
                 self.widgets_list.append(widget)
 
     def __parse_target(self, target_element):
-        label = _(target_element.getAttribute(u'label'))
+        label = _(target_element.getAttribute('label'))
         label_widget = HIGEntryLabel(label)
         target_widget = TargetEntry(self.ops)
         target_widget.connect("changed", self.update_target)
         return label_widget, target_widget
 
     def __parse_option_list(self, option_list_element):
-        children = option_list_element.getElementsByTagName(u'option')
+        children = option_list_element.getElementsByTagName('option')
 
         label_widget = HIGEntryLabel(
-                _(option_list_element.getAttribute(u'label')))
+                _(option_list_element.getAttribute('label')))
         option_list_widget = OptionList(self.ops)
 
         for child in children:
-            option = child.getAttribute(u'option')
-            argument = child.getAttribute(u'argument')
-            label = _(child.getAttribute(u'label'))
+            option = child.getAttribute('option')
+            argument = child.getAttribute('argument')
+            label = _(child.getAttribute('label'))
             option_list_widget.append(option, argument, label)
             self.profilehelp.add_label(option, label)
             self.profilehelp.add_shortdesc(
-                    option, _(child.getAttribute(u'short_desc')))
+                    option, _(child.getAttribute('short_desc')))
             self.profilehelp.add_example(
-                    option, child.getAttribute(u'example'))
+                    option, child.getAttribute('example'))
 
         option_list_widget.update()
 
@@ -374,10 +376,10 @@ class OptionTab(object):
         return label_widget, option_list_widget
 
     def __parse_option_check(self, option_check):
-        option = option_check.getAttribute(u'option')
-        label = _(option_check.getAttribute(u'label'))
-        short_desc = _(option_check.getAttribute(u'short_desc'))
-        example = option_check.getAttribute(u'example')
+        option = option_check.getAttribute('option')
+        label = _(option_check.getAttribute('label'))
+        short_desc = _(option_check.getAttribute('short_desc'))
+        example = option_check.getAttribute('example')
 
         self.profilehelp.add_label(option, label)
         self.profilehelp.add_shortdesc(option, short_desc)
@@ -399,7 +401,7 @@ class OptionTab(object):
         return check, auxiliary_widget
 
     def fill_table(self, table, expand_fill=True):
-        yopt = (0, gtk.EXPAND | gtk.FILL)[expand_fill]
+        yopt = (0, Gtk.AttachOptions.EXPAND | Gtk.AttachOptions.FILL)[expand_fill]
         for y, widget in enumerate(self.widgets_list):
             if widget[1] is None:
                 table.attach(widget[0], 0, 2, y, y + 1, yoptions=yopt)
@@ -495,12 +497,12 @@ class OptionBuilder(object):
         dic = {}
         for group in self.groups:
             grp = self.xml.getElementsByTagName(group)[0]
-            dic[group] = grp.getAttribute(u'label')
+            dic[group] = grp.getAttribute('label')
         return dic
 
     def __parse_groups(self):
-        return [g_name.getAttribute(u'name') for g_name in
-                self.xml.getElementsByTagName(u'groups')[0].getElementsByTagName(u'group')]  # noqa
+        return [g_name.getAttribute('name') for g_name in
+                self.xml.getElementsByTagName('groups')[0].getElementsByTagName('group')]  # noqa
 
     def __parse_tabs(self):
         dic = {}
@@ -516,14 +518,14 @@ class OptionBuilder(object):
         return dic
 
 
-class OptionList(gtk.ComboBox):
+class OptionList(Gtk.ComboBox):
     def __init__(self, ops):
         self.ops = ops
 
-        self.list = gtk.ListStore(str, str, str)
-        gtk.ComboBox.__init__(self, self.list)
+        self.list = Gtk.ListStore(str, str, str)
+        Gtk.ComboBox.__init__(self, self.list)
 
-        cell = gtk.CellRendererText()
+        cell = Gtk.CellRendererText()
         self.pack_start(cell, True)
         self.add_attribute(cell, 'text', 2)
 
@@ -555,12 +557,12 @@ class OptionList(gtk.ComboBox):
         self.options.append(option)
 
 
-class OptionCheck(gtk.CheckButton):
+class OptionCheck(Gtk.CheckButton):
     def __init__(self, option, label):
         opt = label
         if option is not None and option != "":
             opt += " (%s)" % option
 
-        gtk.CheckButton.__init__(self, opt, use_underline=False)
+        Gtk.CheckButton.__init__(self, opt, use_underline=False)
 
         self.option = option

--- a/zenmap/zenmapGUI/OptionBuilder.py
+++ b/zenmap/zenmapGUI/OptionBuilder.py
@@ -271,9 +271,9 @@ class OptionFile(Gtk.HBox):
         self.check = check
 
         self.entry = Gtk.Entry()
-        self.pack_start(self.entry, True, True)
+        self.pack_start(self.entry, True, True, 0)
         button = HIGButton(stock=Gtk.STOCK_OPEN)
-        self.pack_start(button, False)
+        self.pack_start(button, False, True, 0)
 
         button.connect("clicked", self.clicked_cb)
 

--- a/zenmap/zenmapGUI/OptionBuilder.py
+++ b/zenmap/zenmapGUI/OptionBuilder.py
@@ -191,13 +191,13 @@ class OptionEntry(Gtk.Entry):
 
     def check_toggled_cb(self, check):
         if check.get_active():
-            self.ops[self.option] = self.get_text().decode("UTF-8")
+            self.ops[self.option] = self.get_text()
         else:
             self.ops[self.option] = None
 
     def changed_cb(self, widget):
         self.check.set_active(True)
-        self.ops[self.option] = self.get_text().decode("UTF-8")
+        self.ops[self.option] = self.get_text()
 
 
 class OptionExtras(Gtk.Entry):
@@ -219,18 +219,18 @@ class OptionExtras(Gtk.Entry):
 
     def check_toggled_cb(self, check):
         if check.get_active():
-            self.ops.extras = [self.get_text().decode("UTF-8")]
+            self.ops.extras = [self.get_text()]
         else:
             self.ops.extras = []
 
     def changed_cb(self, widget):
         self.check.set_active(True)
-        self.ops.extras = [self.get_text().decode("UTF-8")]
+        self.ops.extras = [self.get_text()]
 
 
 class OptionLevel(Gtk.SpinButton):
     def __init__(self, option, ops, check):
-        Gtk.SpinButton.__init__(self, Gtk.Adjustment(0, 0, 10, 1), 0.0, 0)
+        Gtk.SpinButton.__init__(self, adjustment=Gtk.Adjustment(0, 0, 10, 1), climb_rate=0.0, digits=0)
         self.option = option
         self.ops = ops
         self.check = check
@@ -292,13 +292,13 @@ class OptionFile(Gtk.HBox):
 
     def check_toggled_cb(self, check):
         if check.get_active():
-            self.ops[self.option] = self.entry.get_text().decode("UTF-8")
+            self.ops[self.option] = self.entry.get_text()
         else:
             self.ops[self.option] = None
 
     def changed_cb(self, widget):
         self.check.set_active(True)
-        self.ops[self.option] = self.entry.get_text().decode("UTF-8")
+        self.ops[self.option] = self.entry.get_text()
 
     def clicked_cb(self, button):
         dialog = AllFilesFileChooserDialog(_("Choose file"))
@@ -321,7 +321,7 @@ class TargetEntry(Gtk.Entry):
         self.ops.target_specs = self.get_targets()
 
     def get_targets(self):
-        return split_quoted(self.get_text().decode("UTF-8"))
+        return split_quoted(self.get_text())
 
 
 class OptionTab(object):
@@ -523,7 +523,7 @@ class OptionList(Gtk.ComboBox):
         self.ops = ops
 
         self.list = Gtk.ListStore(str, str, str)
-        Gtk.ComboBox.__init__(self, self.list)
+        Gtk.ComboBox.__init__(self, model=self.list)
 
         cell = Gtk.CellRendererText()
         self.pack_start(cell, True)

--- a/zenmap/zenmapGUI/Print.py
+++ b/zenmap/zenmapGUI/Print.py
@@ -139,15 +139,16 @@
 # Add options to the print dialog to control the font, coloring, and anything
 # else. This might go in a separate Print Setup dialog.
 
-import gtk
-import gobject
-import pango
+import gi
 
-MONOSPACE_FONT_DESC = pango.FontDescription("Monospace 12")
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GLib, Pango
+
+MONOSPACE_FONT_DESC = Pango.FontDescription("Monospace 12")
 
 
-class PrintState (object):
-    """This is the userdatum passed to gtk.PrintOperation callbacks."""
+class PrintState(object):
+    """This is the userdatum passed to Gtk.PrintOperation callbacks."""
 
     def __init__(self, inventory, entry):
         """entry is a ScansListStoreEntry."""
@@ -158,7 +159,7 @@ class PrintState (object):
             # Still running, failed, or cancelled.
             output = entry.command.get_output()
         if not output:
-            output = u"\n"
+            output = "\n"
         self.lines = output.splitlines()
 
     def begin_print(self, op, context):
@@ -169,7 +170,7 @@ class PrintState (object):
         layout.set_text("dummy")
         line = layout.get_line(0)
         # get_extents()[1][3] is the height of the logical rectangle.
-        line_height = line.get_extents()[1][3] / float(pango.SCALE)
+        line_height = line.get_extents()[1][3] / float(Pango.SCALE)
 
         page_height = context.get_height()
         self.lines_per_page = int(page_height / line_height)
@@ -191,13 +192,13 @@ class PrintState (object):
 
 
 def run_print_operation(inventory, entry):
-    op = gtk.PrintOperation()
+    op = Gtk.PrintOperation()
     state = PrintState(inventory, entry)
     op.connect("begin-print", state.begin_print)
     op.connect("draw-page", state.draw_page)
     try:
-        op.run(gtk.PRINT_OPERATION_ACTION_PRINT_DIALOG, None)
-    except gobject.GError:
+        op.run(Gtk.PrintOperationAction.PRINT_DIALOG, None)
+    except GLib.GError:
         # Canceling the print operation can result in the error
         #   GError: Error from StartDoc
         # http://seclists.org/nmap-dev/2012/q4/161

--- a/zenmap/zenmapGUI/Print.py
+++ b/zenmap/zenmapGUI/Print.py
@@ -142,6 +142,7 @@
 import gi
 
 gi.require_version("Gtk", "3.0")
+gi.require_version("PangoCairo", "1.0")
 from gi.repository import Gtk, GLib, Pango, PangoCairo
 
 MONOSPACE_FONT_DESC = Pango.FontDescription("Monospace 12")

--- a/zenmap/zenmapGUI/Print.py
+++ b/zenmap/zenmapGUI/Print.py
@@ -142,7 +142,7 @@
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, GLib, Pango
+from gi.repository import Gtk, GLib, Pango, PangoCairo
 
 MONOSPACE_FONT_DESC = Pango.FontDescription("Monospace 12")
 
@@ -167,14 +167,14 @@ class PrintState(object):
         # Typeset a dummy line to get the exact line height.
         layout = context.create_pango_layout()
         layout.set_font_description(MONOSPACE_FONT_DESC)
-        layout.set_text("dummy")
+        layout.set_text("dummy", -1)
         line = layout.get_line(0)
-        # get_extents()[1][3] is the height of the logical rectangle.
-        line_height = line.get_extents()[1][3] / float(Pango.SCALE)
+        # get_extents()[1].height is the height of the logical rectangle.
+        line_height = line.get_extents()[1].height / Pango.SCALE
 
         page_height = context.get_height()
         self.lines_per_page = int(page_height / line_height)
-        op.set_n_pages((len(self.lines) - 1) / self.lines_per_page + 1)
+        op.set_n_pages((len(self.lines) - 1) // self.lines_per_page + 1)
 
     def draw_page(self, op, context, page_nr):
         this_page_lines = self.lines[
@@ -184,11 +184,11 @@ class PrintState(object):
         # Do no wrapping.
         layout.set_width(-1)
         layout.set_font_description(MONOSPACE_FONT_DESC)
-        text = "\n".join(this_page_lines).encode("utf8")
-        layout.set_text(text)
+        text = "\n".join(this_page_lines)
+        layout.set_text(text, -1)
 
         cr = context.get_cairo_context()
-        cr.show_layout(layout)
+        PangoCairo.show_layout(cr, layout)
 
 
 def run_print_operation(inventory, entry):

--- a/zenmap/zenmapGUI/ProfileCombo.py
+++ b/zenmap/zenmapGUI/ProfileCombo.py
@@ -137,7 +137,7 @@ import zenmapCore.I18N  # lgtm[py/unused-import]
 
 class ProfileCombo(Gtk.ComboBoxText, object):
     def __init__(self):
-        Gtk.ComboBoxText.__init__(self, model=Gtk.ListStore(str), has_entry=True)
+        Gtk.ComboBoxText.__init__(self, has_entry=True)
 
         self.completion = Gtk.EntryCompletion()
         self.get_child().set_completion(self.completion)
@@ -147,13 +147,10 @@ class ProfileCombo(Gtk.ComboBoxText, object):
         self.update()
 
     def set_profiles(self, profiles):
-        list = self.get_model()
-        for i in range(len(list)):
-            iter = list.get_iter_first()
-            del(list[iter])
+        self.remove_all()
 
         for command in profiles:
-            list.append([command])
+            self.append_text(command)
 
     def update(self):
         profile = CommandProfile()
@@ -163,13 +160,13 @@ class ProfileCombo(Gtk.ComboBoxText, object):
 
         self.set_profiles(profiles)
 
-    def get_selected_profile(self):
+    @property
+    def selected_profile(self):
         return self.get_child().get_text()
 
-    def set_selected_profile(self, profile):
+    @selected_profile.setter
+    def selected_profile(self, profile):
         self.get_child().set_text(profile)
-
-    selected_profile = property(get_selected_profile, set_selected_profile)
 
 if __name__ == "__main__":
     w = Gtk.Window()

--- a/zenmap/zenmapGUI/ProfileCombo.py
+++ b/zenmap/zenmapGUI/ProfileCombo.py
@@ -126,17 +126,20 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 from zenmapCore.UmitConf import CommandProfile
 import zenmapCore.I18N  # lgtm[py/unused-import]
 
 
-class ProfileCombo(gtk.ComboBoxEntry, object):
+class ProfileCombo(Gtk.ComboBox, object):
     def __init__(self):
-        gtk.ComboBoxEntry.__init__(self, gtk.ListStore(str), 0)
+        Gtk.ComboBox.__init__(self, Gtk.ListStore(str), 0, has_entry=True)
 
-        self.completion = gtk.EntryCompletion()
+        self.completion = Gtk.EntryCompletion()
         self.child.set_completion(self.completion)
         self.completion.set_model(self.get_model())
         self.completion.set_text_column(0)
@@ -169,10 +172,10 @@ class ProfileCombo(gtk.ComboBoxEntry, object):
     selected_profile = property(get_selected_profile, set_selected_profile)
 
 if __name__ == "__main__":
-    w = gtk.Window()
+    w = Gtk.Window()
     p = ProfileCombo()
     p.update()
     w.add(p)
     w.show_all()
 
-    gtk.main()
+    Gtk.main()

--- a/zenmap/zenmapGUI/ProfileCombo.py
+++ b/zenmap/zenmapGUI/ProfileCombo.py
@@ -137,10 +137,10 @@ import zenmapCore.I18N  # lgtm[py/unused-import]
 
 class ProfileCombo(Gtk.ComboBox, object):
     def __init__(self):
-        Gtk.ComboBox.__init__(self, Gtk.ListStore(str), 0, has_entry=True)
+        Gtk.ComboBox.__init__(self, model=Gtk.ListStore(str), has_entry=True)
 
         self.completion = Gtk.EntryCompletion()
-        self.child.set_completion(self.completion)
+        self.get_child().set_completion(self.completion)
         self.completion.set_model(self.get_model())
         self.completion.set_text_column(0)
 
@@ -149,7 +149,7 @@ class ProfileCombo(Gtk.ComboBox, object):
     def set_profiles(self, profiles):
         list = self.get_model()
         for i in range(len(list)):
-            iter = list.get_iter_root()
+            iter = list.get_iter_first()
             del(list[iter])
 
         for command in profiles:
@@ -164,10 +164,10 @@ class ProfileCombo(Gtk.ComboBox, object):
         self.set_profiles(profiles)
 
     def get_selected_profile(self):
-        return self.child.get_text()
+        return self.get_child().get_text()
 
     def set_selected_profile(self, profile):
-        self.child.set_text(profile)
+        self.get_child().set_text(profile)
 
     selected_profile = property(get_selected_profile, set_selected_profile)
 

--- a/zenmap/zenmapGUI/ProfileCombo.py
+++ b/zenmap/zenmapGUI/ProfileCombo.py
@@ -135,9 +135,9 @@ from zenmapCore.UmitConf import CommandProfile
 import zenmapCore.I18N  # lgtm[py/unused-import]
 
 
-class ProfileCombo(Gtk.ComboBox, object):
+class ProfileCombo(Gtk.ComboBoxText, object):
     def __init__(self):
-        Gtk.ComboBox.__init__(self, model=Gtk.ListStore(str), has_entry=True)
+        Gtk.ComboBoxText.__init__(self, model=Gtk.ListStore(str), has_entry=True)
 
         self.completion = Gtk.EntryCompletion()
         self.get_child().set_completion(self.completion)
@@ -176,6 +176,7 @@ if __name__ == "__main__":
     p = ProfileCombo()
     p.update()
     w.add(p)
-    w.show_all()
 
+    w.connect("delete-event", lambda x, y: Gtk.main_quit())
+    w.show_all()
     Gtk.main()

--- a/zenmap/zenmapGUI/ProfileEditor.py
+++ b/zenmap/zenmapGUI/ProfileEditor.py
@@ -299,7 +299,7 @@ class ProfileEditor(HIGWindow):
         self.middle_box._pack_expand_fill(self.help_vbox)
 
         # Packing buttons to lower box
-        self.lower_box.pack_end(self.buttons_hbox)
+        self.lower_box.pack_end(self.buttons_hbox, True, True, 0)
 
         # Packing the three vertical boxes to the main box
         self.main_whole_box._pack_noexpand_nofill(self.upper_box)
@@ -436,12 +436,12 @@ class ProfileEditor(HIGWindow):
             image.set_from_stock(
                     Gtk.STOCK_DIALOG_WARNING, Gtk.IconSize.DIALOG)
 
-            vbox.pack_start(alert)
-            vbox.pack_start(text)
-            hbox.pack_start(image)
-            hbox.pack_start(vbox)
+            vbox.pack_start(alert, True, True, 0)
+            vbox.pack_start(text, True, True, 0)
+            hbox.pack_start(image, True, True, 0)
+            hbox.pack_start(vbox, True, True, 0)
 
-            dialog.vbox.pack_start(hbox)
+            dialog.vbox.pack_start(hbox, True, True, 0)
             dialog.vbox.show_all()
 
             response = dialog.run()

--- a/zenmap/zenmapGUI/ProfileEditor.py
+++ b/zenmap/zenmapGUI/ProfileEditor.py
@@ -126,7 +126,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 from zenmapGUI.higwidgets.higwindows import HIGWindow
 from zenmapGUI.higwidgets.higboxes import HIGVBox, HIGHBox, HIGSpacer, \
@@ -151,7 +154,7 @@ class ProfileEditor(HIGWindow):
         HIGWindow.__init__(self)
         self.connect("delete_event", self.exit)
         self.set_title(_('Profile Editor'))
-        self.set_position(gtk.WIN_POS_CENTER)
+        self.set_position(Gtk.WindowPosition.CENTER)
 
         self.deletable = deletable
         self.profile_name = profile_name
@@ -235,20 +238,20 @@ class ProfileEditor(HIGWindow):
         self.lower_box = HIGHBox()
 
         #self.main_vbox = HIGVBox()
-        self.command_entry = gtk.Entry()
+        self.command_entry = Gtk.Entry()
         self.command_entry_changed_cb_id = self.command_entry.connect(
                 "changed", self.command_entry_changed_cb)
 
         self.scan_button = HIGButton(_("Scan"))
         self.scan_button.connect("clicked", self.run_scan)
 
-        self.notebook = gtk.Notebook()
+        self.notebook = Gtk.Notebook()
 
         # Profile info page
         self.profile_info_vbox = HIGVBox()
         self.profile_info_label = HIGSectionLabel(_('Profile Information'))
         self.profile_name_label = HIGEntryLabel(_('Profile name'))
-        self.profile_name_entry = gtk.Entry()
+        self.profile_name_entry = Gtk.Entry()
         self.profile_name_entry.connect(
                 'enter-notify-event', self.update_help_name)
         self.profile_description_label = HIGEntryLabel(_('Description'))
@@ -261,13 +264,13 @@ class ProfileEditor(HIGWindow):
         # Buttons
         self.buttons_hbox = HIGHBox()
 
-        self.cancel_button = HIGButton(stock=gtk.STOCK_CANCEL)
+        self.cancel_button = HIGButton(stock=Gtk.STOCK_CANCEL)
         self.cancel_button.connect('clicked', self.exit)
 
-        self.delete_button = HIGButton(stock=gtk.STOCK_DELETE)
+        self.delete_button = HIGButton(stock=Gtk.STOCK_DELETE)
         self.delete_button.connect('clicked', self.delete_profile)
 
-        self.save_button = HIGButton(_("Save Changes"), stock=gtk.STOCK_SAVE)
+        self.save_button = HIGButton(_("Save Changes"), stock=Gtk.STOCK_SAVE)
         self.save_button.connect('clicked', self.save_profile)
 
         ###
@@ -306,7 +309,7 @@ class ProfileEditor(HIGWindow):
 
         # Packing profile information tab on notebook
         self.notebook.append_page(
-                self.profile_info_vbox, gtk.Label(_('Profile')))
+                self.profile_info_vbox, Gtk.Label(_('Profile')))
         self.profile_info_vbox.set_border_width(5)
         table = HIGTable()
         self.profile_info_vbox._pack_noexpand_nofill(self.profile_info_label)
@@ -360,7 +363,7 @@ class ProfileEditor(HIGWindow):
         else:
             hbox = tab.get_hmain_box()
             vbox.pack_start(hbox, True, True, 0)
-        self.notebook.append_page(vbox, gtk.Label(tab_name))
+        self.notebook.append_page(vbox, Gtk.Label(tab_name))
 
     def save_profile(self, widget):
         if self.overwrite:
@@ -415,8 +418,8 @@ class ProfileEditor(HIGWindow):
 
     def delete_profile(self, widget=None, extra=None):
         if self.deletable:
-            dialog = HIGDialog(buttons=(gtk.STOCK_OK, gtk.RESPONSE_OK,
-                                        gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL))
+            dialog = HIGDialog(buttons=(Gtk.STOCK_OK, Gtk.ResponseType.OK,
+                                        Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL))
             alert = HIGEntryLabel('<b>' + _("Deleting Profile") + '</b>')
             text = HIGEntryLabel(_(
                 'Your profile is going to be deleted! ClickOk to continue, '
@@ -429,9 +432,9 @@ class ProfileEditor(HIGWindow):
             vbox.set_border_width(5)
             vbox.set_spacing(12)
 
-            image = gtk.Image()
+            image = Gtk.Image()
             image.set_from_stock(
-                    gtk.STOCK_DIALOG_WARNING, gtk.ICON_SIZE_DIALOG)
+                    Gtk.STOCK_DIALOG_WARNING, Gtk.IconSize.DIALOG)
 
             vbox.pack_start(alert)
             vbox.pack_start(text)
@@ -443,7 +446,7 @@ class ProfileEditor(HIGWindow):
 
             response = dialog.run()
             dialog.destroy()
-            if response == gtk.RESPONSE_CANCEL:
+            if response == Gtk.ResponseType.CANCEL:
                 return True
             self.profile.remove_profile(self.profile_name)
 
@@ -467,4 +470,4 @@ class ProfileEditor(HIGWindow):
 if __name__ == '__main__':
     p = ProfileEditor()
     p.show_all()
-    gtk.main()
+    Gtk.main()

--- a/zenmap/zenmapGUI/ProfileEditor.py
+++ b/zenmap/zenmapGUI/ProfileEditor.py
@@ -251,6 +251,7 @@ class ProfileEditor(HIGWindow):
         self.profile_info_vbox = HIGVBox()
         self.profile_info_label = HIGSectionLabel(_('Profile Information'))
         self.profile_name_label = HIGEntryLabel(_('Profile name'))
+        self.profile_name_label.set_line_wrap(False)
         self.profile_name_entry = Gtk.Entry()
         self.profile_name_entry.connect(
                 'enter-notify-event', self.update_help_name)

--- a/zenmap/zenmapGUI/ProfileEditor.py
+++ b/zenmap/zenmapGUI/ProfileEditor.py
@@ -309,7 +309,7 @@ class ProfileEditor(HIGWindow):
 
         # Packing profile information tab on notebook
         self.notebook.append_page(
-                self.profile_info_vbox, Gtk.Label(_('Profile')))
+                self.profile_info_vbox, Gtk.Label(label=_('Profile')))
         self.profile_info_vbox.set_border_width(5)
         table = HIGTable()
         self.profile_info_vbox._pack_noexpand_nofill(self.profile_info_label)
@@ -363,7 +363,7 @@ class ProfileEditor(HIGWindow):
         else:
             hbox = tab.get_hmain_box()
             vbox.pack_start(hbox, True, True, 0)
-        self.notebook.append_page(vbox, Gtk.Label(tab_name))
+        self.notebook.append_page(vbox, Gtk.Label(label=tab_name))
 
     def save_profile(self, widget):
         if self.overwrite:
@@ -385,7 +385,7 @@ class ProfileEditor(HIGWindow):
 
         buf = self.profile_description_text.get_buffer()
         description = buf.get_text(
-                buf.get_start_iter(), buf.get_end_iter())
+                buf.get_start_iter(), buf.get_end_iter(), include_hidden_chars=True)
 
         try:
             self.profile.add_profile(
@@ -422,7 +422,7 @@ class ProfileEditor(HIGWindow):
                                         Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL))
             alert = HIGEntryLabel('<b>' + _("Deleting Profile") + '</b>')
             text = HIGEntryLabel(_(
-                'Your profile is going to be deleted! ClickOk to continue, '
+                'Your profile is going to be deleted! Click Ok to continue, '
                 'or Cancel to go back to Profile Editor.'))
             hbox = HIGHBox()
             hbox.set_border_width(5)

--- a/zenmap/zenmapGUI/ProfileEditor.py
+++ b/zenmap/zenmapGUI/ProfileEditor.py
@@ -201,7 +201,7 @@ class ProfileEditor(HIGWindow):
         self.update_command()
 
     def command_entry_changed_cb(self, widget):
-        command_string = self.command_entry.get_text().decode("UTF-8")
+        command_string = self.command_entry.get_text()
         self.ops.parse_string(command_string)
         self.inhibit_command_update = True
         self.option_builder.update()
@@ -454,7 +454,7 @@ class ProfileEditor(HIGWindow):
         self.destroy()
 
     def run_scan(self, widget=None):
-        command_string = self.command_entry.get_text().decode("UTF-8")
+        command_string = self.command_entry.get_text()
         self.scan_interface.command_toolbar.command = command_string
         self.scan_interface.start_scan_cb()
         self.exit()

--- a/zenmap/zenmapGUI/ScanHostDetailsPage.py
+++ b/zenmap/zenmapGUI/ScanHostDetailsPage.py
@@ -192,19 +192,19 @@ class HostDetails(HIGVBox):
         self.set_comment(host.comment)
 
     def __create_widgets(self):
-        self.host_status_expander = Gtk.Expander(
+        self.host_status_expander = Gtk.Expander.new(
                 '<b>' + _('Host Status') + '</b>')
-        self.address_expander = Gtk.Expander('<b>' + _('Addresses') + '</b>')
-        self.hostnames_expander = Gtk.Expander('<b>' + _('Hostnames') + '</b>')
-        self.os_expander = Gtk.Expander('<b>' + _('Operating System') + '</b>')
-        self.portsused_expander = Gtk.Expander(
+        self.address_expander = Gtk.Expander.new('<b>' + _('Addresses') + '</b>')
+        self.hostnames_expander = Gtk.Expander.new('<b>' + _('Hostnames') + '</b>')
+        self.os_expander = Gtk.Expander.new('<b>' + _('Operating System') + '</b>')
+        self.portsused_expander = Gtk.Expander.new(
                 '<b>' + _('Ports used') + '</b>')
-        self.osclass_expander = Gtk.Expander('<b>' + _('OS Classes') + '</b>')
-        self.tcp_expander = Gtk.Expander('<b>' + _('TCP Sequence') + '</b>')
-        self.ip_expander = Gtk.Expander('<b>' + _('IP ID Sequence') + '</b>')
-        self.tcpts_expander = Gtk.Expander(
+        self.osclass_expander = Gtk.Expander.new('<b>' + _('OS Classes') + '</b>')
+        self.tcp_expander = Gtk.Expander.new('<b>' + _('TCP Sequence') + '</b>')
+        self.ip_expander = Gtk.Expander.new('<b>' + _('IP ID Sequence') + '</b>')
+        self.tcpts_expander = Gtk.Expander.new(
                 '<b>' + _('TCP TS Sequence') + '</b>')
-        self.comment_expander = Gtk.Expander('<b>' + _('Comments') + '</b>')
+        self.comment_expander = Gtk.Expander.new('<b>' + _('Comments') + '</b>')
         self.os_image = Gtk.Image()
         self.vulnerability_image = Gtk.Image()
 
@@ -306,9 +306,9 @@ class HostDetails(HIGVBox):
         table.attach(self.lastboot_label, 0, 1, 6, 7)
         table.attach(self.info_lastboot_label, 1, 2, 6, 7)
 
-        table.attach(self.os_image, 2, 4, 0, 3, xoptions=1, yoptions=0)
+        table.attach(self.os_image, 2, 4, 0, 3, xoptions=Gtk.AttachOptions.EXPAND)
         table.attach(
-                self.vulnerability_image, 2, 4, 4, 7, xoptions=1, yoptions=0)
+                self.vulnerability_image, 2, 4, 4, 7, xoptions=Gtk.AttachOptions.EXPAND)
 
         table.set_col_spacing(1, 50)
 

--- a/zenmap/zenmapGUI/ScanHostDetailsPage.py
+++ b/zenmap/zenmapGUI/ScanHostDetailsPage.py
@@ -126,7 +126,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 from zenmapGUI.higwidgets.higexpanders import HIGExpander
 from zenmapGUI.higwidgets.higboxes import HIGVBox, HIGHBox,\
@@ -189,21 +192,21 @@ class HostDetails(HIGVBox):
         self.set_comment(host.comment)
 
     def __create_widgets(self):
-        self.host_status_expander = gtk.Expander(
+        self.host_status_expander = Gtk.Expander(
                 '<b>' + _('Host Status') + '</b>')
-        self.address_expander = gtk.Expander('<b>' + _('Addresses') + '</b>')
-        self.hostnames_expander = gtk.Expander('<b>' + _('Hostnames') + '</b>')
-        self.os_expander = gtk.Expander('<b>' + _('Operating System') + '</b>')
-        self.portsused_expander = gtk.Expander(
+        self.address_expander = Gtk.Expander('<b>' + _('Addresses') + '</b>')
+        self.hostnames_expander = Gtk.Expander('<b>' + _('Hostnames') + '</b>')
+        self.os_expander = Gtk.Expander('<b>' + _('Operating System') + '</b>')
+        self.portsused_expander = Gtk.Expander(
                 '<b>' + _('Ports used') + '</b>')
-        self.osclass_expander = gtk.Expander('<b>' + _('OS Classes') + '</b>')
-        self.tcp_expander = gtk.Expander('<b>' + _('TCP Sequence') + '</b>')
-        self.ip_expander = gtk.Expander('<b>' + _('IP ID Sequence') + '</b>')
-        self.tcpts_expander = gtk.Expander(
+        self.osclass_expander = Gtk.Expander('<b>' + _('OS Classes') + '</b>')
+        self.tcp_expander = Gtk.Expander('<b>' + _('TCP Sequence') + '</b>')
+        self.ip_expander = Gtk.Expander('<b>' + _('IP ID Sequence') + '</b>')
+        self.tcpts_expander = Gtk.Expander(
                 '<b>' + _('TCP TS Sequence') + '</b>')
-        self.comment_expander = gtk.Expander('<b>' + _('Comments') + '</b>')
-        self.os_image = gtk.Image()
-        self.vulnerability_image = gtk.Image()
+        self.comment_expander = Gtk.Expander('<b>' + _('Comments') + '</b>')
+        self.os_image = Gtk.Image()
+        self.vulnerability_image = Gtk.Image()
 
         # Host Status expander
         self.host_state_label = HIGEntryLabel(_('State:'))
@@ -313,10 +316,10 @@ class HostDetails(HIGVBox):
         self._pack_noexpand_nofill(self.host_status_expander)
 
     def set_os_image(self, image):
-            self.os_image.set_from_stock(image, gtk.ICON_SIZE_DIALOG)
+            self.os_image.set_from_stock(image, Gtk.IconSize.DIALOG)
 
     def set_vulnerability_image(self, image):
-        self.vulnerability_image.set_from_stock(image, gtk.ICON_SIZE_DIALOG)
+        self.vulnerability_image.set_from_stock(image, Gtk.IconSize.DIALOG)
 
     def set_addresses(self, address):
         self.address_expander.set_use_markup(True)
@@ -374,7 +377,7 @@ class HostDetails(HIGVBox):
             self.os_expander.set_use_markup(True)
             self.os_expander.set_expanded(True)
             table, hbox = self.create_table_hbox()
-            progress = gtk.ProgressBar()
+            progress = Gtk.ProgressBar()
 
             if 'accuracy' in os:
                 progress.set_fraction(float(os['accuracy']) / 100.0)
@@ -443,7 +446,7 @@ class HostDetails(HIGVBox):
                 table.attach(HIGEntryLabel(o['osfamily']), 2, 3, y1, y2)
                 table.attach(HIGEntryLabel(o['osgen']), 3, 4, y1, y2)
 
-                progress = gtk.ProgressBar()
+                progress = Gtk.ProgressBar()
                 progress.set_text(o['accuracy'] + '%')
                 progress.set_fraction(float(o['accuracy']) / 100.0)
                 table.attach(progress, 4, 5, y1, y2)
@@ -457,7 +460,7 @@ class HostDetails(HIGVBox):
             self.tcp_expander.set_use_markup(True)
             table, hbox = self.create_table_hbox()
 
-            combo = gtk.combo_box_new_text()
+            combo = Gtk.ComboBoxText()
             for v in tcpseq['values'].split(','):
                 combo.append_text(v)
 
@@ -478,7 +481,7 @@ class HostDetails(HIGVBox):
             self.ip_expander.set_use_markup(True)
             table, hbox = self.create_table_hbox()
 
-            combo = gtk.combo_box_new_text()
+            combo = Gtk.ComboBoxText()
 
             for i in ipseq['values'].split(','):
                 combo.append_text(i)
@@ -497,7 +500,7 @@ class HostDetails(HIGVBox):
             self.tcpts_expander.set_use_markup(True)
             table, hbox = self.create_table_hbox()
 
-            combo = gtk.combo_box_new_text()
+            combo = Gtk.ComboBoxText()
 
             for i in tcptsseq['values'].split(','):
                 combo.append_text(i)
@@ -518,13 +521,13 @@ class HostDetails(HIGVBox):
 
         hbox = HIGHBox()
 
-        self.comment_scrolled = gtk.ScrolledWindow()
+        self.comment_scrolled = Gtk.ScrolledWindow()
         self.comment_scrolled.set_border_width(5)
         self.comment_scrolled.set_policy(
-                gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
+                Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
 
-        self.comment_txt_vw = gtk.TextView()
-        self.comment_txt_vw.set_wrap_mode(gtk.WRAP_WORD)
+        self.comment_txt_vw = Gtk.TextView()
+        self.comment_txt_vw.set_wrap_mode(Gtk.WrapMode.WORD)
         self.comment_txt_vw.get_buffer().set_text(comment)
 
         self.comment_scrolled.add(self.comment_txt_vw)

--- a/zenmap/zenmapGUI/ScanHostsView.py
+++ b/zenmap/zenmapGUI/ScanHostsView.py
@@ -209,8 +209,8 @@ class ScanHostsView(HIGVBox, object):
         self.host_mode_button.set_active(True)
 
         self.buttons_box.set_border_width(5)
-        self.buttons_box.pack_start(self.host_mode_button)
-        self.buttons_box.pack_start(self.service_mode_button)
+        self.buttons_box.pack_start(self.host_mode_button, True, True, 0)
+        self.buttons_box.pack_start(self.service_mode_button, True, True, 0)
 
     def _connect_widgets(self):
         self.host_mode_button.connect("toggled", self.host_mode)

--- a/zenmap/zenmapGUI/ScanHostsView.py
+++ b/zenmap/zenmapGUI/ScanHostsView.py
@@ -126,7 +126,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 from zenmapGUI.higwidgets.higboxes import HIGVBox
 from zenmapGUI.Icons import get_os_icon
@@ -146,7 +149,7 @@ def cmp_treemodel_addr(model, iter_a, iter_b):
 
 
 class ScanHostsView(HIGVBox, object):
-    HOST_MODE, SERVICE_MODE = range(2)
+    HOST_MODE, SERVICE_MODE = list(range(2))
 
     def __init__(self, scan_interface):
         HIGVBox.__init__(self)
@@ -171,31 +174,31 @@ class ScanHostsView(HIGVBox, object):
 
     def _create_widgets(self):
         # Mode buttons
-        self.host_mode_button = gtk.ToggleButton(_("Hosts"))
-        self.service_mode_button = gtk.ToggleButton(_("Services"))
-        self.buttons_box = gtk.HBox()
+        self.host_mode_button = Gtk.ToggleButton(_("Hosts"))
+        self.service_mode_button = Gtk.ToggleButton(_("Services"))
+        self.buttons_box = Gtk.HBox()
 
         # Main window vbox
         self.main_vbox = HIGVBox()
 
         # Host list
-        self.host_list = gtk.ListStore(object, str, str)
+        self.host_list = Gtk.ListStore(object, str, str)
         self.host_list.set_sort_func(1000, cmp_treemodel_addr)
-        self.host_list.set_sort_column_id(1000, gtk.SORT_ASCENDING)
-        self.host_view = gtk.TreeView(self.host_list)
-        self.pic_column = gtk.TreeViewColumn(_('OS'))
-        self.host_column = gtk.TreeViewColumn(_('Host'))
-        self.os_cell = gtk.CellRendererPixbuf()
-        self.host_cell = gtk.CellRendererText()
+        self.host_list.set_sort_column_id(1000, Gtk.SortType.ASCENDING)
+        self.host_view = Gtk.TreeView(self.host_list)
+        self.pic_column = Gtk.TreeViewColumn(_('OS'))
+        self.host_column = Gtk.TreeViewColumn(_('Host'))
+        self.os_cell = Gtk.CellRendererPixbuf()
+        self.host_cell = Gtk.CellRendererText()
 
         # Service list
-        self.service_list = gtk.ListStore(str)
-        self.service_list.set_sort_column_id(0, gtk.SORT_ASCENDING)
-        self.service_view = gtk.TreeView(self.service_list)
-        self.service_column = gtk.TreeViewColumn(_('Service'))
-        self.service_cell = gtk.CellRendererText()
+        self.service_list = Gtk.ListStore(str)
+        self.service_list.set_sort_column_id(0, Gtk.SortType.ASCENDING)
+        self.service_view = Gtk.TreeView(self.service_list)
+        self.service_column = Gtk.TreeViewColumn(_('Service'))
+        self.service_cell = Gtk.CellRendererText()
 
-        self.scrolled = gtk.ScrolledWindow()
+        self.scrolled = Gtk.ScrolledWindow()
 
     def _pack_widgets(self):
         self.main_vbox.set_spacing(0)
@@ -241,14 +244,14 @@ class ScanHostsView(HIGVBox, object):
     def _set_scrolled(self):
         self.scrolled.set_border_width(5)
         self.scrolled.set_size_request(150, -1)
-        self.scrolled.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
+        self.scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
 
     def _set_service_list(self):
         self.service_view.set_enable_search(True)
         self.service_view.set_search_column(0)
 
         selection = self.service_view.get_selection()
-        selection.set_mode(gtk.SELECTION_MULTIPLE)
+        selection.set_mode(Gtk.SelectionMode.MULTIPLE)
         self.service_view.append_column(self.service_column)
 
         self.service_column.set_resizable(True)
@@ -262,7 +265,7 @@ class ScanHostsView(HIGVBox, object):
         self.host_view.set_search_column(1)
 
         selection = self.host_view.get_selection()
-        selection.set_mode(gtk.SELECTION_MULTIPLE)
+        selection.set_mode(Gtk.SelectionMode.MULTIPLE)
 
         self.host_view.append_column(self.pic_column)
         self.host_view.append_column(self.host_column)
@@ -296,7 +299,7 @@ class ScanHostsView(HIGVBox, object):
         # Treeview?"
         sort_column_id = self.host_list.get_sort_column_id()
         self.host_list.set_default_sort_func(lambda *args: -1)
-        self.host_list.set_sort_column_id(-1, gtk.SORT_ASCENDING)
+        self.host_list.set_sort_column_id(-1, Gtk.SortType.ASCENDING)
         self.host_view.freeze_child_notify()
         self.host_view.set_model(None)
 
@@ -343,8 +346,8 @@ class ScanHostsView(HIGVBox, object):
         self.service_list.append([service])
 
 if __name__ == "__main__":
-    w = gtk.Window()
+    w = Gtk.Window()
     h = ScanHostsView(None)
     w.add(h)
     w.show_all()
-    gtk.main()
+    Gtk.main()

--- a/zenmap/zenmapGUI/ScanHostsView.py
+++ b/zenmap/zenmapGUI/ScanHostsView.py
@@ -142,7 +142,7 @@ def treemodel_get_addrs_for_sort(model, iter):
 
 
 # Used to sort hosts by address.
-def cmp_treemodel_addr(model, iter_a, iter_b):
+def cmp_treemodel_addr(model, iter_a, iter_b, *_):
     addrs_a = treemodel_get_addrs_for_sort(model, iter_a)
     addrs_b = treemodel_get_addrs_for_sort(model, iter_b)
     return cmp(addrs_a, addrs_b)

--- a/zenmap/zenmapGUI/ScanHostsView.py
+++ b/zenmap/zenmapGUI/ScanHostsView.py
@@ -143,12 +143,15 @@ def treemodel_get_addrs_for_sort(model, iter):
 
 # Used to sort hosts by address.
 def cmp_treemodel_addr(model, iter_a, iter_b, *_):
+    # this whole thing needs work
+    def cmp(a, b):
+        return (a > b) - (a < b)
     addrs_a = treemodel_get_addrs_for_sort(model, iter_a)
     addrs_b = treemodel_get_addrs_for_sort(model, iter_b)
     return cmp(addrs_a, addrs_b)
 
 
-class ScanHostsView(HIGVBox, object):
+class ScanHostsView(HIGVBox):
     HOST_MODE, SERVICE_MODE = list(range(2))
 
     def __init__(self, scan_interface):
@@ -174,8 +177,8 @@ class ScanHostsView(HIGVBox, object):
 
     def _create_widgets(self):
         # Mode buttons
-        self.host_mode_button = Gtk.ToggleButton(_("Hosts"))
-        self.service_mode_button = Gtk.ToggleButton(_("Services"))
+        self.host_mode_button = Gtk.ToggleButton(label=_("Hosts"))
+        self.service_mode_button = Gtk.ToggleButton(label=_("Services"))
         self.buttons_box = Gtk.HBox()
 
         # Main window vbox
@@ -185,7 +188,7 @@ class ScanHostsView(HIGVBox, object):
         self.host_list = Gtk.ListStore(object, str, str)
         self.host_list.set_sort_func(1000, cmp_treemodel_addr)
         self.host_list.set_sort_column_id(1000, Gtk.SortType.ASCENDING)
-        self.host_view = Gtk.TreeView(self.host_list)
+        self.host_view = Gtk.TreeView(model=self.host_list)
         self.pic_column = Gtk.TreeViewColumn(_('OS'))
         self.host_column = Gtk.TreeViewColumn(_('Host'))
         self.os_cell = Gtk.CellRendererPixbuf()
@@ -194,7 +197,7 @@ class ScanHostsView(HIGVBox, object):
         # Service list
         self.service_list = Gtk.ListStore(str)
         self.service_list.set_sort_column_id(0, Gtk.SortType.ASCENDING)
-        self.service_view = Gtk.TreeView(self.service_list)
+        self.service_view = Gtk.TreeView(model=self.service_list)
         self.service_column = Gtk.TreeViewColumn(_('Service'))
         self.service_cell = Gtk.CellRendererText()
 
@@ -349,5 +352,7 @@ if __name__ == "__main__":
     w = Gtk.Window()
     h = ScanHostsView(None)
     w.add(h)
+
+    w.connect("delete-event", lambda x, y: Gtk.main_quit())
     w.show_all()
     Gtk.main()

--- a/zenmap/zenmapGUI/ScanInterface.py
+++ b/zenmap/zenmapGUI/ScanInterface.py
@@ -947,8 +947,8 @@ class ScanResult(Gtk.HPaned):
         self.filter_toggle_button = Gtk.ToggleButton(_("Filter Hosts"))
 
         vbox = Gtk.VBox()
-        vbox.pack_start(self.scan_host_view, True, True)
-        vbox.pack_start(self.filter_toggle_button, False)
+        vbox.pack_start(self.scan_host_view, True, True, 0)
+        vbox.pack_start(self.filter_toggle_button, False, True, 0)
         self.pack1(vbox)
         self.pack2(self.scan_result_notebook, True, False)
 

--- a/zenmap/zenmapGUI/ScanInterface.py
+++ b/zenmap/zenmapGUI/ScanInterface.py
@@ -126,9 +126,12 @@
 # *                                                                         *
 # ***************************************************************************/
 
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GLib
+
 import errno
-import gtk
-import gobject
 import os
 import time
 import sys
@@ -288,8 +291,8 @@ class ScanInterface(HIGVBox):
     def filter_changed(self, filter_bar):
         # Restart the timer to start the filter.
         if self.filter_timeout_id:
-            gobject.source_remove(self.filter_timeout_id)
-        self.filter_timeout_id = gobject.timeout_add(
+            GLib.source_remove(self.filter_timeout_id)
+        self.filter_timeout_id = GLib.timeout_add(
                 self.FILTER_DELAY, self.filter_hosts,
                 filter_bar.get_filter_string())
 
@@ -436,7 +439,7 @@ class ScanInterface(HIGVBox):
         if target != '':
             try:
                 self.toolbar.add_new_target(target)
-            except IOError, e:
+            except IOError as e:
                 # We failed to save target_list.txt; treat it as read-only.
                 # Probably it's owned by root and this is a normal user.
                 log.debug(">>> Error saving %s: %s" % (
@@ -449,7 +452,7 @@ class ScanInterface(HIGVBox):
                         "Maybe the selected/typed profile doesn't exist. "
                         "Please check the profile name or type the nmap "
                         "command you would like to execute."),
-                    type=gtk.MESSAGE_ERROR)
+                    type=Gtk.MessageType.ERROR)
             warn_dialog.run()
             warn_dialog.destroy()
             return
@@ -499,7 +502,7 @@ class ScanInterface(HIGVBox):
                 pass
             # Create TreeRowReferences because those persist while we change
             # the model.
-            selected_refs.append(gtk.TreeRowReference(model, path))
+            selected_refs.append(Gtk.TreeRowReference(model, path))
         # Delete the entries from the ScansListStore.
         for ref in selected_refs:
             model.remove(model.get_iter(ref.get_path()))
@@ -531,11 +534,11 @@ class ScanInterface(HIGVBox):
         completion."""
         try:
             command_execution = NmapCommand(command)
-        except IOError, e:
+        except IOError as e:
             warn_dialog = HIGAlertDialog(
                         message_format=_("Error building command"),
                         secondary_text=_("Error message: %s") % str(e),
-                        type=gtk.MESSAGE_ERROR)
+                        type=Gtk.MessageType.ERROR)
             warn_dialog.run()
             warn_dialog.destroy()
             return
@@ -543,8 +546,8 @@ class ScanInterface(HIGVBox):
 
         try:
             command_execution.run_scan()
-        except OSError, e:
-            text = unicode(e.strerror, errors='replace')
+        except OSError as e:
+            text = str(e.strerror, errors='replace')
             # Handle ENOENT specially.
             if e.errno == errno.ENOENT:
                 # nmap_command_path comes from zenmapCore.NmapCommand.
@@ -556,7 +559,7 @@ class ScanInterface(HIGVBox):
                     if fsencoding:
                         path_env = path_env.decode(fsencoding, 'replace')
                     default_paths = path_env.split(os.pathsep)
-                text += u"\n\n{}\n\n{}".format(
+                text += "\n\n{}\n\n{}".format(
                         _("This means that the nmap executable was "
                             "not found in your system PATH, which is"),
                         path_env or _("<undefined>")
@@ -566,15 +569,15 @@ class ScanInterface(HIGVBox):
                     p not in default_paths)]
                 if len(extra_paths) > 0:
                     if len(extra_paths) == 1:
-                        text += u"\n\n" + _("plus the extra directory")
+                        text += "\n\n" + _("plus the extra directory")
                     else:
-                        text += u"\n\n" + _("plus the extra directories")
-                    text += u"\n\n" + os.pathsep.join(extra_paths)
+                        text += "\n\n" + _("plus the extra directories")
+                    text += "\n\n" + os.pathsep.join(extra_paths)
             else:
-                text += u" (%d)" % e.errno
+                text += " (%d)" % e.errno
             warn_dialog = HIGAlertDialog(
                 message_format=_("Error executing command"),
-                secondary_text=text, type=gtk.MESSAGE_ERROR)
+                secondary_text=text, type=Gtk.MessageType.ERROR)
             warn_dialog.run()
             warn_dialog.destroy()
             return
@@ -598,7 +601,7 @@ class ScanInterface(HIGVBox):
         self.scan_result.refresh_nmap_output()
 
         # Add a timeout function
-        self.verify_thread_timeout_id = gobject.timeout_add(
+        self.verify_thread_timeout_id = GLib.timeout_add(
             NMAP_OUTPUT_REFRESH_INTERVAL, self.verify_execution)
 
     def verify_execution(self):
@@ -637,12 +640,12 @@ class ScanInterface(HIGVBox):
         parsed = NmapParser()
         try:
             parsed.parse_file(command.get_xml_output_filename())
-        except IOError, e:
+        except IOError as e:
             # It's possible to run Nmap without generating an XML output file,
             # like with "nmap -V".
             if e.errno != errno.ENOENT:
                 raise
-        except xml.sax.SAXParseException, e:
+        except xml.sax.SAXParseException as e:
             try:
                 # Some options like --iflist cause Nmap to emit an empty XML
                 # file. Ignore the exception in this case.
@@ -655,7 +658,7 @@ class ScanInterface(HIGVBox):
                         secondary_text=_(
                             "There was an error while parsing the XML file "
                             "generated from the scan:\n\n%s""") % str(e),
-                        type=gtk.MESSAGE_ERROR)
+                        type=Gtk.MessageType.ERROR)
                 warn_dialog.run()
                 warn_dialog.destroy()
         else:
@@ -664,13 +667,13 @@ class ScanInterface(HIGVBox):
             self.scan_result.refresh_nmap_output()
             try:
                 self.inventory.add_scan(parsed)
-            except Exception, e:
+            except Exception as e:
                 warn_dialog = HIGAlertDialog(
                         message_format=_("Cannot merge scan"),
                         secondary_text=_(
                             "There was an error while merging the new scan's "
                             "XML:\n\n%s") % str(e),
-                        type=gtk.MESSAGE_ERROR)
+                        type=Gtk.MessageType.ERROR)
                 warn_dialog.run()
                 warn_dialog.destroy()
         parsed.set_xml_is_temp(command.xml_is_temp)
@@ -932,18 +935,18 @@ class ScanInterface(HIGVBox):
         host_page.thaw()
 
 
-class ScanResult(gtk.HPaned):
+class ScanResult(Gtk.HPaned):
     """This is the pane that has the "Host"/"Service" column (ScanHostsView) on
     the left and the "Nmap Output"/"Ports / Hosts"/etc. (ScanResultNotebook) on
     the right. It's the part of the interface below the toolbar."""
     def __init__(self, inventory, scans_store, scan_interface=None):
-        gtk.HPaned.__init__(self)
+        Gtk.HPaned.__init__(self)
 
         self.scan_host_view = ScanHostsView(scan_interface)
         self.scan_result_notebook = ScanResultNotebook(inventory, scans_store)
-        self.filter_toggle_button = gtk.ToggleButton(_("Filter Hosts"))
+        self.filter_toggle_button = Gtk.ToggleButton(_("Filter Hosts"))
 
-        vbox = gtk.VBox()
+        vbox = Gtk.VBox()
         vbox.pack_start(self.scan_host_view, True, True)
         vbox.pack_start(self.filter_toggle_button, False)
         self.pack1(vbox)
@@ -991,11 +994,11 @@ class ScanResultNotebook(HIGNotebook):
         self.scans_list.scans_list.connect(
                 "row-activated", self._scan_row_activated)
 
-        self.append_page(self.nmap_output_page, gtk.Label(_('Nmap Output')))
-        self.append_page(self.open_ports_page, gtk.Label(_('Ports / Hosts')))
-        self.append_page(self.topology_page, gtk.Label(_('Topology')))
-        self.append_page(self.host_details_page, gtk.Label(_('Host Details')))
-        self.append_page(self.scans_list_page, gtk.Label(_('Scans')))
+        self.append_page(self.nmap_output_page, Gtk.Label(_('Nmap Output')))
+        self.append_page(self.open_ports_page, Gtk.Label(_('Ports / Hosts')))
+        self.append_page(self.topology_page, Gtk.Label(_('Topology')))
+        self.append_page(self.host_details_page, Gtk.Label(_('Host Details')))
+        self.append_page(self.scans_list_page, Gtk.Label(_('Scans')))
 
     def host_mode(self):
         self.open_ports.host.host_mode()
@@ -1016,7 +1019,7 @@ class ScanResultNotebook(HIGNotebook):
         self.topology = TopologyPage(inventory)
         self.scans_list = ScanScanListPage(scans_store)
 
-        self.no_selected = gtk.Label(_('No host selected.'))
+        self.no_selected = Gtk.Label(_('No host selected.'))
         self.host_details = self.no_selected
 
         self.open_ports_page.add(self.open_ports)

--- a/zenmap/zenmapGUI/ScanInterface.py
+++ b/zenmap/zenmapGUI/ScanInterface.py
@@ -364,7 +364,7 @@ class ScanInterface(HIGVBox):
         self.set_profile_name_quiet("")
 
     def _target_entry_changed(self, editable):
-        target_string = self.toolbar.get_selected_target()
+        target_string = self.toolbar.selected_target
         targets = split_quoted(target_string)
 
         ops = NmapOptions()
@@ -377,8 +377,8 @@ class ScanInterface(HIGVBox):
         entries. If the command corresponding to the current profile is not
         blank, use it. Otherwise use the current contents of the command
         entry."""
-        profile_name = self.toolbar.get_selected_profile()
-        target_string = self.toolbar.get_selected_target()
+        profile_name = self.toolbar.selected_profile
+        target_string = self.toolbar.selected_target
 
         cmd_profile = CommandProfile()
         command_string = cmd_profile.get_command(profile_name)
@@ -395,7 +395,7 @@ class ScanInterface(HIGVBox):
         if len(targets) > 0:
             ops.target_specs = targets
         else:
-            self.toolbar.set_selected_target(join_quoted(ops.target_specs))
+            self.toolbar.selected_target = join_quoted(ops.target_specs)
 
         self.set_command_quiet(ops.render_string())
 
@@ -413,7 +413,7 @@ class ScanInterface(HIGVBox):
         further "changed" signals."""
         self.toolbar.target_entry.handler_block(
                 self.target_entry_changed_handler)
-        self.toolbar.set_selected_target(target_string)
+        self.toolbar.selected_target = target_string
         self.toolbar.target_entry.handler_unblock(
                 self.target_entry_changed_handler)
 
@@ -422,7 +422,7 @@ class ScanInterface(HIGVBox):
         further "changed" signals."""
         self.toolbar.profile_entry.handler_block(
                 self.profile_entry_changed_handler)
-        self.toolbar.set_selected_profile(profile_name)
+        self.toolbar.selected_profile = profile_name
         self.toolbar.profile_entry.handler_unblock(
                 self.profile_entry_changed_handler)
 

--- a/zenmap/zenmapGUI/ScanNmapOutputPage.py
+++ b/zenmap/zenmapGUI/ScanNmapOutputPage.py
@@ -210,7 +210,7 @@ class ScanNmapOutputPage(HIGVBox):
 
         hbox = HIGHBox()
 
-        self.scans_list = Gtk.ComboBox(scans_store)
+        self.scans_list = Gtk.ComboBox(model=scans_store)
         cell = Gtk.CellRendererText()
         self.scans_list.pack_start(cell, True)
         self.scans_list.set_cell_data_func(cell, scan_entry_data_func)

--- a/zenmap/zenmapGUI/ScanNmapOutputPage.py
+++ b/zenmap/zenmapGUI/ScanNmapOutputPage.py
@@ -144,7 +144,7 @@ import zenmapCore.I18N  # lgtm[py/unused-import]
 
 def scan_entry_data_func(widget, cell_renderer, model, iter):
     """Set the properties of a cell renderer for a scan entry."""
-    cell_renderer.set_property("ellipsize", Pango.EllipsizeMode.ELLIPSIZE_END)
+    cell_renderer.set_property("ellipsize", Pango.EllipsizeMode.END)
     cell_renderer.set_property("style", Pango.Style.NORMAL)
     cell_renderer.set_property("strikethrough", False)
     entry = model.get_value(iter, 0)

--- a/zenmap/zenmapGUI/ScanNmapOutputPage.py
+++ b/zenmap/zenmapGUI/ScanNmapOutputPage.py
@@ -126,9 +126,11 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
-import gobject
-import pango
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GObject, GdkPixbuf, Pango
+
 import os
 
 from zenmapGUI.higwidgets.higboxes import HIGHBox, HIGVBox
@@ -142,14 +144,14 @@ import zenmapCore.I18N  # lgtm[py/unused-import]
 
 def scan_entry_data_func(widget, cell_renderer, model, iter):
     """Set the properties of a cell renderer for a scan entry."""
-    cell_renderer.set_property("ellipsize", pango.ELLIPSIZE_END)
-    cell_renderer.set_property("style", pango.STYLE_NORMAL)
+    cell_renderer.set_property("ellipsize", Pango.EllipsizeMode.ELLIPSIZE_END)
+    cell_renderer.set_property("style", Pango.Style.NORMAL)
     cell_renderer.set_property("strikethrough", False)
     entry = model.get_value(iter, 0)
     if entry is None:
         return
     if entry.running:
-        cell_renderer.set_property("style", pango.STYLE_ITALIC)
+        cell_renderer.set_property("style", Pango.Style.ITALIC)
     elif entry.finished:
         pass
     elif entry.failed or entry.canceled:
@@ -157,21 +159,21 @@ def scan_entry_data_func(widget, cell_renderer, model, iter):
     cell_renderer.set_property("text", entry.get_command_string())
 
 
-class Throbber(gtk.Image):
+class Throbber(Gtk.Image):
     """This is a little progress indicator that animates while a scan is
     running."""
     try:
-        still = gtk.gdk.pixbuf_new_from_file(
+        still = GdkPixbuf.Pixbuf.new_from_file(
                 os.path.join(Path.pixmaps_dir, "throbber.png"))
-        anim = gtk.gdk.PixbufAnimation(
+        anim = GdkPixbuf.PixbufAnimation(
                 os.path.join(Path.pixmaps_dir, "throbber.gif"))
-    except Exception, e:
+    except Exception as e:
         log.debug("Error loading throbber images: %s." % str(e))
         still = None
         anim = None
 
     def __init__(self):
-        gtk.Image.__init__(self)
+        Gtk.Image.__init__(self)
         self.set_from_pixbuf(self.still)
         self.animating = False
 
@@ -195,7 +197,7 @@ class ScanNmapOutputPage(HIGVBox):
     the combo box selection changes."""
 
     __gsignals__ = {
-        "changed": (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, ())
+        "changed": (GObject.SignalFlags.RUN_FIRST, GObject.TYPE_NONE, ())
     }
 
     def __init__(self, scans_store):
@@ -208,8 +210,8 @@ class ScanNmapOutputPage(HIGVBox):
 
         hbox = HIGHBox()
 
-        self.scans_list = gtk.ComboBox(scans_store)
-        cell = gtk.CellRendererText()
+        self.scans_list = Gtk.ComboBox(scans_store)
+        cell = Gtk.CellRendererText()
         self.scans_list.pack_start(cell, True)
         self.scans_list.set_cell_data_func(cell, scan_entry_data_func)
         hbox._pack_expand_fill(self.scans_list)
@@ -221,7 +223,7 @@ class ScanNmapOutputPage(HIGVBox):
         self.throbber = Throbber()
         hbox._pack_noexpand_nofill(self.throbber)
 
-        self.details_button = gtk.Button(_("Details"))
+        self.details_button = Gtk.Button(_("Details"))
         self.details_button.connect("clicked", self._show_details)
         hbox._pack_noexpand_nofill(self.details_button)
 
@@ -295,7 +297,7 @@ class ScanNmapOutputPage(HIGVBox):
         if not entry.finished:
             return
         if self._details_windows.get(entry) is None:
-            window = gtk.Window()
+            window = Gtk.Window()
             window.add(ScanRunDetailsPage(entry.parsed))
 
             def close_details(details, event, entry):

--- a/zenmap/zenmapGUI/ScanOpenPortsPage.py
+++ b/zenmap/zenmapGUI/ScanOpenPortsPage.py
@@ -234,7 +234,7 @@ class HostOpenPorts(HIGVBox):
         self.port_tree.set_sort_func(1000, cmp_port_tree_addr)
         self.port_tree.set_sort_column_id(1000, Gtk.SortType.ASCENDING)
 
-        self.port_view = Gtk.TreeView(self.port_list)
+        self.port_view = Gtk.TreeView(model=self.port_list)
 
         self.cell_icon = Gtk.CellRendererPixbuf()
         self.cell_port = Gtk.CellRendererText()
@@ -262,7 +262,7 @@ class HostOpenPorts(HIGVBox):
         self.host_tree.set_sort_func(1000, cmp_host_tree_addr)
         self.host_tree.set_sort_column_id(1000, Gtk.SortType.ASCENDING)
 
-        self.host_view = Gtk.TreeView(self.host_list)
+        self.host_view = Gtk.TreeView(model=self.host_list)
 
         self.cell_host_icon = Gtk.CellRendererPixbuf()
         self.cell_host = Gtk.CellRendererText()
@@ -521,6 +521,7 @@ if __name__ == "__main__":
     w = Gtk.Window()
     h = HostOpenPorts()
     w.add(h)
-    w.show_all()
 
+    w.connect("delete-event", lambda x, y: Gtk.main_quit())
+    w.show_all()
     Gtk.main()

--- a/zenmap/zenmapGUI/ScanOpenPortsPage.py
+++ b/zenmap/zenmapGUI/ScanOpenPortsPage.py
@@ -126,7 +126,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 from zenmapGUI.higwidgets.higboxes import HIGVBox
 
@@ -136,9 +139,9 @@ import zenmapCore.I18N  # lgtm[py/unused-import]
 
 def findout_service_icon(port_info):
     if port_info["port_state"] in ["open", "open|filtered"]:
-        return gtk.STOCK_YES
+        return Gtk.STOCK_YES
     else:
-        return gtk.STOCK_NO
+        return Gtk.STOCK_NO
 
 
 def get_version_string(d):
@@ -190,10 +193,10 @@ def cmp_host_tree_addr(model, iter_a, iter_b):
     return cmp_addrs(host_a, host_b)
 
 
-class ScanOpenPortsPage(gtk.ScrolledWindow):
+class ScanOpenPortsPage(Gtk.ScrolledWindow):
     def __init__(self):
-        gtk.ScrolledWindow.__init__(self)
-        self.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
+        Gtk.ScrolledWindow.__init__(self)
+        self.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
 
         self.__create_widgets()
 
@@ -218,65 +221,65 @@ class HostOpenPorts(HIGVBox):
         # host hostname icon port protocol state service version
         # The hostname column is shown only when more than one host is selected
         # (hence port_tree not port_list is used).
-        self.port_list = gtk.ListStore(
+        self.port_list = Gtk.ListStore(
                 object, str, str, int, str, str, str, str)
-        self.port_tree = gtk.TreeStore(
+        self.port_tree = Gtk.TreeStore(
                 object, str, str, int, str, str, str, str)
 
         self.port_list.set_sort_func(1000, cmp_port_list_addr)
-        self.port_list.set_sort_column_id(1000, gtk.SORT_ASCENDING)
+        self.port_list.set_sort_column_id(1000, Gtk.SortType.ASCENDING)
         self.port_tree.set_sort_func(1000, cmp_port_tree_addr)
-        self.port_tree.set_sort_column_id(1000, gtk.SORT_ASCENDING)
+        self.port_tree.set_sort_column_id(1000, Gtk.SortType.ASCENDING)
 
-        self.port_view = gtk.TreeView(self.port_list)
+        self.port_view = Gtk.TreeView(self.port_list)
 
-        self.cell_icon = gtk.CellRendererPixbuf()
-        self.cell_port = gtk.CellRendererText()
+        self.cell_icon = Gtk.CellRendererPixbuf()
+        self.cell_port = Gtk.CellRendererText()
 
-        self.port_columns['hostname'] = gtk.TreeViewColumn(_('Host'))
-        self.port_columns['icon'] = gtk.TreeViewColumn('')
-        self.port_columns['port_number'] = gtk.TreeViewColumn(_('Port'))
-        self.port_columns['protocol'] = gtk.TreeViewColumn(_('Protocol'))
-        self.port_columns['state'] = gtk.TreeViewColumn(_('State'))
-        self.port_columns['service'] = gtk.TreeViewColumn(_('Service'))
-        self.port_columns['version'] = gtk.TreeViewColumn(_('Version'))
+        self.port_columns['hostname'] = Gtk.TreeViewColumn(_('Host'))
+        self.port_columns['icon'] = Gtk.TreeViewColumn('')
+        self.port_columns['port_number'] = Gtk.TreeViewColumn(_('Port'))
+        self.port_columns['protocol'] = Gtk.TreeViewColumn(_('Protocol'))
+        self.port_columns['state'] = Gtk.TreeViewColumn(_('State'))
+        self.port_columns['service'] = Gtk.TreeViewColumn(_('Service'))
+        self.port_columns['version'] = Gtk.TreeViewColumn(_('Version'))
 
         # Host services view
         self.host_columns = {}
         # service icon host hostname port protocol state version
         # service is shown only when more than one service is selected (hence
         # host_tree not host_list is used).
-        self.host_list = gtk.ListStore(
+        self.host_list = Gtk.ListStore(
                 str, str, object, str, int, str, str, str)
-        self.host_tree = gtk.TreeStore(
+        self.host_tree = Gtk.TreeStore(
                 str, str, object, str, int, str, str, str)
 
         self.host_list.set_sort_func(1000, cmp_host_list_addr)
-        self.host_list.set_sort_column_id(1000, gtk.SORT_ASCENDING)
+        self.host_list.set_sort_column_id(1000, Gtk.SortType.ASCENDING)
         self.host_tree.set_sort_func(1000, cmp_host_tree_addr)
-        self.host_tree.set_sort_column_id(1000, gtk.SORT_ASCENDING)
+        self.host_tree.set_sort_column_id(1000, Gtk.SortType.ASCENDING)
 
-        self.host_view = gtk.TreeView(self.host_list)
+        self.host_view = Gtk.TreeView(self.host_list)
 
-        self.cell_host_icon = gtk.CellRendererPixbuf()
-        self.cell_host = gtk.CellRendererText()
+        self.cell_host_icon = Gtk.CellRendererPixbuf()
+        self.cell_host = Gtk.CellRendererText()
 
-        self.host_columns['service'] = gtk.TreeViewColumn(_('Service'))
-        self.host_columns['icon'] = gtk.TreeViewColumn('')
-        self.host_columns['hostname'] = gtk.TreeViewColumn(_('Hostname'))
-        self.host_columns['protocol'] = gtk.TreeViewColumn(_('Protocol'))
-        self.host_columns['port_number'] = gtk.TreeViewColumn(_('Port'))
-        self.host_columns['state'] = gtk.TreeViewColumn(_('State'))
-        self.host_columns['version'] = gtk.TreeViewColumn(_('Version'))
+        self.host_columns['service'] = Gtk.TreeViewColumn(_('Service'))
+        self.host_columns['icon'] = Gtk.TreeViewColumn('')
+        self.host_columns['hostname'] = Gtk.TreeViewColumn(_('Hostname'))
+        self.host_columns['protocol'] = Gtk.TreeViewColumn(_('Protocol'))
+        self.host_columns['port_number'] = Gtk.TreeViewColumn(_('Port'))
+        self.host_columns['state'] = Gtk.TreeViewColumn(_('State'))
+        self.host_columns['version'] = Gtk.TreeViewColumn(_('Version'))
 
-        self.scroll_ports_hosts = gtk.ScrolledWindow()
+        self.scroll_ports_hosts = Gtk.ScrolledWindow()
 
     def _set_host_list(self):
         self.host_view.set_enable_search(True)
         self.host_view.set_search_column(2)
 
         selection = self.host_view.get_selection()
-        selection.set_mode(gtk.SELECTION_MULTIPLE)
+        selection.set_mode(Gtk.SelectionMode.MULTIPLE)
 
         columns = ["service", "icon", "hostname", "port_number",
                    "protocol", "state", "version"]
@@ -315,14 +318,14 @@ class HostOpenPorts(HIGVBox):
         self.host_columns['service'].set_visible(False)
 
         self.scroll_ports_hosts.set_policy(
-                gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
+                Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
 
     def _set_port_list(self):
         self.port_view.set_enable_search(True)
         self.port_view.set_search_column(3)
 
         selection = self.port_view.get_selection()
-        selection.set_mode(gtk.SELECTION_MULTIPLE)
+        selection.set_mode(Gtk.SelectionMode.MULTIPLE)
 
         self.port_view.append_column(self.port_columns['hostname'])
         self.port_view.append_column(self.port_columns['icon'])
@@ -365,7 +368,7 @@ class HostOpenPorts(HIGVBox):
         self.port_columns['hostname'].set_visible(False)
 
         self.scroll_ports_hosts.set_policy(
-                gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
+                Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
 
     def port_mode(self):
         child = self.scroll_ports_hosts.get_child()
@@ -512,9 +515,9 @@ class HostOpenPorts(HIGVBox):
             del(self.host_tree[iter])
 
 if __name__ == "__main__":
-    w = gtk.Window()
+    w = Gtk.Window()
     h = HostOpenPorts()
     w.add(h)
     w.show_all()
 
-    gtk.main()
+    Gtk.main()

--- a/zenmap/zenmapGUI/ScanOpenPortsPage.py
+++ b/zenmap/zenmapGUI/ScanOpenPortsPage.py
@@ -161,33 +161,36 @@ def get_version_string(d):
 
 def get_addrs(host):
     if host is None:
-        return None
+        return []
     return host.get_addrs_for_sort()
 
 
 def cmp_addrs(host_a, host_b):
+    # this whole thing needs work
+    def cmp(a, b):
+        return (a > b) - (a < b)
     return cmp(get_addrs(host_a), get_addrs(host_b))
 
 
-def cmp_port_list_addr(model, iter_a, iter_b):
+def cmp_port_list_addr(model, iter_a, iter_b, *_):
     host_a = model.get_value(iter_a, 0)
     host_b = model.get_value(iter_b, 0)
     return cmp_addrs(host_a, host_b)
 
 
-def cmp_port_tree_addr(model, iter_a, iter_b):
+def cmp_port_tree_addr(model, iter_a, iter_b, *_):
     host_a = model.get_value(iter_a, 0)
     host_b = model.get_value(iter_b, 0)
     return cmp_addrs(host_a, host_b)
 
 
-def cmp_host_list_addr(model, iter_a, iter_b):
+def cmp_host_list_addr(model, iter_a, iter_b, *_):
     host_a = model.get_value(iter_a, 2)
     host_b = model.get_value(iter_b, 2)
     return cmp_addrs(host_a, host_b)
 
 
-def cmp_host_tree_addr(model, iter_a, iter_b):
+def cmp_host_tree_addr(model, iter_a, iter_b, *_):
     host_a = model.get_value(iter_a, 2)
     host_b = model.get_value(iter_b, 2)
     return cmp_addrs(host_a, host_b)
@@ -496,22 +499,22 @@ class HostOpenPorts(HIGVBox):
 
     def clear_port_list(self):
         for i in range(len(self.port_list)):
-            iter = self.port_list.get_iter_root()
+            iter = self.port_list.get_iter_first()
             del(self.port_list[iter])
 
     def clear_host_list(self):
         for i in range(len(self.host_list)):
-            iter = self.host_list.get_iter_root()
+            iter = self.host_list.get_iter_first()
             del(self.host_list[iter])
 
     def clear_port_tree(self):
         for i in range(len(self.port_tree)):
-            iter = self.port_tree.get_iter_root()
+            iter = self.port_tree.get_iter_first()
             del(self.port_tree[iter])
 
     def clear_host_tree(self):
         for i in range(len(self.host_tree)):
-            iter = self.host_tree.get_iter_root()
+            iter = self.host_tree.get_iter_first()
             del(self.host_tree[iter])
 
 if __name__ == "__main__":

--- a/zenmap/zenmapGUI/ScanRunDetailsPage.py
+++ b/zenmap/zenmapGUI/ScanRunDetailsPage.py
@@ -126,7 +126,11 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
 from zenmapGUI.higwidgets.higboxes import HIGVBox, HIGHBox,\
         hig_box_space_holder
 from zenmapGUI.higwidgets.higtables import HIGTable
@@ -154,7 +158,7 @@ class ScanRunDetailsPage(HIGVBox):
         self.debug_label = HIGEntryLabel(_('Debug level:'))
         self.info_debug_label = HIGEntryLabel(na)
 
-        self.command_expander = gtk.Expander(
+        self.command_expander = Gtk.Expander(
                 "<b>" + _("Command Info") + "</b>")
         self.command_expander.set_use_markup(True)
 
@@ -208,7 +212,7 @@ class ScanRunDetailsPage(HIGVBox):
         self.closed_label = HIGEntryLabel(_('Closed ports:'))
         self.info_closed_label = HIGEntryLabel(na)
 
-        self.general_expander = gtk.Expander(
+        self.general_expander = Gtk.Expander(
                 "<b>" + _("General Info") + "</b>")
         self.general_expander.set_use_markup(True)
 
@@ -270,7 +274,7 @@ class ScanRunDetailsPage(HIGVBox):
         self.info_closed_label.set_text(str(scan.get_closed_ports()))
 
         for scaninfo in scan.get_scaninfo():
-            exp = gtk.Expander('<b>%s - %s</b>' % (
+            exp = Gtk.Expander('<b>%s - %s</b>' % (
                 _('Scan Info'), scaninfo['type'].capitalize()))
             exp.set_use_markup(True)
 
@@ -309,7 +313,7 @@ class ScanRunDetailsPage(HIGVBox):
     def make_services_display(self, services):
         """Return a widget displaying a list of services like
         1-1027,1029-1033,1040,1043,1050,1058-1059,1067-1068,1076,1080"""
-        combo = gtk.combo_box_new_text()
+        combo = Gtk.ComboBoxText()
 
         for i in services.split(","):
             combo.append_text(i)
@@ -324,8 +328,8 @@ if __name__ == "__main__":
     parsed = NmapParser()
     parsed.parse_file(filename)
     run_details = ScanRunDetailsPage(parsed)
-    window = gtk.Window()
+    window = Gtk.Window()
     window.add(run_details)
-    window.connect("delete-event", lambda *args: gtk.main_quit())
+    window.connect("delete-event", lambda *args: Gtk.main_quit())
     window.show_all()
-    gtk.main()
+    Gtk.main()

--- a/zenmap/zenmapGUI/ScanRunDetailsPage.py
+++ b/zenmap/zenmapGUI/ScanRunDetailsPage.py
@@ -158,7 +158,7 @@ class ScanRunDetailsPage(HIGVBox):
         self.debug_label = HIGEntryLabel(_('Debug level:'))
         self.info_debug_label = HIGEntryLabel(na)
 
-        self.command_expander = Gtk.Expander(
+        self.command_expander = Gtk.Expander.new(
                 "<b>" + _("Command Info") + "</b>")
         self.command_expander.set_use_markup(True)
 
@@ -212,7 +212,7 @@ class ScanRunDetailsPage(HIGVBox):
         self.closed_label = HIGEntryLabel(_('Closed ports:'))
         self.info_closed_label = HIGEntryLabel(na)
 
-        self.general_expander = Gtk.Expander(
+        self.general_expander = Gtk.Expander.new(
                 "<b>" + _("General Info") + "</b>")
         self.general_expander.set_use_markup(True)
 
@@ -274,7 +274,7 @@ class ScanRunDetailsPage(HIGVBox):
         self.info_closed_label.set_text(str(scan.get_closed_ports()))
 
         for scaninfo in scan.get_scaninfo():
-            exp = Gtk.Expander('<b>%s - %s</b>' % (
+            exp = Gtk.Expander.new('<b>%s - %s</b>' % (
                 _('Scan Info'), scaninfo['type'].capitalize()))
             exp.set_use_markup(True)
 

--- a/zenmap/zenmapGUI/ScanScanListPage.py
+++ b/zenmap/zenmapGUI/ScanScanListPage.py
@@ -137,7 +137,7 @@ from zenmapGUI.higwidgets.higscrollers import HIGScrolledWindow
 import zenmapCore.I18N  # lgtm[py/unused-import]
 
 
-def status_data_func(widget, cell_renderer, model, iter):
+def status_data_func(widget, cell_renderer, model, iter, data):
     entry = model.get_value(iter, 0)
     if entry.running:
         status = _("Running")
@@ -153,9 +153,9 @@ def status_data_func(widget, cell_renderer, model, iter):
     cell_renderer.set_property("text", status)
 
 
-def command_data_func(widget, cell_renderer, model, iter):
+def command_data_func(widget, cell_renderer, model, iter, data):
     entry = model.get_value(iter, 0)
-    cell_renderer.set_property("ellipsize", Pango.EllipsizeMode.ELLIPSIZE_END)
+    cell_renderer.set_property("ellipsize", Pango.EllipsizeMode.END)
     cell_renderer.set_property("text", entry.get_command_string())
 
 

--- a/zenmap/zenmapGUI/ScanScanListPage.py
+++ b/zenmap/zenmapGUI/ScanScanListPage.py
@@ -176,13 +176,13 @@ class ScanScanListPage(HIGVBox):
 
         status_col = Gtk.TreeViewColumn(_("Status"))
         cell = Gtk.CellRendererText()
-        status_col.pack_start(cell)
+        status_col.pack_start(cell, True)
         status_col.set_cell_data_func(cell, status_data_func)
         self.scans_list.append_column(status_col)
 
         command_col = Gtk.TreeViewColumn(_("Command"))
         cell = Gtk.CellRendererText()
-        command_col.pack_start(cell)
+        command_col.pack_start(cell, True)
         command_col.set_cell_data_func(cell, command_data_func)
         self.scans_list.append_column(command_col)
 
@@ -190,7 +190,7 @@ class ScanScanListPage(HIGVBox):
         scrolled_window.set_border_width(0)
         scrolled_window.add(self.scans_list)
 
-        self.pack_start(scrolled_window, True, True)
+        self.pack_start(scrolled_window, True, True, 0)
 
         hbox = HIGHBox()
         buttonbox = Gtk.HButtonBox()
@@ -198,17 +198,17 @@ class ScanScanListPage(HIGVBox):
         buttonbox.set_spacing(4)
 
         self.append_button = HIGButton(_("Append Scan"), Gtk.STOCK_ADD)
-        buttonbox.pack_start(self.append_button, False)
+        buttonbox.pack_start(self.append_button, False, True, 0)
 
         self.remove_button = HIGButton(_("Remove Scan"), Gtk.STOCK_REMOVE)
-        buttonbox.pack_start(self.remove_button, False)
+        buttonbox.pack_start(self.remove_button, False, True, 0)
 
         self.cancel_button = HIGButton(_("Cancel Scan"), Gtk.STOCK_CANCEL)
-        buttonbox.pack_start(self.cancel_button, False)
+        buttonbox.pack_start(self.cancel_button, False, True, 0)
 
-        hbox.pack_start(buttonbox, padding=4)
+        hbox.pack_start(buttonbox, True, True, 4)
 
-        self.pack_start(hbox, False, padding=4)
+        self.pack_start(hbox, False, True, 4)
 
         self._update()
 

--- a/zenmap/zenmapGUI/ScanScanListPage.py
+++ b/zenmap/zenmapGUI/ScanScanListPage.py
@@ -126,8 +126,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
-import pango
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Pango
 
 from zenmapGUI.higwidgets.higboxes import HIGHBox, HIGVBox
 from zenmapGUI.higwidgets.higbuttons import HIGButton
@@ -153,7 +155,7 @@ def status_data_func(widget, cell_renderer, model, iter):
 
 def command_data_func(widget, cell_renderer, model, iter):
     entry = model.get_value(iter, 0)
-    cell_renderer.set_property("ellipsize", pango.ELLIPSIZE_END)
+    cell_renderer.set_property("ellipsize", Pango.EllipsizeMode.ELLIPSIZE_END)
     cell_renderer.set_property("text", entry.get_command_string())
 
 
@@ -168,18 +170,18 @@ class ScanScanListPage(HIGVBox):
 
         scans_store.connect("row-changed", self._row_changed)
 
-        self.scans_list = gtk.TreeView(scans_store)
+        self.scans_list = Gtk.TreeView(scans_store)
         self.scans_list.get_selection().connect(
                 "changed", self._selection_changed)
 
-        status_col = gtk.TreeViewColumn(_("Status"))
-        cell = gtk.CellRendererText()
+        status_col = Gtk.TreeViewColumn(_("Status"))
+        cell = Gtk.CellRendererText()
         status_col.pack_start(cell)
         status_col.set_cell_data_func(cell, status_data_func)
         self.scans_list.append_column(status_col)
 
-        command_col = gtk.TreeViewColumn(_("Command"))
-        cell = gtk.CellRendererText()
+        command_col = Gtk.TreeViewColumn(_("Command"))
+        cell = Gtk.CellRendererText()
         command_col.pack_start(cell)
         command_col.set_cell_data_func(cell, command_data_func)
         self.scans_list.append_column(command_col)
@@ -191,17 +193,17 @@ class ScanScanListPage(HIGVBox):
         self.pack_start(scrolled_window, True, True)
 
         hbox = HIGHBox()
-        buttonbox = gtk.HButtonBox()
-        buttonbox.set_layout(gtk.BUTTONBOX_START)
+        buttonbox = Gtk.HButtonBox()
+        buttonbox.set_layout(Gtk.ButtonBoxStyle.START)
         buttonbox.set_spacing(4)
 
-        self.append_button = HIGButton(_("Append Scan"), gtk.STOCK_ADD)
+        self.append_button = HIGButton(_("Append Scan"), Gtk.STOCK_ADD)
         buttonbox.pack_start(self.append_button, False)
 
-        self.remove_button = HIGButton(_("Remove Scan"), gtk.STOCK_REMOVE)
+        self.remove_button = HIGButton(_("Remove Scan"), Gtk.STOCK_REMOVE)
         buttonbox.pack_start(self.remove_button, False)
 
-        self.cancel_button = HIGButton(_("Cancel Scan"), gtk.STOCK_CANCEL)
+        self.cancel_button = HIGButton(_("Cancel Scan"), Gtk.STOCK_CANCEL)
         buttonbox.pack_start(self.cancel_button, False)
 
         hbox.pack_start(buttonbox, padding=4)

--- a/zenmap/zenmapGUI/ScanToolbar.py
+++ b/zenmap/zenmapGUI/ScanToolbar.py
@@ -255,8 +255,8 @@ if __name__ == "__main__":
     stool = ScanToolbar()
     sctool = ScanCommandToolbar()
 
-    box.pack_start(stool)
-    box.pack_start(sctool)
+    box.pack_start(stool, True, True, 0)
+    box.pack_start(sctool, True, True, 0)
 
     w.connect("delete-event", lambda x, y: Gtk.main_quit())
     w.show_all()

--- a/zenmap/zenmapGUI/ScanToolbar.py
+++ b/zenmap/zenmapGUI/ScanToolbar.py
@@ -155,7 +155,7 @@ class ScanCommandToolbar(HIGHBox):
 
     def get_command(self):
         """Retrieve command entry"""
-        return self.command_entry.get_text().decode("UTF-8")
+        return self.command_entry.get_text()
 
     def set_command(self, command):
         """Set a command entry"""
@@ -194,11 +194,11 @@ class ScanToolbar(HIGHBox):
         self._pack_noexpand_nofill(self.cancel_button)
 
         # Skip over the dropdown arrow so you can tab to the profile entry.
-        self.target_entry.set_focus_chain((self.target_entry.child,))
+        self.target_entry.set_focus_chain((self.target_entry.get_child(),))
 
-        self.target_entry.child.connect('activate',
+        self.target_entry.get_child().connect('activate',
                         lambda x: self.profile_entry.grab_focus())
-        self.profile_entry.child.connect('activate',
+        self.profile_entry.get_child().connect('activate',
                         lambda x: self.scan_button.clicked())
 
     def _create_target(self):
@@ -223,7 +223,7 @@ class ScanToolbar(HIGHBox):
 
     def get_selected_target(self):
         """Return currently selected target"""
-        return self.target_entry.selected_target.decode("UTF-8")
+        return self.target_entry.selected_target
 
     def set_selected_target(self, target):
         """Modify currently selected target"""

--- a/zenmap/zenmapGUI/ScanToolbar.py
+++ b/zenmap/zenmapGUI/ScanToolbar.py
@@ -126,7 +126,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 from zenmapGUI.higwidgets.higboxes import HIGHBox
 from zenmapGUI.higwidgets.higlabels import HIGEntryLabel
@@ -145,7 +148,7 @@ class ScanCommandToolbar(HIGHBox):
         HIGHBox.__init__(self)
 
         self.command_label = HIGEntryLabel(_("Command:"))
-        self.command_entry = gtk.Entry()
+        self.command_entry = Gtk.Entry()
 
         self._pack_noexpand_nofill(self.command_label)
         self._pack_expand_fill(self.command_entry)
@@ -176,9 +179,9 @@ class ScanToolbar(HIGHBox):
         self._create_target()
         self._create_profile()
 
-        self.scan_button = gtk.Button(_("Scan"))
+        self.scan_button = Gtk.Button(_("Scan"))
         #self.scan_button = HIGButton(_("Scan "), gtk.STOCK_MEDIA_PLAY)
-        self.cancel_button = gtk.Button(_("Cancel"))
+        self.cancel_button = Gtk.Button(_("Cancel"))
         #self.cancel_button = HIGButton(_("Cancel "), gtk.STOCK_CANCEL)
 
         self._pack_noexpand_nofill(self.target_label)
@@ -245,8 +248,8 @@ class ScanToolbar(HIGHBox):
     selected_target = property(get_selected_target, set_selected_target)
 
 if __name__ == "__main__":
-    w = gtk.Window()
-    box = gtk.VBox()
+    w = Gtk.Window()
+    box = Gtk.VBox()
     w.add(box)
 
     stool = ScanToolbar()
@@ -255,6 +258,6 @@ if __name__ == "__main__":
     box.pack_start(stool)
     box.pack_start(sctool)
 
-    w.connect("delete-event", lambda x, y: gtk.main_quit())
+    w.connect("delete-event", lambda x, y: Gtk.main_quit())
     w.show_all()
-    gtk.main()
+    Gtk.main()

--- a/zenmap/zenmapGUI/ScanToolbar.py
+++ b/zenmap/zenmapGUI/ScanToolbar.py
@@ -179,10 +179,8 @@ class ScanToolbar(HIGHBox):
         self._create_target()
         self._create_profile()
 
-        self.scan_button = Gtk.Button(_("Scan"))
-        #self.scan_button = HIGButton(_("Scan "), gtk.STOCK_MEDIA_PLAY)
-        self.cancel_button = Gtk.Button(_("Cancel"))
-        #self.cancel_button = HIGButton(_("Cancel "), gtk.STOCK_CANCEL)
+        self.scan_button = Gtk.Button(label=_("Scan"))
+        self.cancel_button = Gtk.Button(label=_("Cancel"))
 
         self._pack_noexpand_nofill(self.target_label)
         self._pack_expand_fill(self.target_entry)
@@ -221,11 +219,13 @@ class ScanToolbar(HIGHBox):
     def add_new_target(self, target):
         self.target_entry.add_new_target(target)
 
-    def get_selected_target(self):
+    @property
+    def selected_target(self):
         """Return currently selected target"""
         return self.target_entry.selected_target
 
-    def set_selected_target(self, target):
+    @selected_target.setter
+    def selected_target(self, target):
         """Modify currently selected target"""
         self.target_entry.selected_target = target
 
@@ -236,16 +236,15 @@ class ScanToolbar(HIGHBox):
         """Modify profile"""
         self.profile_entry.set_profiles(profiles)
 
-    def get_selected_profile(self):
+    @property
+    def selected_profile(self):
         """Return currently selected profile"""
         return self.profile_entry.selected_profile
 
-    def set_selected_profile(self, profile):
+    @selected_profile.setter
+    def selected_profile(self, profile):
         """Modify currently selected profile"""
         self.profile_entry.selected_profile = profile
-
-    selected_profile = property(get_selected_profile, set_selected_profile)
-    selected_target = property(get_selected_target, set_selected_target)
 
 if __name__ == "__main__":
     w = Gtk.Window()

--- a/zenmap/zenmapGUI/ScansListStore.py
+++ b/zenmap/zenmapGUI/ScansListStore.py
@@ -126,7 +126,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 
 class ScansListStoreEntry(object):
@@ -134,7 +137,7 @@ class ScansListStoreEntry(object):
     otherwise represented by very different classes."""
 
     # Possible states for the scan to be in.
-    UNINITIALIZED, RUNNING, FINISHED, FAILED, CANCELED = range(5)
+    UNINITIALIZED, RUNNING, FINISHED, FAILED, CANCELED = list(range(5))
 
     def __init__(self):
         self.state = self.UNINITIALIZED
@@ -169,11 +172,11 @@ class ScansListStoreEntry(object):
     canceled = property(lambda self: self.state == self.CANCELED)
 
 
-class ScansListStore(gtk.ListStore):
-    """This is a specialization of a gtk.ListStore that holds running,
+class ScansListStore(Gtk.ListStore):
+    """This is a specialization of a Gtk.ListStore that holds running,
     completed, and failed scans."""
     def __init__(self):
-        gtk.ListStore.__init__(self, object)
+        Gtk.ListStore.__init__(self, object)
 
     def add_running_scan(self, command):
         """Add a running NmapCommand object to the list of scans."""

--- a/zenmap/zenmapGUI/ScriptInterface.py
+++ b/zenmap/zenmapGUI/ScriptInterface.py
@@ -127,8 +127,11 @@
 
 # This module is responsible for interface present under "Scripting" tab.
 
-import gobject
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GLib
+
 import sys
 import tempfile
 
@@ -169,7 +172,7 @@ def text_buffer_insert_nsedoc(buf, nsedoc):
         elif event.type == "list_end":
             pass
         elif event.type == "list_item_start":
-            buf.insert(buf.get_end_iter(), u"\u2022\u00a0")  # bullet nbsp
+            buf.insert(buf.get_end_iter(), "\u2022\u00a0")  # bullet nbsp
         elif event.type == "list_item_end":
             buf.insert(buf.get_end_iter(), "\n")
         elif event.type == "text":
@@ -190,28 +193,28 @@ class ScriptHelpXMLContentHandler (xml.sax.handler.ContentHandler):
         self.nselib_dir = None
 
     def startElement(self, name, attrs):
-        if name == u"directory":
-            if u"name" not in attrs:
+        if name == "directory":
+            if "name" not in attrs:
                 raise ValueError(
-                        u'"directory" element did not have "name" attribute')
-            dirname = attrs[u"name"]
-            if u"path" not in attrs:
+                        '"directory" element did not have "name" attribute')
+            dirname = attrs["name"]
+            if "path" not in attrs:
                 raise ValueError(
-                        u'"directory" element did not have "path" attribute')
-            path = attrs[u"path"].encode("raw_unicode_escape").decode(
+                        '"directory" element did not have "path" attribute')
+            path = attrs["path"].encode("raw_unicode_escape").decode(
                     sys.getfilesystemencoding())
-            if dirname == u"scripts":
+            if dirname == "scripts":
                 self.scripts_dir = path
-            elif dirname == u"nselib":
+            elif dirname == "nselib":
                 self.nselib_dir = path
             else:
                 # Ignore.
                 pass
-        elif name == u"script":
-            if u"filename" not in attrs:
+        elif name == "script":
+            if "filename" not in attrs:
                 raise ValueError(
-                        u'"script" element did not have "filename" attribute')
-            self.script_filenames.append(attrs[u"filename"])
+                        '"script" element did not have "filename" attribute')
+            self.script_filenames.append(attrs["filename"])
 
     @staticmethod
     def parse_nmap_script_help(f):
@@ -246,21 +249,21 @@ class ScriptInterface:
         self.prev_script_spec = None
         self.focusedentry = None
 
-        self.liststore = gtk.ListStore(str, "gboolean", object)
+        self.liststore = Gtk.ListStore(str, "gboolean", object)
 
-        self.file_liststore = gtk.ListStore(str, "gboolean")
+        self.file_liststore = Gtk.ListStore(str, "gboolean")
 
         # Arg name, arg value, (name, desc) tuple.
-        self.arg_liststore = gtk.ListStore(str, str, object)
+        self.arg_liststore = Gtk.ListStore(str, str, object)
 
         # This is what is shown initially. After the initial Nmap run to get
         # the list of script is finished, this will be replaced with a TreeView
         # showing the scripts or an error message.
-        self.script_list_container = gtk.VBox()
+        self.script_list_container = Gtk.VBox()
         self.script_list_container.pack_start(self.make_please_wait_widget())
         self.hmainbox.pack_start(self.script_list_container, False, False, 0)
 
-        self.nmap_error_widget = gtk.Label(_(
+        self.nmap_error_widget = Gtk.Label(_(
             "There was an error getting the list of scripts from Nmap. "
             "Try upgrading Nmap."))
         self.nmap_error_widget.set_line_wrap(True)
@@ -298,7 +301,7 @@ class ScriptInterface:
         nmap_process = NmapCommand(command_string)
         try:
             nmap_process.run_scan(stderr=stderr)
-        except Exception, e:
+        except Exception as e:
             callback(False, None)
             stderr.close()
             return
@@ -306,7 +309,7 @@ class ScriptInterface:
 
         self.script_list_widget.set_sensitive(False)
 
-        gobject.timeout_add(
+        GLib.timeout_add(
                 self.NMAP_DELAY, self.script_list_timer_callback,
                 nmap_process, callback)
 
@@ -345,7 +348,7 @@ class ScriptInterface:
         try:
             handler = ScriptHelpXMLContentHandler.parse_nmap_script_help(
                     process.stdout_file)
-        except (ValueError, xml.sax.SAXParseException), e:
+        except (ValueError, xml.sax.SAXParseException) as e:
             log.debug("--script-help parse exception: %s" % str(e))
             return False
 
@@ -406,7 +409,7 @@ class ScriptInterface:
         try:
             handler = ScriptHelpXMLContentHandler.parse_nmap_script_help(
                     process.stdout_file)
-        except (ValueError, xml.sax.SAXParseException), e:
+        except (ValueError, xml.sax.SAXParseException) as e:
             log.debug("--script-help parse exception: %s" % str(e))
             return False
 
@@ -442,8 +445,8 @@ class ScriptInterface:
         involving the creation of a subprocess, we don't do it for every typed
         character."""
         if self.script_list_timeout_id:
-            gobject.source_remove(self.script_list_timeout_id)
-        self.script_list_timeout_id = gobject.timeout_add(
+            GLib.source_remove(self.script_list_timeout_id)
+        self.script_list_timeout_id = GLib.timeout_add(
                 self.SCRIPT_LIST_DELAY,
                 self.update_script_list_from_spec, spec)
 
@@ -480,8 +483,8 @@ A list of arguments that affect the selected script. Enter a value by \
 clicking in the value field beside the argument name.""")
 
     def make_please_wait_widget(self):
-        vbox = gtk.VBox()
-        label = gtk.Label(_("Please wait."))
+        vbox = Gtk.VBox()
+        label = Gtk.Label(_("Please wait."))
         label.set_line_wrap(True)
         vbox.pack_start(label)
         return vbox
@@ -489,25 +492,25 @@ clicking in the value field beside the argument name.""")
     def make_script_list_widget(self):
         """Creates and packs widgets associated with left hand side of
         Interface."""
-        vbox = gtk.VBox()
+        vbox = Gtk.VBox()
 
         scrolled_window = HIGScrolledWindow()
-        scrolled_window.set_policy(gtk.POLICY_ALWAYS, gtk.POLICY_ALWAYS)
+        scrolled_window.set_policy(Gtk.PolicyType.ALWAYS, Gtk.PolicyType.ALWAYS)
         # Expand only vertically.
         scrolled_window.set_size_request(175, -1)
-        listview = gtk.TreeView(self.liststore)
+        listview = Gtk.TreeView(self.liststore)
         listview.set_headers_visible(False)
         listview.connect("enter-notify-event", self.update_help_ls_cb)
         selection = listview.get_selection()
         selection.connect("changed", self.selection_changed_cb)
-        cell = gtk.CellRendererText()
-        togglecell = gtk.CellRendererToggle()
+        cell = Gtk.CellRendererText()
+        togglecell = Gtk.CellRendererToggle()
         togglecell.set_property("activatable", True)
         togglecell.connect("toggled", self.toggled_cb, self.liststore)
-        col = gtk.TreeViewColumn(_('Names'))
-        col.set_sizing(gtk.TREE_VIEW_COLUMN_GROW_ONLY)
+        col = Gtk.TreeViewColumn(_('Names'))
+        col.set_sizing(Gtk.TreeViewColumnSizing.GROW_ONLY)
         col.set_resizable(True)
-        togglecol = gtk.TreeViewColumn(None, togglecell)
+        togglecol = Gtk.TreeViewColumn(None, togglecell)
         togglecol.add_attribute(togglecell, "active", 1)
         listview.append_column(togglecol)
         listview.append_column(col)
@@ -519,24 +522,24 @@ clicking in the value field beside the argument name.""")
 
         self.file_scrolled_window = HIGScrolledWindow()
         self.file_scrolled_window.set_policy(
-                gtk.POLICY_ALWAYS, gtk.POLICY_ALWAYS)
+                Gtk.PolicyType.ALWAYS, Gtk.PolicyType.ALWAYS)
         self.file_scrolled_window.set_size_request(175, -1)
         self.file_scrolled_window.hide()
         self.file_scrolled_window.set_no_show_all(True)
 
-        self.file_listview = gtk.TreeView(self.file_liststore)
+        self.file_listview = Gtk.TreeView(self.file_liststore)
         self.file_listview.set_headers_visible(False)
-        col = gtk.TreeViewColumn(None)
+        col = Gtk.TreeViewColumn(None)
         self.file_listview.append_column(col)
-        cell = gtk.CellRendererToggle()
+        cell = Gtk.CellRendererToggle()
         col.pack_start(cell, True)
         cell.set_property("activatable", True)
         col.add_attribute(cell, "active", 1)
         cell.connect("toggled", self.toggled_cb, self.file_liststore)
 
-        col = gtk.TreeViewColumn(None)
+        col = Gtk.TreeViewColumn(None)
         self.file_listview.append_column(col)
-        cell = gtk.CellRendererText()
+        cell = Gtk.CellRendererText()
         col.pack_start(cell)
         col.add_attribute(cell, "text", 0)
 
@@ -545,12 +548,12 @@ clicking in the value field beside the argument name.""")
         vbox.pack_start(self.file_scrolled_window, False)
 
         hbox = HIGHBox(False, 2)
-        self.remove_file_button = HIGButton(stock=gtk.STOCK_REMOVE)
+        self.remove_file_button = HIGButton(stock=Gtk.STOCK_REMOVE)
         self.remove_file_button.connect(
                 "clicked", self.remove_file_button_clicked_cb)
         self.remove_file_button.set_sensitive(False)
         hbox.pack_end(self.remove_file_button)
-        add_file_button = HIGButton(stock=gtk.STOCK_ADD)
+        add_file_button = HIGButton(stock=Gtk.STOCK_ADD)
         add_file_button.connect("clicked", self.add_file_button_clicked_cb)
         hbox.pack_end(add_file_button)
 
@@ -608,35 +611,35 @@ clicking in the value field beside the argument name.""")
         """Creates and packs widgets related to displaying the description
         box."""
         sw = HIGScrolledWindow()
-        sw.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_ALWAYS)
-        sw.set_shadow_type(gtk.SHADOW_OUT)
+        sw.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.ALWAYS)
+        sw.set_shadow_type(Gtk.ShadowType.OUT)
         sw.set_border_width(5)
-        text_view = gtk.TextView()
+        text_view = Gtk.TextView()
         text_view.connect("enter-notify-event", self.update_help_desc_cb)
         self.text_buffer = text_view.get_buffer()
         self.text_buffer.create_tag("Usage", font="Monospace")
         self.text_buffer.create_tag("Output", font="Monospace")
-        text_view.set_wrap_mode(gtk.WRAP_WORD)
+        text_view.set_wrap_mode(Gtk.WrapMode.WORD)
         text_view.set_editable(False)
-        text_view.set_justification(gtk.JUSTIFY_LEFT)
+        text_view.set_justification(Gtk.Justification.LEFT)
         sw.add(text_view)
         return sw
 
     def make_arguments_widget(self):
         """Creates and packs widgets related to arguments box."""
-        vbox = gtk.VBox()
-        vbox.pack_start(gtk.Label(_("Arguments")), False, False, 0)
+        vbox = Gtk.VBox()
+        vbox.pack_start(Gtk.Label(_("Arguments")), False, False, 0)
         arg_window = HIGScrolledWindow()
-        arg_window.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_ALWAYS)
-        arg_window.set_shadow_type(gtk.SHADOW_OUT)
+        arg_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.ALWAYS)
+        arg_window.set_shadow_type(Gtk.ShadowType.OUT)
 
-        arg_listview = gtk.TreeView(self.arg_liststore)
+        arg_listview = Gtk.TreeView(self.arg_liststore)
         arg_listview.connect("motion-notify-event", self.update_help_arg_cb)
-        argument = gtk.CellRendererText()
-        self.value = gtk.CellRendererText()
+        argument = Gtk.CellRendererText()
+        self.value = Gtk.CellRendererText()
         self.value.connect("edited", self.value_edited_cb, self.arg_liststore)
-        arg_col = gtk.TreeViewColumn("Arguments\t")
-        val_col = gtk.TreeViewColumn("values")
+        arg_col = Gtk.TreeViewColumn("Arguments\t")
+        val_col = Gtk.TreeViewColumn("values")
         arg_listview.append_column(arg_col)
         arg_listview.append_column(val_col)
         arg_col.pack_start(argument, True)
@@ -721,7 +724,7 @@ clicking in the value field beside the argument name.""")
         response = self.script_file_chooser.run()
         filenames = self.script_file_chooser.get_filenames()
         self.script_file_chooser.hide()
-        if response != gtk.RESPONSE_OK:
+        if response != Gtk.ResponseType.OK:
             return
         for filename in filenames:
             self.file_liststore.append([filename, True])
@@ -742,7 +745,7 @@ clicking in the value field beside the argument name.""")
 
     def set_description(self, entry):
         """Sets the content that is to be displayed in the description box."""
-        self.text_buffer.set_text(u"")
+        self.text_buffer.set_text("")
 
         self.text_buffer.insert(self.text_buffer.get_end_iter(), """\
 Categories: %(cats)s

--- a/zenmap/zenmapGUI/ScriptInterface.py
+++ b/zenmap/zenmapGUI/ScriptInterface.py
@@ -260,7 +260,7 @@ class ScriptInterface:
         # the list of script is finished, this will be replaced with a TreeView
         # showing the scripts or an error message.
         self.script_list_container = Gtk.VBox()
-        self.script_list_container.pack_start(self.make_please_wait_widget())
+        self.script_list_container.pack_start(self.make_please_wait_widget(), True, True, 0)
         self.hmainbox.pack_start(self.script_list_container, False, False, 0)
 
         self.nmap_error_widget = Gtk.Label(_(
@@ -339,9 +339,9 @@ class ScriptInterface:
         for child in self.script_list_container.get_children():
             self.script_list_container.remove(child)
         if status and self.handle_initial_script_list_output(process):
-            self.script_list_container.pack_start(self.script_list_widget)
+            self.script_list_container.pack_start(self.script_list_widget, True, True, 0)
         else:
-            self.script_list_container.pack_start(self.nmap_error_widget)
+            self.script_list_container.pack_start(self.nmap_error_widget, True, True, 0)
 
     def handle_initial_script_list_output(self, process):
         process.stdout_file.seek(0)
@@ -486,7 +486,7 @@ clicking in the value field beside the argument name.""")
         vbox = Gtk.VBox()
         label = Gtk.Label(_("Please wait."))
         label.set_line_wrap(True)
-        vbox.pack_start(label)
+        vbox.pack_start(label, True, True, 0)
         return vbox
 
     def make_script_list_widget(self):
@@ -514,7 +514,7 @@ clicking in the value field beside the argument name.""")
         togglecol.add_attribute(togglecell, "active", 1)
         listview.append_column(togglecol)
         listview.append_column(col)
-        col.pack_start(cell, True)
+        col.pack_start(cell, True, True, 0)
         col.add_attribute(cell, "text", 0)
         scrolled_window.add(listview)
         scrolled_window.show()
@@ -532,7 +532,7 @@ clicking in the value field beside the argument name.""")
         col = Gtk.TreeViewColumn(None)
         self.file_listview.append_column(col)
         cell = Gtk.CellRendererToggle()
-        col.pack_start(cell, True)
+        col.pack_start(cell, True, True, 0)
         cell.set_property("activatable", True)
         col.add_attribute(cell, "active", 1)
         cell.connect("toggled", self.toggled_cb, self.file_liststore)
@@ -540,22 +540,22 @@ clicking in the value field beside the argument name.""")
         col = Gtk.TreeViewColumn(None)
         self.file_listview.append_column(col)
         cell = Gtk.CellRendererText()
-        col.pack_start(cell)
+        col.pack_start(cell, True, True, 0)
         col.add_attribute(cell, "text", 0)
 
         self.file_listview.show_all()
         self.file_scrolled_window.add(self.file_listview)
-        vbox.pack_start(self.file_scrolled_window, False)
+        vbox.pack_start(self.file_scrolled_window, False, True, 0)
 
         hbox = HIGHBox(False, 2)
         self.remove_file_button = HIGButton(stock=Gtk.STOCK_REMOVE)
         self.remove_file_button.connect(
                 "clicked", self.remove_file_button_clicked_cb)
         self.remove_file_button.set_sensitive(False)
-        hbox.pack_end(self.remove_file_button)
+        hbox.pack_end(self.remove_file_button, True, True, 0)
         add_file_button = HIGButton(stock=Gtk.STOCK_ADD)
         add_file_button.connect("clicked", self.add_file_button_clicked_cb)
-        hbox.pack_end(add_file_button)
+        hbox.pack_end(add_file_button, True, True, 0)
 
         vbox.pack_start(hbox, False, False, 0)
 
@@ -642,9 +642,9 @@ clicking in the value field beside the argument name.""")
         val_col = Gtk.TreeViewColumn("values")
         arg_listview.append_column(arg_col)
         arg_listview.append_column(val_col)
-        arg_col.pack_start(argument, True)
+        arg_col.pack_start(argument, True, True, 0)
         arg_col.add_attribute(argument, "text", 0)
-        val_col.pack_start(self.value, True)
+        val_col.pack_start(self.value, True, True, 0)
         val_col.add_attribute(self.value, "text", 1)
 
         arg_window.add(arg_listview)

--- a/zenmap/zenmapGUI/ScriptInterface.py
+++ b/zenmap/zenmapGUI/ScriptInterface.py
@@ -160,7 +160,7 @@ paths_config = PathsConfig()
 def text_buffer_insert_nsedoc(buf, nsedoc):
     """Inserts NSEDoc at the end of the buffer, with markup turned into proper
     tags."""
-    if not buf.tag_table.lookup("NSEDOC_CODE_TAG"):
+    if not buf.get_tag_table().lookup("NSEDOC_CODE_TAG"):
         buf.create_tag("NSEDOC_CODE_TAG", font="Monospace")
     for event in zenmapCore.NSEDocParser.nsedoc_parse(nsedoc):
         if event.type == "paragraph_start":
@@ -514,7 +514,7 @@ clicking in the value field beside the argument name.""")
         togglecol.add_attribute(togglecell, "active", 1)
         listview.append_column(togglecol)
         listview.append_column(col)
-        col.pack_start(cell, True, True, 0)
+        col.pack_start(cell, True)
         col.add_attribute(cell, "text", 0)
         scrolled_window.add(listview)
         scrolled_window.show()
@@ -532,7 +532,7 @@ clicking in the value field beside the argument name.""")
         col = Gtk.TreeViewColumn(None)
         self.file_listview.append_column(col)
         cell = Gtk.CellRendererToggle()
-        col.pack_start(cell, True, True, 0)
+        col.pack_start(cell, True)
         cell.set_property("activatable", True)
         col.add_attribute(cell, "active", 1)
         cell.connect("toggled", self.toggled_cb, self.file_liststore)
@@ -540,7 +540,7 @@ clicking in the value field beside the argument name.""")
         col = Gtk.TreeViewColumn(None)
         self.file_listview.append_column(col)
         cell = Gtk.CellRendererText()
-        col.pack_start(cell, True, True, 0)
+        col.pack_start(cell, True)
         col.add_attribute(cell, "text", 0)
 
         self.file_listview.show_all()
@@ -642,9 +642,9 @@ clicking in the value field beside the argument name.""")
         val_col = Gtk.TreeViewColumn("values")
         arg_listview.append_column(arg_col)
         arg_listview.append_column(val_col)
-        arg_col.pack_start(argument, True, True, 0)
+        arg_col.pack_start(argument, True)
         arg_col.add_attribute(argument, "text", 0)
-        val_col.pack_start(self.value, True, True, 0)
+        val_col.pack_start(self.value, True)
         val_col.add_attribute(self.value, "text", 1)
 
         arg_window.add(arg_listview)

--- a/zenmap/zenmapGUI/SearchGUI.py
+++ b/zenmap/zenmapGUI/SearchGUI.py
@@ -349,10 +349,10 @@ class SearchGUI(Gtk.VBox, object):
     def _pack_widgets(self):
         # Packing label, search box and buttons
         self.search_top_hbox.set_spacing(4)
-        self.search_top_hbox.pack_start(self.search_label, False)
-        self.search_top_hbox.pack_start(self.search_entry, True)
-        self.search_top_hbox.pack_start(self.expressions_btn, False)
-        self.search_top_hbox.pack_start(self.search_tooltip_btn, False)
+        self.search_top_hbox.pack_start(self.search_label, False, True, 0)
+        self.search_top_hbox.pack_start(self.search_entry, True, True, 0)
+        self.search_top_hbox.pack_start(self.expressions_btn, False, True, 0)
+        self.search_top_hbox.pack_start(self.search_tooltip_btn, False, True, 0)
 
         # The expressions (if any) should be tightly packed so that they don't
         # take too much screen real-estate
@@ -365,10 +365,10 @@ class SearchGUI(Gtk.VBox, object):
 
         # Packing it all together
         self.set_spacing(4)
-        self.pack_start(self.search_top_hbox, False)
-        self.pack_start(self.expr_vbox, False)
-        self.pack_start(self.result_scrolled, True)
-        self.pack_start(self.no_db_warning, False)
+        self.pack_start(self.search_top_hbox, False, True, 0)
+        self.pack_start(self.expr_vbox, False, True, 0)
+        self.pack_start(self.result_scrolled, True, True, 0)
+        self.pack_start(self.no_db_warning, False, True, 0)
 
     def _connect_events(self):
         self.search_entry.connect("changed", self.update_search_entry)
@@ -385,7 +385,7 @@ class SearchGUI(Gtk.VBox, object):
             # This is the first time the user has clicked on "Show Expressions"
             # and the search entry box is empty, so we add a single Criterion
             # row
-            self.expr_vbox.pack_start(Criterion(self))
+            self.expr_vbox.pack_start(Criterion(self), True, True, 0)
 
         if self.expressions_btn.get_active():
             # The Expressions GUI is about to be displayed. It needs to reflect
@@ -413,7 +413,7 @@ class SearchGUI(Gtk.VBox, object):
                     if (op not in gui_ops) or (arg not in gui_ops[op]):
                         # We need to add this pair to the GUI
                         self.expr_vbox.pack_start(
-                                Criterion(self, op, arg), False)
+                                Criterion(self, op, arg), False, True, 0)
 
             # Now we check if there are any leftover criterion rows that aren't
             # present in the search_dict (for example, if a user has deleted
@@ -425,7 +425,7 @@ class SearchGUI(Gtk.VBox, object):
                     criterion.destroy()
             # If we have deleted all rows, add an empty one
             if len(self.expr_vbox.get_children()) == 0:
-                self.expr_vbox.pack_start(Criterion(self))
+                self.expr_vbox.pack_start(Criterion(self), True, True, 0)
 
             # Display all elements
             self.expr_vbox.show_all()
@@ -447,7 +447,7 @@ class SearchGUI(Gtk.VBox, object):
 
         # Make a new Criteria row and insert it after the calling row
         criteria = Criterion(self, "keyword")
-        self.expr_vbox.pack_start(criteria, False)
+        self.expr_vbox.pack_start(criteria, False, True, 0)
         self.expr_vbox.reorder_child(criteria, caller_index + 1)
         criteria.show_all()
 
@@ -570,8 +570,8 @@ class SearchGUI(Gtk.VBox, object):
 
         cell = Gtk.CellRendererText()
 
-        self.result_title_column.pack_start(cell, True)
-        self.result_date_column.pack_start(cell, True)
+        self.result_title_column.pack_start(cell, True, True, 0)
+        self.result_date_column.pack_start(cell, True, True, 0)
 
         self.result_title_column.set_attributes(cell, text=0)
         self.result_date_column.set_attributes(cell, text=1)
@@ -641,10 +641,10 @@ class Criterion(Gtk.HBox):
         self.remove_btn = HIGButton(" ", Gtk.STOCK_REMOVE)
 
     def _pack_widgets(self):
-        self.pack_start(self.operator_combo, False)
-        self.pack_start(self.subcriterion, True, True)
-        self.pack_start(self.add_btn, False)
-        self.pack_start(self.remove_btn, False)
+        self.pack_start(self.operator_combo, False, True, 0)
+        self.pack_start(self.subcriterion, True, True, 0)
+        self.pack_start(self.add_btn, False, True, 0)
+        self.pack_start(self.remove_btn, False, True, 0)
 
     def _connect_events(self):
         self.operator_combo.connect("changed", self.operator_changed)
@@ -691,7 +691,7 @@ class Criterion(Gtk.HBox):
         self.subcriterion = self.new_subcriterion(operator)
 
         # Pack it, and place it on the right side of the ComboBox
-        self.pack_start(self.subcriterion, True, True)
+        self.pack_start(self.subcriterion, True, True, 0)
         self.reorder_child(self.subcriterion, 1)
 
         # Notify the search window about the change
@@ -739,7 +739,7 @@ class SimpleSubcriterion(Subcriterion):
             self.entry.set_text(self.argument)
 
     def _pack_widgets(self):
-        self.pack_start(self.entry, True)
+        self.pack_start(self.entry, True, True, 0)
 
     def _connect_widgets(self):
         self.entry.connect("changed", self.entry_changed)
@@ -777,9 +777,9 @@ class PortSubcriterion(Subcriterion):
                 states.index(self.operator.replace("_", "|")))
 
     def _pack_widgets(self):
-        self.pack_start(self.entry, True)
-        self.pack_start(self.label, False)
-        self.pack_start(self.port_state_combo, False)
+        self.pack_start(self.entry, True, True, 0)
+        self.pack_start(self.label, False, True, 0)
+        self.pack_start(self.port_state_combo, False, True, 0)
 
     def _connect_widgets(self):
         self.entry.connect("changed", self.entry_changed)
@@ -812,8 +812,8 @@ class DirSubcriterion(Subcriterion):
         self.chooser_btn = HIGButton("Choose...", Gtk.STOCK_OPEN)
 
     def _pack_widgets(self):
-        self.pack_start(self.dir_entry, True)
-        self.pack_start(self.chooser_btn, False)
+        self.pack_start(self.dir_entry, True, True, 0)
+        self.pack_start(self.chooser_btn, False, True, 0)
 
     def _connect_widgets(self):
         self.chooser_btn.connect("clicked", self.choose_clicked)
@@ -886,8 +886,8 @@ class DateSubcriterion(Subcriterion):
         self.date_button = HIGButton()
 
     def _pack_widgets(self):
-        self.pack_start(self.date_criterion_combo, False)
-        self.pack_start(self.date_button, True)
+        self.pack_start(self.date_criterion_combo, False, True, 0)
+        self.pack_start(self.date_button, True, True, 0)
 
     def _connect_widgets(self):
         self.date_criterion_combo.connect(

--- a/zenmap/zenmapGUI/SearchGUI.py
+++ b/zenmap/zenmapGUI/SearchGUI.py
@@ -433,7 +433,7 @@ class SearchGUI(Gtk.VBox, object):
             # The Expressions GUI is about to be hidden. No updates to the
             # search entry field are necessary, since it gets updated on every
             # change in one of the criterion rows.
-            self.expr_vbox.hide_all()
+            self.expr_vbox.hide()
             self.search_entry.set_sensitive(True)
 
     def close(self):

--- a/zenmap/zenmapGUI/SearchGUI.py
+++ b/zenmap/zenmapGUI/SearchGUI.py
@@ -126,7 +126,11 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
 import re
 import copy
 
@@ -208,12 +212,12 @@ class SearchParser(object):
         self.search_gui.init_search_dirs(self.search_dict.pop("dir", []))
 
 
-class SearchGUI(gtk.VBox, object):
+class SearchGUI(Gtk.VBox, object):
     """This class is a VBox that holds the search entry field and buttons on
     top, and the results list on the bottom. The "Cancel" and "Open" buttons
     are a part of the SearchWindow class, not SearchGUI."""
     def __init__(self, search_window):
-        gtk.VBox.__init__(self)
+        Gtk.VBox.__init__(self)
 
         self._create_widgets()
         self._pack_widgets()
@@ -236,7 +240,7 @@ class SearchGUI(gtk.VBox, object):
         if self.options["search_db"]:
             try:
                 self.search_db = SearchDB()
-            except ImportError, e:
+            except ImportError as e:
                 self.search_db = SearchDummy()
                 self.no_db_warning.show()
                 self.no_db_warning.set_text(
@@ -318,25 +322,25 @@ class SearchGUI(gtk.VBox, object):
         # Search box and buttons
         self.search_top_hbox = HIGHBox()
         self.search_label = HIGSectionLabel(_("Search:"))
-        self.search_entry = gtk.Entry()
+        self.search_entry = Gtk.Entry()
         self.expressions_btn = HIGToggleButton(
-                _("Expressions "), gtk.STOCK_EDIT)
+                _("Expressions "), Gtk.STOCK_EDIT)
 
         # The quick reference tooltip button
-        self.search_tooltip_btn = HIGButton(" ", gtk.STOCK_INFO)
+        self.search_tooltip_btn = HIGButton(" ", Gtk.STOCK_INFO)
 
         # The expression VBox. This is only visible once the user clicks on
         # "Expressions"
-        self.expr_vbox = gtk.VBox()
+        self.expr_vbox = Gtk.VBox()
 
         # Results section
-        self.result_list = gtk.ListStore(str, str, int)  # title, date, id
-        self.result_view = gtk.TreeView(self.result_list)
-        self.result_scrolled = gtk.ScrolledWindow()
-        self.result_title_column = gtk.TreeViewColumn(_("Scan"))
-        self.result_date_column = gtk.TreeViewColumn(_("Date"))
+        self.result_list = Gtk.ListStore(str, str, int)  # title, date, id
+        self.result_view = Gtk.TreeView(self.result_list)
+        self.result_scrolled = Gtk.ScrolledWindow()
+        self.result_title_column = Gtk.TreeViewColumn(_("Scan"))
+        self.result_date_column = Gtk.TreeViewColumn(_("Date"))
 
-        self.no_db_warning = gtk.Label()
+        self.no_db_warning = Gtk.Label()
         self.no_db_warning.set_line_wrap(True)
         self.no_db_warning.set_no_show_all(True)
 
@@ -357,7 +361,7 @@ class SearchGUI(gtk.VBox, object):
         # Packing the result section
         self.result_scrolled.add(self.result_view)
         self.result_scrolled.set_policy(
-                gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
+                Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
 
         # Packing it all together
         self.set_spacing(4)
@@ -404,7 +408,7 @@ class SearchGUI(gtk.VBox, object):
             # We compare the search entry field to the Expressions GUI. Every
             # (operator, value) pair must be present in the GUI after this loop
             # is done.
-            for op, args in self.search_dict.iteritems():
+            for op, args in self.search_dict.items():
                 for arg in args:
                     if (op not in gui_ops) or (arg not in gui_ops[op]):
                         # We need to add this pair to the GUI
@@ -499,7 +503,7 @@ class SearchGUI(gtk.VBox, object):
                 self.append_result(result)
                 matched += 1
 
-        for search_dir in self.search_dirs.itervalues():
+        for search_dir in self.search_dirs.values():
             total += len(search_dir.get_scan_results())
             for result in search_dir.search(**self.search_dict):
                 self.append_result(result)
@@ -549,7 +553,7 @@ class SearchGUI(gtk.VBox, object):
         self.result_view.set_search_column(0)
 
         selection = self.result_view.get_selection()
-        selection.set_mode(gtk.SELECTION_MULTIPLE)
+        selection.set_mode(Gtk.SelectionMode.MULTIPLE)
 
         self.result_view.append_column(self.result_title_column)
         self.result_view.append_column(self.result_date_column)
@@ -564,7 +568,7 @@ class SearchGUI(gtk.VBox, object):
         self.result_title_column.set_reorderable(True)
         self.result_date_column.set_reorderable(True)
 
-        cell = gtk.CellRendererText()
+        cell = Gtk.CellRendererText()
 
         self.result_title_column.pack_start(cell, True)
         self.result_date_column.pack_start(cell, True)
@@ -575,7 +579,7 @@ class SearchGUI(gtk.VBox, object):
     selected_results = property(get_selected_results)
 
 
-class Criterion(gtk.HBox):
+class Criterion(Gtk.HBox):
     """This class holds one criterion row, represented as an HBox.  It holds a
     ComboBox and a Subcriterion's subclass instance, depending on the selected
     entry in the ComboBox. For example, when the 'Target' option is selected, a
@@ -585,7 +589,7 @@ class Criterion(gtk.HBox):
     def __init__(self, search_window, operator="keyword", argument=""):
         """A reference to the search window is passed so that we can call
         add_criterion and remove_criterion."""
-        gtk.HBox.__init__(self)
+        Gtk.HBox.__init__(self)
 
         self.search_window = search_window
         self.default_operator = operator
@@ -612,17 +616,17 @@ class Criterion(gtk.HBox):
 
     def _create_widgets(self):
         # A ComboBox containing the list of operators
-        self.operator_combo = gtk.combo_box_new_text()
+        self.operator_combo = Gtk.ComboBoxText()
 
         # Sort all the keys from combo_entries and make an entry for each of
         # them
-        sorted_entries = self.combo_entries.keys()
+        sorted_entries = list(self.combo_entries.keys())
         sorted_entries.sort()
         for name in sorted_entries:
             self.operator_combo.append_text(name)
 
         # Select the default operator
-        for entry, operators in self.combo_entries.iteritems():
+        for entry, operators in self.combo_entries.items():
             for operator in operators:
                 if operator == self.default_operator:
                     self.operator_combo.set_active(sorted_entries.index(entry))
@@ -633,8 +637,8 @@ class Criterion(gtk.HBox):
                 self.default_operator, self.default_argument)
 
         # The "add" and "remove" buttons
-        self.add_btn = HIGButton(" ", gtk.STOCK_ADD)
-        self.remove_btn = HIGButton(" ", gtk.STOCK_REMOVE)
+        self.add_btn = HIGButton(" ", Gtk.STOCK_ADD)
+        self.remove_btn = HIGButton(" ", Gtk.STOCK_REMOVE)
 
     def _pack_widgets(self):
         self.pack_start(self.operator_combo, False)
@@ -700,12 +704,12 @@ class Criterion(gtk.HBox):
     argument = property(get_argument)
 
 
-class Subcriterion(gtk.HBox):
+class Subcriterion(Gtk.HBox):
     """This class is a base class for all subcriterion types. Depending on the
     criterion selected in the Criterion's ComboBox, a subclass of Subcriterion
     is created to display the appropriate GUI."""
     def __init__(self):
-        gtk.HBox.__init__(self)
+        Gtk.HBox.__init__(self)
 
         self.operator = ""
         self.argument = ""
@@ -730,7 +734,7 @@ class SimpleSubcriterion(Subcriterion):
         self._connect_widgets()
 
     def _create_widgets(self):
-        self.entry = gtk.Entry()
+        self.entry = Gtk.Entry()
         if self.argument:
             self.entry.set_text(self.argument)
 
@@ -758,13 +762,13 @@ class PortSubcriterion(Subcriterion):
         self._connect_widgets()
 
     def _create_widgets(self):
-        self.entry = gtk.Entry()
+        self.entry = Gtk.Entry()
         if self.argument:
             self.entry.set_text(self.argument)
 
-        self.label = gtk.Label("  is  ")
+        self.label = Gtk.Label("  is  ")
 
-        self.port_state_combo = gtk.combo_box_new_text()
+        self.port_state_combo = Gtk.ComboBoxText()
         states = ["open", "scanned", "closed", "filtered", "unfiltered",
                 "open|filtered", "closed|filtered"]
         for state in states:
@@ -802,10 +806,10 @@ class DirSubcriterion(Subcriterion):
         self._connect_widgets()
 
     def _create_widgets(self):
-        self.dir_entry = gtk.Entry()
+        self.dir_entry = Gtk.Entry()
         if self.argument:
             self.dir_entry.set_text(self.argument)
-        self.chooser_btn = HIGButton("Choose...", gtk.STOCK_OPEN)
+        self.chooser_btn = HIGButton("Choose...", Gtk.STOCK_OPEN)
 
     def _pack_widgets(self):
         self.pack_start(self.dir_entry, True)
@@ -819,7 +823,7 @@ class DirSubcriterion(Subcriterion):
         # Display a directory chooser dialog
         chooser_dlg = DirectoryChooserDialog("Include folder in search")
 
-        if chooser_dlg.run() == gtk.RESPONSE_OK:
+        if chooser_dlg.run() == Gtk.ResponseType.OK:
             self.dir_entry.set_text(chooser_dlg.get_filename())
 
         chooser_dlg.destroy()
@@ -869,7 +873,7 @@ class DateSubcriterion(Subcriterion):
         self.argument += "~" * self.fuzzies
 
     def _create_widgets(self):
-        self.date_criterion_combo = gtk.combo_box_new_text()
+        self.date_criterion_combo = Gtk.ComboBoxText()
         self.date_criterion_combo.append_text("is")
         self.date_criterion_combo.append_text("after")
         self.date_criterion_combo.append_text("before")
@@ -903,7 +907,7 @@ class DateSubcriterion(Subcriterion):
 
     def update_button(self, widget):
         cal_date = widget.get_date()
-        # Add 1 to month because gtk.Calendar date is zero-based.
+        # Add 1 to month because Gtk.Calendar date is zero-based.
         self.date = datetime.date(cal_date[0], cal_date[1] + 1, cal_date[2])
 
         # Set the argument, using the search format
@@ -934,12 +938,12 @@ class DateSubcriterion(Subcriterion):
     _date = datetime.date.today()
 
 
-class DateCalendar(gtk.Window, object):
+class DateCalendar(Gtk.Window, object):
     def __init__(self):
-        gtk.Window.__init__(self, gtk.WINDOW_POPUP)
-        self.set_position(gtk.WIN_POS_MOUSE)
+        Gtk.Window.__init__(self, Gtk.WindowType.POPUP)
+        self.set_position(Gtk.WindowPosition.MOUSE)
 
-        self.calendar = gtk.Calendar()
+        self.calendar = Gtk.Calendar()
         self.add(self.calendar)
 
     def connect_calendar(self, update_button_cb):

--- a/zenmap/zenmapGUI/SearchGUI.py
+++ b/zenmap/zenmapGUI/SearchGUI.py
@@ -520,7 +520,7 @@ class SearchGUI(Gtk.VBox, object):
 
     def clear_result_list(self):
         for i in range(len(self.result_list)):
-            iter = self.result_list.get_iter_root()
+            iter = self.result_list.get_iter_first()
             del(self.result_list[iter])
 
     def append_result(self, parsed_result):
@@ -570,8 +570,8 @@ class SearchGUI(Gtk.VBox, object):
 
         cell = Gtk.CellRendererText()
 
-        self.result_title_column.pack_start(cell, True, True, 0)
-        self.result_date_column.pack_start(cell, True, True, 0)
+        self.result_title_column.pack_start(cell, True)
+        self.result_date_column.pack_start(cell, True)
 
         self.result_title_column.set_attributes(cell, text=0)
         self.result_date_column.set_attributes(cell, text=1)

--- a/zenmap/zenmapGUI/SearchWindow.py
+++ b/zenmap/zenmapGUI/SearchWindow.py
@@ -162,7 +162,7 @@ else:
             self.vbox.set_border_width(4)
 
 
-class SearchWindow(BaseSearchWindow, object):
+class SearchWindow(BaseSearchWindow):
     def __init__(self, load_method, append_method):
         BaseSearchWindow.__init__(self)
 
@@ -242,11 +242,9 @@ class SearchWindow(BaseSearchWindow, object):
         # Close Search Window
         self.close()
 
-    def get_results(self):
-        # Return list with parsed objects from result list store
+    @property
+    def results(self):
         return self.search_gui.selected_results
-
-    results = property(get_results)
 
 
 if __name__ == "__main__":

--- a/zenmap/zenmapGUI/SearchWindow.py
+++ b/zenmap/zenmapGUI/SearchWindow.py
@@ -126,7 +126,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 from zenmapGUI.SearchGUI import SearchGUI
 
@@ -149,11 +152,11 @@ if is_maemo():
         def _pack_widgets(self):
             pass
 else:
-    class BaseSearchWindow(gtk.Window):
+    class BaseSearchWindow(Gtk.Window):
         def __init__(self):
-            gtk.Window.__init__(self)
+            Gtk.Window.__init__(self)
             self.set_title(_("Search Scans"))
-            self.set_position(gtk.WIN_POS_CENTER)
+            self.set_position(Gtk.WindowPosition.CENTER)
 
         def _pack_widgets(self):
             self.vbox.set_border_width(4)
@@ -175,19 +178,19 @@ class SearchWindow(BaseSearchWindow, object):
     def _create_widgets(self):
         self.vbox = HIGVBox()
 
-        self.bottom_hbox = gtk.HBox()
-        self.bottom_label = gtk.Label()
-        self.btn_box = gtk.HButtonBox()
-        self.btn_open = HIGButton(stock=gtk.STOCK_OPEN)
-        self.btn_append = HIGButton(_("Append"), gtk.STOCK_ADD)
-        self.btn_close = HIGButton(stock=gtk.STOCK_CLOSE)
+        self.bottom_hbox = Gtk.HBox()
+        self.bottom_label = Gtk.Label()
+        self.btn_box = Gtk.HButtonBox()
+        self.btn_open = HIGButton(stock=Gtk.STOCK_OPEN)
+        self.btn_append = HIGButton(_("Append"), Gtk.STOCK_ADD)
+        self.btn_close = HIGButton(stock=Gtk.STOCK_CLOSE)
 
         self.search_gui = SearchGUI(self)
 
     def _pack_widgets(self):
         BaseSearchWindow._pack_widgets(self)
 
-        self.btn_box.set_layout(gtk.BUTTONBOX_END)
+        self.btn_box.set_layout(Gtk.ButtonBoxStyle.END)
         self.btn_box.set_spacing(4)
         self.btn_box.pack_start(self.btn_close)
         self.btn_box.pack_start(self.btn_append)
@@ -247,6 +250,6 @@ class SearchWindow(BaseSearchWindow, object):
 
 
 if __name__ == "__main__":
-    search = SearchWindow(lambda x: gtk.main_quit(), lambda x: gtk.main_quit())
+    search = SearchWindow(lambda x: Gtk.main_quit(), lambda x: Gtk.main_quit())
     search.show_all()
-    gtk.main()
+    Gtk.main()

--- a/zenmap/zenmapGUI/SearchWindow.py
+++ b/zenmap/zenmapGUI/SearchWindow.py
@@ -192,20 +192,20 @@ class SearchWindow(BaseSearchWindow, object):
 
         self.btn_box.set_layout(Gtk.ButtonBoxStyle.END)
         self.btn_box.set_spacing(4)
-        self.btn_box.pack_start(self.btn_close)
-        self.btn_box.pack_start(self.btn_append)
-        self.btn_box.pack_start(self.btn_open)
+        self.btn_box.pack_start(self.btn_close, True, True, 0)
+        self.btn_box.pack_start(self.btn_append, True, True, 0)
+        self.btn_box.pack_start(self.btn_open, True, True, 0)
 
         self.bottom_label.set_alignment(0.0, 0.5)
         self.bottom_label.set_use_markup(True)
 
         self.bottom_hbox.set_spacing(4)
-        self.bottom_hbox.pack_start(self.bottom_label, True)
-        self.bottom_hbox.pack_start(self.btn_box, False)
+        self.bottom_hbox.pack_start(self.bottom_label, True, True, 0)
+        self.bottom_hbox.pack_start(self.btn_box, False, True, 0)
 
         self.vbox.set_spacing(4)
-        self.vbox.pack_start(self.search_gui, True, True)
-        self.vbox.pack_start(self.bottom_hbox, False)
+        self.vbox.pack_start(self.search_gui, True, True, 0)
+        self.vbox.pack_start(self.bottom_hbox, False, True, 0)
 
         self.add(self.vbox)
 

--- a/zenmap/zenmapGUI/TargetCombo.py
+++ b/zenmap/zenmapGUI/TargetCombo.py
@@ -134,9 +134,9 @@ from gi.repository import Gtk
 from zenmapCore.TargetList import target_list
 
 
-class TargetCombo(Gtk.ComboBox):
+class TargetCombo(Gtk.ComboBoxText):
     def __init__(self):
-        Gtk.ComboBox.__init__(self, model=Gtk.ListStore(str), has_entry=True)
+        Gtk.ComboBoxText.__init__(self, model=Gtk.ListStore(str), has_entry=True)
 
         self.completion = Gtk.EntryCompletion()
         self.get_child().set_completion(self.completion)
@@ -171,6 +171,7 @@ if __name__ == "__main__":
     w = Gtk.Window()
     t = TargetCombo()
     w.add(t)
-    w.show_all()
 
+    w.connect("delete-event", lambda x, y: Gtk.main_quit())
+    w.show_all()
     Gtk.main()

--- a/zenmap/zenmapGUI/TargetCombo.py
+++ b/zenmap/zenmapGUI/TargetCombo.py
@@ -136,7 +136,7 @@ from zenmapCore.TargetList import target_list
 
 class TargetCombo(Gtk.ComboBoxText):
     def __init__(self):
-        Gtk.ComboBoxText.__init__(self, model=Gtk.ListStore(str), has_entry=True)
+        Gtk.ComboBoxText.__init__(self, has_entry=True)
 
         self.completion = Gtk.EntryCompletion()
         self.get_child().set_completion(self.completion)
@@ -146,26 +146,23 @@ class TargetCombo(Gtk.ComboBoxText):
         self.update()
 
     def update(self):
-        t_model = self.get_model()
-        for i in range(len(t_model)):
-            iter = t_model.get_iter_first()
-            del(t_model[iter])
+        self.remove_all()
 
         t_list = target_list.get_target_list()
         for target in t_list[:15]:
-            t_model.append([target.replace('\n', '')])
+            self.append_text(target.replace('\n', ''))
 
     def add_new_target(self, target):
         target_list.add_target(target)
         self.update()
 
-    def get_selected_target(self):
+    @property
+    def selected_target(self):
         return self.get_child().get_text()
 
-    def set_selected_target(self, target):
+    @selected_target.setter
+    def selected_target(self, target):
         self.get_child().set_text(target)
-
-    selected_target = property(get_selected_target, set_selected_target)
 
 if __name__ == "__main__":
     w = Gtk.Window()

--- a/zenmap/zenmapGUI/TargetCombo.py
+++ b/zenmap/zenmapGUI/TargetCombo.py
@@ -126,16 +126,19 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 from zenmapCore.TargetList import target_list
 
 
-class TargetCombo(gtk.ComboBoxEntry):
+class TargetCombo(Gtk.ComboBox):
     def __init__(self):
-        gtk.ComboBoxEntry.__init__(self, gtk.ListStore(str), 0)
+        Gtk.ComboBox.__init__(self, Gtk.ListStore(str), 0, has_entry=True)
 
-        self.completion = gtk.EntryCompletion()
+        self.completion = Gtk.EntryCompletion()
         self.child.set_completion(self.completion)
         self.completion.set_model(self.get_model())
         self.completion.set_text_column(0)
@@ -165,9 +168,9 @@ class TargetCombo(gtk.ComboBoxEntry):
     selected_target = property(get_selected_target, set_selected_target)
 
 if __name__ == "__main__":
-    w = gtk.Window()
+    w = Gtk.Window()
     t = TargetCombo()
     w.add(t)
     w.show_all()
 
-    gtk.main()
+    Gtk.main()

--- a/zenmap/zenmapGUI/TargetCombo.py
+++ b/zenmap/zenmapGUI/TargetCombo.py
@@ -136,10 +136,10 @@ from zenmapCore.TargetList import target_list
 
 class TargetCombo(Gtk.ComboBox):
     def __init__(self):
-        Gtk.ComboBox.__init__(self, Gtk.ListStore(str), 0, has_entry=True)
+        Gtk.ComboBox.__init__(self, model=Gtk.ListStore(str), has_entry=True)
 
         self.completion = Gtk.EntryCompletion()
-        self.child.set_completion(self.completion)
+        self.get_child().set_completion(self.completion)
         self.completion.set_model(self.get_model())
         self.completion.set_text_column(0)
 
@@ -148,7 +148,7 @@ class TargetCombo(Gtk.ComboBox):
     def update(self):
         t_model = self.get_model()
         for i in range(len(t_model)):
-            iter = t_model.get_iter_root()
+            iter = t_model.get_iter_first()
             del(t_model[iter])
 
         t_list = target_list.get_target_list()
@@ -160,10 +160,10 @@ class TargetCombo(Gtk.ComboBox):
         self.update()
 
     def get_selected_target(self):
-        return self.child.get_text()
+        return self.get_child().get_text()
 
     def set_selected_target(self, target):
-        self.child.set_text(target)
+        self.get_child().set_text(target)
 
     selected_target = property(get_selected_target, set_selected_target)
 

--- a/zenmap/zenmapGUI/TopologyPage.py
+++ b/zenmap/zenmapGUI/TopologyPage.py
@@ -126,7 +126,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 from zenmapGUI.higwidgets.higboxes import HIGVBox
 
@@ -152,9 +155,9 @@ class TopologyPage(HIGVBox):
         self._pack_widgets()
 
     def _create_widgets(self):
-        self.rn_hbox = gtk.HBox()
+        self.rn_hbox = Gtk.HBox()
         self.rn_hbox.set_spacing(4)
-        self.rn_vbox = gtk.VBox()
+        self.rn_vbox = Gtk.VBox()
 
         # RadialNet's widgets
         self.radialnet = RadialNet.RadialNet(RadialNet.LAYOUT_WEIGHTED)
@@ -170,9 +173,9 @@ class TopologyPage(HIGVBox):
         self.radialnet.set_no_show_all(True)
 
         self.slow_vbox = HIGVBox()
-        self.slow_label = gtk.Label()
+        self.slow_label = Gtk.Label()
         self.slow_vbox.pack_start(self.slow_label, False, False)
-        show_button = gtk.Button(_("Show the topology anyway"))
+        show_button = Gtk.Button(_("Show the topology anyway"))
         show_button.connect("clicked", self.show_anyway)
         self.slow_vbox.pack_start(show_button, False, False)
         self.slow_vbox.show_all()

--- a/zenmap/zenmapGUI/TopologyPage.py
+++ b/zenmap/zenmapGUI/TopologyPage.py
@@ -174,10 +174,10 @@ class TopologyPage(HIGVBox):
 
         self.slow_vbox = HIGVBox()
         self.slow_label = Gtk.Label()
-        self.slow_vbox.pack_start(self.slow_label, False, False)
+        self.slow_vbox.pack_start(self.slow_label, False, False, 0)
         show_button = Gtk.Button(_("Show the topology anyway"))
         show_button.connect("clicked", self.show_anyway)
-        self.slow_vbox.pack_start(show_button, False, False)
+        self.slow_vbox.pack_start(show_button, False, False, 0)
         self.slow_vbox.show_all()
         self.slow_vbox.set_no_show_all(True)
         self.slow_vbox.hide()
@@ -185,17 +185,17 @@ class TopologyPage(HIGVBox):
         self.radialnet.show()
 
     def _pack_widgets(self):
-        self.rn_hbox.pack_start(self.display_panel, True, True)
-        self.rn_hbox.pack_start(self.control, False)
+        self.rn_hbox.pack_start(self.display_panel, True, True, 0)
+        self.rn_hbox.pack_start(self.control, False, True, 0)
 
-        self.rn_vbox.pack_start(self.rn_hbox, True, True)
-        self.rn_vbox.pack_start(self.fisheye, False)
+        self.rn_vbox.pack_start(self.rn_hbox, True, True, 0)
+        self.rn_vbox.pack_start(self.fisheye, False, True, 0)
 
-        self.pack_start(self.rn_toolbar, False, False)
-        self.pack_start(self.rn_vbox, True, True)
+        self.pack_start(self.rn_toolbar, False, False, 0)
+        self.pack_start(self.rn_vbox, True, True, 0)
 
-        self.display_panel.pack_start(self.slow_vbox, True, False)
-        self.display_panel.pack_start(self.radialnet, True, True)
+        self.display_panel.pack_start(self.slow_vbox, True, False, 0)
+        self.display_panel.pack_start(self.radialnet, True, True, 0)
 
     def add_scan(self, scan):
         """Parses a given XML file and adds the parsed result to the network

--- a/zenmap/zenmapGUI/higwidgets/__init__.py
+++ b/zenmap/zenmapGUI/higwidgets/__init__.py
@@ -136,17 +136,17 @@ This is mostly implemented by subclassing from the GTK classes, and
 providing defaults that better match the HIG specifications/recommendations.
 """
 
-from gtkutils import *
-from higboxes import *
-from higbuttons import *
-from higdialogs import *
-from higentries import *
-from higexpanders import *
-from higlabels import *
-from higlogindialogs import *
-from higprogressbars import *
-from higscrollers import *
-from higspinner import *
-from higtables import *
-from higtextviewers import *
-from higwindows import *
+from .gtkutils import *
+from .higboxes import *
+from .higbuttons import *
+from .higdialogs import *
+from .higentries import *
+from .higexpanders import *
+from .higlabels import *
+from .higlogindialogs import *
+from .higprogressbars import *
+from .higscrollers import *
+from .higspinner import *
+from .higtables import *
+from .higtextviewers import *
+from .higwindows import *

--- a/zenmap/zenmapGUI/higwidgets/gtkutils.py
+++ b/zenmap/zenmapGUI/higwidgets/gtkutils.py
@@ -135,29 +135,31 @@ higwidgets/gtkutils.py
 __all__ = ['gtk_version_major', 'gtk_version_minor', 'gtk_version_release',
            'gtk_constant_name', 'gobject_register']
 
-import gtk
-import gobject
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 # version information
-gtk_version_major, gtk_version_minor, gtk_version_release = gtk.gtk_version
-assert gtk_version_major == 2
+gtk_version_major, gtk_version_minor, gtk_version_release = gi.version_info
+assert gtk_version_major == 3
 
 
 def gtk_constant_name(group, value):
     """
     Returns the (py)GTK+ name of a constant, given its group name
     """
-    group_response = {-1: 'gtk.RESPONSE_NONE',
-                      -2: 'gtk.RESPONSE_REJECT',
-                      -3: 'gtk.RESPONSE_ACCEPT',
-                      -4: 'gtk.RESPONSE_DELETE_EVENT',
-                      -5: 'gtk.RESPONSE_OK',
-                      -6: 'gtk.RESPONSE_CANCEL',
-                      -7: 'gtk.RESPONSE_CLOSE',
-                      -8: 'gtk.RESPONSE_YES',
-                      -9: 'gtk.RESPONSE_NO',
-                      -10: 'gtk.RESPONSE_APPLY',
-                      -11: 'gtk.RESPONSE_HELP'}
+    group_response = {-1: 'Gtk.ResponseType.NONE',
+                      -2: 'Gtk.ResponseType.REJECT',
+                      -3: 'Gtk.ResponseType.ACCEPT',
+                      -4: 'Gtk.ResponseType.DELETE_EVENT',
+                      -5: 'Gtk.ResponseType.OK',
+                      -6: 'Gtk.ResponseType.CANCEL',
+                      -7: 'Gtk.ResponseType.CLOSE',
+                      -8: 'Gtk.ResponseType.YES',
+                      -9: 'Gtk.ResponseType.NO',
+                      -10: 'Gtk.ResponseType.APPLY',
+                      -11: 'Gtk.ResponseType.HELP'}
 
     groups = {'response': group_response}
 
@@ -168,8 +170,7 @@ def gobject_register(klass):
     """
     Register a given object by calling gobject.type_register.
 
-    Actually gobject.type_register is only called if the pygtk version in use
-    is not 2.8 at least.
+    This is no longer being used:
+    https://wiki.gnome.org/Projects/PyGTK/WhatsNew28
     """
-    if gtk_version_minor < 8:
-        gobject.type_register(klass)
+    pass

--- a/zenmap/zenmapGUI/higwidgets/higboxes.py
+++ b/zenmap/zenmapGUI/higwidgets/higboxes.py
@@ -142,10 +142,10 @@ from gi.repository import Gtk
 
 class HIGBox(Gtk.Box):
     def _pack_noexpand_nofill(self, widget):
-        self.pack_start(widget, expand=False, fill=False)
+        self.pack_start(widget, False, False, 0)
 
     def _pack_expand_fill(self, widget):
-        self.pack_start(widget, expand=True, fill=True)
+        self.pack_start(widget, True, True, 0)
 
 
 class HIGHBox(Gtk.HBox, HIGBox):

--- a/zenmap/zenmapGUI/higwidgets/higboxes.py
+++ b/zenmap/zenmapGUI/higwidgets/higboxes.py
@@ -148,20 +148,18 @@ class HIGBox(Gtk.Box):
         self.pack_start(widget, True, True, 0)
 
 
-class HIGHBox(HIGBox):
+class HIGHBox(Gtk.HBox, HIGBox):
     def __init__(self, homogeneous=False, spacing=12):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, spacing=spacing)
-        self.set_homogeneous(homogeneous)
+        Gtk.HBox.__init__(self, homogeneous, spacing)
 
     pack_section_label = HIGBox._pack_noexpand_nofill
     pack_label = HIGBox._pack_noexpand_nofill
     pack_entry = HIGBox._pack_expand_fill
 
 
-class HIGVBox(HIGBox):
+class HIGVBox(Gtk.VBox, HIGBox):
     def __init__(self, homogeneous=False, spacing=12):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=spacing)
-        self.set_homogeneous(homogeneous)
+        Gtk.VBox.__init__(self, homogeneous, spacing)
 
     # Packs a widget as a line, so it doesn't expand vertically
     pack_line = HIGBox._pack_noexpand_nofill

--- a/zenmap/zenmapGUI/higwidgets/higboxes.py
+++ b/zenmap/zenmapGUI/higwidgets/higboxes.py
@@ -134,10 +134,13 @@ higwidgets/higboxes.py
 
 __all__ = ['HIGHBox', 'HIGVBox']
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 
-class HIGBox(gtk.Box):
+class HIGBox(Gtk.Box):
     def _pack_noexpand_nofill(self, widget):
         self.pack_start(widget, expand=False, fill=False)
 
@@ -145,18 +148,18 @@ class HIGBox(gtk.Box):
         self.pack_start(widget, expand=True, fill=True)
 
 
-class HIGHBox(gtk.HBox, HIGBox):
+class HIGHBox(Gtk.HBox, HIGBox):
     def __init__(self, homogeneous=False, spacing=12):
-        gtk.HBox.__init__(self, homogeneous, spacing)
+        Gtk.HBox.__init__(self, homogeneous, spacing)
 
     pack_section_label = HIGBox._pack_noexpand_nofill
     pack_label = HIGBox._pack_noexpand_nofill
     pack_entry = HIGBox._pack_expand_fill
 
 
-class HIGVBox(gtk.VBox, HIGBox):
+class HIGVBox(Gtk.VBox, HIGBox):
     def __init__(self, homogeneous=False, spacing=12):
-        gtk.VBox.__init__(self, homogeneous, spacing)
+        Gtk.VBox.__init__(self, homogeneous, spacing)
 
     # Packs a widget as a line, so it doesn't expand vertically
     pack_line = HIGBox._pack_noexpand_nofill
@@ -178,4 +181,4 @@ class HIGSpacer(HIGHBox):
 
 
 def hig_box_space_holder():
-    return gtk.Label("    ")
+    return Gtk.Label("    ")

--- a/zenmap/zenmapGUI/higwidgets/higboxes.py
+++ b/zenmap/zenmapGUI/higwidgets/higboxes.py
@@ -147,19 +147,26 @@ class HIGBox(Gtk.Box):
     def _pack_expand_fill(self, widget):
         self.pack_start(widget, True, True, 0)
 
+    def add(self, widget):
+        # Make default packing arguments same as before (Gtk.Box has expand
+        # set to False by default).
+        self.pack_start(widget, True, True, 0)
 
-class HIGHBox(Gtk.HBox, HIGBox):
+
+class HIGHBox(HIGBox):
     def __init__(self, homogeneous=False, spacing=12):
-        Gtk.HBox.__init__(self, homogeneous, spacing)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL,
+                         homogeneous=homogeneous, spacing=spacing)
 
     pack_section_label = HIGBox._pack_noexpand_nofill
     pack_label = HIGBox._pack_noexpand_nofill
     pack_entry = HIGBox._pack_expand_fill
 
 
-class HIGVBox(Gtk.VBox, HIGBox):
+class HIGVBox(HIGBox):
     def __init__(self, homogeneous=False, spacing=12):
-        Gtk.VBox.__init__(self, homogeneous, spacing)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL,
+                         homogeneous=homogeneous, spacing=spacing)
 
     # Packs a widget as a line, so it doesn't expand vertically
     pack_line = HIGBox._pack_noexpand_nofill

--- a/zenmap/zenmapGUI/higwidgets/higboxes.py
+++ b/zenmap/zenmapGUI/higwidgets/higboxes.py
@@ -181,4 +181,4 @@ class HIGSpacer(HIGHBox):
 
 
 def hig_box_space_holder():
-    return Gtk.Label("    ")
+    return Gtk.Label(label="    ")

--- a/zenmap/zenmapGUI/higwidgets/higboxes.py
+++ b/zenmap/zenmapGUI/higwidgets/higboxes.py
@@ -148,18 +148,20 @@ class HIGBox(Gtk.Box):
         self.pack_start(widget, True, True, 0)
 
 
-class HIGHBox(Gtk.HBox, HIGBox):
+class HIGHBox(HIGBox):
     def __init__(self, homogeneous=False, spacing=12):
-        Gtk.HBox.__init__(self, homogeneous, spacing)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, spacing=spacing)
+        self.set_homogeneous(homogeneous)
 
     pack_section_label = HIGBox._pack_noexpand_nofill
     pack_label = HIGBox._pack_noexpand_nofill
     pack_entry = HIGBox._pack_expand_fill
 
 
-class HIGVBox(Gtk.VBox, HIGBox):
+class HIGVBox(HIGBox):
     def __init__(self, homogeneous=False, spacing=12):
-        Gtk.VBox.__init__(self, homogeneous, spacing)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=spacing)
+        self.set_homogeneous(homogeneous)
 
     # Packs a widget as a line, so it doesn't expand vertically
     pack_line = HIGBox._pack_noexpand_nofill

--- a/zenmap/zenmapGUI/higwidgets/higbuttons.py
+++ b/zenmap/zenmapGUI/higwidgets/higbuttons.py
@@ -132,7 +132,7 @@ higwidgets/higbuttons.py
    button related classes
 """
 
-__all__ = ['HIGMixButton', 'HIGButton']
+__all__ = ['HIGButton', 'HIGToggleButton']
 
 import gi
 
@@ -140,15 +140,17 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 
-class HIGMixButton (Gtk.HBox):
+class HIGMixButton(Gtk.Box):
     def __init__(self, title, stock):
-        Gtk.HBox.__init__(self, False, 4)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL,
+                         homogeneous=False, spacing=4)
         self.img = Gtk.Image()
         self.img.set_from_stock(stock, Gtk.IconSize.BUTTON)
 
-        self.lbl = Gtk.Label(title)
+        self.lbl = Gtk.Label.new(title)
 
-        self.hbox1 = Gtk.HBox(False, 2)
+        self.hbox1 = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL,
+                             homogeneous=False, spacing=2)
         self.hbox1.pack_start(self.img, False, False, 0)
         self.hbox1.pack_start(self.lbl, False, False, 0)
 
@@ -157,14 +159,14 @@ class HIGMixButton (Gtk.HBox):
         self.pack_start(self.hbox1, True, True, 0)
 
 
-class HIGButton (Gtk.Button):
+class HIGButton(Gtk.Button):
     def __init__(self, title="", stock=None):
         if title and stock:
             Gtk.Button.__init__(self)
             content = HIGMixButton(title, stock)
             self.add(content)
         elif title and not stock:
-            Gtk.Button.__init__(self, title)
+            Gtk.Button.__init__(self, label=title)
         elif stock:
             Gtk.Button.__init__(self, stock=stock)
         else:
@@ -178,9 +180,9 @@ class HIGToggleButton(Gtk.ToggleButton):
             content = HIGMixButton(title, stock)
             self.add(content)
         elif title and not stock:
-            Gtk.ToggleButton.__init__(self, title)
+            Gtk.ToggleButton.__init__(self, label=title)
         elif stock:
-            Gtk.ToggleButton.__init__(self, stock)
+            Gtk.ToggleButton.__init__(self, stock=stock)
             self.set_use_stock(True)
         else:
             Gtk.ToggleButton.__init__(self)

--- a/zenmap/zenmapGUI/higwidgets/higbuttons.py
+++ b/zenmap/zenmapGUI/higwidgets/higbuttons.py
@@ -152,9 +152,9 @@ class HIGMixButton (Gtk.HBox):
         self.hbox1.pack_start(self.img, False, False, 0)
         self.hbox1.pack_start(self.lbl, False, False, 0)
 
-        self.align = Gtk.Alignment(0.5, 0.5, 0, 0)
-        self.pack_start(self.align)
-        self.pack_start(self.hbox1)
+        self.align = Gtk.Alignment.new(0.5, 0.5, 0, 0)
+        self.pack_start(self.align, True, True, 0)
+        self.pack_start(self.hbox1, True, True, 0)
 
 
 class HIGButton (Gtk.Button):

--- a/zenmap/zenmapGUI/higwidgets/higbuttons.py
+++ b/zenmap/zenmapGUI/higwidgets/higbuttons.py
@@ -134,50 +134,53 @@ higwidgets/higbuttons.py
 
 __all__ = ['HIGMixButton', 'HIGButton']
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 
-class HIGMixButton (gtk.HBox):
+class HIGMixButton (Gtk.HBox):
     def __init__(self, title, stock):
-        gtk.HBox.__init__(self, False, 4)
-        self.img = gtk.Image()
-        self.img.set_from_stock(stock, gtk.ICON_SIZE_BUTTON)
+        Gtk.HBox.__init__(self, False, 4)
+        self.img = Gtk.Image()
+        self.img.set_from_stock(stock, Gtk.IconSize.BUTTON)
 
-        self.lbl = gtk.Label(title)
+        self.lbl = Gtk.Label(title)
 
-        self.hbox1 = gtk.HBox(False, 2)
+        self.hbox1 = Gtk.HBox(False, 2)
         self.hbox1.pack_start(self.img, False, False, 0)
         self.hbox1.pack_start(self.lbl, False, False, 0)
 
-        self.align = gtk.Alignment(0.5, 0.5, 0, 0)
+        self.align = Gtk.Alignment(0.5, 0.5, 0, 0)
         self.pack_start(self.align)
         self.pack_start(self.hbox1)
 
 
-class HIGButton (gtk.Button):
+class HIGButton (Gtk.Button):
     def __init__(self, title="", stock=None):
         if title and stock:
-            gtk.Button.__init__(self)
+            Gtk.Button.__init__(self)
             content = HIGMixButton(title, stock)
             self.add(content)
         elif title and not stock:
-            gtk.Button.__init__(self, title)
+            Gtk.Button.__init__(self, title)
         elif stock:
-            gtk.Button.__init__(self, stock=stock)
+            Gtk.Button.__init__(self, stock=stock)
         else:
-            gtk.Button.__init__(self)
+            Gtk.Button.__init__(self)
 
 
-class HIGToggleButton(gtk.ToggleButton):
+class HIGToggleButton(Gtk.ToggleButton):
     def __init__(self, title="", stock=None):
         if title and stock:
-            gtk.ToggleButton.__init__(self)
+            Gtk.ToggleButton.__init__(self)
             content = HIGMixButton(title, stock)
             self.add(content)
         elif title and not stock:
-            gtk.ToggleButton.__init__(self, title)
+            Gtk.ToggleButton.__init__(self, title)
         elif stock:
-            gtk.ToggleButton.__init__(self, stock)
+            Gtk.ToggleButton.__init__(self, stock)
             self.set_use_stock(True)
         else:
-            gtk.ToggleButton.__init__(self)
+            Gtk.ToggleButton.__init__(self)

--- a/zenmap/zenmapGUI/higwidgets/higdialogs.py
+++ b/zenmap/zenmapGUI/higwidgets/higdialogs.py
@@ -145,10 +145,13 @@ class HIGDialog(Gtk.Dialog):
     HIGFied Dialog
     """
     def __init__(self, title='', parent=None, flags=0, buttons=()):
-        Gtk.Dialog.__init__(self, title, parent, flags, buttons)
+        Gtk.Dialog.__init__(self, title=title, parent=parent, flags=flags)
         self.set_border_width(5)
         self.vbox.set_border_width(2)
         self.vbox.set_spacing(6)
+
+        if buttons:
+            self.add_buttons(*buttons)
 
 
 class HIGAlertDialog(Gtk.MessageDialog):
@@ -167,7 +170,8 @@ class HIGAlertDialog(Gtk.MessageDialog):
                  message_format=None,
                  secondary_text=None):
 
-        Gtk.MessageDialog.__init__(self, parent, flags, type, buttons)
+        Gtk.MessageDialog.__init__(self, parent=parent, flags=flags,
+                                   message_type=type, buttons=buttons)
 
         self.set_resizable(False)
 
@@ -178,11 +182,7 @@ class HIGAlertDialog(Gtk.MessageDialog):
         self.set_markup(
                 "<span weight='bold'size='larger'>%s</span>" % message_format)
         if secondary_text:
-            # GTK up to version 2.4 does not have secondary_text
-            try:
-                self.format_secondary_text(secondary_text)
-            except Exception:
-                pass
+            self.format_secondary_text(secondary_text)
 
 
 if __name__ == '__main__':

--- a/zenmap/zenmapGUI/higwidgets/higdialogs.py
+++ b/zenmap/zenmapGUI/higwidgets/higdialogs.py
@@ -134,23 +134,24 @@ higwidgets/higdialogs.py
 
 __all__ = ['HIGDialog', 'HIGAlertDialog']
 
-import gtk
+import gi
 
-from gtkutils import gtk_version_minor
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 
-class HIGDialog(gtk.Dialog):
+class HIGDialog(Gtk.Dialog):
     """
     HIGFied Dialog
     """
     def __init__(self, title='', parent=None, flags=0, buttons=()):
-        gtk.Dialog.__init__(self, title, parent, flags, buttons)
+        Gtk.Dialog.__init__(self, title, parent, flags, buttons)
         self.set_border_width(5)
         self.vbox.set_border_width(2)
         self.vbox.set_spacing(6)
 
 
-class HIGAlertDialog(gtk.MessageDialog):
+class HIGAlertDialog(Gtk.MessageDialog):
     """
     HIGfied Alert Dialog.
 
@@ -158,15 +159,15 @@ class HIGAlertDialog(gtk.MessageDialog):
     http://developer.gnome.org/projects/gup/hig/2.0/windows-alert.html
     """
 
-    def __init__(self, parent=None, flags=0, type=gtk.MESSAGE_INFO,
+    def __init__(self, parent=None, flags=0, type=Gtk.MessageType.INFO,
                  # HIG mandates that every Alert should have an "affirmative
                  # button that dismisses the alert and performs the action
                  # suggested"
-                 buttons=gtk.BUTTONS_OK,
+                 buttons=Gtk.ButtonsType.OK,
                  message_format=None,
                  secondary_text=None):
 
-        gtk.MessageDialog.__init__(self, parent, flags, type, buttons)
+        Gtk.MessageDialog.__init__(self, parent, flags, type, buttons)
 
         self.set_resizable(False)
 
@@ -190,7 +191,7 @@ if __name__ == '__main__':
 
     # HIGDialog
     d = HIGDialog(title='HIGDialog',
-                  buttons=(gtk.STOCK_OK, gtk.RESPONSE_ACCEPT))
+                  buttons=(Gtk.ButtonsType.OK, Gtk.ResponseType.ACCEPT))
     dialog_label = HIGDialogLabel('A HIGDialogLabel on a HIGDialog')
     dialog_label.show()
     d.vbox.pack_start(dialog_label)

--- a/zenmap/zenmapGUI/higwidgets/higdialogs.py
+++ b/zenmap/zenmapGUI/higwidgets/higdialogs.py
@@ -194,11 +194,11 @@ if __name__ == '__main__':
                   buttons=(Gtk.ButtonsType.OK, Gtk.ResponseType.ACCEPT))
     dialog_label = HIGDialogLabel('A HIGDialogLabel on a HIGDialog')
     dialog_label.show()
-    d.vbox.pack_start(dialog_label)
+    d.vbox.pack_start(dialog_label, True, True, 0)
 
     entry_label = HIGEntryLabel('A HIGEntryLabel on a HIGDialog')
     entry_label.show()
-    d.vbox.pack_start(entry_label)
+    d.vbox.pack_start(entry_label, True, True, 0)
 
     d.run()
     d.destroy()

--- a/zenmap/zenmapGUI/higwidgets/higdialogs.py
+++ b/zenmap/zenmapGUI/higwidgets/higdialogs.py
@@ -191,7 +191,7 @@ if __name__ == '__main__':
 
     # HIGDialog
     d = HIGDialog(title='HIGDialog',
-                  buttons=(Gtk.ButtonsType.OK, Gtk.ResponseType.ACCEPT))
+                  buttons=(Gtk.STOCK_OK, Gtk.ResponseType.ACCEPT))
     dialog_label = HIGDialogLabel('A HIGDialogLabel on a HIGDialog')
     dialog_label.show()
     d.vbox.pack_start(dialog_label, True, True, 0)

--- a/zenmap/zenmapGUI/higwidgets/higentries.py
+++ b/zenmap/zenmapGUI/higwidgets/higentries.py
@@ -132,11 +132,14 @@ higwidgets/higentries.py
    entries related classes
 """
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 __all__ = ('HIGTextEntry', 'HIGPasswordEntry')
 
-HIGTextEntry = gtk.Entry
+HIGTextEntry = Gtk.Entry
 
 
 class HIGPasswordEntry(HIGTextEntry):

--- a/zenmap/zenmapGUI/higwidgets/higexpanders.py
+++ b/zenmap/zenmapGUI/higwidgets/higexpanders.py
@@ -134,14 +134,17 @@ higwidgets/higexpanders.py
 
 __all__ = ['HIGExpander']
 
-import gtk
+import gi
 
-from higboxes import HIGHBox, hig_box_space_holder
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
+from .higboxes import HIGHBox, hig_box_space_holder
 
 
-class HIGExpander(gtk.Expander):
+class HIGExpander(Gtk.Expander):
     def __init__(self, label):
-        gtk.Expander.__init__(self)
+        Gtk.Expander.__init__(self)
 
         self.set_use_markup(True)
         self.set_label(label)

--- a/zenmap/zenmapGUI/higwidgets/higframe.py
+++ b/zenmap/zenmapGUI/higwidgets/higframe.py
@@ -160,15 +160,15 @@ if __name__ == "__main__":
     w = Gtk.Window()
 
     hframe = HIGFrame("Sample HIGFrame")
-    aalign = Gtk.Alignment(0, 0, 0, 0)
+    aalign = Gtk.Alignment.new(0, 0, 0, 0)
     aalign.set_padding(12, 0, 24, 0)
     abox = Gtk.VBox()
     aalign.add(abox)
     hframe.add(aalign)
     w.add(hframe)
 
-    for i in xrange(5):
-        abox.pack_start(Gtk.Label("Sample %d" % i), False, False, 3)
+    for i in range(5):
+        abox.pack_start(Gtk.Label(label="Sample %d" % i), False, False, 3)
 
     w.connect('destroy', lambda d: Gtk.main_quit())
     w.show_all()

--- a/zenmap/zenmapGUI/higwidgets/higframe.py
+++ b/zenmap/zenmapGUI/higwidgets/higframe.py
@@ -134,18 +134,21 @@ higwidgets/higframe.py
 
 __all__ = ['HIGFrame']
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 
-class HIGFrame(gtk.Frame):
+class HIGFrame(Gtk.Frame):
     """
     Frame without border with bold label.
     """
     def __init__(self, label=None):
-        gtk.Frame.__init__(self)
+        Gtk.Frame.__init__(self)
 
-        self.set_shadow_type(gtk.SHADOW_NONE)
-        self._flabel = gtk.Label()
+        self.set_shadow_type(Gtk.ShadowType.NONE)
+        self._flabel = Gtk.Label()
         self._set_label(label)
         self.set_label_widget(self._flabel)
 
@@ -154,20 +157,20 @@ class HIGFrame(gtk.Frame):
 
 # Demo
 if __name__ == "__main__":
-    w = gtk.Window()
+    w = Gtk.Window()
 
     hframe = HIGFrame("Sample HIGFrame")
-    aalign = gtk.Alignment(0, 0, 0, 0)
+    aalign = Gtk.Alignment(0, 0, 0, 0)
     aalign.set_padding(12, 0, 24, 0)
-    abox = gtk.VBox()
+    abox = Gtk.VBox()
     aalign.add(abox)
     hframe.add(aalign)
     w.add(hframe)
 
     for i in xrange(5):
-        abox.pack_start(gtk.Label("Sample %d" % i), False, False, 3)
+        abox.pack_start(Gtk.Label("Sample %d" % i), False, False, 3)
 
-    w.connect('destroy', lambda d: gtk.main_quit())
+    w.connect('destroy', lambda d: Gtk.main_quit())
     w.show_all()
 
-    gtk.main()
+    Gtk.main()

--- a/zenmap/zenmapGUI/higwidgets/higlabels.py
+++ b/zenmap/zenmapGUI/higwidgets/higlabels.py
@@ -166,7 +166,7 @@ class HIGHintSectionLabel(Gtk.HBox, object):
         self.label = HIGSectionLabel(text)
         self.hint = Hint(hint)
 
-        self.pack_start(self.label, False, False)
+        self.pack_start(self.label, False, False, 0)
         self.pack_start(self.hint, False, False, 5)
 
 

--- a/zenmap/zenmapGUI/higwidgets/higlabels.py
+++ b/zenmap/zenmapGUI/higwidgets/higlabels.py
@@ -151,7 +151,8 @@ class HIGSectionLabel(Gtk.Label):
         if text:
             self.set_markup("<b>%s</b>" % (text))
             self.set_justify(Gtk.Justification.LEFT)
-            self.set_alignment(0, 0.50)
+            self.props.xalign = 0
+            self.props.yalign = 0.5
             self.set_line_wrap(True)
 
 
@@ -176,8 +177,8 @@ class Hint(Gtk.EventBox, object):
         self.hint = hint
 
         self.hint_image = Gtk.Image()
-        self.hint_image.set_from_stock(
-                Gtk.STOCK_DIALOG_INFO, Gtk.IconSize.SMALL_TOOLBAR)
+        self.hint_image.set_from_icon_name(
+                "dialog-information", Gtk.IconSize.SMALL_TOOLBAR)
 
         self.add(self.hint_image)
 
@@ -192,19 +193,23 @@ class HintWindow(Gtk.Window):
     def __init__(self, hint):
         Gtk.Window.__init__(self, type=Gtk.WindowType.POPUP)
         self.set_position(Gtk.WindowPosition.MOUSE)
-        bg_color = Gdk.color_parse("#fbff99")
+        self.set_resizable(False)
 
-        self.modify_bg(Gtk.StateType.NORMAL, bg_color)
+        bg_color = Gdk.RGBA()
+        bg_color.parse("#fbff99")
+        self.override_background_color(Gtk.StateFlags.NORMAL, bg_color)
 
         self.event = Gtk.EventBox()
-        self.event.modify_bg(Gtk.StateType.NORMAL, bg_color)
+        self.event.override_background_color(Gtk.StateFlags.NORMAL, bg_color)
         self.event.set_border_width(10)
         self.event.connect("button-press-event", self.close)
 
         self.hint_label = Gtk.Label(label=hint)
         self.hint_label.set_use_markup(True)
         self.hint_label.set_line_wrap(True)
-        self.hint_label.set_alignment(0.0, 0.5)
+        self.hint_label.set_max_width_chars(52)
+        self.hint_label.props.xalign = 0
+        self.hint_label.props.yalign = 0.5
 
         self.event.add(self.hint_label)
         self.add(self.event)
@@ -218,9 +223,10 @@ class HIGEntryLabel(Gtk.Label):
     Simple label, like the ones used to label entries
     """
     def __init__(self, text=None):
-        Gtk.Label.__init__(self, text)
+        Gtk.Label.__init__(self, label=text)
         self.set_justify(Gtk.Justification.LEFT)
-        self.set_alignment(0, 0.50)
+        self.props.xalign = 0
+        self.props.yalign = 0.5
         self.set_use_markup(True)
         self.set_line_wrap(True)
 
@@ -230,7 +236,7 @@ class HIGDialogLabel(Gtk.Label):
     Centered, line-wrappable label, usually used on dialogs.
     """
     def __init__(self, text=None):
-        Gtk.Label.__init__(self, text)
+        Gtk.Label.__init__(self, label=text)
         self.set_justify(Gtk.Justification.CENTER)
         self.set_use_markup(True)
         self.set_line_wrap(True)

--- a/zenmap/zenmapGUI/higwidgets/higlabels.py
+++ b/zenmap/zenmapGUI/higwidgets/higlabels.py
@@ -190,7 +190,7 @@ class Hint(Gtk.EventBox, object):
 
 class HintWindow(Gtk.Window):
     def __init__(self, hint):
-        Gtk.Window.__init__(self, Gtk.WindowType.POPUP)
+        Gtk.Window.__init__(self, type=Gtk.WindowType.POPUP)
         self.set_position(Gtk.WindowPosition.MOUSE)
         bg_color = Gdk.color_parse("#fbff99")
 
@@ -201,7 +201,7 @@ class HintWindow(Gtk.Window):
         self.event.set_border_width(10)
         self.event.connect("button-press-event", self.close)
 
-        self.hint_label = Gtk.Label(hint)
+        self.hint_label = Gtk.Label(label=hint)
         self.hint_label.set_use_markup(True)
         self.hint_label.set_line_wrap(True)
         self.hint_label.set_alignment(0.0, 0.5)

--- a/zenmap/zenmapGUI/higwidgets/higlabels.py
+++ b/zenmap/zenmapGUI/higwidgets/higlabels.py
@@ -136,29 +136,32 @@ __all__ = [
     'HIGSectionLabel', 'HIGHintSectionLabel', 'HIGEntryLabel', 'HIGDialogLabel'
     ]
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Gdk
 
 
-class HIGSectionLabel(gtk.Label):
+class HIGSectionLabel(Gtk.Label):
     """
     Bold label, used to define sections
     """
     def __init__(self, text=None):
-        gtk.Label.__init__(self)
+        Gtk.Label.__init__(self)
         if text:
             self.set_markup("<b>%s</b>" % (text))
-            self.set_justify(gtk.JUSTIFY_LEFT)
+            self.set_justify(Gtk.Justification.LEFT)
             self.set_alignment(0, 0.50)
             self.set_line_wrap(True)
 
 
-class HIGHintSectionLabel(gtk.HBox, object):
+class HIGHintSectionLabel(Gtk.HBox, object):
     """
     Bold label used to define sections, with a little icon that shows up a hint
     when mouse is over it.
     """
     def __init__(self, text=None, hint=None):
-        gtk.HBox.__init__(self)
+        Gtk.HBox.__init__(self)
 
         self.label = HIGSectionLabel(text)
         self.hint = Hint(hint)
@@ -167,14 +170,14 @@ class HIGHintSectionLabel(gtk.HBox, object):
         self.pack_start(self.hint, False, False, 5)
 
 
-class Hint(gtk.EventBox, object):
+class Hint(Gtk.EventBox, object):
     def __init__(self, hint):
-        gtk.EventBox.__init__(self)
+        Gtk.EventBox.__init__(self)
         self.hint = hint
 
-        self.hint_image = gtk.Image()
+        self.hint_image = Gtk.Image()
         self.hint_image.set_from_stock(
-                gtk.STOCK_DIALOG_INFO, gtk.ICON_SIZE_SMALL_TOOLBAR)
+                Gtk.STOCK_DIALOG_INFO, Gtk.IconSize.SMALL_TOOLBAR)
 
         self.add(self.hint_image)
 
@@ -185,20 +188,20 @@ class Hint(gtk.EventBox, object):
         hint_window.show_all()
 
 
-class HintWindow(gtk.Window):
+class HintWindow(Gtk.Window):
     def __init__(self, hint):
-        gtk.Window.__init__(self, gtk.WINDOW_POPUP)
-        self.set_position(gtk.WIN_POS_MOUSE)
-        bg_color = gtk.gdk.color_parse("#fbff99")
+        Gtk.Window.__init__(self, Gtk.WindowType.POPUP)
+        self.set_position(Gtk.WindowPosition.MOUSE)
+        bg_color = Gdk.color_parse("#fbff99")
 
-        self.modify_bg(gtk.STATE_NORMAL, bg_color)
+        self.modify_bg(Gtk.StateType.NORMAL, bg_color)
 
-        self.event = gtk.EventBox()
-        self.event.modify_bg(gtk.STATE_NORMAL, bg_color)
+        self.event = Gtk.EventBox()
+        self.event.modify_bg(Gtk.StateType.NORMAL, bg_color)
         self.event.set_border_width(10)
         self.event.connect("button-press-event", self.close)
 
-        self.hint_label = gtk.Label(hint)
+        self.hint_label = Gtk.Label(hint)
         self.hint_label.set_use_markup(True)
         self.hint_label.set_line_wrap(True)
         self.hint_label.set_alignment(0.0, 0.5)
@@ -210,33 +213,33 @@ class HintWindow(gtk.Window):
         self.destroy()
 
 
-class HIGEntryLabel(gtk.Label):
+class HIGEntryLabel(Gtk.Label):
     """
     Simple label, like the ones used to label entries
     """
     def __init__(self, text=None):
-        gtk.Label.__init__(self, text)
-        self.set_justify(gtk.JUSTIFY_LEFT)
+        Gtk.Label.__init__(self, text)
+        self.set_justify(Gtk.Justification.LEFT)
         self.set_alignment(0, 0.50)
         self.set_use_markup(True)
         self.set_line_wrap(True)
 
 
-class HIGDialogLabel(gtk.Label):
+class HIGDialogLabel(Gtk.Label):
     """
     Centered, line-wrappable label, usually used on dialogs.
     """
     def __init__(self, text=None):
-        gtk.Label.__init__(self, text)
-        self.set_justify(gtk.JUSTIFY_CENTER)
+        Gtk.Label.__init__(self, text)
+        self.set_justify(Gtk.Justification.CENTER)
         self.set_use_markup(True)
         self.set_line_wrap(True)
 
 if __name__ == "__main__":
-    w = gtk.Window()
+    w = Gtk.Window()
     h = HIGHintSectionLabel("Label", "Hint")
     w.add(h)
-    w.connect("delete-event", lambda x, y: gtk.main_quit())
+    w.connect("delete-event", lambda x, y: Gtk.main_quit())
     w.show_all()
 
-    gtk.main()
+    Gtk.main()

--- a/zenmap/zenmapGUI/higwidgets/higlogindialogs.py
+++ b/zenmap/zenmapGUI/higwidgets/higlogindialogs.py
@@ -169,7 +169,7 @@ class HIGLoginDialog(HIGDialog):
         self.username_password_table.attach_entry(self.password_entry,
                                                   1, 2, 1, 2)
 
-        self.vbox.pack_start(self.username_password_table, False, False)
+        self.vbox.pack_start(self.username_password_table, False, False, 0)
         self.set_default_response(Gtk.ResponseType.ACCEPT)
 
     def run(self):

--- a/zenmap/zenmapGUI/higwidgets/higlogindialogs.py
+++ b/zenmap/zenmapGUI/higwidgets/higlogindialogs.py
@@ -134,12 +134,15 @@ higwidgets/higlogindialog.py
 
 __all__ = ['HIGLoginDialog']
 
-import gtk
+import gi
 
-from higdialogs import HIGDialog
-from higlabels import HIGEntryLabel
-from higtables import HIGTable
-from higentries import HIGTextEntry, HIGPasswordEntry
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
+from .higdialogs import HIGDialog
+from .higlabels import HIGEntryLabel
+from .higtables import HIGTable
+from .higentries import HIGTextEntry, HIGPasswordEntry
 
 
 class HIGLoginDialog(HIGDialog):
@@ -147,8 +150,8 @@ class HIGLoginDialog(HIGDialog):
     A dialog that asks for basic login information (username / password)
     """
     def __init__(self, title='Login',
-                 buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL,
-                          gtk.STOCK_OK, gtk.RESPONSE_ACCEPT)):
+                 buttons=(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                          Gtk.STOCK_OK, Gtk.ResponseType.ACCEPT)):
         HIGDialog.__init__(self, title, buttons=buttons)
 
         self.username_label = HIGEntryLabel("Username:")
@@ -167,7 +170,7 @@ class HIGLoginDialog(HIGDialog):
                                                   1, 2, 1, 2)
 
         self.vbox.pack_start(self.username_password_table, False, False)
-        self.set_default_response(gtk.RESPONSE_ACCEPT)
+        self.set_default_response(Gtk.ResponseType.ACCEPT)
 
     def run(self):
         self.show_all()
@@ -180,5 +183,5 @@ if __name__ == '__main__':
     # HIGLoginDialog
     d = HIGLoginDialog()
     response_value = d.run()
-    print gtk_constant_name('response', response_value)
+    print(gtk_constant_name('response', response_value))
     d.destroy()

--- a/zenmap/zenmapGUI/higwidgets/hignotebooks.py
+++ b/zenmap/zenmapGUI/higwidgets/hignotebooks.py
@@ -126,26 +126,28 @@
 # *                                                                         *
 # ***************************************************************************/
 
-import gtk
-import gobject
+import gi
 
-from higboxes import HIGHBox
-from higbuttons import HIGButton
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GObject
+
+from .higboxes import HIGHBox
+from .higbuttons import HIGButton
 
 
-class HIGNotebook(gtk.Notebook):
+class HIGNotebook(Gtk.Notebook):
     def __init__(self):
-        gtk.Notebook.__init__(self)
+        Gtk.Notebook.__init__(self)
         self.popup_enable()
 
 
 class HIGClosableTabLabel(HIGHBox):
     __gsignals__ = {
-            'close-clicked': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE, ())
+            'close-clicked': (GObject.SIGNAL_RUN_LAST, GObject.TYPE_NONE, ())
             }
 
     def __init__(self, label_text=""):
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
         #HIGHBox.__init__(self, spacing=4)
 
         self.label_text = label_text
@@ -154,12 +156,12 @@ class HIGClosableTabLabel(HIGHBox):
         #self.property_map = {"label_text" : self.label.get_label}
 
     def __create_widgets(self):
-        self.label = gtk.Label(self.label_text)
-        self.close_image = gtk.Image()
-        self.close_image.set_from_stock(gtk.STOCK_CLOSE, gtk.ICON_SIZE_BUTTON)
+        self.label = Gtk.Label(self.label_text)
+        self.close_image = Gtk.Image()
+        self.close_image.set_from_stock(Gtk.STOCK_CLOSE, Gtk.IconSize.BUTTON)
         self.close_button = HIGButton()
         self.close_button.set_size_request(20, 20)
-        self.close_button.set_relief(gtk.RELIEF_NONE)
+        self.close_button.set_relief(Gtk.ReliefStyle.NONE)
         self.close_button.set_focus_on_click(False)
         self.close_button.add(self.close_image)
 
@@ -192,6 +194,6 @@ class HIGClosableTabLabel(HIGHBox):
     def set_label(self, label):
         self.label.set_text(label)
 
-gobject.type_register(HIGClosableTabLabel)
+GObject.type_register(HIGClosableTabLabel)
 
 HIGAnimatedTabLabel = HIGClosableTabLabel

--- a/zenmap/zenmapGUI/higwidgets/hignotebooks.py
+++ b/zenmap/zenmapGUI/higwidgets/hignotebooks.py
@@ -143,7 +143,7 @@ class HIGNotebook(Gtk.Notebook):
 
 class HIGClosableTabLabel(HIGHBox):
     __gsignals__ = {
-            'close-clicked': (GObject.SIGNAL_RUN_LAST, GObject.TYPE_NONE, ())
+            'close-clicked': (GObject.SignalFlags.RUN_LAST, GObject.TYPE_NONE, ())
             }
 
     def __init__(self, label_text=""):
@@ -156,7 +156,7 @@ class HIGClosableTabLabel(HIGHBox):
         #self.property_map = {"label_text" : self.label.get_label}
 
     def __create_widgets(self):
-        self.label = Gtk.Label(self.label_text)
+        self.label = Gtk.Label.new(self.label_text)
         self.close_image = Gtk.Image()
         self.close_image.set_from_stock(Gtk.STOCK_CLOSE, Gtk.IconSize.BUTTON)
         self.close_button = HIGButton()

--- a/zenmap/zenmapGUI/higwidgets/higprogressbars.py
+++ b/zenmap/zenmapGUI/higwidgets/higprogressbars.py
@@ -134,9 +134,12 @@ higwidgets/higprogressbars.py
 
 __all__ = ['HIGLabeledProgressBar']
 
-import gtk
+import gi
 
-from higboxes import HIGHBox
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
+from .higboxes import HIGHBox
 
 
 class HIGLabeledProgressBar(HIGHBox):
@@ -145,7 +148,7 @@ class HIGLabeledProgressBar(HIGHBox):
         if label:
             self.label = HIGEntryLabel(label)
             self.pack_label(self.label)
-            self.progress_bar = gtk.ProgressBar()
+            self.progress_bar = Gtk.ProgressBar()
             self.progress_bar.set_size_request(80, 16)
             self.pack_label(self.progress_bar)
 

--- a/zenmap/zenmapGUI/higwidgets/higscrollers.py
+++ b/zenmap/zenmapGUI/higwidgets/higscrollers.py
@@ -134,11 +134,14 @@ higwidgets/higscrollers.py
 
 __all__ = ['HIGScrolledWindow']
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 
-class HIGScrolledWindow(gtk.ScrolledWindow):
+class HIGScrolledWindow(Gtk.ScrolledWindow):
     def __init__(self):
-        gtk.ScrolledWindow.__init__(self)
-        self.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
+        Gtk.ScrolledWindow.__init__(self)
+        self.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         self.set_border_width(5)

--- a/zenmap/zenmapGUI/higwidgets/higspinner.py
+++ b/zenmap/zenmapGUI/higwidgets/higspinner.py
@@ -430,8 +430,8 @@ class HIGSpinner(Gtk.EventBox):
 
         width = self.current_pixbuf.get_width()
         height = self.current_pixbuf.get_height()
-        x_offset = (self.allocation.width - width) / 2
-        y_offset = (self.allocation.height - height) / 2
+        x_offset = (self.allocation.width - width) // 2
+        y_offset = (self.allocation.height - height) // 2
 
         pix_area = Gdk.Rectangle(x_offset + self.allocation.x,
                                  y_offset + self.allocation.y,

--- a/zenmap/zenmapGUI/higwidgets/higspinner.py
+++ b/zenmap/zenmapGUI/higwidgets/higspinner.py
@@ -134,10 +134,13 @@ higwidgets/higspinner.py
 
 __all__ = ['HIGSpinner']
 
-import gtk
-import gobject
+import gi
 
-from gtkutils import gobject_register
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GLib, Gdk, GdkPixbuf
+
+
+from .gtkutils import gobject_register
 
 
 class HIGSpinnerImages:
@@ -200,15 +203,15 @@ class HIGSpinnerImages:
         new_animated = []
         for p in self.animated_pixbufs:
             new_animated.append(p.scale_simple(width, height,
-                                               gtk.gdk.INTERP_BILINEAR))
+                                               GdkPixbuf.InterpType.BILINEAR))
         self.animated_pixbufs = new_animated
 
         for k in self.static_pixbufs:
             self.static_pixbufs[k] = self.static_pixbufs[k].scale_simple(
-                    width, height, gtk.gdk.INTERP_BILINEAR)
+                    width, height, GdkPixbuf.InterpType.BILINEAR)
 
         self.rest_pixbuf = self.rest_pixbuf.scale_simple(
-                width, height, gtk.gdk.INTERP_BILINEAR)
+                width, height, GdkPixbuf.InterpType.BILINEAR)
 
         self.images_width = width
         self.images_height = height
@@ -224,7 +227,7 @@ class HIGSpinnerCache:
         self.spinner_images = HIGSpinnerImages()
 
         # These are on Private member in the C implementation
-        self.icon_theme = gtk.IconTheme()
+        self.icon_theme = Gtk.IconTheme()
         self.originals = None
         self.images = None
 
@@ -271,7 +274,7 @@ class HIGSpinnerCache:
 
     def load_animated_from_filename(self, filename, size):
         # grid_pixbuf is a pixbuf that holds the entire
-        grid_pixbuf = gtk.gdk.pixbuf_new_from_file(filename)
+        grid_pixbuf = GdkPixbuf.Pixbuf.new_from_file(filename)
         grid_width = grid_pixbuf.get_width()
         grid_height = grid_pixbuf.get_height()
 
@@ -289,7 +292,7 @@ class HIGSpinnerCache:
         self.load_static_from_filename(filename)
 
     def load_static_from_filename(self, filename, key_name=None):
-        icon_pixbuf = gtk.gdk.pixbuf_new_from_file(filename)
+        icon_pixbuf = GdkPixbuf.Pixbuf.new_from_file(filename)
 
         if key_name is None:
             key_name = filename.split(".")[0]
@@ -325,7 +328,7 @@ class HIGSpinnerCache:
                                                           image_format)
 
 
-class HIGSpinner(gtk.EventBox):
+class HIGSpinner(Gtk.EventBox):
     """Simple spinner, such as the one found in webbrowsers and file managers.
 
     You can construct it with the optional parameters:
@@ -334,11 +337,11 @@ class HIGSpinner(gtk.EventBox):
     * height, the height that will be set for the images
     """
 
-    __gsignals__ = {'expose-event': 'override',
-                    'size-request': 'override'}
+    #__gsignals__ = {'expose-event': 'override',
+    #                'size-request': 'override'}
 
     def __init__(self):
-        gtk.EventBox.__init__(self)
+        Gtk.EventBox.__init__(self)
 
         #self.set_events(self.get_events())
 
@@ -393,13 +396,13 @@ class HIGSpinner(gtk.EventBox):
     def start(self):
         """Starts the animation"""
         if self.timer_task == 0:
-            self.timer_task = gobject.timeout_add(self.timeout,
+            self.timer_task = GLib.timeout_add(self.timeout,
                                                   self.__bump_frame)
 
     def pause(self):
         """Pauses the animation"""
         if self.timer_task != 0:
-            gobject.source_remove(self.timer_task)
+            GLib.source_remove(self.timer_task)
 
         self.timer_task = 0
         self.queue_draw()
@@ -430,23 +433,26 @@ class HIGSpinner(gtk.EventBox):
         x_offset = (self.allocation.width - width) / 2
         y_offset = (self.allocation.height - height) / 2
 
-        pix_area = gtk.gdk.Rectangle(x_offset + self.allocation.x,
-                                     y_offset + self.allocation.y,
-                                     width, height)
+        pix_area = Gdk.Rectangle(x_offset + self.allocation.x,
+                                 y_offset + self.allocation.y,
+                                 width, height)
 
         dest = event.area.intersect(pix_area)
 
-        # If a graphic context doesn't not exist yet, create one
-        if self.gc is None:
-            self.gc = gtk.gdk.GC(self.window)
-        #gc = self.gc
-
-        self.window.draw_pixbuf(self.gc,
-                                self.current_pixbuf,
-                                dest.x - x_offset - self.allocation.x,
-                                dest.y - y_offset - self.allocation.y,
-                                dest.x, dest.y,
-                                dest.width, dest.height)
+#        # If a graphic context doesn't not exist yet, create one
+#        if self.gc is None:
+#            self.gc = gtk.gdk.GC(self.window)
+#        #gc = self.gc
+#
+#        cairo = self.window.cairo_create()
+#
+#
+#        self.window.draw_pixbuf(self.gc,
+#                                self.current_pixbuf,
+#                                dest.x - x_offset - self.allocation.x,
+#                                dest.y - y_offset - self.allocation.y,
+#                                dest.x, dest.y,
+#                                dest.width, dest.height)
 
     def do_size_request(self, requisition):
         # http://www.pygtk.org/pygtk2reference/class-gtkrequisition.html

--- a/zenmap/zenmapGUI/higwidgets/higtables.py
+++ b/zenmap/zenmapGUI/higwidgets/higtables.py
@@ -134,13 +134,16 @@ higwidgets/higlogindialog.py
 
 __all__ = ['HIGTable']
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 #from higlabels import *
 #from higentries import *
 
 
-class HIGTable(gtk.Table):
+class HIGTable(Gtk.Table):
     """
     A HIGFied table
     """
@@ -150,7 +153,7 @@ class HIGTable(gtk.Table):
     # - Generic attach function that detects the widget type
 
     def __init__(self, rows=1, columns=1, homogeneous=False):
-        gtk.Table.__init__(self, rows, columns, homogeneous)
+        Gtk.Table.__init__(self, rows, columns, homogeneous)
         self.set_row_spacings(6)
         self.set_col_spacings(12)
 
@@ -158,7 +161,7 @@ class HIGTable(gtk.Table):
         self.columns = columns
 
     def attach_label(self, widget, x0, x, y0, y):
-        self.attach(widget, x0, x, y0, y, xoptions=gtk.FILL)
+        self.attach(widget, x0, x, y0, y, xoptions=Gtk.AttachOptions.FILL)
 
     def attach_entry(self, widget, x0, x, y0, y):
-        self.attach(widget, x0, x, y0, y, xoptions=gtk.FILL | gtk.EXPAND)
+        self.attach(widget, x0, x, y0, y, xoptions=Gtk.AttachOptions.FILL | Gtk.AttachOptions.EXPAND)

--- a/zenmap/zenmapGUI/higwidgets/higtables.py
+++ b/zenmap/zenmapGUI/higwidgets/higtables.py
@@ -153,7 +153,7 @@ class HIGTable(Gtk.Table):
     # - Generic attach function that detects the widget type
 
     def __init__(self, rows=1, columns=1, homogeneous=False):
-        Gtk.Table.__init__(self, rows, columns, homogeneous)
+        Gtk.Table.__init__(self, n_rows=rows, n_columns=columns, homogeneous=homogeneous)
         self.set_row_spacings(6)
         self.set_col_spacings(12)
 

--- a/zenmap/zenmapGUI/higwidgets/higtextviewers.py
+++ b/zenmap/zenmapGUI/higwidgets/higtextviewers.py
@@ -134,11 +134,14 @@ higwidgets/higtextviewers.py
 
 __all__ = ['HIGTextView']
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 
-class HIGTextView(gtk.TextView):
+class HIGTextView(Gtk.TextView):
     def __init__(self, text=''):
-        gtk.TextView.__init__(self)
-        self.set_wrap_mode(gtk.WRAP_WORD)
+        Gtk.TextView.__init__(self)
+        self.set_wrap_mode(Gtk.WrapMode.WORD)
         self.get_buffer().set_text(text)

--- a/zenmap/zenmapGUI/higwidgets/higwindows.py
+++ b/zenmap/zenmapGUI/higwidgets/higwindows.py
@@ -132,17 +132,20 @@ higwidgets/higwindows.py
    window related classes
 """
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 
 __all__ = ('HIGWindow', 'HIGMainWindow')
 
 
-class HIGWindow(gtk.Window):
+class HIGWindow(Gtk.Window):
     """HIGFied Window"""
-    def __init__(self, type=gtk.WINDOW_TOPLEVEL):
-        gtk.Window.__init__(self, type)
+    def __init__(self, type=Gtk.WindowType.TOPLEVEL):
+        Gtk.Window.__init__(self, type)
         self.set_border_width(5)
 
 # The Application main window should have no borders...
 # so it should be really a gtk.Window
-HIGMainWindow = gtk.Window
+HIGMainWindow = Gtk.Window


### PR DESCRIPTION
Hi; as part of our migration effort away from Python 2, I managed to port whole Zenmap to Python 3 and pygobject library. Except for some minor visual glitches (like windows being wider than in current version) and most likely several hidden bugs I wasn't able to find yet, it is fully functional and will most likely go into the next update of Solaris.

Its only big issue is that it is not Python 2 and PyGTK backward compatible. I don't think it's that big of a deal as both are obsolete today and many Linux distributions don't ship them anymore, but you might think otherwise. Python 2 compatibility can be most likely brought back with the addition of #1972, PyGTK compatibility would require much more effort.

This, together with #1807 and some `setup.py` and `configure` changes (I have those ready as well), should be enough to completely port Nmap to Python 3.

It still needs some work (mostly cleaning up), but I wanted to make this PR now so that you know that this exists and can make comments :).

Last note: I did the testing on 7.80 version of Nmap and not current master, so there might be some issues after the rebase, but those should be minor and quickly fixed.
