### PR TITLE
make libdnet-stripped and nbase compile by VS2015+

### DIFF
--- a/libdnet-stripped/include/dnet_winconfig.h
+++ b/libdnet-stripped/include/dnet_winconfig.h
@@ -270,7 +270,9 @@ int	strlcpy(char *, const char *, int);
 char	*strsep(char **, const char *);
 #endif
 
+#if _MSC_VER < 1900
 #define snprintf _snprintf
+#endif
 
 /* Without this, Windows will give us all sorts of crap about using functions
    like strcpy() even if they are done safely */

--- a/nbase/nbase.h
+++ b/nbase/nbase.h
@@ -293,7 +293,9 @@ extern "C" int vsnprintf (char *, size_t, const char *, va_list);
 #define tzset _tzset
 
 #if !defined(__GNUC__)
+#if _MSC_VER < 1900
 #define snprintf _snprintf
+#endif
 #endif
 
 #define strcasecmp _stricmp


### PR DESCRIPTION
new Visual Studio's (2015+) complain about macro redifinition of snprintf and libdnet-stripped and nbase libs failt to build