### PR TITLE
Fix an exception thrown in smb-system-info.nse script edge case

### DIFF
--- a/scripts/smb-system-info.nse
+++ b/scripts/smb-system-info.nse
@@ -120,7 +120,7 @@ local function get_info_registry(host)
   -- Processor information
   result['status-number_of_processors'], result['number_of_processors']   = reg_get_value(smbstate, openhklm_result['handle'], "SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment", "NUMBER_OF_PROCESSORS")
   if(result['status-number_of_processors'] == false) then
-    result['number_of_processors'] = 0
+    result['number_of_processors'] = '0'
   end
   result['status-os'], result['os']                                         = reg_get_value(smbstate, openhklm_result['handle'], "SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment", "OS")
   result['status-path'], result['path']                                     = reg_get_value(smbstate, openhklm_result['handle'], "SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment", "Path")


### PR DESCRIPTION
Recently, I have been looking at pentesting SMB services and noticed a small issue with the `smb-system-info.nse` script.

## Issue
```
NSE: [smb-system-info 127.0.0.1] SMB: Added account '' to account list
NSE: [smb-system-info 127.0.0.1] SMB: Added account 'guest' to account list
NSE: [smb-system-info 127.0.0.1] SMB: WARNING: the server appears to be Unix; your mileage may vary.
NSE: [smb-system-info 127.0.0.1] SMB: Extended login to 127.0.0.1 as BC9598980B0E\guest failed, but was given guest access (username may be wrong, or system may only allow guest)
NSE: smb-system-info against 127.0.0.1 threw an error!
scripts/smb-system-info.nse:133: attempt to index a number value (field 'number_of_processors')
stack traceback:
	scripts/smb-system-info.nse:133: in upvalue 'get_info_registry'
	scripts/smb-system-info.nse:186: in function <scripts/smb-system-info.nse:184>
	(...tail calls...)
```

## Steps to reproduce

I was able to reproduce the issue by start a samba Docker container via
```
docker run -it -p 139:139 -p 445:445 dperson/samba -p -S
```
and then executing the NSE script on it
```
nmap -d -p 445 --script scripts/smb-system-info.nse 127.0.0.1
```

## Cause
The error is caused by the integer assignment [here](https://github.com/nmap/nmap/blob/972ed6bac0951dbf6fac7e13550f6a429b316e4e/scripts/smb-system-info.nse#L123) which is later treated as a string [here](https://github.com/nmap/nmap/blob/972ed6bac0951dbf6fac7e13550f6a429b316e4e/scripts/smb-system-info.nse#L133).

## Solution
I have replaced the integer with its string representation ([commit](https://github.com/vanjo9800/nmap/commit/b8536731560175f31d61d64fa216ec19a7667c60)).