### PR TITLE
Ncat: IDENTICAL_BRANCHES reported by Coverity

### DIFF
--- a/ncat/http.c
+++ b/ncat/http.c
@@ -1456,7 +1456,7 @@ static const char *http_read_credentials(const char *s,
                 if (str_equal_i(value, "MD5"))
                     credentials->u.digest.algorithm = ALGORITHM_MD5;
                 else
-                    credentials->u.digest.algorithm = ALGORITHM_MD5;
+                    credentials->u.digest.algorithm = ALGORITHM_UNKNOWN;
             } else if (str_equal_i(name, "qop")) {
                 if (str_equal_i(value, "auth"))
                     credentials->u.digest.qop = QOP_AUTH;


### PR DESCRIPTION
Looks to be a simple copy&paste mistake, similar code in the same file, but in http_read_challenge():
~~~
1249 static const char *http_read_challenge(const char *s, struct http_challenge *challenge)
1250 {
...
1321             } else if (str_equal_i(name, "algorithm")) {
1322                 if (str_equal_i(value, "MD5"))
1323                     challenge->digest.algorithm = ALGORITHM_MD5;
1324                 else
1325                     challenge->digest.algorithm = ALGORITHM_UNKNOWN;
~~~