### PR TITLE
ncat: Support domain name response from socks5 proxy

### DIFF
--- a/ncat/ncat_connect.c
+++ b/ncat/ncat_connect.c
@@ -916,6 +916,14 @@ static int do_proxy_socks5(void)
     case SOCKS5_ATYP_IPv4:
         bndaddrlen = 4 + 2;
         break;
+    case SOCKS5_ATYP_NAME:
+        if (socket_buffer_readcount(&stateful_buf, socksbuf, 1) < 0) {
+            loguser("Error: number of octets of domain name missing.\n");
+            close(sd);
+            return -1;
+        }
+        bndaddrlen = socksbuf[0] + 2;
+        break;
     case SOCKS5_ATYP_IPv6:
         bndaddrlen = 16 + 2;
         break;

--- a/ncat/ncat_connect.c
+++ b/ncat/ncat_connect.c
@@ -660,7 +660,7 @@ static int do_proxy_socks5(void)
     size_t addrlen;
     char addrstr[INET6_ADDRSTRLEN];
     size_t bndaddrlen;
-    char bndaddr[16 + 2]; /* IPv4/IPv6 address and port */
+    char bndaddr[255 + 2]; /* IPv4/IPv6 address | FQDN and port */
     size_t remainderlen;
     char* remainder;
 
@@ -922,7 +922,7 @@ static int do_proxy_socks5(void)
             close(sd);
             return -1;
         }
-        bndaddrlen = socksbuf[0] + 2;
+        bndaddrlen = (unsigned char) socksbuf[0] + 2;
         break;
     case SOCKS5_ATYP_IPv6:
         bndaddrlen = 16 + 2;


### PR DESCRIPTION
Some socks5 proxy server returns `3: Domain Name` as an `Address Type` value.
Here is an example of response packet:
![image](https://user-images.githubusercontent.com/216323/132878168-2f5fa5ab-2d9f-4e2d-a9a4-767464ced3a9.png)

But current ncat implementation does not support this type and ends up with `"Error: invalid proxy bind address type"`:

https://github.com/nmap/nmap/blob/b0bd2776a7dbb887e5dd6ae92bceb63be1aecc7a/ncat/ncat_connect.c#L915-L923

This kind of response is described in [RFC1928](https://datatracker.ietf.org/doc/html/rfc1928#section-6), so should be supported.