### PR TITLE
script/http-ls: tiny fix in regexp

### DIFF
--- a/scripts/http-ls.nse
+++ b/scripts/http-ls.nse
@@ -138,7 +138,7 @@ local function list_files(host, port, url, output, maxdepth, basedir)
   end
 
   local patterns = {
-    '<[Aa] [Hh][Rr][Ee][Ff]="([^"]+)">[^<]+</[Aa]></[Tt][Dd]><[Tt][Dd][^>]*> *([0-9]+-[A-Za-z0-9]+-[0-9]+ [0-9]+:[0-9]+) *</[Tt][Dd]><[Tt][Dd][^>]*> *([^<]+)</[Tt][Dd]>',
+    '<[Aa] [Hh][Rr][Ee][Ff]="([^"]+)">[^<]+</[Aa]> *</[Tt][Dd]><[Tt][Dd][^>]*> *([0-9]+-[A-Za-z0-9]+-[0-9]+ [0-9]+:[0-9]+) *</[Tt][Dd]><[Tt][Dd][^>]*> *([^<][^<]-) *</[Tt][Dd]>',
     '<[Aa] [Hh][Rr][Ee][Ff]="([^"]+)">[^<]+</[Aa]> *([0-9]+-[A-Za-z0-9]+-[0-9]+ [0-9]+:[0-9]+) *([^ \r\n]+)',
   }
   for _, pattern in ipairs(patterns) do


### PR DESCRIPTION
The current regexp would miss some specific cases.

I have found a (random) target to show the problem:

```
# nmap -n -PS880 -p 880 -sSV --script http-ls 36.94.125.20
```

Output without the patch:
```
PORT    STATE SERVICE VERSION
880/tcp open  http    Apache httpd 2.4.41 ((Win64) OpenSSL/1.1.1c PHP/5.6.39)
| http-ls: Volume /
| SIZE  TIME              FILENAME
| 62    2021-07-14 16:50  autofullscreen_firefox.txt
|_
|_http-server-header: Apache/2.4.41 (Win64) OpenSSL/1.1.1c PHP/5.6.39
```

Output with the patch:
```
PORT    STATE SERVICE VERSION
880/tcp open  http    Apache httpd 2.4.41 ((Win64) OpenSSL/1.1.1c PHP/5.6.39)
|_http-server-header: Apache/2.4.41 (Win64) OpenSSL/1.1.1c PHP/5.6.39
| http-ls: Volume /
|   maxfiles limit reached (10)
| SIZE  TIME              FILENAME
| -     2020-10-05 20:45  admin/
| -     2016-02-15 18:58  antrian/
| -     2020-10-12 05:00  antrian_salah/
| -     2016-02-15 18:58  antrianv2/
| -     2021-01-18 18:26  api_dkpp/
| 62    2021-07-14 16:50  autofullscreen_firefox.txt
| -     2021-11-26 17:56  cgi-bin/
| -     2021-01-31 12:36  dkpp/
| -     2020-12-16 12:29  dkpp_1/
| -     2021-01-18 09:09  dkpp_peg/
|_
```