### PR TITLE
Exclude container packages from not-root warnings

### DIFF
--- a/zenmap/zenmapGUI/App.py
+++ b/zenmap/zenmapGUI/App.py
@@ -275,7 +275,8 @@ Do this now? \
         repair_dialog.destroy()
 
     # Display a "you're not root" warning if appropriate.
-    if not is_root():
+    # Containers like Flatpak are ignored in this case.
+    if not is_root() and os.environ.get('container') is None:
         non_root = NonRootWarning()
         non_root.run()
         non_root.destroy()


### PR DESCRIPTION
This change is in relation with this package:
https://github.com/flathub/flathub/pull/2121

Since containerised instances of Zenmap can never gain root-access, it seems that it's better to ignore the message in this case.