### PR TITLE
Trace arp fix

### DIFF
--- a/tcpip.cc
+++ b/tcpip.cc
@@ -192,6 +192,7 @@ void PacketTrace::traceArp(pdirection pdir, const u8 *frame, u32 len,
     inet_ntop(AF_INET, (char*)&arp->data.ar_tpa, who_has, sizeof(who_has));
     inet_ntop(AF_INET, (char*)&arp->data.ar_spa, tell, sizeof(tell));
     Snprintf(arpdesc, sizeof(arpdesc), "who-has %s tell %s", who_has, tell);
+  }
   else { /* assume a 'ARP REPLY' */
     inet_ntop(AF_INET, (char*)&arp->data.ar_tpa, who_has, sizeof(who_has));
     Snprintf(arpdesc, sizeof(arpdesc),

--- a/utils.cc
+++ b/utils.cc
@@ -626,7 +626,7 @@ char *mmapfile(char *fname, s64 *length, int openflags) {
   if (lowsize == INVALID_FILE_SIZE && GetLastError() != NO_ERROR) {
     pfatal("%s(%u): GetFileSize(), file '%s'", __FILE__, __LINE__, fname);
   }
-  *length = lowsize + highsize << sizeof(DWORD);
+  *length = lowsize + ((s64) highsize << 32);
   if (*length < 0) {
     fatal("%s(%u): size too large, file '%s'", __FILE__, __LINE__, fname);
   }


### PR DESCRIPTION
Make `PacketTrace::traceArp()` is little nicer:
* Lifted `MACtoa()` from `nping/net_util.cc`. Ideally this could be added to `libnetutil`.
* Define a `struct arp_frame` to cast the `*frame` into.

(not sure this PR works; seems to be >1 commits here).