### PR TITLE
Update nmap-services

### DIFF
--- a/nmap-services
+++ b/nmap-services
@@ -21344,6 +21344,7 @@ unknown	40063/udp	0.000518
 unknown	40071/udp	0.001036
 unknown	40074/udp	0.001036
 unknown	40076/udp	0.000518
+sap-internet-graphics-server	40080/tcp	0.000518    # HTTP SAP Internet Graphics Server (IGS)
 unknown	40089/udp	0.000518
 unknown	40090/udp	0.000518
 unknown	40093/udp	0.000518


### PR DESCRIPTION
Add port: 40080 - SAP Internet Graphics Server (IGS) default port

The **Internet Graphics Service (IGS)** where it provides a way infrastructure to enable developers to display graphics in an internet browser with minimal effort. It has been integrated in several different SAP UI technologies where it provides a way for data from another SAP system or data source to be utilized to generate dynamic graphical or non-graphical output.