### PR TITLE
[NSE] Improve ip-forwarding nse script

### DIFF
--- a/scripts/ip-forwarding.nse
+++ b/scripts/ip-forwarding.nse
@@ -5,62 +5,61 @@ local stdnse = require "stdnse"
 local ipOps = require "ipOps"
 
 description = [[
-Detects whether the remote device has ip forwarding or "Internet connection
-sharing" enabled, by sending an ICMP echo request to a given target using
-the scanned host as default gateway.
+Checks whether ipv4 forwarding is enabled on the targeted host. The targeted host needs to be on
+the same network. The check is based on an ICMP echo request, that is send to the target with
+a destination address of 8.8.8.8 and a time-to-live (TTL) of 1. The server's response depends on
+it's forwarding settings:
 
-The given target can be a routed or a LAN host and needs to be able to respond
-to ICMP requests (ping) in order for the test to be successful. In addition,
-if the given target is a routed host, the scanned host needs to have the proper
-routing to reach it.
+1. If IPv4 forwarding is disabled, the server ignores the packet and causes a time out.
+2. If IPv4 forwarding is enabled, the server either replies with an ICMP type 3 packet
+   (destination unreachable) or an ICMP type 11 packet (time-to-live exceeded).
 
-In order to use the scanned host as default gateway Nmap needs to discover
-the MAC address. This requires Nmap to be run in privileged mode and the host
-to be on the LAN.
+Depending on the response send by the server, we know whether forwarding is enabled or not.
+
+This check is based on the original ip-forwarding check of nmap written by Patrik Karlsson.
 ]]
 
 ---
 -- @usage
--- sudo nmap -sn <target> --script ip-forwarding --script-args='target=www.example.com'
+-- sudo nmap --script=ip-forwarding -sn <target>
 --
 -- @output
 -- | ip-forwarding:
--- |_  The host has ip forwarding enabled, tried ping against (www.example.com)
---
--- @args ip-forwarding.target a LAN or routed target responding to ICMP echo
---        requests (ping).
+-- |_  The host has ip forwarding enabled!
 --
 
-author = "Patrik Karlsson"
-license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+author = "Tobias Neitzel (@qtc_de)"
+license = "Same as Nmap. See https://nmap.org/book/man-legal.html"
 categories = {"safe", "discovery"}
-
-local arg_target = stdnse.get_script_args(SCRIPT_NAME .. ".target")
 
 hostrule = function(host)
   if ( not(host.mac_addr) ) then
-    stdnse.debug1("Failed to determine hosts remote MAC address" )
+    stdnse.debug1("Failed to determine remote hosts MAC address" )
   end
-  return (arg_target ~= nil and host.mac_addr ~= nil)
+  return (host.mac_addr ~= nil)
 end
 
 
-icmpEchoRequest = function(ifname, host, addr)
+icmpEchoRequest = function(ifname, host)
   local iface = nmap.get_interface_info(ifname)
   local dnet, pcap = nmap.new_dnet(), nmap.new_socket()
 
+  ident = math.random(256,65635)
+
   pcap:set_timeout(5000)
-  pcap:pcap_open(iface.device, 128, false, ("ether src %s and icmp and ( icmp[0] = 0 or icmp[0] = 5 ) and dst %s"):format(stdnse.format_mac(host.mac_addr), iface.address))
+  pcap:pcap_open(iface.device, 128, false, ("icmp and ( icmp[0] = 3 or icmp[0] = 11 ) and icmp[32:2] = %d and dst %s"):format(ident, iface.address))
+
   dnet:ethernet_open(iface.device)
 
   local probe = packet.Frame:new()
   probe.mac_src = iface.mac
   probe.mac_dst = host.mac_addr
   probe.ip_bin_src = ipOps.ip_to_str(iface.address)
-  probe.ip_bin_dst = ipOps.ip_to_str(addr)
-  probe.echo_id = 0x1234
+  probe.ip_bin_dst = ipOps.ip_to_str('8.8.8.8')
+  probe.echo_id = ident
   probe.echo_seq = 6
-  probe.echo_data = "Nmap host discovery."
+  probe.ip_ttl = 1
+  probe.echo_data = "Nmap ip-forwarding check."
   probe:build_icmp_echo_request()
   probe:build_icmp_header()
   probe:build_ip_packet()
@@ -72,33 +71,17 @@ icmpEchoRequest = function(ifname, host, addr)
   return status
 end
 
+
 local function fail(err) return stdnse.format_output(false, err) end
 
-action = function(host)
 
+action = function(host)
   local ifname = nmap.get_interface() or host.interface
   if ( not(ifname) ) then
     return fail("Failed to determine the network interface name")
   end
 
-  local target = ipOps.ip_to_bin(arg_target)
-  if ( not(target) ) then
-    local status
-    status, target = dns.query(arg_target, { dtype='A' })
-    if ( not(status) ) then
-      return fail(("Failed to lookup hostname: %s"):format(arg_target))
-    end
-  else
-    target = arg_target
+  if (icmpEchoRequest(ifname, host)) then
+    return ("\n  The host has ip forwarding enabled!")
   end
-
-  if ( target == host.ip ) then
-    return fail("Target can not be the same as the scanned host")
-  end
-
-  if (icmpEchoRequest(ifname, host, target)) then
-    return ("\n  The host has ip forwarding enabled, tried ping against (%s)"):format(arg_target)
-  end
-
 end
-


### PR DESCRIPTION
Hi there :wave:

during one of our recent assessments we ([@usdAG](https://twitter.com/usdag)) became aware of the ip-forwarding NSE script of Nmap. It worked great, but despite being already useful in its current state, we found some improvements that make the script easier to use and more reliable. The changes we made are summarized below:

In it's current state the NSE script requires an additional host as input argument, which is used to test the forwarding against. We think that this is unnecessary, as one can also use the same approach as e.g. ``traceroute`` to determine whether a target is forwarding packets. By setting the ``ttl`` to one within of the probe packet, a forwarding target will respond either with a ``time-to-live exceeded`` or ``destination unreachable`` icmp packet. On the other hand, non forwarding targets will simply ignore the packet.

This makes it possible to determine the forwarding setting without relying on an additional target. Furthermore, it should make the script more reliable, as firewall rules between the different target hosts can no longer influence the test result.

Finally I want to leave a note on the pcap filter: We intentionally left out the source mac address and source IP address of the target within the pcap filter. The reason is that we encountered an interesting edge case, where the target had two network interfaces within the same local network. In this case, the target sent the ``time-to-live exceeded`` packet randomly from one of these two network interfaces, although the incoming packet was only targeted to one of them. Despite being only an edge case, we wanted to also cover this situation and decided to only filter against the ID of the icmp packet. This is generated randomly within the script and should be a sufficiently unique identifier in almost all situations.