### PR TITLE
Improvements in SMB2 dialect negotiation

### DIFF
--- a/scripts/smb-protocols.nse
+++ b/scripts/smb-protocols.nse
@@ -7,11 +7,11 @@ Attempts to list the supported protocols and dialects of a SMB server.
 
 The script attempts to initiate a connection using the dialects:
 * NT LM 0.12 (SMBv1)
-* 2.02       (SMBv2)
-* 2.10       (SMBv2)
-* 3.00       (SMBv3)
-* 3.02       (SMBv3)
-* 3.11       (SMBv3)
+* 2.0.2      (SMBv2)
+* 2.1        (SMBv2)
+* 3.0        (SMBv3)
+* 3.0.2      (SMBv3)
+* 3.1.1      (SMBv3)
 
 Additionally if SMBv1 is found enabled, it will mark it as insecure. This
 script is the successor to the (removed) smbv2-enabled script.
@@ -25,20 +25,20 @@ script is the successor to the (removed) smbv2-enabled script.
 -- | smb-protocols:
 -- |   dialects:
 -- |     NT LM 0.12 (SMBv1) [dangerous, but default]
--- |     2.02
--- |     2.10
--- |     3.00
--- |     3.02
--- |_    3.11
+-- |     2.0.2
+-- |     2.1
+-- |     3.0
+-- |     3.0.2
+-- |_    3.1.1
 --
 -- @xmloutput
 -- <table key="dialects">
 -- <elem>NT LM 0.12 (SMBv1) [dangerous, but default]</elem>
--- <elem>2.02</elem>
--- <elem>2.10</elem>
--- <elem>3.00</elem>
--- <elem>3.02</elem>
--- <elem>3.11</elem>
+-- <elem>2.0.2</elem>
+-- <elem>2.1</elem>
+-- <elem>3.0</elem>
+-- <elem>3.0.2</elem>
+-- <elem>3.1.1</elem>
 -- </table>
 ---
 

--- a/scripts/smb2-security-mode.nse
+++ b/scripts/smb2-security-mode.nse
@@ -22,11 +22,11 @@ References:
 --
 -- @output
 -- | smb2-security-mode:
--- |   3.11:
+-- |   3.1.1:
 -- |_    Message signing enabled but not required
 --
 -- @xmloutput
--- <table key="3.11">
+-- <table key="3.1.1">
 -- <elem>Message signing enabled but not required</elem>
 -- </table>
 ---
@@ -40,53 +40,43 @@ hostrule = function(host)
 end
 
 action = function(host,port)
-  local status, smbstate, overrides
+  local status, smbstate
   local output = stdnse.output_table()
-  overrides = overrides or {}
 
-  local smb2_dialects = {0x0202, 0x0210, 0x0300, 0x0302, 0x0311}
-
-  for i, dialect in pairs(smb2_dialects) do
-    -- we need a clean connection for each negotiate request
-    status, smbstate = smb.start(host)
-    if(status == false) then
-      return false, smbstate
-    end
-    overrides['Dialects'] = {dialect}
-    status, dialect = smb2.negotiate_v2(smbstate, overrides)
-    if status then
-      local message_signing = {}
-
-      -- Signing configuration. SMBv2 servers support two flags:
-      -- * Message signing enabled
-      -- * Message signing required
-      local signing_enabled, signing_required
-      if smbstate['security_mode'] & 0x01 == 0x01 then
-        signing_enabled = true
-      end
-      if smbstate['security_mode'] & 0x02 == 0x02 then
-        signing_required = true
-      end
-
-      if signing_enabled and signing_required then
-        table.insert(message_signing, "Message signing enabled and required")
-      elseif signing_enabled and not(signing_required) then
-        table.insert(message_signing, "Message signing enabled but not required")
-      elseif not(signing_enabled) and not(signing_required) then
-        table.insert(message_signing, "Message signing is disabled and not required!")
-      elseif not(signing_enabled) and signing_required then
-        table.insert(message_signing, "Message signing is disabled!")
-      end
-      output[stdnse.tohex(dialect, {separator = ".", group = 2})] = message_signing
-      -- We exit after first accepted dialect,
-      --  SMB signing configuration appears to be global so
-      --  there is no point of trying other dialects.
-      break
-    end
-
-    smb.stop(smbstate)
-    status = false
+  status, smbstate = smb.start(host)
+  if(status == false) then
+    return false, smbstate
   end
