### PR TITLE
Fix Issue #2296

### DIFF
--- a/nmap.cc
+++ b/nmap.cc
@@ -1777,7 +1777,6 @@ int nmap_main(int argc, char *argv[]) {
   int i;
   std::vector<Target *> Targets;
   time_t now;
-  struct hostent *target = NULL;
   time_t timep;
   char mytime[128];
   struct addrset *exclude_group;

--- a/scripts/redis-info.nse
+++ b/scripts/redis-info.nse
@@ -138,7 +138,7 @@ local extras = {
         local ip = item:match("addr=%[?([0-9a-f:.]+)%]?:[0-9]+ ")
         if not item or 0 == #item then goto continue end
         client_ips[ip] = true;
-        ::continue:
+        ::continue::
       end
       if not next(client_ips) then
         return nil


### PR DESCRIPTION
fixes nmap#2296

When the item doesn't exist the script fails and results in "ERROR: Script execution failed (use -d to debug)" as the script output. This patch simply skips over the non-existent item and continues the loop.