### PR TITLE
Fix wrong *length

### DIFF
--- a/utils.cc
+++ b/utils.cc
@@ -626,7 +626,7 @@ char *mmapfile(char *fname, s64 *length, int openflags) {
   if (lowsize == INVALID_FILE_SIZE && GetLastError() != NO_ERROR) {
     pfatal("%s(%u): GetFileSize(), file '%s'", __FILE__, __LINE__, fname);
   }
-  *length = lowsize + highsize << sizeof(DWORD);
+  *length = lowsize + ((s64) highsize << 32);
   if (*length < 0) {
     fatal("%s(%u): size too large, file '%s'", __FILE__, __LINE__, fname);
   }


### PR DESCRIPTION
A `highsize` should be the upper 32-bit of a signed 64-bit value.
But nobody have ever tried this function with a >2GByte .log-file before (?)