### PR TITLE
added script for getting network interfaces via NetBIOS

### DIFF
--- a/nselib/netbios.lua
+++ b/nselib/netbios.lua
@@ -445,7 +445,7 @@ function nbquery(host, nbname, options)
         return false, "ERROR: Response contained no answers"
       end
       local dname = string.char(#resp.output.answers[1].dname) .. resp.output.answers[1].dname
-      table.insert( results, { peer = resp.peer, name = name_decode(dname) } )
+      table.insert( results, { peer = resp.peer, name = name_decode(dname), data = resp.output.answers[1].data } )
     end
     return true, results
   else

--- a/nselib/netbios.lua
+++ b/nselib/netbios.lua
@@ -450,7 +450,7 @@ function nbquery(host, nbname, options)
     return true, results
   else
     local dname = string.char(#response.answers[1].dname) .. response.answers[1].dname
-    return true, { { peer = host.ip, name = name_decode(dname) } }
+    return true, { { peer = host.ip, name = name_decode(dname), data = response.answers[1].data } }
   end
 end
 

--- a/scripts/netbios-interfaces.nse
+++ b/scripts/netbios-interfaces.nse
@@ -1,0 +1,68 @@
+local netbios = require "netbios"
+local nmap = require "nmap"
+local string = require "string"
+local tab = require "tab"
+
+description = [[
+Attempts to retrieve the target's network interfaces.
+It is very useful for finding pathes to isolated networks.
+]]
+
+---
+-- @usage
+-- sudo nmap -sU --script netbios-interfaces.nse -p137 <host>
+--
+-- @output
+-- Host script results:
+-- | netbios-interfaces: 
+-- | 10.0.0.64
+-- |_12.0.0.1
+
+
+
+author = {"Andrey Zhukov from USSC"}
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+
+categories = {"default", "discovery", "safe"}
+
+
+hostrule = function(host)
+
+  -- The following is an attempt to only run this script against hosts
+  -- that will probably respond to a UDP 137 probe.  One might argue
+  -- that sending a single UDP packet and waiting for a response is no
+  -- big deal and that it should be done for every host.  In that case
+  -- simply change this rule to always return true.
+
+  local port_t135 = nmap.get_port_state(host,
+    {number=135, protocol="tcp"})
+  local port_t139 = nmap.get_port_state(host,
+    {number=139, protocol="tcp"})
+  local port_t445 = nmap.get_port_state(host,
+    {number=445, protocol="tcp"})
+  local port_u137 = nmap.get_port_state(host,
+    {number=137, protocol="udp"})
+
+  return (port_t135 ~= nil and port_t135.state == "open") or
+    (port_t139 ~= nil and port_t139.state == "open") or
+    (port_t445 ~= nil and port_t445.state == "open") or
+    (port_u137 ~= nil and
+      (port_u137.state == "open" or
+      port_u137.state == "open|filtered"))
+end
+
+get_ip = function(buf)
+  return tostring(string.byte(buf:sub(1,2))) .. "." .. tostring(string.byte(buf:sub(2,3))) .. "." .. tostring(string.byte(buf:sub(3,4))) .. "." .. tostring(string.byte(buf:sub(4,5)))
+end
+
+action = function(host)
+  local outtab = tab.new(1)
+  local status, server_name = netbios.get_server_name(host)
+  local status, result = netbios.nbquery(host, server_name, { multiple = true })
+  for k, v in ipairs(result) do
+    for i=1,string.len(v.data),6 do
+      tab.addrow(outtab, get_ip(v.data:sub(i+2,i+2+4)))
+    end
+  end
+  return "\n" .. tab.dump(outtab)
+end

--- a/scripts/netbios-interfaces.nse
+++ b/scripts/netbios-interfaces.nse
@@ -2,6 +2,7 @@ local shortport = require "shortport"
 local netbios = require "netbios"
 local string = require "string"
 local stdnse = require "stdnse"
+local table = require "table"
 
 description = [[
 Attempts to retrieve via NetBIOS the target's network interfaces.
@@ -19,10 +20,17 @@ In particular, it is very useful for finding paths to non-routed networks if tar
 -- | netbios-interfaces: 
 -- |   hostname: NOTEBOOK-NB3
 -- |   interfaces: 
--- |     192.168.128.100
+-- |     10.5.4.89
+-- |     192.168.56.1
 -- |     172.24.80.1
--- |     172.27.96.1
 -- MAC Address: 9C:7B:EF:AA:BB:CC (Hewlett Packard)
+--
+-- @xmloutput
+-- <table key="interfaces">
+-- <elem>10.5.4.89</elem>
+-- <elem>192.168.56.1</elem>
+-- <elem>172.24.80.1</elem>
+-- </table>
 
 
 author = {"Andrey Zhukov from USSC"}
@@ -30,7 +38,7 @@ license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 
 categories = {"default", "discovery", "safe"}
 
-portrule = shortport.portnumber(137, "udp", {"open", "open|filtered"})
+portrule = shortport.portnumber(137, "udp")
 
 get_ip = function(buf)
   return table.concat({buf:byte(1, 4)}, ".")
@@ -40,18 +48,18 @@ action = function(host)
   local output = stdnse.output_table()
   local status, server_name = netbios.get_server_name(host)
   if(not(status)) then
-    return output, "Failed to get hostname"
+    return stdnse.format_output(false, "Failed to get NetBIOS name of the target")
   end
-  local status, result = netbios.nbquery(host, server_name, { multiple = true })
+  local status, result = netbios.nbquery(host, server_name)
   if(not(status)) then
-    return output, "Failed to get remote network interfaces"
+    return stdnse.format_output(false, "Failed to get remote network interfaces")
   end
   output.hostname = server_name
   output.interfaces = {}
   for k, v in ipairs(result) do
     for i=1,string.len(v.data),6 do
-      output.interfaces[#output.interfaces + 1] = get_ip(v.data:sub(i+2,i+2+4))
+      output.interfaces[#output.interfaces + 1] = get_ip(v.data:sub(i+2,i+2+4-1))
     end
   end
-  return output, ""
+  return output
 end

--- a/scripts/script.db
+++ b/scripts/script.db
@@ -389,6 +389,7 @@ Entry { filename = "ndmp-fs-info.nse", categories = { "discovery", "safe", } }
 Entry { filename = "ndmp-version.nse", categories = { "version", } }
 Entry { filename = "nessus-brute.nse", categories = { "brute", "intrusive", } }
 Entry { filename = "nessus-xmlrpc-brute.nse", categories = { "brute", "intrusive", } }
+Entry { filename = "netbios-interfaces.nse", categories = { "default", "discovery", "safe", } }
 Entry { filename = "netbus-auth-bypass.nse", categories = { "auth", "safe", "vuln", } }
 Entry { filename = "netbus-brute.nse", categories = { "brute", "intrusive", } }
 Entry { filename = "netbus-info.nse", categories = { "default", "discovery", "safe", } }


### PR DESCRIPTION
It is not very famous trick. We can gather network interfaces through netbios as:
```
nmblookup -A 10.0.0.64
nmblookup -B 10.0.0.64 WIN7X64VM
```
```
querying WIN7X64VM on 10.0.0.64
10.0.0.64 WIN7X64VM<00>
12.0.0.1 WIN7X64VM<00>
```
Or the same with python:
```
from nmb.NetBIOS import NetBIOS # pip2 install pysmb
netbios_names = netbios.queryIPForName( "10.0.0.64", timeout=0.1 )
print ', '.join( (netbios.queryName( netbios_names[0], ip="10.0.0.64" ) or []) + netbios_names )
```
