### PR TITLE
Fix initial position out of string

### DIFF
--- a/nselib/msrpc.lua
+++ b/nselib/msrpc.lua
@@ -551,7 +551,13 @@ function rap_netserverenum2(smbstate, domain, server_type, detail_level)
 
     -- pos needs to be rounded to the next even multiple of 16
     pos = pos + ( 16 - (#server.name % 16) ) - 1
-
+    
+    local fmt = "<BBI4I2I2"
+    if #data - pos + 1 < string.packsize(fmt) then
+       stdnse.debug1("MSRPC: ERROR: Ran off the end of SMB packet")
+       return true, entries       
+    end
+    
     if ( detail_level > 0 ) then
       local comment_offset, _
       server.version = {}


### PR DESCRIPTION
Hi Nmap Team

I got this error in my script:

NSE: [smb-mbenum 192.17.1.21] MSRPC: Parsing Browser Service response
NSE: [smb-mbenum 192.17.1.21] MSRPC: Browser service returned 2 entries
NSE: [smb-mbenum 192.17.1.21] MSRPC: Found name: PVE
NSE: [smb-mbenum 192.17.1.21] MSRPC: Found name: storage
NSE: smb-mbenum against 192.17.1.21 threw an error!
/usr/bin/../share/nmap/nselib/msrpc.lua:559: bad argument #3 to 'unpack' (initial position out of string)
stack traceback:
        [C]: in function 'string.unpack'
        /usr/bin/../share/nmap/nselib/msrpc.lua:559: in function 'msrpc.rap_netserverenum2'
        /usr/bin/../share/nmap/scripts/smb-mbenum.nse:174: in function </usr/bin/../share/nmap/scripts/smb-mbenum.nse:134>
        (...tail calls...)

Fixed :-)
