### PR TITLE
Use promiscuous mode to capture DHCP responses

### DIFF
--- a/scripts/broadcast-dhcp-discover.nse
+++ b/scripts/broadcast-dhcp-discover.nse
@@ -236,7 +236,7 @@ action = function()
 
     local sock, co
     sock = nmap.new_socket()
-    sock:pcap_open(iface, 1500, false, "ip && udp dst port 68")
+    sock:pcap_open(iface, 1500, true, "ip && udp dst port 68")
     co = stdnse.new_thread( dhcp_listener, sock, iface, macaddr, timeout, xid, result )
     threads[co] = true
   end


### PR DESCRIPTION
Script `broadcast-dhcp-discover` does not use promiscuous mode for collecting DHCP responses. This choice is definitely valid, as the script instead sets the broadcast flag on its requests, instructing DHCP servers to broadcast the responses, as opposed to sending them just to the client MAC address.

Unfortunately some DHCP servers, such as VMware Workstation, are not compliant with [RFC 2131, section 4.1](https://www.rfc-editor.org/rfc/rfc2131.html#section-4.1), by not honoring the broadcast flag. Specifically:

> If 'giaddr' is zero and 'ciaddr' is zero, and the broadcast bit is set, then the server broadcasts DHCPOFFER and DHCPACK messages to 0xffffffff.

I am proposing to use promiscuous mode to increase the chance of capturing unicast DHCP responses. This appears to work fairly reliably, as the client MAC address supplied in the script DHCP request is not likely to be actively tracked in the L2 switching tables.

This PR will be committed after June 1st, unless concerns are raised.