### PR TITLE
Add warning for no space between "-PS" and "portlist"

### DIFF
--- a/nmap.cc
+++ b/nmap.cc
@@ -274,6 +274,7 @@ static void printusage() {
          "  -sn: Ping Scan - disable port scan\n"
          "  -Pn: Treat all hosts as online -- skip host discovery\n"
          "  -PS/PA/PU/PY[portlist]: TCP SYN/ACK, UDP or SCTP discovery to given ports\n"
+         "    No space before [portlist]!\n"
          "  -PE/PP/PM: ICMP echo, timestamp, and netmask request discovery probes\n"
          "  -PO[protocol list]: IP Protocol Ping\n"
          "  -n/-R: Never do DNS resolution/Always resolve [default: sometimes]\n"


### PR DESCRIPTION
It's already written in the documentation but I think having a reminder is a good idea :)
I'm trying to write a way to detect when it happens too