### PR TITLE
Specify AI_ADDRCONFIG flag for getaddinfo

### DIFF
--- a/ncat/ncat_core.c
+++ b/ncat/ncat_core.c
@@ -221,7 +221,7 @@ int resolve(const char *hostname, unsigned short port,
     struct sockaddr_list sl;
     int result;
 
-    flags = 0;
+    flags = AI_ADDRCONFIG;
     if (o.nodns)
         flags |= AI_NUMERICHOST;
 


### PR DESCRIPTION
This filter ipv6 adresses out for systems withoun ipv6
and fix ncat failures on cleanup with ipv6 disabled.

Bug-Url: https://bugzilla.redhat.com/1899824