### PR TITLE
Ncat: match traditional and OpenBSD netcat behaviour of terminating on EOF

### DIFF
--- a/ncat/docs/ncat.xml
+++ b/ncat/docs/ncat.xml
@@ -876,6 +876,19 @@
 
       <varlistentry>
         <term>
+          <option>--no-terminate</option> (Do not terminate on stdin/socket EOF)
+          <indexterm><primary><option>--no-terminate</option> (Ncat option)</primary></indexterm>
+        </term>
+        <listitem>
+          <para>If this option is passed, Ncat will not terminate when EOF is
+          seen on the socket or stdin when connected over TCP. This used to be
+          the default in Ncat in the past, and is provided for
+          backwards-compatibility.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>
           <option>-n</option>,
           <option>--nodns</option> (Do not resolve hostnames)
           <indexterm><primary><option>--nodns</option> (Ncat option)</primary></indexterm>

--- a/ncat/ncat_connect.c
+++ b/ncat/ncat_connect.c
@@ -1274,8 +1274,8 @@ static void read_stdin_handler(nsock_pool nsp, nsock_event evt, void *data)
     if (status == NSE_STATUS_EOF) {
         if (!o.noshutdown)
             shutdown(nsock_iod_get_sd(cs.sock_nsi), SHUT_WR);
-        /* In --send-only mode or non-TCP mode, exit after EOF on stdin. */
-        if (o.proto != IPPROTO_TCP || (o.proto == IPPROTO_TCP && o.sendonly))
+        /* Unless --no-terminate is specified, exit after EOF on stdin. */
+        if (o.proto != IPPROTO_TCP || !o.noterminate)
             nsock_loop_quit(nsp);
         return;
     } else if (status == NSE_STATUS_ERROR) {
@@ -1325,8 +1325,8 @@ static void read_socket_handler(nsock_pool nsp, nsock_event evt, void *data)
 #else
         Close(STDOUT_FILENO);
 #endif
-        /* In --recv-only mode or non-TCP mode, exit after EOF on the socket. */
-        if (o.proto != IPPROTO_TCP || (o.proto == IPPROTO_TCP && o.recvonly))
+        /* Unless --no-terminate is specified, exit after EOF on the socket. */
+        if (o.proto != IPPROTO_TCP || !o.noterminate)
             nsock_loop_quit(nsp);
         return;
     } else if (status == NSE_STATUS_ERROR) {

--- a/ncat/ncat_core.c
+++ b/ncat/ncat_core.c
@@ -107,6 +107,7 @@ void options_init(void)
     o.sendonly = 0;
     o.recvonly = 0;
     o.noshutdown = 0;
+    o.noterminate = 0;
     o.telnet = 0;
     o.linedelay = 0;
     o.chat = 0;

--- a/ncat/ncat_core.h
+++ b/ncat/ncat_core.h
@@ -111,6 +111,7 @@ struct options {
     int sendonly;
     int recvonly;
     int noshutdown;
+    int noterminate;
     int telnet;
     int linedelay;
     int chat;

--- a/ncat/ncat_main.c
+++ b/ncat/ncat_main.c
@@ -263,6 +263,7 @@ int main(int argc, char *argv[])
         {"source",          required_argument,  NULL,         's'},
         {"send-only",       no_argument,        &o.sendonly,  1},
         {"no-shutdown",     no_argument,        &o.noshutdown,1},
+        {"no-terminate",    no_argument,        &o.noterminate,1},
         {"broker",          no_argument,        NULL,         0},
         {"chat",            no_argument,        NULL,         0},
         {"talk",            no_argument,        NULL,         0},
@@ -615,6 +616,7 @@ int main(int argc, char *argv[])
 "      --send-only            Only send data, ignoring received; quit on EOF\n"
 "      --recv-only            Only receive data, never send anything\n"
 "      --no-shutdown          Continue half-duplex when receiving EOF on stdin\n"
+"      --no-terminate         Do not exit when EOF is received on socket/stdin\n"
 "      --allow                Allow only given hosts to connect to Ncat\n"
 "      --allowfile            A file of hosts allowed to connect to Ncat\n"
 "      --deny                 Deny given hosts from connecting to Ncat\n"


### PR DESCRIPTION
Also implements a switch for backwards compatibility with the previous
behaviour, --no-terminate. Previously discussed at
https://seclists.org/nmap-dev/2017/q2/94

Fixes #1779, #894 and #1413.

---

Hi people and apologies for the unwieldy title!

Right now, Ncat keeps running when the remote end closes the connection.
Only when the client pushes more bytes into Ncat, it fails with "Broken
pipe." For example, this makes it impossible to wrap Ncat in a
while-loop to keep reconnecting.

Here is a simple PoC of the problem:
 - run `ncat -l 1234` in one terminal and `nc ::1 1234` in another.
 - ^C the listen-mode ncat.
 - hit return (possibly twice) in the connect-mode ncat.

With the current version, this prints "Ncat: Broken pipe."; with the
patch applied, it works and the connect-mode ncat exits.

This has been requested multiple times [1] [2] [3] [4], and was accepted
in 2017 by dmiller [5] and fyodor [6], who for lack of feedback back
then didn't go ahead with it.

To get Ncat's previous behaviour, I opted for a new command line switch,
--no-terminate, instead of overloading --keep-open (as Daniel
suggested), as I felt it is unintuitive to have an option that does two
different things depending on the context (-l vs no -l). I was
contemplating overloading --no-shutdown, but didn't, as it is already a
backwards-compatibility-option for openbsd-nc, so changing it didn't
feel right.

[1]: https://seclists.org/nmap-dev/2017/q2/67
[2]: https://github.com/nmap/nmap/issues/894
[3]: https://github.com/nmap/nmap/issues/1413
[4]: https://github.com/nmap/nmap/issues/1779
[5]: https://seclists.org/nmap-dev/2017/q2/94
[6]: https://seclists.org/nmap-dev/2017/q2/134
