### PR TITLE
Relabel generic rpcbind as sunrpc; Explicitly print when RPC grinder can't determine service

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -12284,11 +12284,11 @@ match ossec-agent m=^\xdf\x06\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01\x97\|\0\
 match riverbed-stats m|^a\x0f\x02\x04fiji\x02\x01\0\x02\x01\0\x02\x01\0$| p/Riverbed Steelhead Mobile caching proxy statistics/ d/proxy server/
 
 #RPC Response, MSG_ACCEPTED, any AUTH type
-match rpcbind m|^\x80\0\0.\x72\xfe\x1d\x13\0\0\0\x01\0\0\0\0\0\0\0[\x00-\x03\x06]|
+match sunrpc m|^\x80\0\0.\x72\xfe\x1d\x13\0\0\0\x01\0\0\0\0\0\0\0[\x00-\x03\x06]|
 # RPC Response, MSG_DENIED, RPC_MISMATCH
-match rpcbind m|^\x80\0\0.\x72\xfe\x1d\x13\0\0\0\x01\0\0\0\x01\0\0\0\x00\0\0\0[\x00-\x02]\0\0\0[\x00-\x02]|
+match sunrpc m|^\x80\0\0.\x72\xfe\x1d\x13\0\0\0\x01\0\0\0\x01\0\0\0\x00\0\0\0[\x00-\x02]\0\0\0[\x00-\x02]|
 # RPC Response, MSG_DENIED, AUTH_ERROR, any status
-match rpcbind m|^\x80\0\0.\x72\xfe\x1d\x13\0\0\0\x01\0\0\0\x01\0\0\0\x01\0\0\0[\x00-\x07]|
+match sunrpc m|^\x80\0\0.\x72\xfe\x1d\x13\0\0\0\x01\0\0\0\x01\0\0\0\x01\0\0\0[\x00-\x07]|
 
 match rtdscchcch m|^\x03\x11\0\x02V1\xec\xe7\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\xdd\0\x04\0\0| p/SIX Market Data Feed (MDF)/ cpe:/a:six_group:market_data_feed/
 
@@ -12362,8 +12362,8 @@ match slp-srvreg m|^\x02\x05\0\0\x12\0\0\0\0\0\0\x02\0\x02en\0\x0e$| p/IBM Direc
 
 match radius m|^\x03\xfe\0\x14................$|s p/Juniper Steel-Belted Radius radiusd/
 
-match rpcbind m|^\x72\xFE\x1D\x13\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01|
-match rpcbind m|^\x72\xFE\x1D\x13\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x02|
+match sunrpc m|^\x72\xFE\x1D\x13\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01|
+match sunrpc m|^\x72\xFE\x1D\x13\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x02|
 # OpenAFS 1.2.10 on Linux 2.4.22
 match kerberos-sec m|^\x04\n\0\0\0\0\0\0\0\0\0\0\x04code = 4: packet version number unknown\0| p/OpenAFS/ cpe:/a:openafs:openafs/
 # talk-server-0.17 (linux), ports 517-518/udp
@@ -14875,7 +14875,7 @@ match megaraid-monitor m|^\x02\0\0\0\0\0\0/\0\0\0\0\0\0\0\0\0@\x1f\0\0\0\0\0\0\0
 match routeros-api m|^\x06!fatal\rnot logged in\0| p/MikroTik RouterOS API/ o/RouterOS/ cpe:/o:mikrotik:routeros/
 
 # Interesting service: Not sure if it's RPC
-match rpcbind m|^\x18\0\x01\x02Invalid packet length\0| p/Amanda voicemail system/ d/telecom-misc/
+match sunrpc m|^\x18\0\x01\x02Invalid packet length\0| p/Amanda voicemail system/ d/telecom-misc/
 # Moved this from SSLSessionReq because it seems more reliable.
 # May need to generalize and grab the language if we see non-"en" responses
 match srvloc m|^\x02\x02\0\0\x12\0\0\0\0\0\0\0\0\x02en\0\x02$| p/Apple slpd/ o/Mac OS/ cpe:/o:apple:mac_os/a

--- a/nselib/rpc.lua
+++ b/nselib/rpc.lua
@@ -102,16 +102,16 @@ _ENV = stdnse.module("rpc", stdnse.seeall)
 
 -- RPC args using the nmap.registry.args
 RPC_args = {
-  ["rpcbind"] = { proto = 'rpc.protocol' },
+  ["sunrpc"] = { proto = 'rpc.protocol' },
   ["nfs"] = { ver = 'nfs.version' },
   ["mountd"] = { ver = 'mount.version' },
 }
 
 -- Defines the order in which to try to connect to the RPC programs
 -- TCP appears to be more stable than UDP in most cases, so try it first
-local RPC_PROTOCOLS = (nmap.registry.args and nmap.registry.args[RPC_args['rpcbind'].proto] and
-  type(nmap.registry.args[RPC_args['rpcbind'].proto]) == 'table') and
-nmap.registry.args[RPC_args['rpcbind'].proto] or { "tcp", "udp" }
+local RPC_PROTOCOLS = (nmap.registry.args and nmap.registry.args[RPC_args['sunrpc'].proto] and
+  type(nmap.registry.args[RPC_args['sunrpc'].proto]) == 'table') and
+nmap.registry.args[RPC_args['sunrpc'].proto] or { "tcp", "udp" }
 
 -- used to cache the contents of the rpc datafile
 local RPC_PROGRAMS
@@ -121,7 +121,7 @@ local mutex = nmap.mutex("rpc")
 
 -- Supported protocol versions
 RPC_version = {
-  ["rpcbind"] = { min=2, max=4 },
+  ["sunrpc"] = { min=2, max=4 },
   ["nfs"] = { min=1, max=3 },
   ["mountd"] = { min=1, max=3 },
 }

--- a/scripts/rpcinfo.nse
+++ b/scripts/rpcinfo.nse
@@ -104,7 +104,7 @@ action = function(host, port)
         if nmapport and (nmapport.state == "open" or nmapport.state == "open|filtered") then
           nmapport.version = nmapport.version or {}
           -- If we don't already know it, or we only know that it's "rpcbind"
-          if nmapport.service == nil or nmapport.version.service_dtype == "table" or port.service == "rpcbind" then
+          if nmapport.service == nil or nmapport.version.service_dtype == "table" or port.service == "sunrpc" then
             nmapport.version.name = rpc.Util.ProgNumberToName(progid)
             nmapport.version.extrainfo = "RPC #" .. progid
             if #v2.version > 1 then


### PR DESCRIPTION
See https://github.com/nmap/nmap/issues/2363