### PR TITLE
Fix attempt to concatenate a  nil value

### DIFF
--- a/ncat/scripts/httpd.lua
+++ b/ncat/scripts/httpd.lua
@@ -50,7 +50,7 @@ function read_line(max_len)
         if chr == "\n" then
             return ret, true
         end
-        ret = ret .. chr
+        ret = ret .. (chr or "")
     end
 
     return ret, false


### PR DESCRIPTION
Hi Nmap Team 

I got this error in my script:

```
Ncat: Error running the Lua script: /tmp/httpd.lua:53: attempt to concatenate a 
nil value (local 'chr')
stack traceback:
        /tmp/httpd.lua:53: in function 'read_line'
        /tmp/httpd.lua:335: in main chunk. QUITTING.
```

Got this fix on line 53 `(chr or "")`