### PR TITLE
Fix NTLM host info parsing for older Windows versions

### DIFF
--- a/nselib/smbauth.lua
+++ b/nselib/smbauth.lua
@@ -863,7 +863,7 @@ function get_host_info_from_security_blob(security_blob)
     ntlm_challenge[ "target_realm" ] = unicode.utf16to8( target_realm )
   end
 
-  if hpos + domain_length > #security_blob then
+  if hpos + 8 + domain_length > #security_blob then
     -- Context, Target Information, and OS Version structure are all omitted
     -- Probably Win9x
     return ntlm_challenge


### PR DESCRIPTION
While scanning a Windows NT 4 (Service Pack 3) with options '--script http-ntlm-info -p80 -d -vv', the script threw this error
```
NSE: Starting http-ntlm-info against 10.1.1.3:80.
NSE: http-ntlm-info against 10.1.1.3:80 threw an error!
/usr/local/bin/../share/nmap/nselib/smbauth.lua:919: bad argument #3 to 'unpack' (initial position out of string)
stack traceback:
        [C]: in function 'string.unpack'
        /usr/local/bin/../share/nmap/nselib/smbauth.lua:919: in function 'smbauth.get_host_info_from_security_blob'
        /usr/local/bin/../share/nmap/scripts/http-ntlm-info.nse:87: in function </usr/local/bin/../share/nmap/scripts/http-ntlm-info.nse:69>
        (...tail calls...)
```
This is because the condition that verifies if the NTLM message payload contains only the domain name of the host did not take into account the 8 bytes 'Reserved' field into its calculation, so I fixed that.


Before the patch:
```
PORT   STATE SERVICE
80/tcp open  http
|_http-ntlm-info: ERROR: Script execution failed (use -d to debug)
```
After:
```
PORT   STATE SERVICE
80/tcp open  http
| http-ntlm-info: 
|_  Target_Name: WNT4-TSRV-SP3
```

I tested my patch on all of Windows versions, and noticed no regressions of the ntlm-info scripts, it only fixes this specific bug for NT4.