### PR TITLE
ssh2: fix positive mpint value packing in kex

### DIFF
--- a/nselib/ssh2.lua
+++ b/nselib/ssh2.lua
@@ -57,7 +57,7 @@ transport.pack_mpint = function( bn )
   local bytes, packed
   bytes = bn:num_bytes()
   packed = bn:tobin()
-  if bytes % 8 == 0 then
+  if bn:num_bits() % 8 == 0 then
     bytes = bytes + 1
     packed = '\0' .. packed
   end


### PR DESCRIPTION
Packed positive mpint values must be preceded with zero byte when MSB of
the value is set as per rfc4251. Taking modulo 8 on the number of bytes
in the bignum value can not determine value of MSB. Fix the MSB check to
use modulo 8 on the number of significant bits instead.

On the server side, OpenSSH was unable to unpack these mpint values used
in key exchange as they ended up negative.

    sshd: ssh_dispatch_run_fatal: Connection from x.x.x.x port yyyyy: bignum is negative [preauth]

Callers of fetch_host_key() are not getting back any errors from these
failures. Consequently, host key scanning would intermittently return
only partial results.