### PR TITLE
Print the device names once

### DIFF
--- a/output.cc
+++ b/output.cc
@@ -297,9 +297,9 @@ static void print_iflist_pcap_mapping(const struct interface_info *iflist,
     for (leftover_p = leftover_pcap_ifs.begin();
          leftover_p != leftover_pcap_ifs.end();
          leftover_p++) {
-      Tbl.addItem(i + 1, 0, false, "<none>");
-      Tbl.addItem(i + 1, 1, false, (*leftover_p)->name);
-      i++;
+      Tbl.addItem(line, 0, false, "<none>");
+      Tbl.addItem(line, 1, false, (*leftover_p)->name);
+      line++;
     }
 
     log_write(LOG_PLAIN, "%s\n", Tbl.printableTable(NULL));

--- a/output.cc
+++ b/output.cc
@@ -246,7 +246,7 @@ static void print_iflist_pcap_mapping(const struct interface_info *iflist,
   char errbuf[PCAP_ERRBUF_SIZE];
   std::list<const pcap_if_t *> leftover_pcap_ifs;
   std::list<const pcap_if_t *>::iterator leftover_p;
-  int i;
+  int i, line;
 
   /* Build a list of "leftover" libpcap interfaces. Initially it contains all
      the interfaces. */
@@ -259,14 +259,16 @@ static void print_iflist_pcap_mapping(const struct interface_info *iflist,
   }
 
   if (numifs > 0 || !leftover_pcap_ifs.empty()) {
+    char pcap_last[50] = "";
+    
     NmapOutputTable Tbl(1 + numifs + leftover_pcap_ifs.size(), 2);
 
     Tbl.addItem(0, 0, false, "DEV");
     Tbl.addItem(0, 1, false, "WINDEVICE");
 
     /* Show the libdnet names and what they map to. */
-    for (i = 0; i < numifs; i++) {
-      char pcap_name[1024];
+    for (line = 1, i = 0; i < numifs; i++) {
+      char pcap_name[50];
 
       if (DnetName2PcapName(iflist[i].devname, pcap_name, sizeof(pcap_name))) {
         /* We got a name. Remove it from the list of leftovers. */
@@ -282,8 +284,12 @@ static void print_iflist_pcap_mapping(const struct interface_info *iflist,
         Strncpy(pcap_name, "<none>", sizeof(pcap_name));
       }
 
-      Tbl.addItem(i + 1, 0, false, iflist[i].devname);
-      Tbl.addItem(i + 1, 1, true, pcap_name);
+      if (strcmp(pcap_name, pcap_last)) {
+        Tbl.addItem(line, 0, false, iflist[i].devname);
+        Tbl.addItem(line, 1, true, pcap_name);
+        line++;
+      }
+      Strncpy(pcap_last, pcap_name, sizeof(pcap_last));
     }
 
     /* Show the "leftover" libpcap interface names (those without a libdnet


### PR DESCRIPTION
Currently, a `nmap --iflist` will print:
```
DEV    WINDEVICE
eth0   \Device\NPF_{3A46ACA0-CBED-44BC-A239-6AEA3D0C451D}
eth0   \Device\NPF_{3A46ACA0-CBED-44BC-A239-6AEA3D0C451D}
eth0   \Device\NPF_{3A46ACA0-CBED-44BC-A239-6AEA3D0C451D}
eth0   \Device\NPF_{3A46ACA0-CBED-44BC-A239-6AEA3D0C451D}
eth0   \Device\NPF_{3A46ACA0-CBED-44BC-A239-6AEA3D0C451D}
eth0   \Device\NPF_{3A46ACA0-CBED-44BC-A239-6AEA3D0C451D}
eth1   \Device\NPF_{DBEF7D48-8CD5-456C-9475-5C53F52616CC}
eth1   \Device\NPF_{DBEF7D48-8CD5-456C-9475-5C53F52616CC}
eth2   \Device\NPF_{F92984E3-5D40-4AD9-B054-41288EAE699F}
eth3   \Device\NPF_{7B640089-F33E-4886-823D-87966FA4616F}
eth3   \Device\NPF_{7B640089-F33E-4886-823D-87966FA4616F}
lo0    <none>
lo0    <none>
```

Fix it to drop duplicates. Thus in my case becoming:
```
DEV    WINDEVICE
eth0   \Device\NPF_{3A46ACA0-CBED-44BC-A239-6AEA3D0C451D
eth1   \Device\NPF_{DBEF7D48-8CD5-456C-9475-5C53F52616CC
eth2   \Device\NPF_{F92984E3-5D40-4AD9-B054-41288EAE699F
eth3   \Device\NPF_{7B640089-F33E-4886-823D-87966FA4616F
lo0    <none>
```