### PR TITLE
Zenmap : Fix the python version

### DIFF
--- a/zenmap/zenmap
+++ b/zenmap/zenmap
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 # ***********************IMPORTANT NMAP LICENSE TERMS************************


### PR DESCRIPTION
Currently the default version of python is version 3, zenmap tends to use version 3 of python which causes a possible error when launching it.
Issue : #2279