### PR TITLE
Edited .gnmap output so it matches original input. Virtual host support!

### DIFF
--- a/Target.cc
+++ b/Target.cc
@@ -347,7 +347,7 @@ const char *Target::NameIP(char *buf, size_t buflen) const {
   if (targetname)
     Snprintf(buf, buflen, "%s (%s)", targetname, targetipstring);
   else if (hostname)
-    Snprintf(buf, buflen, "%s (%s)", hostname, targetipstring);
+    Snprintf(buf, buflen, "%s (%s)", targetipstring, hostname);
   else
     Strncpy(buf, targetipstring, buflen);
   return buf;

--- a/output.cc
+++ b/output.cc
@@ -528,8 +528,7 @@ void printportoutput(const Target *currenths, const PortList *plist) {
     return;
 
   xml_start_tag("ports");
-  log_write(LOG_MACHINE, "Host: %s (%s)", currenths->targetipstr(),
-            currenths->HostName());
+  log_write(LOG_MACHINE, "Host: %s ", currenths->NameIP());
 
   if ((o.verbose > 1 || o.debugging) && currenths->StartTime()) {
     time_t tm_secs, tm_sece;
@@ -1430,8 +1429,7 @@ void write_host_header(const Target *currenths) {
 void write_host_status(const Target *currenths) {
   if (o.listscan) {
     /* write "unknown" to machine and xml */
-    log_write(LOG_MACHINE, "Host: %s (%s)\tStatus: Unknown\n",
-              currenths->targetipstr(), currenths->HostName());
+    log_write(LOG_MACHINE, "Host: %s\tStatus: Unknown\n", currenths->NameIP());
     write_xml_initial_hostinfo(currenths, "unknown");
   } else if (currenths->weird_responses) {
     /* SMURF ADDRESS */
@@ -1443,9 +1441,8 @@ void write_host_status(const Target *currenths) {
     xml_attribute("responses", "%d", currenths->weird_responses);
     xml_close_empty_tag();
     xml_newline();
-    log_write(LOG_MACHINE, "Host: %s (%s)\tStatus: Smurf (%d responses)\n",
-              currenths->targetipstr(), currenths->HostName(),
-              currenths->weird_responses);
+    log_write(LOG_MACHINE, "Host: %s\tStatus: Smurf (%d responses)\n", currenths->NameIP(),
+                currenths->weird_responses);
 
     if (o.noportscan) {
       log_write(LOG_PLAIN, "Host seems to be a subnet broadcast address (returned %d extra pings).%s\n",
@@ -1471,11 +1468,9 @@ void write_host_status(const Target *currenths) {
                   num_to_string_sigdigits(currenths->to.srtt / 1000000.0, 2));
       log_write(LOG_PLAIN, ".\n");
 
-      log_write(LOG_MACHINE, "Host: %s (%s)\tStatus: Up\n",
-                currenths->targetipstr(), currenths->HostName());
+      log_write(LOG_MACHINE, "Host: %s\tStatus: Up\n", currenths->NameIP());
     } else if (currenths->flags & HOST_DOWN) {
-      log_write(LOG_MACHINE, "Host: %s (%s)\tStatus: Down\n",
-                currenths->targetipstr(), currenths->HostName());
+      log_write(LOG_MACHINE, "Host: %s\tStatus: Down\n", currenths->NameIP());
     }
   }
 }


### PR DESCRIPTION
.gnmap originally takes provided hostnames, performs an IP lookup, and then resolves the IP address. 

I changed the .gnmap output to use the NameIP() function so that it will list the provided input. 

In the case of a provided hostname, .gnmap will list the provided hostname then list the IP lookup within parenthesis:
Host: <provided-hostname> (IP address)

When providing an IP address, .gnmap will list the IP address then list the resolved IP address within parenthesis:
Host: <provided-IP> (IP DNS lookup)

This helps immensely when dealing with virtual hosts. 