### PR TITLE
Fix #1026 by eliminating unnecessary delays on Windows and VS2019 build fix

### DIFF
--- a/nbase/nbase_misc.c
+++ b/nbase/nbase_misc.c
@@ -363,6 +363,7 @@ int fselect(int s, fd_set *rmaster, fd_set *wmaster, fd_set *emaster, struct tim
     fd_set rset, wset, eset;
     int r_stdin = rmaster != NULL && FD_ISSET(STDIN_FILENO, rmaster);
     int e_stdin = emaster != NULL && FD_ISSET(STDIN_FILENO, emaster);
+    int stdin_ready = 0;
 
     /* Figure out whether there are any FDs in the sets, as @$@!$# Windows
        returns WSAINVAL (10022) if you call a select() with no FDs, even though
@@ -440,6 +441,12 @@ int fselect(int s, fd_set *rmaster, fd_set *wmaster, fd_set *emaster, struct tim
         if (emaster)
             eset = *emaster;
 
+        if(r_stdin) {
+            stdin_ready = win_stdin_ready();
+            if(stdin_ready)
+                stv.tv_usec = 0; /* get status but don't wait since stdin is ready */
+        }
+
         fds_ready = 0;
         /* selecting on anything other than stdin? */
         if (s > 1)
@@ -447,7 +454,7 @@ int fselect(int s, fd_set *rmaster, fd_set *wmaster, fd_set *emaster, struct tim
         else
             usleep(stv.tv_sec * 1000000UL + stv.tv_usec);
 
-        if (fds_ready > -1 && r_stdin && win_stdin_ready()) {
+        if (fds_ready > -1 && stdin_ready) {
             FD_SET(STDIN_FILENO, &rset);
             fds_ready++;
         }

--- a/ncat/ncat_ssl.c
+++ b/ncat/ncat_ssl.c
@@ -208,7 +208,7 @@ static int wildcard_match(const char *pattern, const char *hostname, int len)
 
         /* Ensure there's at least one more dot, not counting a dot at the
            end. */
-        dot = memchr(p, '.', remaining);
+        dot = (const char *) memchr(p, '.', remaining);
         if (dot == NULL /* not found */
           || dot - p == remaining /* dot in last position */
           || *(dot + 1) == '\0') /* dot immediately before null terminator */


### PR DESCRIPTION
I had to add an explicit cast to avoid `\ncat_ssl.c(211,40): error C2440: '=': cannot convert from 'const void *' to 'const char *'` and checkout the svn for the build environment but I was then able to build in VS2019 and run and verify that the problem is fixed.