### PR TITLE
Update vnc.lua

### DIFF
--- a/nselib/vnc.lua
+++ b/nselib/vnc.lua
@@ -667,6 +667,11 @@ VNC = {
   end,
 
   login_ard = function(self, username, password)
+    -- Check for empty username
+    if not username then
+      return false, "No username provided"
+    end
+    
     -- Thanks to David Simmons for describing this protocol:
     -- https://cafbit.com/post/apple_remote_desktop_quirks/
     local status, buf = self.socket:receive_bytes(4)


### PR DESCRIPTION
ARD login requires a username and password. If the username is empty the script will fail. This change will skip attempts which have an empty username.

Here is an example of how ARD bruteforce could be run:

`nmap --script vnc-brute.nse --script-args "userdb=user.txt,passdb=pass.txt,vnc-brute.bruteusers=true"  -p5900 -iL ips.txt`

Without this change vnc-brute will fail :
```
NSE: vnc-brute against 10.10.0.45:5900 threw an error!
/usr/local/bin/../share/nmap/nselib/vnc.lua:704: attempt to get length of a nil value (local 'username')
stack traceback:
	/usr/local/bin/../share/nmap/nselib/vnc.lua:704: in function </usr/local/bin/../share/nmap/nselib/vnc.lua:669>
	(...tail calls...)
	...ocal/Cellar/nmap/7.80_1/share/nmap/scripts/vnc-brute.nse:123: in method 'check'
	/usr/local/bin/../share/nmap/nselib/brute.lua:988: in method 'start'
	...ocal/Cellar/nmap/7.80_1/share/nmap/scripts/vnc-brute.nse:149: in function <...ocal/Cellar/nmap/7.80_1/share/nmap/scripts/vnc-brute.nse:140>
	(...tail calls...)
```

Additionally, we should not add `username = username or ""` as ARD login will never have an empty username. If password only auth is requested nmap will automatically use VNC Authentication type 2.