+  --  SMB signing configuration appears to be global so
+  --  there is no point of trying different dialects.
+  status, dialect = smb2.negotiate_v2(smbstate)
+  if status then
+    local message_signing = {}
+    -- Signing configuration. SMBv2 servers support two flags:
+    -- * Message signing enabled
+    -- * Message signing required
+    local signing_enabled, signing_required
+    if smbstate['security_mode'] & 0x01 == 0x01 then
+      signing_enabled = true
+    end
+    if smbstate['security_mode'] & 0x02 == 0x02 then
+      signing_required = true
+    end
+    if signing_enabled and signing_required then
+      table.insert(message_signing, "Message signing enabled and required")
+    elseif signing_enabled and not(signing_required) then
+      table.insert(message_signing, "Message signing enabled but not required")
+    elseif not(signing_enabled) and not(signing_required) then
+      table.insert(message_signing, "Message signing is disabled and not required!")
+    elseif not(signing_enabled) and signing_required then
+      table.insert(message_signing, "Message signing is disabled!")
+    end
+    output[smb2.dialect_name(dialect)] = message_signing
+    -- We exit after first accepted dialect,
+  end
+
+  smb.stop(smbstate)
+  status = false
 
   if #output>0 then
     return output

--- a/scripts/smb2-time.nse
+++ b/scripts/smb2-time.nse
@@ -31,11 +31,10 @@ hostrule = function(host)
 end
 
 action = function(host,port)
-  local smbstate, status, overrides
+  local smbstate, status
   local output = stdnse.output_table()
-  overrides = {}
   status, smbstate = smb.start(host)
-  status = smb2.negotiate_v2(smbstate, overrides)
+  status = smb2.negotiate_v2(smbstate)
 
   if status then
     datetime.record_skew(host, smbstate.time, os.time())

--- a/scripts/smb2-vuln-uptime.nse
+++ b/scripts/smb2-vuln-uptime.nse
@@ -107,13 +107,11 @@ This security update resolves a privately reported vulnerability in Microsoft
 }
 
 local function check_vulns(host, port)
-  local smbstate, status, overrides
+  local smbstate, status
   local vulns_detected = {}
 
-  overrides = {}
-  overrides['Dialects'] = {0x0202}
   status, smbstate = smb.start(host)
-  status = smb2.negotiate_v2(smbstate, overrides)
+  status = smb2.negotiate_v2(smbstate)
 
   if not status then
     stdnse.debug2("Negotiation failed")


### PR DESCRIPTION
There are a few weaknesses in the current handling of SMB 2 dialect negotiation:

* Scripts `smb-protocols` and `smb2-capabilities` lack a check whether SMB 2 is supported by the target. Instead, they immediately start with probing one dialect revision at a time. The effect is that for older SMB 2 implementations, such as Windows 7, they are sending probes for dialects that are guaranteed to fail. The issue is even more pronounced with targets that do not support SMB 2 at all, such as XP. In this case, a native SMB2 probe does not result in any response from the target so the script pauses until the probe times out. The time-out is set to 10s, which means that in total the script is guaranteed to take at least 50s under these conditions (with 5 supported dialects).

* Script `smb2-security-mode` iterates through SMB 2 dialects until it succeeds with negotiating a session with the target. If the target supports only the latest dialects, such as 3.1.1, then the script performance is notably degraded.

* Script `smb2-vuln-uptime` hard-codes one specific SMB 2 dialect to use. If the target does not support it then the script fails. Other scripts, such as `smb2-time`, do not explicitly force a dialect but they leave the dialect negotiation completely up to function `smb2.negotiate_v2`, which again defaults to a single specific dialect so these scripts might suffer the same fate.


This proposed code implements the following changes:

* Scripts that are looping through all dialects by design are now guarded with early SMB 2 negotiation, which determines the highest supported dialect revision and, implicitly, whether SMB 2 is supported at all. This means that the dialect loop can be terminated early, as soon as the highest revision is reached.

* Scripts that do not have to force a specific dialect with the target are now relying on function `smb2.negotiate_v2`, which has been modified to propose all supported dialects to the target by default, maximizing the chance that the negotiation succeeds.

* Various duplicated instances of the list of supported SMB 2 dialect revision codes have been centralized and replaced with calls to function `smb2.dialects`. Similarly, duplicated code for converting integer revision codes to human-friendly strings has been replaced with calls to function `smb2.dialect_name`.

* Cosmetically, all SMB 2 dialect names have been modified to match official revisions: 2.0.2, 2.1, 3.0, 3.0.2, and 3.1.1. The same revisions were previously called 2.02, 2.10, 3.00, 3.02, and 3.11. 

#### Performance Comparison

test / target|Win XP Pro SP3|Win 7 Pro SP1|Win 10 Ent 1909|Samba 4.12.5 (SMB3 only)
-|--------------|-------------|---------------|------------------------
SMB 2 dialects|none|2.0.2 - 2.1|2.0.2 - 3.1.1|3.1.1
smb-protocols|-40s (-79%)|-3s (-39%)|0s (0%)|0s (0%)
smb2-capabilities|-40s (-79%)|-2s (-30%)|0s (0%)|0s (0%)
smb2-security-mode|-40s (-79%)|0s (0%)|0s (0%)|-2s (-83%)
smb2-time|0s (0%)|0s (0%)|0s (0%)|old version fails
smb2-vuln-uptime|0s (0%)|0s (0%)|0s (0%)|old version fails


@cldrn In some cases it was not clear why the current code was designed this way so there is a decent chance that I have missed some important aspect. Could you please review?
