### PR TITLE
http-shellshock: Fix false positive by matching at start of line

### DIFF
--- a/scripts/http-shellshock.nse
+++ b/scripts/http-shellshock.nse
@@ -87,7 +87,7 @@ function generate_http_req(host, port, uri, custom_header, cmd)
     cmd = '() { :;}; '..cmd
  else
     rnd = rand.random_alpha(15)
-    cmd = '() { :;}; echo; echo "'..rnd..'"'
+    cmd = '() { :;}; echo; echo -n '..rnd:sub(1, 1)..'; echo '..rnd:sub(2)..''
   end
   -- Plant the payload in the HTTP headers
   local options = {header={}}


### PR DESCRIPTION
Running the `http-shellshock` script on a [Zulip](https://zulip.com/) installation results in a false positive because Zulip (intentionally and safely) [reflects](https://github.com/zulip/zulip/blob/3.0/templates/zerver/portico.html#L11) the HTTP `User-Agent` header as the `data-platform` attribute on a `<div>` so that it can be matched with CSS rules.

If an actually vulnerable server were really running our payload

    () { :;}; echo; echo "therandomstring"

then the extra `echo` would cause `therandomstring` to appear at the start of a line. So we can avoid the false positive by only triggering on matches at the start of a line.