### PR TITLE
Update nmap-mac-prefixes using a new script

### DIFF
--- a/make-mac-prefixes.py
+++ b/make-mac-prefixes.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+# Processes registered MAC address prefixes from IEEE MA-L Assignments (CSV)
+# https://standards-oui.ieee.org/oui/oui.csv from stdin and outputs (to stdout)
+# Nmap's "nmap-mac-prefixes" with a few additional unregistered OUIs.
+#
+# Usage: cat oui.csv | ./make-mac-prefixes.py > nmap-mac-prefixes
+# Tip: curl https://standards-oui.ieee.org/oui/oui.csv | ./make-mac-prefixes.py
+#
+# Author : Esa Jokinen (oh2fih)
+# ------------------------------------------------------------------------------
+
+import sys, os, csv, re
+
+# Sort the list by MAC prefix: True = sort, False = preserve original order.
+SORT = False
+
+HEADER = """\
+# MAC prefix list generated with make-mac-prefixes.py by Esa Jokinen (oh2fih).
+# Original data comes from IEEE's https://standards-oui.ieee.org/oui/oui.csv
+# These values are known as Organizationally Unique Identifiers (OUIs) in 
+# MAC Address Block Large (MA-L) including large blocks of EUI-48 and EUI-64.
+# See https://standards.ieee.org/products-programs/regauth/\
+"""
+
+ADDITIONS = [
+    "525400 QEMU virtual NIC",
+    "B0C420 Bochs virtual NIC",
+    "DEADCA PearPC virtual NIC",
+    "00FFD1 Cooperative Linux virtual NIC",
+    "080027 Oracle VirtualBox virtual NIC",
+]
+
+
+def main(csvdata):
+    """Return processed (and optionally sorted) OUIs with ADDITIONS"""
+    OUIs = []
+
+    CSVReader = csv.reader(
+        csvdata.readlines(), dialect="excel", delimiter=",", quotechar='"'
+    )
+    next(CSVReader, None)  # skip the headers
+    for Row in CSVReader:
+        if validatePrefix(Row[1]):
+            OUIs.append(Row[1] + " " + shorten(decapitalize(Row[2])))
+        else:
+            print(f"# Invalid prefix '{Row[1]}' in {Row}", file=sys.stderr)
+
+    if not OUIs:
+        print(f"# Incorrect input format; oui.csv expected.", file=sys.stderr)
+        exit(1)
+    else:
+        print(f"# Found {len(OUIs)} registed OUIs.", file=sys.stderr)
+
+    for addition in ADDITIONS:
+        OUIs.append(addition)
+    print(f"# Added {len(ADDITIONS)} unregisted OUIs.", file=sys.stderr)
+
+    if SORT:
+        OUIs.sort()
+        print(f"# Sorted by MAC prefix.", file=sys.stderr)
+    return OUIs
+
+
+def decapitalize(string):
+    """Un-capitalize an all-caps company name"""
+    decapitalized = ""
+    words = string.split()
+
+    for word in words:
+        sumcaps = sum(1 for elem in word if elem.isupper())
+        sumalpha = sum(1 for elem in word if elem.isalpha())
+        if len(word) > 4 and sumcaps == sumalpha:
+            word = word.lower().capitalize()
+
+        if len(decapitalized) > 0:
+            decapitalized = f"{decapitalized} {word}"
+        else:
+            decapitalized = f"{word}"
+
+    return decapitalized
+
+
+def shorten(string):
+    """Rules to shorten the names a bit, such as eliminating Inc."""
+    string = re.sub(r",.{1,6}$", "", string)
+    string = re.sub(
+        r" (Corporation|Inc|Ltd|Corp|S\.A|Co|llc|pty|l\.l\.c|s\.p\.a|b\.v)(\.|\b)",
+        "",
+        string,
+        flags=re.IGNORECASE,
+    )
+    string = re.sub(r"\s+.$", "", string)
+    return string
+
+
+def validatePrefix(prefix):
+    """Validates a MAC prefix: must consist of six hexadecimal characters"""
+    if re.match(r"^([0-9a-fA-F]{6})$", prefix):
+        return True
+    else:
+        return False
+
+
+if __name__ == "__main__":
+    """Reads oui.csv from stdin & print nmap-mac-prefixes to stdout"""
+    if os.isatty(sys.stdin.fileno()):
+        print(f"# Please provide oui.csv from a pipe.", file=sys.stderr)
+        exit(1)
+    print(f"{HEADER}")
+    print(f"\n".join(main(sys.stdin)))

--- a/make-mac-prefixes.py
+++ b/make-mac-prefixes.py
@@ -43,7 +43,7 @@ def main(csvdata):
     next(CSVReader, None)  # skip the headers
     for Row in CSVReader:
         if validatePrefix(Row[1]):
-            OUIs.append(Row[1] + " " + shorten(decapitalize(Row[2])))
+            OUIs.append(f"{Row[1]} {shorten(decapitalize(Row[2]))}")
         else:
             print(f"# Invalid prefix '{Row[1]}' in {Row}", file=sys.stderr)
 

--- a/nmap-mac-prefixes
+++ b/nmap-mac-prefixes
@@ -1,8 +1,8 @@
-# $Id: $ generated with make-mac-prefixes.pl
-# Original data comes from http://standards.ieee.org/regauth/oui/oui.txt
-# These values are known as Organizationally Unique Identifiers (OUIs)
-# See http://standards.ieee.org/faqs/OUI.html
-# We have added a few unregistered OUIs at the end.
+# MAC prefix list generated with make-mac-prefixes.py by Esa Jokinen (oh2fih).
+# Original data comes from IEEE's https://standards-oui.ieee.org/oui/oui.csv
+# These values are known as Organizationally Unique Identifiers (OUIs) in 
+# MAC Address Block Large (MA-L) including large blocks of EUI-48 and EUI-64.
+# See https://standards.ieee.org/products-programs/regauth/
 002272 American Micro-Fuel Device
 00D0EF IGT
 086195 Rockwell Automation
@@ -35,7 +35,7 @@ D82918 Huawei Technologies
 D0D003 Samsung Electronics
 64B21D Chengdu Phycom Tech
 C42996 Signify
-980637 Ieee Registration Authority
+980637 IEEE Registration Authority
 8CB84A Samsung Electro-mechanics(thailand)
 98E8FA Nintendo
 38C4E8 NSS Sp. z o.o.
@@ -76,7 +76,6 @@ D462EA Huawei Technologies
 94DC4E AEV, spol. s r. o.
 1442FC Texas Instruments
 AC5D5C Fn-link Technology Limited
-A4AE11 Hon Hai Precision Ind.
 54DED0 Sevio Srl
 6C5E3B Cisco Systems
 401920 Movon
@@ -125,7 +124,7 @@ C8EAF8 zte
 CC8826 LG Innotek
 EC5B73 Advanced & Wise Technology
 E0CB1D Private
-848BCD Ieee Registration Authority
+848BCD IEEE Registration Authority
 14C03E Arris Group
 C089AB Arris Group
 D44DA4 Murata Manufacturing
@@ -143,7 +142,7 @@ B03055 China Mobile IOT Company Limited
 905C34 Sirius Electronic Systems Srl
 D46A35 Cisco Systems
 D09C7A Xiaomi Communications
-C82C2B Ieee Registration Authority
+C82C2B IEEE Registration Authority
 8020DA Sagemcom Broadband SAS
 68847E Fujitsu Limited
 003085 Cisco Systems
@@ -152,14 +151,14 @@ C4B36A Cisco Systems
 70F754 Ampak Technology
 6C8BD3 Cisco Systems
 68974B Shenzhen Costar Electronics
-34E1D1 Ieee Registration Authority
+34E1D1 IEEE Registration Authority
 0021B7 Lexmark International
-00A0B0 I-O Data Device
-2479F3 Guangdong Oppo Mobile Telecommunications
+00A0B0 I-O DATA Device
+2479F3 Guangdong OPPO Mobile Telecommunications
 80A235 Edgecore Networks
 30EA26 Sycada BV
 9C497F Integrated Device Technology (Malaysia) Sdn. Bhd.
-C4E39F Guangdong Oppo Mobile Telecommunications
+C4E39F Guangdong OPPO Mobile Telecommunications
 F89A78 Huawei Technologies
 88F872 Huawei Technologies
 EC5623 Huawei Technologies
@@ -175,7 +174,7 @@ EC5623 Huawei Technologies
 14B457 Silicon Laboratories
 DC962C NST Audio
 18022D Huawei Technologies
-D8BC59 Shenzhen Dapu Microelectronics
+D8BC59 Shenzhen DAPU Microelectronics
 089798 Compal Information (kunshan)
 246F28 Espressif
 8C79F5 Samsung Electronics
@@ -191,42 +190,40 @@ B0518E Holl technologyLtd.
 AC8FF8 Nokia
 6003A6 Inteno Broadband Technology AB
 7C5259 Sichuan Jiuzhou Electronic Technology
-44B295 SichuanAI-LinkTechnologyCo.
+44B295 Sichuan AI-Link Technology
 9424E1 Alcatel-Lucent Enterprise
 F8CA59 NetComm Wireless
 88B291 Apple
 C42AD0 Apple
 CCD281 Apple
 200DB0 Shenzhen Four Seas Global Link Network Technology
-D81EDD Guangdong Oppo Mobile Telecommunications
+D81EDD Guangdong OPPO Mobile Telecommunications
 D43FCB Arris Group
 5C7695 Technicolor CH USA
 F84D33 Fiberhome Telecommunication Technologies
 C08ACD Guangzhou Shiyuan Electronic Technology Company Limited
 ACF6F7 LG Electronics (Mobile Communications)
-48E6C0 Simcom Wireless Solutions
+48E6C0 SIMCom Wireless Solutions
 383C9C Fujian Newland Payment Technology
-C02E25 Guangdong Oppo Mobile Telecommunications
+C02E25 Guangdong OPPO Mobile Telecommunications
 107717 Shenzhen Chuangwei-rgb Electronics
 A86D5F Raisecom Technology
 58ECED Integrated Device Technology (Malaysia) Sdn. Bhd.
 005079 Private
 100C6B Netgear
-505FB5 Askey Computer
 C4F0EC Fiberhome Telecommunication Technologies
 E80FC8 Universal Electronics
 E45D37 Juniper Networks
 00EEAB Cisco Systems
 54A703 Tp-link Technologies
 907A58 Zegna-Daidong Limited
-E009BF Shenzhentong BO Weitechnology
+E009BF Shenzhen TONG BO WEI Technology
 00131E peiker acustic GmbH
 846991 Nokia
 001BF7 Lund IP Products AB
 783607 Cermate Technologies
 B00073 Wistron Neweb
 D88DC8 Atil Technology
-88DE7C Askey Computer
 A8E2C1 Texas Instruments
 909A77 Texas Instruments
 04EE03 Texas Instruments
@@ -249,17 +246,16 @@ D49234 NEC
 D8C7C8 Aruba, a Hewlett Packard Enterprise Company
 703A0E Aruba, a Hewlett Packard Enterprise Company
 204C03 Aruba, a Hewlett Packard Enterprise Company
-58C6F0 Guangdong Oppo Mobile Telecommunications
+58C6F0 Guangdong OPPO Mobile Telecommunications
 84A06E Sagemcom Broadband SAS
-A43EA0 Icomm HK Limited
+A43EA0 iComm HK Limited
 64C2DE LG Electronics (Mobile Communications)
 8C444F Humax
 006762 Fiberhome Telecommunication Technologies
 2CC407 machineQ
 B4ED19 Pie Digital
-40DF02 Line BIZ Plus
+40DF02 LINE BIZ Plus
 CCE194 Juniper Networks
-900218 BSkyB
 144E2A Ciena
 84139F zte
 F051EA Fitbit
@@ -270,12 +266,12 @@ E09F2A Iton Technology
 AC5AEE China Mobile Group Device
 70BC10 Microsoft
 884A18 Opulinks
-9C69B4 Ieee Registration Authority
+9C69B4 IEEE Registration Authority
 500084 Siemens Canada
 44B433 tide.co.
 D8A6FD Ghost Locomotion
 DC21B9 SentecLtd
-6CDFFB Ieee Registration Authority
+6CDFFB IEEE Registration Authority
 247D4D Texas Instruments
 8850F6 Shenzhen Jingxun Software Telecommunication Technology
 E498BB Phyplus Microelectronics Limited
@@ -289,21 +285,21 @@ F00EBF ZettaHash
 703509 Cisco Systems
 441AFA New H3C Technologies
 04072E VTech Electronics
-780ED1 Trumpf Werkzeugmaschinen Gmbh+co.kg
+780ED1 Trumpf Werkzeugmaschinen GmbH+Co.KG
 44ECCE Juniper Networks
 F82F08 Molex CMS
 441C12 Technicolor CH USA
-4428A3 Jiangsu fulian  Communication Technology
+4428A3 Jiangsu fulian Communication Technology
 10C595 Lenovo
-203233 Shenzhen Bilian Electronicltd
-6829DC Ficosa Electronics S.L.U.
+203233 Shenzhen Bilian Electronic，ltd
+6829DC Ficosa Electronics S.l.u.
 9454DF YST
-7CBC84 Ieee Registration Authority
+7CBC84 IEEE Registration Authority
 F80DF1 Sontex SA
 A49426 Elgama-Elektronika
 E4F14C Private
 A8B456 Cisco Systems
-2CA9F0 Guangdong Oppo Mobile Telecommunications
+2CA9F0 Guangdong OPPO Mobile Telecommunications
 549B72 Ericsson AB
 A047D7 Best IT World (India) Pvt
 6899CD Cisco Systems
@@ -315,7 +311,7 @@ BCB863 Apple
 44E66E Apple
 C0E862 Apple
 F40616 Apple
-0CFE5D Ieee Registration Authority
+0CFE5D IEEE Registration Authority
 3C8D20 Google
 601D91 Motorola Mobility, a Lenovo Company
 D4C94B Motorola Mobility, a Lenovo Company
@@ -335,8 +331,8 @@ F4951B Hefei Radio Communication Technology
 6C3845 Fiberhome Telecommunication Technologies
 2C6104 Shenzhen Fenglian Technology
 BC9325 Ningbo Joyson Preh Car Connect
-D0B60A Xingluo Technology Company  Limited
-049226 Asustek Computer
+D0B60A Xingluo Technology Company Limited
+049226 ASUSTek Computer
 E8ADA6 Sagemcom Broadband SAS
 0C1C19 Longconn Electronics(shenzhen)
 90E710 New H3C Technologies
@@ -364,10 +360,10 @@ A4FC77 Mega Well Limited
 049162 Microchip Technology
 F83880 Apple
 2C79D7 Sagemcom Broadband SAS
-00B4F5 DongGuan Siyoto Electronics,
+00B4F5 DongGuan Siyoto Electronics
 BC3F4E Teleepoch
 1838AE Conspin Solution
-04CF8C Xiaomi Electronics,co.
+04CF8C Xiaomi Electronics,CO.
 0C7512 Shenzhen Kunlun TongTai Technology
 7483C2 Ubiquiti Networks
 E063DA Ubiquiti Networks
@@ -380,7 +376,7 @@ B0AE25 Varikorea
 4C1B86 Arcadyan
 ECC40D Nintendo
 440049 Amazon Technologies
-E86A64 Lcfc(hefei) Electronics Technology
+E86A64 LCFC(HeFei) Electronics Technology
 10A24E Gold3link Electronics
 CCC5E5 Dell
 6CC374 Texas Instruments
@@ -391,26 +387,26 @@ F8D9B8 Open Mesh
 70037E Technicolor CH USA
 D003DF Samsung Electronics
 C423A2 PT. Emsonic Indonesia
-B4CB57 Guangdong Oppo Mobile Telecommunications
+B4CB57 Guangdong OPPO Mobile Telecommunications
 4C1265 Arris Group
 00500C e-Tek Labs
 485F99 Cloud Network Technology (Samoa) Limited
 8834FE Bosch Automotive Products (Suzhou)
 88F7BF vivo Mobile Communication
 D87D7F Sagemcom Broadband SAS
-00051A 3com Europe
-08004E 3com Europe
-00301E 3com Europe
-005004 3com
-000103 3com
-58B568 Securitas Direct Espaa
+00051A 3COM Europe
+08004E 3COM Europe
+00301E 3COM Europe
+005004 3COM
+000103 3COM
+58B568 Securitas Direct España
 484AE9 Hewlett Packard Enterprise
 846A66 Sumitomo Kizai
-18D717 Guangdong Oppo Mobile Telecommunications
+18D717 Guangdong OPPO Mobile Telecommunications
 80B624 IVS
 DCF505 AzureWave Technology
 CCF0FD China Mobile (Hangzhou) Information Technology
-8489EC Ieee Registration Authority
+8489EC IEEE Registration Authority
 88108F Huawei Technologies
 F4631F Huawei Technologies
 A49B4F Huawei Technologies
@@ -419,11 +415,10 @@ A49B4F Huawei Technologies
 008CFA Inventec
 5CFB7C Shenzhen Jingxun Software Telecommunication Technology
 FC039F Samsung Electronics
-02C08C 3com
+02C08C 3COM
 0057C1 LG Electronics (Mobile Communications)
 7C240C Telechips
 00203D Honeywell Environmental & Combustion Controls
-004084 Honeywell International HPS
 A4D990 Samsung Electronics
 006087 Kansai Electric
 DCF719 Cisco Systems
@@ -432,7 +427,7 @@ D4741B Beijing HuaDa ZhiBao Electronic System
 001BC0 Juniper Networks
 2C15E1 Phicomm (Shanghai)
 30D16B Liteon Technology
-98AE71 Vvdn Technologies Pvt
+98AE71 VVDN Technologies Pvt
 A456CC Technicolor CH USA
 AC6E1A Shenzhen Gongjin Electronics
 0080EB Compcontrol
@@ -456,7 +451,7 @@ C0D0FF China Mobile IOT Company Limited
 2C7CE4 Wuhan Tianyu Information Industry
 5803FB Hangzhou Hikvision Digital Technology
 144802 THE Yeolrim
-40313C Xiaomi Electronics,co.
+40313C Xiaomi Electronics,CO.
 FC4596 Compal Information (kunshan)
 A0E534 Stratec Biomedical AG
 444B5D GE Healthcare
@@ -467,7 +462,7 @@ A0E534 Stratec Biomedical AG
 24D76B Syntronic AB
 C4FEE2 Amiccom Electronics
 780CF0 Cisco Systems
-0C8C24 Shenzhen Bilian Electronicltd
+0C8C24 Shenzhen Bilian Electronic，ltd
 8C6D77 Huawei Technologies
 E8C57A Ufispace
 E01283 Shenzhen Fanzhuo Communication Technology
@@ -481,14 +476,13 @@ A0CF5B Cisco Systems
 24D3F2 zte
 D469A5 Miura Systems
 8C8126 Arcom
-D47C44 Ieee Registration Authority
+D47C44 IEEE Registration Authority
 805E4F Fn-link Technology Limited
 8417EF Technicolor CH USA
 3856B5 Peerbridge Health
 7C96D2 Fihonest communication
 C042D0 Juniper Networks
 D0C5D8 Latecoere
-7054B4 Vestel Elektronik San ve Tic. A..
 20A60C Xiaomi Communications
 488AD2 Mercury Communication Technologies
 DCE838 CK Telecom (Shenzhen) Limited
@@ -499,9 +493,8 @@ A8D498 Avira Operations GmbH & KG
 841766 Weifang Goertek Electronics
 2C4D79 Weifang Goertek Electronics
 000C42 Routerboard.com
-0026BD Jtec Card &amp; Communication
+0026BD JTEC Card &amp; Communication
 60D02C Ruckus Wireless
-D058FC BSkyB
 14579F Huawei Technologies
 B44326 Huawei Technologies
 78D294 Netgear
@@ -510,7 +503,7 @@ B44326 Huawei Technologies
 08C5E1 Samsung Electro-mechanics(thailand)
 1866C7 Shenzhen Libre Technology
 5CB3F6 Human, Incorporated
-2C4835 Ieee Registration Authority
+2C4835 IEEE Registration Authority
 482AE3 Wistron InfoComm(Kunshan)Co.
 FCA6CD Fiberhome Telecommunication Technologies
 44C874 China Mobile Group Device
@@ -521,7 +514,7 @@ F85C4D Nokia
 2C584F Arris Group
 F04B3A Juniper Networks
 54BF64 Dell
-A85B6C Robert Bosch Gmbh, CM-CI2
+A85B6C Robert Bosch Gmbh, Cm-ci2
 C8B1EE Qorvo
 00FCBA Cisco Systems
 00CBB4 Shenzhen Ateko Photoelectricity
@@ -531,7 +524,7 @@ C8B1EE Qorvo
 D818D3 Juniper Networks
 149B2F JiangSu ZhongXie Intelligent Technology
 3835FB Sagemcom Broadband SAS
-48DD9D Itel Mobile Limited
+48DD9D ITEL Mobile Limited
 A075EA BoxLock
 F04CD5 Maxlinear
 0001AE Trex Enterprises
@@ -548,21 +541,21 @@ D8160A Nippon Electro-Sensory Devices
 10C07C Blu-ray Disc Association
 40A677 Juniper Networks
 E4B021 Samsung Electronics
-9C7F57 Unic Memory Technology
+9C7F57 UNIC Memory Technology
 B4E01D Conception Electronique
-1C0042 Nari Technology
+1C0042 NARI Technology
 4434A7 Arris Group
 3CE1A1 Universal Global Scientific Industrial
 F898EF Huawei Technologies
 58F987 Huawei Technologies
 A8F5AC Huawei Technologies
 58BAD4 Huawei Technologies
-701D08 99IOT Shenzhen
+701D08 99iot Shenzhen
 7412BB Fiberhome Telecommunication Technologies
-001027 L-3 Communications East
+001027 L-3 Communications EAST
 BC2643 Elprotronic
 04E229 Qingdao Haier Technology
-348B75 Lava International(h.k) Limited
+348B75 LAVA International(h.k) Limited
 9CE895 New H3C Technologies
 00583F PC Aquarius
 903D68 G-Printec
@@ -586,14 +579,14 @@ F099B6 Apple
 58B3FC Shenzhen Rf-link Technology
 2047DA Xiaomi Communications
 2429FE Kyocera
-7C49EB Xiaomi Electronics,co.
+7C49EB Xiaomi Electronics,CO.
 C43306 China Mobile Group Device
 08DFCB Systrome Networks
 A4933F Huawei Technologies
 28AC9E Cisco Systems
 68D482 Shenzhen Gongjin Electronics
 984562 Shanghai Baud Data Communication
-E4C483 Guangdong Oppo Mobile Telecommunications
+E4C483 Guangdong OPPO Mobile Telecommunications
 001FBA Boyoung Tech
 A433D7 MitraStar Technology
 B0ACD2 zte
@@ -601,10 +594,10 @@ B0ACD2 zte
 202D23 Collinear Networks
 90834B Beijing Yunyi Times Technology
 18502A Soarnex
-A8367A Frogblue Technology Gmbh
+A8367A frogblue Technology GmbH
 6CE4DA NEC Platforms
 10E7C6 Hewlett Packard
-1831BF Asustek Computer
+1831BF ASUSTek Computer
 C8FAE1 ARQ Digital
 DCA333 Shenzhen Youhua Technology
 788C54 Ping Communication
@@ -642,12 +635,12 @@ B4A8B9 Cisco Systems
 50DCE7 Amazon Technologies
 649829 Integrated Device Technology (Malaysia) Sdn. Bhd.
 081DC4 Thermo Fisher Scientific Messtechnik GmbH
-785364 Shift Gmbh
+785364 Shift GmbH
 38E60A Xiaomi Communications
 40CBC0 Apple
 C4618B Apple
 CC6EA4 Samsung Electronics
-803A59 At&t
+803A59 AT&T
 588D64 Xi'an Clevbee Technology
 005D73 Cisco Systems
 606D3C Luxshare Precision Industry Company Limited
@@ -673,9 +666,9 @@ F065C2 Yanfeng Visteon Electronics Technology (Shanghai)
 A09D86 Alcatel-Lucent Shanghai Bell
 00C0FF Seagate Cloud Systems
 D45DDF Pegatron
-F8B568 Ieee Registration Authority
+F8B568 IEEE Registration Authority
 2C6B7D Texas Instruments
-88D171 Beghelli S.P.A
+88D171 Beghelli
 A09DC1 China Dragon Technology Limited
 2C4205 Lytx
 A825EB Cambridge Industries(Group)
@@ -686,7 +679,7 @@ C4C563 Tecno Mobile Limited
 80B708 Blue Danube Systems
 08BC20 Hangzhou Royal Cloud Technology
 942A3F Diversey
-2031EB Hdsn
+2031EB HDSN
 F8C96C Fiberhome Telecommunication Technologies
 844823 Woxter Technology
 F41E5E RtBrick
@@ -696,7 +689,7 @@ F41E5E RtBrick
 C8D12A Comtrend
 0CEAC9 Arris Group
 E82A44 Liteon Technology
-10A4BE Shenzhen Bilian Electronicltd
+10A4BE Shenzhen Bilian Electronic，ltd
 ECC06A PowerChord Group Limited
 944996 WiSilica
 F81D0F Hitron Technologies.
@@ -710,7 +703,7 @@ E820E2 Humax
 8C5BF0 Arris Group
 1890D8 Sagemcom Broadband SAS
 88835D Fn-link Technology Limited
-EC9F0D Ieee Registration Authority
+EC9F0D IEEE Registration Authority
 E078A3 Shanghai Winner Information Technology
 0005A7 Hyperchip
 088466 Novartis Pharma AG
@@ -758,7 +751,7 @@ D8ED1C Magna Technology SL
 74373B Uninet
 7C6456 Samsung Electronics
 F46E24 NEC Personal Computers
-888279 Shenzhen Rb-link Intelligent Technologyltd
+888279 Shenzhen Rb-link Intelligent TechnologyLtd
 68C63A Espressif
 A0648F Askey Computer
 C850E9 Raisecom Technology
@@ -778,8 +771,8 @@ A0FE61 Vivint Wireless
 5C2BF5 Vivint Wireless
 CC5A53 Cisco Systems
 006088 Analog Devices
-084ACF Guangdong Oppo Mobile Telecommunications
-2C279E Ieee Registration Authority
+084ACF Guangdong OPPO Mobile Telecommunications
+2C279E IEEE Registration Authority
 8C5F48 Continental Intelligent Transportation Systems
 947EB9 National Narrowband Network Communications
 646E69 Liteon Technology
@@ -810,16 +803,16 @@ CC7EE7 Panasonic AVC Networks Company
 20C6EB Panasonic AVC Networks Company
 64B5C6 Nintendo
 2830AC Frontiir
-D4D2E5 Bkav
+D4D2E5 BKAV
 0050B5 Fichet Securite Electronique
 001439 Blonder Tongue Laboratories
 20A6CD Hewlett Packard Enterprise
 84802D Cisco Systems
 001987 Panasonic Mobile Communications
-741C27 Itel Mobile Limited
+741C27 ITEL Mobile Limited
 00A0AC Gilat Satellite Networks
 002609 Phyllis
-28F537 Ieee Registration Authority
+28F537 IEEE Registration Authority
 94D9B3 Tp-link Technologies
 C84029 Fiberhome Telecommunication Technologies
 F86EEE Huawei Technologies
@@ -827,10 +820,10 @@ F86EEE Huawei Technologies
 B40F3B Tenda Technology,Ltd.Dongguan branch
 00188D Nokia Danmark A/S
 0015AB PRO Sound
-5876C5 Digi I'S
+5876C5 DIGI I'S
 A8B2DA Fujitsu Limited
 001354 Zcomax Technologies
-78D800 Ieee Registration Authority
+78D800 IEEE Registration Authority
 0835B2 CoreEdge Networks
 4C49E3 Xiaomi Communications
 245880 Vizeo
@@ -848,10 +841,9 @@ C4CB6B Airista Flow
 B05508 Huawei Technologies
 B875C0 PayPal
 001C71 Emergent Electronics
-001A93 Erco Leuchten Gmbh
+001A93 ERCO Leuchten GmbH
 94F665 Ruckus Wireless
 B090D4 Shenzhen Hoin Internet Technology
-C0BAE6 Application Solutions (Electronics and Vision)
 8C9F3B Qingdao Hisense Communications
 0014B8 Hill-Rom
 ACED5C Intel Corporate
@@ -884,18 +876,18 @@ C81FEA Avaya
 1C4593 Texas Instruments
 90EC50 C.o.b.o. SPA
 E0D848 Dell
-60271C Videor E. Hartig Gmbh
+60271C Videor E. Hartig GmbH
 00EC0A Xiaomi Communications
 C8D7B0 Samsung Electronics
-6C60EB ZHI Yuan Electronics, Limited
+6C60EB ZHI YUAN Electronics, Limited
 74DADA D-Link International
 D8F1F0 Pepxim International Limited
 DCC8F5 Shanghai UMEinfo
-88D7F6 Asustek Computer
+88D7F6 ASUSTek Computer
 9097F3 Samsung Electronics
 7C1C68 Samsung Electronics
 C087EB Samsung Electronics
-04714B Ieee Registration Authority
+04714B IEEE Registration Authority
 2C41A1 Bose
 4C38D8 Arris Group
 447BBB Shenzhen Youhua Technology
@@ -911,34 +903,34 @@ D4C1C8 zte
 881544 Cisco Meraki
 C4ABB2 vivo Mobile Communication
 80B234 Technicolor CH USA
-44B412 Sius AG
-0CB912 Jm-data Gmbh
+44B412 SIUS AG
+0CB912 Jm-data GmbH
 3CA308 Texas Instruments
 F43E61 Shenzhen Gongjin Electronics
 B4417A Shenzhen Gongjin Electronics
-000062 Bull HN Information Systems
+000062 BULL HN Information Systems
 E8C1D7 Philips
 4C8120 Taicang T&W Electronics
 28A6DB Huawei Technologies
 14A0F8 Huawei Technologies
 C8F86D Alcatel-Lucent Shanghai Bell
-6045CB Asustek Computer
+6045CB ASUSTek Computer
 00118B Alcatel-Lucent Enterprise
 00E0B1 Alcatel-Lucent Enterprise
 00E0DA Alcatel-Lucent Enterprise
-F8BE0D A2UICT
+F8BE0D A2uict
 E442A6 Intel Corporate
 3C678C Huawei Technologies
-D4503F Guangdong Oppo Mobile Telecommunications
+D4503F Guangdong OPPO Mobile Telecommunications
 388C50 LG Electronics
 DC0856 Alcatel-Lucent Enterprise
 1CDA27 vivo Mobile Communication
 90F305 Humax
 4095BD NTmore.Co.
-98AAFC Ieee Registration Authority
+98AAFC IEEE Registration Authority
 00143F Hotway Technology
 D055B2 Integrated Device Technology (Malaysia) Sdn. Bhd.
-144FD7 Ieee Registration Authority
+144FD7 IEEE Registration Authority
 B85510 Zioncom Electronics (Shenzhen)
 049573 zte
 F0D7AA Motorola Mobility, a Lenovo Company
@@ -955,7 +947,7 @@ F8FF0B Electronic Technology
 002365 Insta Elektro GmbH
 6091F3 vivo Mobile Communication
 28395E Samsung Electronics
-38295A Guangdong Oppo Mobile Telecommunications
+38295A Guangdong OPPO Mobile Telecommunications
 88E628 Shenzhen Kezhonglong Optoelectronic Technology
 58238C Technicolor CH USA
 CC82EB Kyocera
@@ -971,7 +963,7 @@ BC2F3D vivo Mobile Communication
 68CC6E Huawei Technologies
 3034D2 Availink
 504061 Nokia
-00108E Hugh Symons Concept Technologies
+00108E HUGH Symons Concept Technologies
 E05163 Arcadyan
 54E3F6 Alcatel-Lucent
 40B034 Hewlett Packard
@@ -980,11 +972,11 @@ B816DB Chant Sincere
 D481D7 Dell
 F42B48 Ubiqam
 50F14A Texas Instruments
-04DEF2 Shenzhen Ecom Technology
+04DEF2 Shenzhen ECOM Technology
 78C1A7 zte
-4C7872 Cav. Uff. Giacomo Cimberio S.p.A.
+4C7872 Cav. Uff. Giacomo Cimberio
 8CF5A3 Samsung Electro-mechanics(thailand)
-8CC8F4 Ieee Registration Authority
+8CC8F4 IEEE Registration Authority
 F483E1 Shanghai Clouder Semiconductor
 083E5D Sagemcom Broadband SAS
 3CBD3E Beijing Xiaomi Electronics
@@ -994,7 +986,7 @@ D47AE2 Samsung Electronics
 6854FD Amazon Technologies
 0003BC COT GmbH
 D4B169 Le Shi Zhi Xin Electronic Technology (Tianjin) Limited
-E44790 Guangdong Oppo Mobile Telecommunications
+E44790 Guangdong OPPO Mobile Telecommunications
 38454C Light Labs
 000A49 F5 Networks
 00A0C8 Adtran
@@ -1016,7 +1008,7 @@ D825B0 Rockeetech Systems
 CCB8A8 Ampak Technology
 1077B0 Fiberhome Telecommunication Technologies
 F01DBC Microsoft
-34049E Ieee Registration Authority
+34049E IEEE Registration Authority
 94FB29 Zebra Technologies
 B0702D Apple
 6C19C0 Apple
@@ -1026,7 +1018,7 @@ B0702D Apple
 8CE117 zte
 688AF0 zte
 C0210D Shenzhen Rf-link Technology
-504B5B Controltronic Gmbh
+504B5B CONTROLtronic GmbH
 B47447 CoreOS
 80D4A5 Huawei Technologies
 04B0E7 Huawei Technologies
@@ -1046,11 +1038,11 @@ C8662C Beijing Haitai Fangyuan High Technology
 8096CA Hon Hai Precision Ind.
 186571 Top Victory Electronics (Taiwan)
 F83F51 Samsung Electronics
-50D753 Conelcom Gmbh
+50D753 Conelcom GmbH
 0CC47A Super Micro Computer
 34D270 Amazon Technologies
 50795B Interexport Telecomunicaciones
-0016D9 Ningbo Bird
+0016D9 Ningbo BIRD
 6CA7FA Youngbo Engineering
 8C7EB3 Lytro
 B4B384 ShenZhen Figigantic Electronic
@@ -1069,8 +1061,8 @@ E0D9E3 Eltex Enterprise
 805EC0 Yealink(xiamen) Network Technology
 007B18 Sentry
 144D67 Zioncom Electronics (Shenzhen)
-4CE173 Ieee Registration Authority
-0CD86C Shenzhen Fast Technologies
+4CE173 IEEE Registration Authority
+0CD86C Shenzhen FAST Technologies
 049790 Lartech telecom
 28EED3 Shenzhen Super D Technology
 24C44A zte
@@ -1091,7 +1083,7 @@ F09FC2 Ubiquiti Networks
 788A20 Ubiquiti Networks
 886B0F Bluegiga Technologies OY
 AC84C9 Sagemcom Broadband SAS
-245CBF Ncse
+245CBF NCSE
 2C3361 Apple
 60A4D0 Samsung Electronics
 008701 Samsung Electronics
@@ -1106,10 +1098,10 @@ C8028F Nova Electronics (Shanghai)
 A46011 Verifone
 5CA933 Luma Home
 00137E CorEdge Networks
-D814D6 Sure System
+D814D6 SURE System
 6CEFC6 Shenzhen Twowing Technologies
 101DC0 Samsung Electronics
-002341 Vanderbilt International (SWE) AB
+002341 Vanderbilt International (swe) AB
 407C7D Nokia
 24590B White Sky Limited
 68EBAE Samsung Electronics
@@ -1124,7 +1116,7 @@ B072BF Murata Manufacturing
 64DAA0 Robert Bosch Smart Home GmbH
 14B837 Shenzhen Youhua Technology
 5C8613 Beijing Zhoenet Technology
-CC7314 Hong Kong Wheatek Technology Limited
+CC7314 HONG KONG Wheatek Technology Limited
 B8EE65 Liteon Technology
 985BB0 Kmdata
 E006E6 Hon Hai Precision Ind.
@@ -1144,14 +1136,14 @@ A41731 Hon Hai Precision Ind.
 00223B Communication Networks
 C0F8DA Hon Hai Precision Ind.
 0011FF Digitro Tecnologia Ltda
-001B94 T.E.M.A.
+001B94 T.e.m.a.
 F0F002 Hon Hai Precision Ind.
 C0CB38 Hon Hai Precision Ind.
 F07BCB Hon Hai Precision Ind.
 50B7C3 Samsung Electronics
 1C5A3E Samsung Electronics
 A02195 Samsung Electronics
-B07870 Wi-next
+B07870 Wi-NEXT
 E47CF9 Samsung Electronics
 4844F7 Samsung Electronics
 001377 Samsung Electronics
@@ -1251,7 +1243,7 @@ E4A387 Control Solutions
 10F96F LG Electronics (Mobile Communications)
 C4438F LG Electronics (Mobile Communications)
 A09169 LG Electronics (Mobile Communications)
-286C07 Xiaomi Electronics,co.
+286C07 Xiaomi Electronics,CO.
 002280 A2B Electronics AB
 404AD4 Widex A/S
 9893CC LG Electronics
@@ -1271,19 +1263,19 @@ F0421C Intel Corporate
 001CD8 BlueAnt Wireless
 0019AB Raycom
 4C334E Hightech
-7C70BC Ieee Registration Authority
-E81863 Ieee Registration Authority
-2CD141 Ieee Registration Authority
-3C39E7 Ieee Registration Authority
-BC6641 Ieee Registration Authority
-80E4DA Ieee Registration Authority
-885D90 Ieee Registration Authority
-C88ED1 Ieee Registration Authority
-B01F81 Ieee Registration Authority
-549A11 Ieee Registration Authority
-B8D812 Ieee Registration Authority
-1C21D1 Ieee Registration Authority
-283638 Ieee Registration Authority
+7C70BC IEEE Registration Authority
+E81863 IEEE Registration Authority
+2CD141 IEEE Registration Authority
+3C39E7 IEEE Registration Authority
+BC6641 IEEE Registration Authority
+80E4DA IEEE Registration Authority
+885D90 IEEE Registration Authority
+C88ED1 IEEE Registration Authority
+B01F81 IEEE Registration Authority
+549A11 IEEE Registration Authority
+B8D812 IEEE Registration Authority
+1C21D1 IEEE Registration Authority
+283638 IEEE Registration Authority
 F485C6 FDT Technologies
 D404FF Juniper Networks
 C8755B Quantify Technology
@@ -1298,7 +1290,7 @@ C8755B Quantify Technology
 48F7C0 Technicolor CH USA
 0015B7 Toshiba
 E89D87 Toshiba
-E09579 Orthosoft, D/b/a Zimmer CAS
+E09579 ORTHOsoft, d/b/a Zimmer CAS
 A0ADA1 JMR Electronics
 BCC00F Fiberhome Telecommunication Technologies
 9CA5C0 vivo Mobile Communication
@@ -1309,7 +1301,7 @@ A854B2 Wistron Neweb
 3044A1 Shanghai Nanchao Information Technology
 CC03FA Technicolor CH USA
 E0ACF1 Cisco Systems
-00015B Italtel S.p.a/rf-up-i
+00015B Italtel/RF-UP-I
 00A0A8 Renex
 00C0AB Telco Systems
 0023F8 Zyxel Communications
@@ -1352,25 +1344,25 @@ ECADB8 Apple
 B4D5BD Intel Corporate
 98AA3C Will i-tech
 BCAD28 Hangzhou Hikvision Digital Technology
-F4911E Zhuhai Ewpe Information Technology
+F4911E Zhuhai EWPE Information Technology
 002552 VXi
 6CE983 Gastron
 28E31F Xiaomi Communications
 989096 Dell
 DC3752 GE
 DCD916 Huawei Technologies
-00022E Teac R& D
+00022E TEAC R&
 0060B0 Hewlett Packard
 7C738B Cocoon Alarm
 F80F84 Natural Security SAS
 44A42D TCT mobile
 70F96D Hangzhou H3C Technologies, Limited
 BC6A44 Commend International GmbH
-F0EE58 Pace Telematics Gmbh
+F0EE58 PACE Telematics GmbH
 083FBC zte
 00C0F0 Kingston Technology Company
 943BB1 Kaonmedia
-0018D7 Javad GNSS
+0018D7 Javad Gnss
 001F09 Jastec
 AC620D Jabil Circuit(Wuxi)
 08000D International Computers
@@ -1379,8 +1371,7 @@ AC620D Jabil Circuit(Wuxi)
 0000C9 Emulex
 0040AA Valmet Automation
 D0B0CD Moen
-7050AF BSkyB
-F4EF9E Sgsg Science & Technology
+F4EF9E SGSG Science & Technology
 1C740D Zyxel Communications
 603ECA Cambridge Medical Robotics
 001F1F Edimax Technology
@@ -1407,7 +1398,7 @@ CCB11A Samsung Electronics
 00C164 Cisco Systems
 DC2DCB Beijing Unis HengYue Technology
 2C9662 Invenit BV
-CCD3E2 Jiangsu Yinhe  Electronics
+CCD3E2 Jiangsu Yinhe Electronics
 E4FAED Samsung Electronics
 288335 Samsung Electronics
 DCCF96 Samsung Electronics
@@ -1418,11 +1409,11 @@ AC44F2 Yamaha
 B07FB9 Netgear
 047E4A moobox
 0080E5 NetApp
-9C5C8E Asustek Computer
+9C5C8E ASUSTek Computer
 C88722 Lumenpulse
 84683E Intel Corporate
 E0CDFD Beijing E3Control Technology
-000895 Dirc Technologie Gmbh &KG
+000895 DIRC Technologie GmbH &KG
 60ACC8 KunTeng
 CCB3AB shenzhen Biocare Bio-Medical Equipment
 E4B318 Intel Corporate
@@ -1474,7 +1465,7 @@ A80600 Samsung Electronics
 F05A09 Samsung Electronics
 503275 Samsung Electronics
 08FC88 Samsung Electronics
-0270B3 Data Recall
+0270B3 DATA Recall
 000136 CyberTAN Technology
 D04D2C Roku
 B0A737 Roku
@@ -1586,7 +1577,7 @@ B8616F Accton Technology
 D4D184 ADB Broadband Italia
 A04FD4 ADB Broadband Italia
 D00ED9 Taicang T&W Electronics
-541473 Wingtech Group (HongKongLimited
+541473 Wingtech Group (HongKong）Limited
 8086F2 Intel Corporate
 E09467 Intel Corporate
 08D40C Intel Corporate
@@ -1628,18 +1619,18 @@ A4BADB Dell
 002564 Dell
 A41F72 Dell
 C46699 vivo Mobile Communication
-C8F230 Guangdong Oppo Mobile Telecommunications
-8C0EE3 Guangdong Oppo Mobile Telecommunications
+C8F230 Guangdong OPPO Mobile Telecommunications
+8C0EE3 Guangdong OPPO Mobile Telecommunications
 C8CD72 Sagemcom Broadband SAS
 F82C18 2Wire
 18017D Harbin Arteor technology
 001556 Sagemcom Broadband SAS
 C0D044 Sagemcom Broadband SAS
 A01B29 Sagemcom Broadband SAS
-74E14A Ieee Registration Authority
-0CEFAF Ieee Registration Authority
-F80278 Ieee Registration Authority
-A0BB3E Ieee Registration Authority
+74E14A IEEE Registration Authority
+0CEFAF IEEE Registration Authority
+F80278 IEEE Registration Authority
+A0BB3E IEEE Registration Authority
 884AEA Texas Instruments
 0022A4 2Wire
 982CBE 2Wire
@@ -1686,11 +1677,9 @@ C8D3A3 D-Link International
 B499BA Hewlett Packard
 047863 Shanghai Mxchip Information Technology
 409F87 Jide Technology (Hong Kong) Limited
-0CF9C0 BSkyB
 4CFF12 Fuze Entertainment
 AC9A22 NXP Semiconductors
-287CDB Hefei  Toycloud Technology
-806AB0 Shenzhen Tinno Mobile Technology
+287CDB Hefei Toycloud Technology
 48AD08 Huawei Technologies
 4CFB45 Huawei Technologies
 009ACD Huawei Technologies
@@ -1698,7 +1687,7 @@ AC9A22 NXP Semiconductors
 F4F5E8 Google
 94EB2C Google
 0CC731 Currant
-70B3D5 Ieee Registration Authority
+70B3D5 IEEE Registration Authority
 28ED6A Apple
 C056E3 Hangzhou Hikvision Digital Technology
 EC3EF7 Juniper Networks
@@ -1750,13 +1739,13 @@ A0B3CC Hewlett Packard
 ECB1D7 Hewlett Packard
 9CB654 Hewlett Packard
 6C3BE5 Hewlett Packard
-B0AA36 Guangdong Oppo Mobile Telecommunications
+B0AA36 Guangdong OPPO Mobile Telecommunications
 784B87 Murata Manufacturing
 E4CE02 WyreStorm Technologies
 40F308 Murata Manufacturing
 808917 Tp-link Technologies
-A09347 Guangdong Oppo Mobile Telecommunications
-E8BBA8 Guangdong Oppo Mobile Telecommunications
+A09347 Guangdong OPPO Mobile Telecommunications
+E8BBA8 Guangdong OPPO Mobile Telecommunications
 942CB3 Humax
 002719 Tp-link Technologies
 40169F Tp-link Technologies
@@ -1779,7 +1768,6 @@ D07AB5 Huawei Technologies
 0019C6 zte
 001DD9 Hon Hai Precision Ind.
 00197D Hon Hai Precision Ind.
-7C4CA5 BSkyB
 0014A4 Hon Hai Precision Ind.
 78DD08 Hon Hai Precision Ind.
 9CD21E Hon Hai Precision Ind.
@@ -1790,7 +1778,6 @@ B43052 Huawei Technologies
 9CD24B zte
 C87B5B zte
 0007D8 Hitron Technologies.
-C03E0F BSkyB
 904E2B Huawei Technologies
 2008ED Huawei Technologies
 0034FE Huawei Technologies
@@ -1844,14 +1831,14 @@ D0B5C2 Texas Instruments
 887556 Cisco Systems
 FC9947 Cisco Systems
 6C2056 Cisco Systems
-0015F2 Asustek Computer
-90E6BA Asustek Computer
-002618 Asustek Computer
-F46D04 Asustek Computer
-00E018 Asustek Computer
-000C6E Asustek Computer
-000EA6 Asustek Computer
-001D60 Asustek Computer
+0015F2 ASUSTek Computer
+90E6BA ASUSTek Computer
+002618 ASUSTek Computer
+F46D04 ASUSTek Computer
+00E018 ASUSTek Computer
+000C6E ASUSTek Computer
+000EA6 ASUSTek Computer
+001D60 ASUSTek Computer
 6C416A Cisco Systems
 ECE1A9 Cisco Systems
 C067AF Cisco Systems
@@ -1960,12 +1947,12 @@ D0A637 Apple
 A85B78 Apple
 C8F650 Apple
 A88E24 Apple
-6C4A39 Bita
+6C4A39 BITA
 847D50 Holley Metering Limited
 50D59C Thai Habel Industrial
 20896F Fiberhome Telecommunication Technologies
 3052CB Liteon Technology
-049645 Wuxi SKY Chip Interconnection Technology
+049645 WUXI SKY CHIP Interconnection Technology
 1CCDE5 Shanghai Wind Technologies
 681401 Hon Hai Precision Ind.
 50A9DE Smartcom - Bulgaria AD
@@ -1986,7 +1973,7 @@ DCDC07 TRP Systems BV
 E8DED6 Intrising Networks
 DC82F6 iPort
 70480F Apple
-3CB72B Plumgrid
+3CB72B PLUMgrid
 489A42 Technomate
 20D160 Private
 BC9C31 Huawei Technologies
@@ -2001,9 +1988,9 @@ AC8995 AzureWave Technology
 20C3A4 RetailNext
 E4C2D1 Huawei Technologies
 D4F4BE Palo Alto Networks
-48B620 Roli
+48B620 ROLI
 D888CE RF Technology
-307CB2 Anov France
+307CB2 ANOV France
 847973 Shanghai Baud Data Communication
 E8B4C8 Samsung Electronics
 D087E2 Samsung Electronics
@@ -2020,7 +2007,7 @@ A8A795 Hon Hai Precision Ind.
 60FD56 Woorisystems
 9870E8 Innatech SDN BHD
 44656A Mega Video Electronic(HK) Industry
-78EB39 Instituto Nacional de Tecnologa Industrial
+78EB39 Instituto Nacional de Tecnología Industrial
 0C756C Anaren Microwave
 D47BB0 Askey Computer
 F0224E Esan electronic
@@ -2047,7 +2034,7 @@ A424DD Cambrionix
 804E81 Samsung Electronics
 C09A71 Xiamen Meitu Mobile Technologyltd
 64167F Polycom
-340B40 Mios Elettronica SRL
+340B40 MIOS Elettronica SRL
 48066A Tempered Networks
 BCF811 Xiamen Dnake Technology
 900A39 Wiio
@@ -2058,7 +2045,7 @@ FC8F90 Samsung Electronics
 74042B Lenovo Mobile Communication (Wuhan) Company Limited
 F87AEF Rosonix Technology
 2028BC Visionscape
-241C04 Shenzhen Jehe Technology Development
+241C04 Shenzhen JEHE Technology Development
 D05C7A Sartura d.o.o.
 887033 Hangzhou Silan Microelectronic
 DC56E6 Shenzhen Bococom Technology
@@ -2093,8 +2080,8 @@ BCD165 Cisco Spvtg
 7C3CB6 Shenzhen Homecare Technology
 20C06D Shenzhen Spacetek Technology
 4886E8 Microsoft
-74A34A Zimi
-A86405 nimbus 9
+74A34A ZIMI
+A86405 nimbus
 30D587 Samsung Electronics
 6828F6 Vubiq Networks
 DC60A1 Teledyne Dalsa Professional Imaging
@@ -2116,16 +2103,16 @@ E887A3 Loxley Public Company Limited
 F88479 Yaojin Technology(Shenzhen)Co.
 2C2997 Microsoft
 D46132 Pro Concept Manufacturer
-54A050 Asustek Computer
+54A050 ASUSTek Computer
 4C2C83 Zhejiang KaNong Network Technology
 908C09 Total Phase
 DC2F03 Step forward Group
-380E7B V.P.S. Thai
-2C3796 Cybo
+380E7B V.p.s. Thai
+2C3796 CYBO
 587FB7 Sonar Industrial
 08EB29 Jiangsu Huitong Group
 409B0D Shenzhen Yourf Kwan Industrial
-D8CB8A Micro-star Intl
+D8CB8A Micro-Star INTL
 70FC8C OneAccess SA
 58108C Intelbras
 4C7403 BQ
@@ -2136,7 +2123,7 @@ C8D019 Shanghai Tigercel Communication Technology
 849681 Cathay Communication
 2CA30E Power Dragon Development Limited
 8486F3 Greenvity Communications
-1C5216 Dongguan Hele Electronics
+1C5216 Dongguan HELE Electronics
 6099D1 Vuzix / Lenovo
 B04515 mira fitness
 14488B Shenzhen Doov Technology
@@ -2147,13 +2134,13 @@ B04515 mira fitness
 94CE31 CTS Limited
 80F8EB RayTight
 D437D7 zte
-2C010B Nascent Technology, - Remkon
+2C010B Nascent Technology, - RemKon
 04DEDB Rockport Networks
 1C4840 IMS Messsysteme GmbH
 6050C1 Kinetek Sports
 2C1A31 Electronics Company Limited
 90B686 Murata Manufacturing
-ECD9D1 Shenzhen TG-NET Botone Technology
+ECD9D1 Shenzhen Tg-net Botone Technology
 6C0273 Shenzhen Jin Yun Video Equipment
 54DF00 Ulterius Technologies
 20ED74 Ability enterprise
@@ -2170,7 +2157,7 @@ B40AC6 Dexon Systems
 D866EE Boxin Communication
 2829CC Corsa Technology Incorporated
 184A6F Alcatel-Lucent Shanghai Bell
-10C37B Asustek Computer
+10C37B ASUSTek Computer
 E85D6B Luminate Wireless
 B40B44 Smartisan Technology
 3431C4 AVM GmbH
@@ -2194,13 +2181,13 @@ C83168 eZEX
 40B3CD Chiyoda Electronics
 24336C Private
 202564 Pegatron
-C8D590 Flight Data Systems
+C8D590 Flight DATA Systems
 7CFF62 Huizhou Super Electron Technology
 84B59C Juniper Networks
 C09D26 Topicon HK Lmd.
 442938 NietZsche enterpriseLtd.
 A0DA92 Nanjing Glarun Atten Technology
-ECF72B HD Digital Tech
+ECF72B HD Digital TECH
 4CF45B Blue Clover Devices
 B06971 DEI Sales
 1889DF CerebrEX
@@ -2213,12 +2200,11 @@ CC95D7 Vizio
 FC09F6 Guangdong Tonze Electric
 BCF61C Geomodeling Wuxi Technology
 FC923B Nokia
-E03F49 Asustek Computer
+E03F49 ASUSTek Computer
 88A73C Ragentek Technology Group
 88D962 Canopus Systems US
 D09C30 Foster Electric Company, Limited
 949F3F Optek Digital Technology company limited
-E817FC Fujitsu Cloud Technologies Limited
 78FEE2 Shanghai Diveo Technology
 086DF2 Shenzhen Mimowave Technology
 48D0CF Universal Electronics
@@ -2228,7 +2214,7 @@ F8F005 Newport Media
 28656B Keystone Microtech
 CC9F35 Transbit Sp. z o.o.
 DCC793 Nokia
-444891 Hdmi Licensing
+444891 HDMI Licensing
 5C254C Avire Global Pte
 D42F23 Akenori PTE
 98C0EB Global Regency
@@ -2248,25 +2234,25 @@ FC07A0 LRE Medical GmbH
 1CEEE8 Ilshin Elecom
 9031CD Onyx Healthcare
 E48184 Nokia
-14C089 Dune HD
+14C089 DUNE HD
 F4B6E5 TerraSem
 60FFDD C.E. Electronics
 24050F MTN Electronic
-AC2DA3 Txtr Gmbh
+AC2DA3 TXTR GmbH
 889CA6 BTB Korea
 90837A General Electric Water & Process Technologies
 80BAE6 Neets
-F8A2B4 Rhewa-waagenfabrik August Freudewald Gmbh &amp;co. KG
+F8A2B4 Rhewa-waagenfabrik August Freudewald GmbH &amp;Co. KG
 E056F4 AxesNetwork Solutions
 84569C Coho Data
 78AE0C Far South Networks
 B024F3 Progeny Systems
 0C54A5 Pegatron
 8C4DB9 Unmonday
-78CA5E Elno
+78CA5E ELNO
 2C5A05 Nokia
 D481CA iDevices
-D858D7 CZ.NIC, z.s.p.o.
+D858D7 Cz.nic, z.s.p.o.
 B0D7C5 Logipix
 A43A69 Vers
 9C44A6 SwiftTest
@@ -2293,15 +2279,15 @@ A03B1B Inspire Tech
 041A04 WaveIP
 34A5E1 Sensorist ApS
 8079AE ShanDong Tecsunrise
-7CBD06 AE Refusol
+7CBD06 AE REFUsol
 94BA56 Shenzhen Coship Electronics
 38DBBB Sunbow Telecom
-448A5B Micro-Star INT'L
+448A5B Micro-Star Int'l
 6C4B7F Vossloh-Schwabe Deutschland GmbH
 908C44 H.K Zongmu Technology
 688AB5 EDP Servicos
 2493CA Voxtronic Austria
-0CCB8D Asco Numatics Gmbh
+0CCB8D ASCO Numatics GmbH
 907990 Benchmark Electronics Romania SRL
 740EDB Optowiz
 6C8366 Nanjing SAC Power Grid Automation
@@ -2309,7 +2295,7 @@ F83D4E Softlink Automation System
 74D435 Giga-byte Technology
 78D99F NuCom HK
 142BD2 Armtel
-9CA10A Scle SFE
+9CA10A SCLE SFE
 88789C Game Technologies SA
 A4895B ARK Infosolutions PVT
 D09D0A Linkcom
@@ -2330,8 +2316,8 @@ F854AF ECI Telecom
 140D4F Flextronics International
 446755 Orbit Irrigation
 E0FAEC Platan sp. z o.o. sp. k.
-7CE56B Esen Optoelectronics Technology
-D44C9C Shenzhen Yoobao Technologyltd
+7CE56B ESEN Optoelectronics Technology
+D44C9C Shenzhen Yoobao TechnologyLtd
 20CEC4 Peraso Technologies
 CC4703 Intercon Systems
 ACCA8E ODA Technologies
@@ -2340,7 +2326,7 @@ ACCA8E ODA Technologies
 6C90B1 SanLogic
 CC7B35 zte
 04D437 ZNV
-CCF407 Eukrea Electromatique Sarl
+CCF407 Eukrea Electromatique SARL
 DC1792 Captivate Network
 28A241 exlar
 509871 Inventum Technologies Private Limited
@@ -2382,12 +2368,12 @@ A4FCCE Security Expert
 341A4C Shenzhen Weibu Electronics
 0488E2 Beats Electronics
 A47ACF Vibicom Communications
-BC261D Hong Kong Tecon Technology
+BC261D HONG KONG Tecon Technology
 E8CE06 SkyHawke Technologies
 C8F386 Shenzhen Xiaoniao Technology
 E0DCA0 Siemens Industrial Automation Products Chengdu
 842F75 Innokas Group
-CC3C3F SA.S.S. Datentechnik AG
+CC3C3F Sa.s.s. Datentechnik AG
 2C69BA RF Controls
 D4BF7F Upvel
 2C72C3 Soundmatters
@@ -2400,7 +2386,7 @@ D4AC4E BODi rS
 A8294C Precision Optical Transceivers
 70C6AC Bosch Automotive Aftermarket
 7C0507 Pegatron
-880905 Mtmcommunications
+880905 MTMCommunications
 30D46A Autosales Incorporated
 282CB2 Tp-link Technologies
 64E599 EFM Networks
@@ -2412,7 +2398,7 @@ A0861D Chengdu Fuhuaxin Technology
 508D6F Chahoo Limited
 E8DE27 Tp-link Technologies
 94ACCA trivum technologies GmbH
-908260 Ieee 1904.1 Working Group
+908260 IEEE 1904.1 Working Group
 D4EE07 Hiwifi
 FCAD0F QTS Networks
 984C04 Zhangzhou Keneng Electrical Equipment
@@ -2424,7 +2410,7 @@ ACDBDA Shenzhen Geniatech
 D42751 Infopia
 103DEA HFC Technology (Beijing)
 F05DC8 Duracell Powermat
-CC5D57 Information  System Research Institute
+CC5D57 Information System Research Institute
 64C667 Barnes&Noble
 F0F260 Mobitec AB
 044CEF Fujian Sanao Technology
@@ -2440,9 +2426,9 @@ B01408 Lightspeed International
 983F9F China SSJ (Suzhou) Network Technology
 B838CA Kyokko Tsushin System
 C44EAC Shenzhen Shiningworth Technology
-A80180 Imago Technologies Gmbh
+A80180 Imago Technologies GmbH
 0C5521 Axiros GmbH
-68A40E BSH Hausgerte GmbH
+68A40E BSH Hausgeräte GmbH
 F4C6D7 blackned GmbH
 D4CA6E u-blox AG
 5C43D2 Hazemeyer
@@ -2456,7 +2442,7 @@ F87B62 Fastwel International, Taiwan Branch
 40270B Mobileeco
 74FE48 Advantech
 80B95C Elftech
-38B5BD E.G.O. Elektro-Ger
+38B5BD E.g.o. Elektro-Ger
 20918A Profalux
 E4EEFD MR&D Manufacturing
 105CBF DuroByte
@@ -2481,11 +2467,11 @@ EC4993 Qihan Technology
 B0ACFA Fujitsu Limited
 8CE081 zte
 A44E2D Adaptive Wireless Solutions
-0CCDFB Edic Systems
-9C8D1A Integ Process Group
+0CCDFB EDIC Systems
+9C8D1A Integ process group
 480362 Desay Electronics(huizhou)co.
 18673F Hanover Displays Limited
-7C0A50 J-MEX
+7C0A50 J-mex
 5011EB SilverNet
 54DF63 Intrakey technologies GmbH
 40F2E9 IBM
@@ -2493,10 +2479,10 @@ A44E2D Adaptive Wireless Solutions
 9C0473 Tecmobile (International)
 B4DFFA Litemax Electronics
 681CA2 Rosewill
-604616 Xiamen Vann Intelligent
+604616 Xiamen VANN Intelligent
 E45614 Suttle Apparatus
 3C83B5 Advance Vision Electronics
-28A192 Gerp Solution
+28A192 GERP Solution
 106FEF Ad-Sol Nissin
 6C40C6 Nimbus Data
 1048B1 Beijing Duokan Technology Limited
@@ -2506,23 +2492,23 @@ DC9FA4 Nokia
 44C39B OOO Rubezh NPO
 C44567 Sambon Precison and Electronics
 48F8B3 Cisco-Linksys
-D8D27C Jema Energy
+D8D27C JEMA Energy
 B01203 Dynamics Hong Kong Limited
 9886B1 Flyaudio (China)
 7093F8 Space Monkey
 28B3AB Genmark Automation
 C4E7BE SCSpro
 58874C Lite-on Clean Energy Technology
-2891D0 Stage Tec Entwicklungsgesellschaft fr professionelle Audiotechnik mbH
+2891D0 Stage Tec Entwicklungsgesellschaft für professionelle Audiotechnik mbH
 C0BD42 ZPA Smart Energy a.s.
 FC52CE Control iD
 5C4A26 Enguity Technology
 60F2EF VisionVera International
 C03F2A Biscotti
-381C4A Simcom Wireless Solutions
+381C4A SIMCom Wireless Solutions
 D8C691 Hichan Technology
 E43FA2 Wuxi DSP Technologies
-F4B72A Time Interconnect
+F4B72A TIME Interconnect
 749975 IBM
 2C625A Finest Security Systems
 2074CF Shenzhen Voxtech
@@ -2545,9 +2531,9 @@ E0A30F Pevco
 20443A Schneider Electric Asia Pacific
 C4393A SMC Networks
 5C2479 Baltech AG
-EC9327 Memmert Gmbh + KG
+EC9327 Memmert GmbH + KG
 A0EF84 Seine Image Int'l
-64517E Long BEN (dongguan) Electronic Technology
+64517E LONG BEN (dongguan) Electronic Technology
 D43D7E Micro-Star Int'l
 ACD9D6 tci GmbH
 48282F zte
@@ -2566,10 +2552,10 @@ ECA29B Kemppi Oy
 04CE14 Wilocity
 C4BA99 I+ME Actia Informatik und Mikro-Elektronik GmbH
 A4934C Cisco Systems
-D0D212 K2NET
+D0D212 K2net
 B0435D NuLEDs
-0808EA Amsc
-E8D483 Ultimate Europe Transportation Equipment Gmbh
+0808EA AMSC
+E8D483 Ultimate Europe Transportation Equipment GmbH
 1C8464 Formosa Wireless Communication
 346E8A Ecosense
 64F242 Gerdes Aktiengesellschaft
@@ -2590,7 +2576,7 @@ B45570 Borea
 00DEFB Cisco Systems
 3CA315 Bless Information & Communications
 F83094 Alcatel-Lucent Telecom Limited
-10A932 Beijing Cyber Cloud Technology
+10A932 Beijing Cyber Cloud Technology 
 34FC6F Alcea
 C0B357 Yoshiki Electronics Industry
 3C98BF Quest Controls
@@ -2601,11 +2587,11 @@ E477D4 Minrray Industry
 E4C806 Ceiec Electric Technology
 E0F9BE Cloudena
 B88F14 Analytica GmbH
-7C94B2 Philips Healthcare Pcci
+7C94B2 Philips Healthcare PCCI
 442B03 Cisco Systems
 F473CA Conversion Sound
 F8F7FF Syn-tech Systems
-A81758 Elektronik System i Ume AB
+A81758 Elektronik System i Umeå AB
 882012 LMI Technologies
 60E956 Ayla Networks
 EC1120 FloDesign Wind Turbine
@@ -2625,23 +2611,22 @@ B49EE6 Shenzhen Technology
 BC4B79 SensingTek
 A49005 China Greatwall Computer Shenzhen
 C40ACB Cisco Systems
-E86D6E Voestalpine Signaling Fareham
-681605 Systems And Electronic Development Fzco
+681605 Systems And Electronic Development FZCO
 D4A02A Cisco Systems
 3C4E47 Etronic A/S
 F48771 Infoblox
 5453ED Sony
 00376D Murata Manufacturing
-50008C Hong Kong Telecommunications (HKT) Limited
+50008C Hong Kong Telecommunications (hkt) Limited
 902B34 Giga-byte Technology
 88C36E Beijing Ereneben lnformation Technology Limited
 4C9E80 Kyokko Electric
-5CEB4E R. Stahl HMI Systems Gmbh
+5CEB4E R. Stahl HMI Systems GmbH
 34AA99 Nokia
 645563 Intelight
 943AF0 Nokia
 645422 Equinox Payments
-080D84 GECO
+080D84 Geco
 88E712 Whirlpool
 D412BB Quadrant Components
 24B88C Crenus
@@ -2663,7 +2648,7 @@ D8052E Skyviia
 D0CF5E Energy Micro AS
 1803FA IBT Interfaces
 306E5C Validus Technologies
-C894D2 Jiangsu Datang  Electronic Products
+C894D2 Jiangsu Datang Electronic Products
 C8A620 Nebula
 EC6264 Global411 Internet Services
 00F051 KWB Gmbh
@@ -2678,7 +2663,7 @@ DCF858 Lorent Networks
 940B2D NetView Technologies(Shenzhen)
 803F5D Winstars Technology
 40BF17 Digistar Telecom. SA
-780738 Z.U.K. Elzab
+780738 Z.u.k. Elzab
 2037BC Kuipers Electronic Engineering BV
 94319B Alphatronics BV
 00E175 AK-Systems
@@ -2723,9 +2708,9 @@ FCE892 Hangzhou Lancable Technology
 1071F9 Cloud Telecomputers
 B8621F Cisco Systems
 F0022B Chrontel
-D453AF Vigo System
+D453AF VIGO System
 18AD4D Polostar Technology
-94C6EB Nova Electronics
+94C6EB NOVA electronics
 843F4E Tri-Tech Manufacturing
 C83232 Hunting Innova
 549478 Silvershore Technology Partners
@@ -2759,13 +2744,13 @@ D0131E Sunrex Technology
 40B3FC Logital Limited
 A4134E Luxul
 B09928 Fujitsu Limited
-04E1C8 IMS Solues em Energia Ltda.
+04E1C8 IMS Soluções em Energia Ltda.
 948FEE Verizon Telematics
 50D6D7 Takahata Precision
 88F077 Cisco Systems
-587521 Cjsc Rtsoft
+587521 CJSC RTSoft
 C40F09 Hermes electronic GmbH
-48F47D TechVision Holding  Internation Limited
+48F47D TechVision Holding Internation Limited
 F081AF IRZ Automation Technologies
 701404 Limited Liability Company
 B435F7 Zhejiang Pearmain Electronicsltd.
@@ -2785,7 +2770,7 @@ AC5E8C Utillink
 C4242E Galvanic Applied Sciences
 24C86E Chaney Instrument
 F0AE51 Xi3
-B80B9D Ropex Industrie-elektronik Gmbh
+B80B9D Ropex Industrie-Elektronik GmbH
 306118 Paradom
 4C7367 Genius Bytes Software Solutions GmbH
 90EA60 SPI Lasers
@@ -2802,7 +2787,7 @@ B4F323 Petatel
 E42FF6 Unicore communication
 84D9C8 Unipattern,
 94AAB8 Joview(Beijing) Technology
-28F358 2C - Trifonov &
+28F358 2C - Trifonov
 14C21D Sabtech Industries
 C88439 Sunrise Technologies
 F0BF97 Sony
@@ -2811,9 +2796,8 @@ EC7D9D CPI
 C81E8E ADV Security (S) Pte
 A88792 Broadband Antenna Tracking Systems
 14F0C5 Xtremio
-E8C229 H-Displays (MSC) Bhd
+E8C229 H-Displays (msc) Bhd
 3CA72B MRV Communications (Networks)
-301A28 Mako Networks
 04E662 Acroname
 F87B8C Amped Wireless
 283410 Enigma Diagnostics Limited
@@ -2843,23 +2827,23 @@ A862A2 Jiwumedia
 FC1FC0 Eurecam
 BC6784 Environics Oy
 68DCE8 PacketStorm Communications
-488E42 Digalog Gmbh
+488E42 Digalog GmbH
 607688 Velodyne
 78CD8E SMC Networks
 2C8065 Harting of North America
 3CC0C6 d&b audiotechnik GmbH
-4468AB Juin Company, Limited
+4468AB JUIN Company, Limited
 F81037 Atopia Systems
 78A683 Precidata
 F02572 Cisco Systems
 04FF51 Novamedia Innovision SP. Z O.O.
-4CB4EA HRD (S) PTE.
+4CB4EA HRD (S) Pte.
 D44C24 Vuppalamritha Magnetic Components
 F8C678 Carefusion
 6CAB4D Digital Payment Technologies
 2CB0DF Soliton Technologies Pvt
 ECE555 Hirschmann Automation
-58F98E Secudos Gmbh
+58F98E Secudos GmbH
 B4C44E VXL eTech Pvt
 707EDE Nastec
 C07E40 Shenzhen XDK Communication Equipment
@@ -2870,23 +2854,23 @@ B4749F Askey Computer
 E05FB9 Cisco Systems
 E0143E Modoosis
 90D852 Comtec
-380197 Tsst Global
+380197 TSST Global
 AC02CF RW Tecnologia Industria e Comercio Ltda
 D41296 Anobit Technologies
 48174C MicroPower technologies
 349A0D ZBD Displays
-90507B Advanced Panmobil Systems Gmbh & KG
+90507B Advanced Panmobil Systems GmbH & KG
 0876FF Thomson Telecom Belgium
 1C7C11 EID
 20AA25 Ip-net
-C4EEF5 II-VI Incorporated
+C4EEF5 Ii-vi Incorporated
 E0CF2D Gemintek
 D491AF Electroacustica General Iberica
 C4B512 General Electric Digital Energy
 0034F1 Radicom Research
 9433DD Taco
 E02538 Titan Pet Products
-CC7A30 Cmax Wireless
+CC7A30 CMAX Wireless
 B88E3A Infinite Technologies JLT
 588D09 Cisco Systems
 C0C1C0 Cisco-Linksys
@@ -2905,7 +2889,7 @@ D46CDA CSM GmbH
 68597F Alcatel Lucent
 F065DD Primax Electronics
 706582 Suzhou Hanming Technologies
-34D2C4 Rena Gmbh Print Systeme
+34D2C4 RENA GmbH Print Systeme
 D4CBAF Nokia
 045D56 camtron industrial
 68234B Nihon Dengyo Kousaku
@@ -2913,7 +2897,7 @@ D4CBAF Nokia
 58BC27 Cisco Systems
 20D607 Nokia
 6CE0B0 Sound4
-9CFFBE Otsl
+9CFFBE OTSL
 00F860 PT. Panggung Electric Citrabuana
 B8BA72 Cynove
 443D21 Nuvolt
@@ -2940,13 +2924,12 @@ CCFCB1 Wireless Technology
 EC66D1 B&W Group
 385FC3 Yu Jeong System,Ltd
 888B5D Storage Appliance
-78C6BB Innovasic
 84A991 Cyber Trans Japan
 68784C Nortel Networks
 F8D756 Simm Tronic Limited
 04A3F3 Emicon
 1C17D3 Cisco Systems
-7CE044 Neon
+7CE044 NEON
 284C53 Intune Networks
 90513F Elettronica Santerno SpA
 8841C1 Orbisat DA Amazonia IND E Aerol SA
@@ -2966,18 +2949,18 @@ E86CDA Supercomputers and Neurocomputers Research Center
 24A42C Koukaam a.s.
 4C3089 Thales Transportation Systems GmbH
 481249 Luxcom Technologies
-24A937 Pure Storage
+24A937 PURE Storage
 348302 iFORCOM
 B43DB2 Degreane Horizon
 84F64C Cross Point BV
-C08B6F S I Sistemas Inteligentes Eletrnicos Ltda
+C08B6F S I Sistemas Inteligentes Eletrônicos Ltda
 F86ECF Arcx
 8C8401 Private
 408493 Clavister AB
-78A6BD Daeyeon Control&instrument
+78A6BD Daeyeon Control&Instrument
 3C1915 GFI Chrono Time
 ECB106 Acuro Networks
-C835B8 Ericsson, EAB/RWI/K
+C835B8 Ericsson, Eab/rwi/k
 F89D0D Control Technology
 2C3F3E Alge-Timing GmbH
 089F97 Leroy Automation
@@ -3024,7 +3007,7 @@ A8F94B Eltex Enterprise
 3CB17F Wattwatchers Ld
 CC5459 OnTime Networks AS
 F8DC7A Variscite
-D4F143 Iproad.
+D4F143 IPROAD.
 B8F732 Aryaka Networks
 E8DFF2 PRF
 B4ED54 Wohler Technologies
@@ -3035,7 +3018,7 @@ B4ED54 Wohler Technologies
 ACE348 MadgeTech
 549A16 Uzushio Electric
 9018AE Shanghai Meridian Technologies,
-0494A1 Catch THE Wind
+0494A1 Catch THE WIND
 003A99 Cisco Systems
 003A9A Cisco Systems
 003A98 Cisco Systems
@@ -3066,8 +3049,8 @@ C82E94 Halfa Enterprise
 F0DE71 Shanghai EDO Technologies
 60D30A Quatius Limited
 24CF21 Shenzhen State Micro Technology
-10BAA5 Gana I&C
-BC9DA5 Dascom Europe Gmbh
+10BAA5 GANA I&C
+BC9DA5 Dascom Europe GmbH
 28FBD3 Ragentek Technology Group
 586ED6 Private
 EC3091 Cisco Systems
@@ -3087,7 +3070,7 @@ D4C766 Acentic GmbH
 002712 MaxVision
 00271F Mipro Electronics
 00270C Cisco Systems
-0026CF Deka R&D
+0026CF DEKA R&D
 0026E7 Shanghai Onlan Communication Tech.
 0026E0 Asiteq
 002703 Testech Electronics Pte
@@ -3095,21 +3078,20 @@ D4C766 Acentic GmbH
 0026A5 Microrobot.co.
 0026A3 FQ Ingenieria Electronica
 00269D M2Mnet
-002697 Alpha  Technologies
+002697 Alpha Technologies
 00268A Terrier SC
 002689 General Dynamics Robotic Systems
 0026C5 Guangdong Gosun Telecommunications
 0026C4 Cadmos microsystems S.r.l.
 0026C8 System Sensor
 00267A wuhan hongxin telecommunication technologies
-0026C2 Scdi
+0026C2 SCDI
 002685 Digital Innovation
 0026A9 Strong Technologies
-002672 Aamp of America
+002672 AAMP of America
 0025FD OBR Centrum Techniki Morskiej
-002600 Teac Australia
+002600 TEAC Australia
 0025FF CreNova Multimedia
-002604 Audio Processing Technology
 002659 Nintendo
 002651 Cisco Systems
 002612 Space Exploration Technologies
@@ -3117,7 +3099,7 @@ D4C766 Acentic GmbH
 00260B Cisco Systems
 002623 JRD Communication
 002627 Truesell
-00264F Krger &Gothe GmbH
+00264F Krüger &Gothe GmbH
 002621 InteliCloud Technology
 00261C Neovia
 002664 Core System Japan
@@ -3140,7 +3122,7 @@ D4C766 Acentic GmbH
 0025B8 Agile Communications
 0025B1 Maya-Creation
 0025A1 Enalasys
-0025F3 Nordwestdeutsche Zhlerrevision
+0025F3 Nordwestdeutsche Zählerrevision
 0025DD Sunnytek Information
 0025CE InnerSpace
 002549 Jeorich Tech.
@@ -3180,7 +3162,7 @@ D4C766 Acentic GmbH
 002475 Compass System(Embedded Dept.)
 0024C3 Cisco Systems
 0024B5 Nortel Networks
-0024B0 Esab AB
+0024B0 ESAB AB
 0024C4 Cisco Systems
 00249D NES Technology
 002464 Bridge Technologies AS
@@ -3208,13 +3190,13 @@ D4C766 Acentic GmbH
 0023EF Zuend Systemtechnik AG
 0023AC Cisco Systems
 0023D8 Ball-It Oy
-00239F Institut fr Prftechnik
+00239F Institut für Prüftechnik
 00239D Mapower Electronics
 00239C Juniper Networks
 002398 Vutlan sro
 00235B Gulfstream
 002359 Benchmark Electronics ( Thailand ) Public Company Limited
-002357 Pitronot Technologies and Engineering P.T.E.
+002357 Pitronot Technologies and Engineering P.t.e.
 002355 Kinco Automation(Shanghai)
 002373 GridIron Systems
 002367 UniControls a.s.
@@ -3257,7 +3239,7 @@ D4C766 Acentic GmbH
 002244 Chengdu Linkon Communications Device
 002250 Point Six Wireless
 00226F 3onedata Technology
-002278 Shenzhen  Tongfang Multimedia  Technology
+002278 Shenzhen Tongfang Multimedia Technology
 00227A Telecom Design
 002260 Afreey
 0021EF Kapsys
@@ -3267,7 +3249,7 @@ D4C766 Acentic GmbH
 00222F Open Grid Computing
 0021F6 Oracle
 002206 Cyberdyne
-002202 Excito Elektronik i Skne AB
+002202 Excito Elektronik i Skåne AB
 002227 uv-electronic GmbH
 00221E Media Devices
 002225 Thales Avionics
@@ -3277,21 +3259,21 @@ D4C766 Acentic GmbH
 00223E IRTrans GmbH
 0021CE NTC-Metrotek
 0021CA ART System
-0021CB SMS Tecnologia Eletronica Ltda
+0021CB SMS Tecnologia Eletronica LTDA
 0021C8 Lohuis Networks
 0021DB Santachi Video Technology (Shenzhen)
 0021BF Hitachi High-Tech Control Systems
-0021BC Zala Computer
-0021B4 Apro Media
+0021BC ZALA Computer
+0021B4 APRO Media
 0021A8 Telephonics
 0021A9 Mobilink Telecom
-00218D AP Router Ind. Eletronica Ltda
+00218D AP Router Ind. Eletronica LTDA
 002190 Goliath Solutions
 002185 Micro-star Int'l
 00219F Satel OY
 002196 Telsey
 002182 SandLinks Systems
-002183 Andritz Hydro Gmbh
+002183 Andritz Hydro GmbH
 0021DF Martin Christ GmbH
 0021D4 Vollmer Werke GmbH
 0021D6 LXI Consortium
@@ -3314,7 +3296,7 @@ D4C766 Acentic GmbH
 001FF6 PS Audio International
 002110 Clearbox Systems
 00210C Cymtec Systems
-00210B Gemini Traze Rfid PVT.
+00210B Gemini Traze RFID PVT.
 001FDD GDI
 001FDA Nortel Networks
 002104 Gigaset Communications GmbH
@@ -3354,7 +3336,7 @@ D4C766 Acentic GmbH
 001F2E Triangle Research Int'l Pte
 001F4B Lineage Power
 001F0D L3 Communications - Telemetry West
-001EFC JSC Massa-k
+001EFC JSC "massa-k"
 001F23 Interacoustics
 001F06 Integrated Dispatch Solutions
 001EBA High Density Devices AS
@@ -3368,13 +3350,13 @@ D4C766 Acentic GmbH
 001EFA Protei
 001EFB Trio Motion Technology
 001EF8 Emfinity
-001ECB RPC Energoautomatika
+001ECB "RPC "Energoautomatika"
 001EA8 Datang Mobile Communications Equipment
 001EAB TeleWell Oy
 001E9F Visioneering Systems
 001E6B Cisco Spvtg
 001E70 Cobham Antenna Systems
-001E61 Itec Gmbh
+001E61 ITEC GmbH
 001E3E KMW
 001E38 Bluecard Software Technology
 001E47 PT. Hariff Daya Tunggal Engineering
@@ -3385,12 +3367,12 @@ D4C766 Acentic GmbH
 001E59 Silicon Turnkey Express
 001E51 Converter Industry Srl
 001E71 MIrcom Group of Companies
-001DC4 Aioi Systems
+001DC4 AIOI Systems
 001DC0 Enphase Energy
 001DBD Versamed
 001DF8 Webpro Vision Technology
 001DF9 Cybiotronics (Far East) Limited
-001DF7 R. Stahl Schaltgerte Gmbh
+001DF7 R. Stahl Schaltgeräte GmbH
 001E05 Xseed Technologies & Computing
 001E07 Winy Technology
 001E0A Syba Tech Limited
@@ -3435,7 +3417,7 @@ D4C766 Acentic GmbH
 001CB5 Neihua Network Technology,LTD.(NHN)
 001CB4 Iridium Satellite
 001CB6 Duzon CNT
-001CC7 Rembrandt Technologies, D/b/a Remstream
+001CC7 Rembrandt Technologies, d/b/a Remstream
 001CBB MusicianLink
 001C8D Mesa Imaging
 001C89 Force Communications
@@ -3452,7 +3434,7 @@ D4C766 Acentic GmbH
 001C16 ThyssenKrupp Elevator
 001C19 secunet Security Networks AG
 001C6C 30805
-001C61 Galaxy  Microsystems LImited
+001C61 Galaxy Microsystems LImited
 001C3B AmRoad Technology
 001C3F International Police Technologies
 001C28 Sphairon Technologies GmbH
@@ -3470,7 +3452,7 @@ D4C766 Acentic GmbH
 001C09 SAE Electronic
 001C0C Tanita
 001BA6 intotech
-001BA4 S.A.E Afikim
+001BA4 S.a.e Afikim
 001BB4 Airvod Limited
 001BB6 Bird Electronic
 001BE8 Ultratronik GmbH
@@ -3483,7 +3465,7 @@ D4C766 Acentic GmbH
 001B45 ABB AS, Division Automation Products
 001B3F ProCurve Networking by HP
 001B41 General Infinity
-001B50 Nizhny Novgorod Factory Named After M.frunze, Fsue (nzif)
+001B50 Nizhny Novgorod Factory named after M.Frunze, FSUE (NZiF)
 001B47 Futarque A/S
 001B6C LookX Digital Media BV
 001B6B Swyx Solutions AG
@@ -3493,7 +3475,7 @@ D4C766 Acentic GmbH
 001B68 Modnnet
 001B62 JHT Optoelectronics
 001B8A 2M Electronic A/S
-001B80 Lord
+001B80 LORD
 001B3E Curtis
 001B37 Computec Oy
 001B07 Mendocino Software
@@ -3525,9 +3507,9 @@ D4C766 Acentic GmbH
 001AC9 Suzuken
 001A79 Telecomunication Technologies
 001AAA Analogic
-001A8B Chunil Electric IND.
-001A8D Avecs Bergen Gmbh
-001AB4 Ffei
+001A8B Chunil Electric Ind.
+001A8D Avecs Bergen GmbH
+001AB4 FFEI
 001AB5 Home Network System
 001AA4 Future University-Hakodate
 001A9F A-Link
@@ -3565,7 +3547,7 @@ D4C766 Acentic GmbH
 00198D Ocean Optics
 001982 SmarDTV
 001985 IT Watchdogs
-001951 Netcons, S.r.o.
+001951 Netcons, s.r.o.
 001957 Saafnet Canada
 001958 Bluetooth SIG
 001956 Cisco Systems
@@ -3595,12 +3577,12 @@ D4C766 Acentic GmbH
 00189F Lenntek
 001899 ShenZhen jieshun Science&Technology Industry
 00186D Zhenjiang Sapphire Electronic Industry
-00186F Setha Industria Eletronica Ltda
+00186F Setha Industria Eletronica LTDA
 001875 AnaCise Testnology Pte
-0018C1 Almitec Informtica e Comrcio
+0018C1 Almitec Informática e Comércio
 0018C4 Raba Technologies
 0018C9 EOps Technology Limited
-0018D8 Arch Meter
+0018D8 ARCH Meter
 0018D9 Santosha Internatonal
 0018CF Baldor Electric Company
 0018BC ZAO NVP Bolid
@@ -3613,7 +3595,7 @@ D4C766 Acentic GmbH
 001811 Neuros Technology International
 0017DE Advantage Six
 0017D7 ION Geophysical
-001837 Universal Abit
+001837 Universal ABIT
 001822 CEC Telecom
 001820 w5networks
 00185D Taiguen Technology (shen-zhen)
@@ -3631,7 +3613,7 @@ D4C766 Acentic GmbH
 0017B1 Acist Medical Systems
 0017A3 MIX s.r.l.
 0017A6 Yosin Electronics
-00179C Deprag Schulz Gmbh u.
+00179C Deprag Schulz GMBH u.
 001796 Rittmeyer AG
 0017E1 Dacos Technologies
 0017E0 Cisco Systems
@@ -3644,7 +3626,7 @@ D4C766 Acentic GmbH
 001781 Greystone Data System
 00178D Checkpoint Systems
 00178E Gunnebo Cash Automation AB
-0017C7 Mara Systems Consulting AB
+0017C7 MARA Systems Consulting AB
 00175D Dongseo system.
 001750 GSI Group, MicroE Systems
 001755 GE Security
@@ -3664,7 +3646,7 @@ D4C766 Acentic GmbH
 001701 KDE
 0016F6 Video Products Group
 0016EE Royaldigital
-0016DE Fast
+0016DE FAST
 0016DA Futronic Technology
 0016D4 Compal Communications
 0016D7 Sunways AG
@@ -3678,7 +3660,7 @@ D4C766 Acentic GmbH
 001705 Methode Electronics
 0016AA Kei Communication Technology
 0016A8 CWT
-0016A6 Dovado FZ-LLC
+0016A6 Dovado Fz-llc
 0016ED Utility
 0016C7 Cisco Systems
 001671 Symphox Information
@@ -3688,7 +3670,7 @@ D4C766 Acentic GmbH
 00163C Rebox
 00167D Sky-Line Information
 001677 Bihl + Wiedemann GmbH
-001655 Fuho Technology
+001655 FUHO Technology
 001646 Cisco Systems
 001648 SSD Company Limited
 001672 Zenway enterprise
@@ -3699,7 +3681,7 @@ D4C766 Acentic GmbH
 0015D8 Interlink Electronics
 0015D4 Emitor AB
 0015D5 Nicevt
-00160C LPL  Development S.A. DE C.V
+00160C LPL Development DE C.V
 00160B TVWorks
 001603 Coolksky
 0015EA Tellumat (Pty)
@@ -3715,7 +3697,7 @@ D4C766 Acentic GmbH
 001619 Lancelan Technologies S.L.
 001625 Impinj
 001586 Xiamen Overseas Chinese Electronic
-00157E Weidmller Interface GmbH & KG
+00157E Weidmüller Interface GmbH & KG
 001580 U-way
 00157C Dave Networks
 00157F ChuanG International Holding
@@ -3730,10 +3712,10 @@ D4C766 Acentic GmbH
 0015BE Iqua
 0015C7 Cisco Systems
 00155E Morgan Stanley
-00150B Sage Infotech
+00150B SAGE Infotech
 001507 Renaissance Learning
 001508 Global Target Enterprise
-001502 Beta Tech
+001502 BETA tech
 0014FD Thecus Technology
 0014FC Extandon
 0014F8 Scientific Atlanta
@@ -3747,9 +3729,9 @@ D4C766 Acentic GmbH
 00153B EMH metering GmbH & KG
 001537 Ventus Networks
 001533 Nadam.co.
-001534 A Beltrnica-Companhia de Comunicaes
+001534 A Beltrónica-Companhia de Comunicações
 00153F Alcatel Alenia Space Italia
-001518 Shenzhen 10MOONS Technology Development
+001518 Shenzhen 10moons Technology Development
 001526 Remote Technologies
 0014F1 Cisco Systems
 0014EA S Digm (Safe Paradigm)
@@ -3757,7 +3739,7 @@ D4C766 Acentic GmbH
 00149F System and Chips
 0014B3 CoreStar International
 0014B1 Axell Wireless Limited
-0014E0 LET'S
+0014E0 Let's
 0014E2 datacom systems
 0014E4 infinias
 0014CC Zetec
@@ -3772,7 +3754,7 @@ D4C766 Acentic GmbH
 00146B Anagran
 001461 Corona
 001462 Digiwell Technology
-001463 Idcs N.V.
+001463 IDCS N.V.
 001465 Novo Nordisk A/S
 001474 K40 Electronics
 00146F Kohler
@@ -3819,17 +3801,17 @@ D4C766 Acentic GmbH
 00136A Hach Lange Sarl
 0013B2 Carallon Limited
 0013AD Sendo
-0013AA ALS  & TEC
+0013AA ALS & TEC
 0013A4 KeyEye Communications
 00134D Inepro BV
 00134B ToGoldenNet Technology
 001384 Advanced Motion Controls
 00137B Movon
-001353 Hydac Filtertechnik Gmbh
+001353 Hydac Filtertechnik GMBH
 001363 Verascape
 001303 GateConnect
 001304 Flaircomm Technologies
-0012F9 Uryu Seisaku
+0012F9 URYU Seisaku
 0012F3 connectBlue AB
 001337 Orient Power Home Network
 001334 Arkados
@@ -3850,7 +3832,7 @@ D4C766 Acentic GmbH
 001294 Sumitomo Electric Device Innovations
 001296 Addlogix
 0012B3 Advance Wireless Technology
-0012B0 Efore Oyj   (Plc)
+0012B0 Efore Oyj (Plc)
 00127F Cisco Systems
 0012A6 Dolby Australia
 0012A4 ThingMagic
@@ -3868,8 +3850,8 @@ D4C766 Acentic GmbH
 001269 Value Electronics
 001250 Tokyo Aircaft Instrument
 001252 Citronix
-001240 Amoi Electronics
-00122E Signal Technology - Aisd
+001240 AMOI Electronics
+00122E Signal Technology - AISD
 001264 daum electronic gmbh
 001261 Adaptix
 001260 Stanton Magnetics
@@ -3884,7 +3866,7 @@ D4C766 Acentic GmbH
 0011D5 Hangzhou Sunyard System Engineering
 0011F8 Airaya
 0011F4 woori-net
-0011F6 Asia Pacific Microsystems
+0011F6 Asia Pacific Microsystems 
 0011F0 Wideful Limited
 0011F1 QinetiQ
 0011ED 802 Global
@@ -3919,7 +3901,7 @@ D4C766 Acentic GmbH
 001119 Solteras
 001150 Belkin
 001146 Telecard-Pribor
-00110D Sanblaze Technology
+00110D SANBlaze Technology
 001106 Siemens NV (Belgium)
 000FF4 Guntermann & Drunck GmbH
 000FF8 Cisco Systems
@@ -3933,12 +3915,12 @@ D4C766 Acentic GmbH
 000FD2 EWA Technologies
 000FCE Kikusui Electronics
 000FEB Cylon Controls
-000FDC Ueda Japan  Radio
+000FDC Ueda Japan Radio
 000F8E Dongyang Telecom
 000F91 Aerotelecom
 000F87 Maxcess International
 000FA1 Gigabit Systems
-000F99 Apac Opto Electronics
+000F99 APAC opto Electronics
 000FF5 GN&S company
 000FE8 Lobos
 000FB2 Broadband Pacenet (India) Pvt.
@@ -3947,10 +3929,9 @@ D4C766 Acentic GmbH
 000FAF Dialog
 000FA5 BWA Technology GmbH
 000F80 Trinity Security Systems
-000F32 Lootom Telcovideo Network Wuxi
 000F2A Cableware Electronics
 000F29 Augmentix
-000F27 Teal Electronics
+000F27 TEAL Electronics
 000F43 Wasabi Systems
 000F48 Polypix
 000F50 StreamScale Limited
@@ -3963,7 +3944,7 @@ D4C766 Acentic GmbH
 000F70 Wintec Industries
 000F74 Qamcom Technology AB
 000F6D Midas Engineering
-000F5F Nicety Technologies (NTS)
+000F5F Nicety Technologies (nts)
 000F5A Peribit Networks
 000F31 Allied Vision Technologies Canada
 000F73 RS Automation
@@ -3974,15 +3955,15 @@ D4C766 Acentic GmbH
 000EF8 SBC ASI
 000EF9 REA Elektronik GmbH
 000EE6 Adimos Systems
-000EF6 E-TEN Information Systems
+000EF6 E-ten Information Systems
 000EEA Shadong Luneng Jicheng Electronics,Co.
 000F0F Real ID Technology
 000F16 JAY HOW Technology,
-000EC6 Asix Electronics
+000EC6 ASIX Electronics
 000EBF Remsdaq Limited
 000EFF Megasolution
 000EE0 Mcharge
-000E9F Temic SDS Gmbh
+000E9F Temic SDS GmbH
 000E96 Cubic Defense Applications
 000E8E SparkLAN Communications
 000E91 Navico Auckland
@@ -3992,17 +3973,17 @@ D4C766 Acentic GmbH
 000E75 New York Air Brake
 000E7C Televes
 000E66 Hitachi Industry & Control Solutions
-000E68 E-TOP Network Technology
+000E68 E-top Network Technology
 000E5E Raisecom Technology
 000E56 4G Systems GmbH & KG
 000E55 Auvitran
 000E73 Tpack A/S
 000E72 CTS electronics
-000E6E MAT S.A. (Mircrelec Advanced Technology)
+000E6E MAT (Mircrelec Advanced Technology)
 000E84 Cisco Systems
 000E87 adp Gauselmann GmbH
 000E92 Open Telecom
-000E53 AV Tech
+000E53 AV TECH
 000DF9 NDS Limited
 000DFD Huges Hi-Tech,
 000DFB Komax AG
@@ -4064,17 +4045,17 @@ D4C766 Acentic GmbH
 000CC0 Genera Oy
 000CA8 Garuda Networks
 000D03 Matrics
-000CFF MRO-TEK Realty Limited
+000CFF Mro-tek Realty Limited
 000CFA Digital Systems
 000CFD Hyundai ImageQuest
 000CD3 Prettl Elektronik Radeberg GmbH
 000CD7 Nallatech
 000CD4 Positron Public Safety Systems
-000CD6 Partner Tech
+000CD6 Partner TECH
 000CB9 LEA
 000CBD Interface Masters
 000CB2 Union
-000CEB Cnmp Networks
+000CEB CNMP Networks
 000CCC Aeroscout
 000CC7 Intelligent Computer Solutions
 000CBE Innominate Security Technologies AG
@@ -4082,7 +4063,7 @@ D4C766 Acentic GmbH
 000CEF Open Networks Engineering
 000C64 X2 MSA Group
 000CA0 StorCase Technology
-000C99 Hitel Link
+000C99 Hitel LINK
 000C5A IBSmm Embedded Electronics Consulting
 000C5E Calypso Medical
 000C61 AC Tech DBA Advanced Digital
@@ -4097,7 +4078,7 @@ D4C766 Acentic GmbH
 000C66 Pronto Networks
 000C88 Apache Micro Peripherals
 000C82 Network Technologies
-000C8D Matrix Vision Gmbh
+000C8D Matrix Vision GmbH
 000C89 AC Electric Vehicles
 000C4E Winbest Technology
 000BFE Castel Broadband Limited
@@ -4128,7 +4109,7 @@ D4C766 Acentic GmbH
 000BD9 General Hydrogen
 000BAB Advantech Technology (china)
 000B6D Solectron Japan Nakaniida
-000BC4 Biotronik Gmbh &
+000BC4 Biotronik GmbH
 000B57 Silicon Laboratories
 000B51 Micetek International
 000B53 Initium
@@ -4136,7 +4117,7 @@ D4C766 Acentic GmbH
 000AFF Kilchherr Elektronik AG
 000B4A Visimetrics (UK)
 000B48 sofrel
-000B1E Kappa Opto-electronics Gmbh
+000B1E Kappa opto-electronics GmbH
 000B1C Sibco bv
 000B37 Manufacture DES Montres Rolex SA
 000AF8 American Telecare
@@ -4147,10 +4128,10 @@ D4C766 Acentic GmbH
 000AA6 Hochiki
 000A9A Aiptek International
 000A94 ShangHai cellink
-000A97 Sonicblue
+000A97 SONICblue
 000A92 Presonus
-000A85 Plat'c2
-000AD0 Niigata Develoment Center,  F.I.T.
+000A85 PLAT'C2
+000AD0 Niigata Develoment Center, F.i.t.
 000AD4 CoreBell Systems
 000ACA Yokoyama Shokai
 000ACE Radiantech
@@ -4170,8 +4151,8 @@ D4C766 Acentic GmbH
 000A66 Mitsubishi Electric System & Service
 000A31 HCV Consulting
 004252 RLX Technologies
-000A70 Mpls Forum
-000A72 STEC
+000A70 MPLS Forum
+000A72 Stec
 000A3D Elo Sistemas Eletronicos
 000A46 ARO Welding Technologies SAS
 000A71 Avrio Technologies
@@ -4184,10 +4165,9 @@ D4C766 Acentic GmbH
 000A20 SVA Networks
 000A24 Octave Communications
 000A19 Valere Power
-0009E5 Hottinger Baldwin Messtechnik GmbH
 0009DE Samjin Information & Communications
 0009E0 Xemics
-000A01 Sohoware
+000A01 SOHOware
 0009EC Daktronics
 0009EE Meikyo Electric
 0009CA iMaxNetworks(Shenzhen)Limited.
@@ -4201,7 +4181,6 @@ D4C766 Acentic GmbH
 0009B9 Action Imaging Solutions
 0009AC Lanvoice
 0009B1 Kanematsu Electronics
-0009B0 Onkyo
 000979 Advanced Television Systems Committee
 000963 Dominion Lasercom
 000966 Trimble Europe BV
@@ -4217,7 +4196,7 @@ D4C766 Acentic GmbH
 00098E ipcas GmbH
 0009AB Netcontrol Oy
 000960 Yozan
-000956 Network Systems Group, (NSG)
+000956 Network Systems Group, (nsg)
 000900 TMT
 000901 Shenzhen Shixuntong Information & Technoligy
 000913 SystemK
@@ -4254,7 +4233,7 @@ D4C766 Acentic GmbH
 0008BD Tepg-us
 0008AE PacketFront Network Products AB
 0008C3 Contex A/S
-0008F3 Wany
+0008F3 WANY
 0008DE 3UP Systems
 000822 InPro Comm
 000823 Texa
@@ -4288,7 +4267,7 @@ D4C766 Acentic GmbH
 0007BF Armillaire Technologies
 0007BB Candera
 0007BD Radionet
-0007C4 Jean
+0007C4 JEAN
 0007B6 Telecom Technology
 0007B7 Samurai Ind. Prods Eletronicos Ltda
 0007B0 Office Details
@@ -4300,7 +4279,7 @@ D4C766 Acentic GmbH
 0007C9 Technol Seven
 0007C7 Synectics Systems Limited
 0007C3 Thomson
-0007A5 Y.D.K
+0007A5 Y.d.k
 00079C Golden Electronics Technology
 0007E4 SoftRadio
 000754 Xyterra Computing
@@ -4310,7 +4289,7 @@ D4C766 Acentic GmbH
 00074D Zebra Technologies
 000732 Aaeon Technology
 000725 Bematech International
-000723 Elcon Systemtechnik Gmbh
+000723 Elcon Systemtechnik GmbH
 00071D Satelsa Sistemas Y Aplicaciones De Telecomunicaciones
 000720 Trutzschler GmbH & KG
 00076E Sinetica Limited
@@ -4326,7 +4305,7 @@ D4C766 Acentic GmbH
 000780 Bluegiga Technologies OY
 000777 Motah
 000724 Telemax
-00071B Cdvi Americas
+00071B CDVI Americas
 000715 General Research of Electronics
 000737 Soriya
 000734 ONStor
@@ -4352,7 +4331,7 @@ D4C766 Acentic GmbH
 000675 Banderacom
 000698 egnite GmbH
 00069C Transmode Systems AB
-000643 Sono Computer
+000643 SONO Computer
 000649 3M Deutschland GmbH
 00063E Opthos
 00063B Arcturus Networks
@@ -4368,20 +4347,20 @@ D4C766 Acentic GmbH
 000686 Zardcom
 000689 yLez Technologies Pte
 000681 Goepel Electronic GmbH
-000658 Helmut Fischer GmbH Institut fr Elektronik und Messtechnik
+000658 Helmut Fischer GmbH Institut für Elektronik und Messtechnik
 0005D3 eProduction Solutions
 000604 @Track Communications
 000606 RapidWAN
 000603 Baker Hughes
 000607 Omni Directional Control Technology
 0005F7 Analog Devices
-00059C Kleinknecht GmbH, Ing. Bro
+00059C Kleinknecht GmbH, Ing. Büro
 0005AE Mediaport USA
 0005B0 Korea Computer Technology
 0005B2 Medison
 000597 Eagle Traffic Control Systems
 0005B5 Broadcom Technologies
-0005CB Rois Technologies
+0005CB ROIS Technologies
 0005C8 Verytech
 0005CD D&M Holdings
 0005A2 Celox Networks
@@ -4396,8 +4375,8 @@ D4C766 Acentic GmbH
 00054D Brans Technologies
 000547 Starent Networks
 00054E Philips
-000546 Kddi Network & Solultions
-000540 Fast
+000546 KDDI Network & Solultions
+000540 FAST
 00053C Xircom
 000544 Valley Technologies
 00052E Cinta Networks
@@ -4426,7 +4405,7 @@ D4C766 Acentic GmbH
 0004D9 Titan Electronics
 0004D8 IPWireless
 000524 BTL System (HK) Limited
-000522 LEA*D
+000522 Lea*d
 000520 Smartronix
 0004EB Paxonet Communications
 0004EF Polestar
@@ -4441,17 +4420,17 @@ D4C766 Acentic GmbH
 0004BC Giantec
 0004AF Digital Fountain
 000456 Cambium Networks Limited
-000458 Fusion X
+000458 Fusion
 00044F Schubert System Elektronik Gmbh
 000446 Cyzentech
 00044A iPolicy Networks
 000440 cyberPIXIE
 00043C Sonos
 0004B2 Essegi SRL
-0004B4 Ciac
+0004B4 CIAC
 0004AD Malibu Networks
 0004A9 SandStream Technologies
-000461 Epox Computer
+000461 EPOX Computer
 000462 Dakos Data & Communication
 00045F Avalue Technology
 00049C Surgient Networks
@@ -4476,15 +4455,15 @@ D4C766 Acentic GmbH
 00042C Minet
 00042A Wireless Networks
 00042B IT Access
-0003D6 Radvision
+0003D6 RADVision
 0003D4 Alloptic
-0003CE Eten Technologies
+0003CE ETEN Technologies
 0003C8 CML Emergency Services
 0003C3 Micronik Multimedia
 000419 Fibercycle Networks
 00041C ipDialog
-000418 TeltronicU.
-000370 NXTV
+000418 Teltronicu.
+000370 Nxtv
 000402 Nexsan Technologies
 0003ED Shinkawa Electric
 0003BD OmniCluster Technologies
@@ -4496,7 +4475,7 @@ D4C766 Acentic GmbH
 00039C OptiMight Communications
 0003B0 Xsense Technology
 0003AA Watlow
-0003A8 Idot Computers
+0003A8 IDOT Computers
 000355 TeraBeam Internet Systems
 000369 Nippon Antenna
 000373 Aselsan A.S
@@ -4511,7 +4490,7 @@ D4C766 Acentic GmbH
 000346 Hitachi Kokusai Electric
 000344 Tietech.Co.
 0002E6 Gould Instrument Systems
-0002E4 JC Hyun Systems
+0002E4 JC HYUN Systems
 0002DE Astrodesign
 0002E2 NDC Infared Engineering
 0002E1 Integrated Network
@@ -4522,7 +4501,7 @@ D4C766 Acentic GmbH
 0002EC Maschoff Design Engineering
 000336 Zetes Technologies
 000337 Vaone
-00033B Tami Tech
+00033B TAMI Tech
 00032D Ibase Technology
 00B052 Atheros Communications
 000343 Martin Professional A/S
@@ -4535,10 +4514,10 @@ D4C766 Acentic GmbH
 0002D3 NetBotz
 0002DA ExiO Communications
 0002D4 PDA Peripherals
-0002D6 Nice Systems
+0002D6 NICE Systems
 00027D Cisco Systems
 00027C Trilithic
-00028B Vdsl Systems OY
+00028B VDSL Systems OY
 00028C Micrel-Synergy Semiconductor
 00028D Movita Technologies
 000298 Broadframe
@@ -4557,7 +4536,7 @@ D4C766 Acentic GmbH
 00024E Datacard Group
 000242 Videoframe Systems
 000244 Surecom Technology
-00023E Selta Telematica S.p.a
+00023E Selta Telematica
 000241 Amer.com
 000207 VisionGlobal Network
 000208 Unify Networks
@@ -4579,7 +4558,7 @@ D4C766 Acentic GmbH
 00020D Micronpc.com
 0001D4 Leisure Time
 0001DD Avail Networks
-0001D5 Haedong Info & Comm
+0001D5 Haedong INFO & COMM
 0001D7 F5 Networks
 0001DE Trango Systems
 0001DC Activetelco
@@ -4628,7 +4607,7 @@ D4C766 Acentic GmbH
 00012C Aravox Technologies
 000142 Cisco Systems
 000164 Cisco Systems
-00015F Digital Design Gmbh
+00015F Digital Design GmbH
 00012B Telenet
 00013F Neighbor World
 000124 Acer Incorporated
@@ -4649,7 +4628,7 @@ D4C766 Acentic GmbH
 00B02D ViaGate Technologies
 0030EE DSG Technology
 00309E Workbit
-0030DE Wago Kontakttechnik Gmbh
+0030DE WAGO Kontakttechnik GmbH
 00303E Radcom
 0030D7 Innovative Systems,
 00B0CE Viveris Technologies
@@ -4657,7 +4636,7 @@ D4C766 Acentic GmbH
 00B04A Cisco Systems
 00B048 Marconi Communications
 00301B Shuttle
-003021 Hsing TECH. Enterprise
+003021 Hsing Tech. Enterprise
 00302C Sylantro Systems
 0030DF Kb/tel Telecomunicaciones
 003030 Harmonix
@@ -4670,17 +4649,17 @@ D4C766 Acentic GmbH
 00308E Cross Match Technologies
 003027 Kerbango
 003033 Orient Telecom
-003008 Avio Digital
+003008 AVIO Digital
 00301D Skystream
-0030BA Ac&t System
+0030BA AC&T System
 0030FD Integrated Systems Design
 0030B9 Ectel
 00307D GRE America
-0030EF Neon Technology
+0030EF NEON Technology
 003096 Cisco Systems
 003039 Softbook Press
-00D0F8 Fujian Star Terminal
-00D0ED Xiox
+00D0F8 Fujian STAR Terminal
+00D0ED XIOX
 00D097 Cisco Systems
 00D08E Grass Valley, A Belden Brand
 00D056 Somat
@@ -4705,22 +4684,22 @@ D4C766 Acentic GmbH
 0030E1 Network Equipment Technologies
 00302B Inalp Networks
 003001 SMP
-00D08B Adva Optical Networking
+00D08B ADVA Optical Networking
 00D0E4 Cisco Systems
 00D05A Symbionics
 00D079 Cisco Systems
 00D021 Regent Electronics
-00D09F Novtek Test Systems
+00D09F Novtek TEST Systems
 00D0FE Astral Point
 00D0D4 V-bits
 00D084 Nexcomm Systems
 00D099 Elcard Wireless Systems Oy
-00D0E7 Vcon Telecommunication
+00D0E7 VCON Telecommunication
 00D01B Mimaki Engineering
 00D00D Micromeritics Instrument
 00D054 SAS Institute
-00D009 Hsing TECH. Enterprise
-00D0F4 Carinthian Tech Institute
+00D009 Hsing Tech. Enterprise
+00D0F4 Carinthian TECH Institute
 00D07D Cosine Communications
 00D083 Invertex
 00D0BA Cisco Systems
@@ -4732,20 +4711,20 @@ D4C766 Acentic GmbH
 0050CB Jetter
 005058 Sangoma Technologies
 005074 Advanced Hi-tech
-00500A Iris Technologies
+00500A IRIS Technologies
 00506D Videojet Systems
 0050CA NET TO NET Technologies
 00D0C7 Pathway
 00D07A Amaquest Computer
 00503F Anchor Games
 005032 Picazo Communications
-00D04A Presence Technology Gmbh
+00D04A Presence Technology GMBH
 00D074 Taqua Systems
 00504D Tokyo Electron Device Limited
 005070 Chaintech Computer
 005023 PG Design Electronics
 00509E Les Technologies SoftAcoustik
-005071 Aiwa
+005071 AIWA
 00505F Brand Innovators
 0050B4 Satchwell Control Systems
 0050D6 Atlas Copco Tools AB
@@ -4753,22 +4732,22 @@ D4C766 Acentic GmbH
 0050DF AirFiber
 0050C5 ADS Technologies
 00508E Optimation
-005028 Aval Communications
+005028 AVAL Communications
 00502F TollBridge Technologies
-0050FE Pctvnet ASA
+0050FE PCTVnet ASA
 0050AB Naltec
-005037 Koga Electronics
+005037 KOGA Electronics
 0050A8 OpenCon Systems
-00509C Beta Research
+00509C BETA Research
 0050B1 Giddings & Lewis
 005006 TAC AB
 005009 Philips Broadband Networks
-005030 Future Plus Systems
+005030 Future PLUS Systems
 005078 Megaton House
 005002 Omnisec AG
 00506A Edeva
 0050AA Konica Minolta Holdings
-005038 Dain Telecom
+005038 DAIN Telecom
 0050B7 Boser Technology
 009088 Baxall Security
 00906C Sartorius Hamburg GmbH
@@ -4777,15 +4756,15 @@ D4C766 Acentic GmbH
 009089 Softcom Microsystems
 0090EE Personal Communications Technologies
 009080 NOT Limited
-0090E8 Moxa Technologies
+0090E8 MOXA Technologies
 0090A1 Flying Pig Systems/High End Systems
 009079 ClearOne
 00909A ONE World Systems
 0090C2 JK microsystems
 0050D0 Minerva Systems
 0050D8 Unicorn Computer
-0050B2 Brodel Gmbh
-009076 FMT Aircraft Gate Support Systems AB
+0050B2 Brodel GmbH
+009076 FMT Aircraft GATE Support Systems AB
 009017 Zypcom
 009049 Entridia
 0090E6 ALi
@@ -4803,7 +4782,7 @@ D4C766 Acentic GmbH
 0090CB Wireless OnLine
 001063 Starguide Digital Networks
 001023 Network Equipment Technologies
-00102B Umax Data Systems
+00102B UMAX DATA Systems
 00908A Bayly Communications
 00900E Handlink Technologies
 0090C1 Peco II
@@ -4818,11 +4797,11 @@ D4C766 Acentic GmbH
 009012 Globespan Semiconductor
 0090B7 Digital Lightwave
 0090A0 8X8
-009047 Giga Fast E.
+009047 GIGA FAST E.
 0090E1 Telena
 009032 Pelcombe Group
 001062 NX Server
-0010F0 Rittal-werk Rudolf LOH Gmbh &
+0010F0 Rittal-werk Rudolf LOH GmbH
 001001 Citel
 00105C Quantum Designs (h.k.)
 0010CF Fiberlane Communications
@@ -4832,21 +4811,21 @@ D4C766 Acentic GmbH
 001036 Inter-tel Integrated Systems
 001039 Vectron Systems AG
 0010B6 Entrata Communications
-0010EC RPCG
+0010EC Rpcg
 001059 Diablo Research
 0010FC Broadband Networks
 001031 Objective Communications
 00106D Axxcelera Broadband Wireless
 00104C Teledyne LeCroy
-0010CC CLP Computer Logistik Planung Gmbh
-001030 Eion
+0010CC CLP Computer Logistik Planung GmbH
+001030 EION
 0010D0 Witcom
 001093 CMS Computers
 00108F Raptor Systems
 0010A4 Xircom
 0010F1 I-O
 001066 Advanced Control Systems
-0010AC Imci Technologies
+0010AC IMCI Technologies
 0010B1 For-a
 0010EE CTI Products
 001041 Bristol Babcock
@@ -4854,13 +4833,13 @@ D4C766 Acentic GmbH
 0010E8 Telocity, Incorporated
 0010A2 TNS
 001065 Radyne
-00109F PAVO
+00109F Pavo
 00101D Winbond Electronics
 001084 K-bot Communications
 001000 Cable Television Laboratories
 001009 Horanet
 0010F8 Texio Technology
-0010C0 ARMA
+0010C0 Arma
 00105B NET Insight AB
 001002 Actia
 0010EB Selsius Systems
@@ -4873,7 +4852,7 @@ D4C766 Acentic GmbH
 00E0DB ViaVideo Communications
 00E0A6 Telogy Networks
 00E09F Pixel Vision
-00E0CC Hero Systems
+00E0CC HERO Systems
 00E080 Control Resources
 00E004 Pmc-sierra
 00E03B Prominet
@@ -4881,7 +4860,7 @@ D4C766 Acentic GmbH
 00E0D7 Sunshine Electronics
 00E0B5 Ardent Communications
 00E068 Merrimac Systems
-00E049 Microwi Electronic Gmbh
+00E049 Microwi Electronic GmbH
 00E095 Advanced-vision Technolgies
 00E00E Avalon Imaging Systems
 00E048 SDL Communications
@@ -4895,28 +4874,28 @@ D4C766 Acentic GmbH
 00E050 Executone Information Systems
 00E023 Telrad
 00E02C AST Computer
-00E067 eac Automation-consulting Gmbh
+00E067 eac Automation-consulting GmbH
 00E0FA TRL Technology
 00E02A Tandberg Television AS
 00E04E Sanyo Denki
 00E012 Pluto Technologies International
 00E04C Realtek Semiconductor
-00E051 Talx
+00E051 TALX
 00606B Synclayer
 00603B Amtec spa
 00E039 Paradyne
-00600B Logware Gmbh
+00600B Logware GmbH
 00E0C7 Eurotech SRL
 00E0AF General Dynamics Information Systems
 00E054 Kodai Hitec
-00E0B9 Byas Systems
+00E0B9 BYAS Systems
 00604B Safe-com GmbH & KG
 00E0EF Dionex
 00E02D InnoMediaLogic
 00E035 Artesyn Embedded Technologies
 00E090 Beckman LAB. Automation DIV.
 006001 InnoSys
-0060FE Lynx System Developers
+0060FE LYNX System Developers
 0060BD Enginuity Communications
 000800 Multitech Systems
 00E085 Global Maintech
@@ -4924,11 +4903,11 @@ D4C766 Acentic GmbH
 00E0B6 Entrada Networks
 00E0F4 Inside Technology A/S
 00E0A0 Wiltron
-00E0F1 That
+00E0F1 THAT
 0060D5 Amada Miyachi
 00603F Patapsco Designs
-0060B5 Keba Gmbh
-006014 Edec
+0060B5 KEBA GmbH
+006014 EDEC
 0060AC Resilience
 00604E Cycle Computer
 0060E1 Orckit Communications
@@ -4936,22 +4915,22 @@ D4C766 Acentic GmbH
 006042 TKS (usa)
 006079 Mainstream Data
 00609A NJK Techno
-00602B Peak Audio
+00602B PEAK Audio
 0060F1 EXP Computer
 0060E6 Shomiti Systems Incorporated
 0060FF QuVis
-006067 Acer Netxus
+006067 ACER Netxus
 00609F Phast
 006040 Netro
 0060CC Emtrak, Incorporated
-00602C Linx Data Terminals
+00602C LINX Data Terminals
 00607E Gigalabs
 0060CD VideoServer
 0060AA Intelligent Devices (idi)
 006025 Active Imaging PLC
-0060A7 Microsens Gmbh & KG
-0005A8 Wyle Electronics
-0060E5 Fuji Automation
+0060A7 Microsens GmbH & KG
+0005A8 WYLE Electronics
+0060E5 FUJI Automation
 00605E Liberty Technology Networking
 0060C6 DCS AG
 00601E Softlab
@@ -4959,11 +4938,11 @@ D4C766 Acentic GmbH
 00606F Clarion OF America
 00A010 Syslogic Datentechnik AG
 00A059 Hamilton Hallmark
-00A039 Ross Technology
+00A039 ROSS Technology
 00A0AD Marconi SPA
 00A0D6 SBE
 00A02E Brand Communications
-00604A Saic Ideas Group
+00604A SAIC Ideas Group
 00A0BD I-tech
 006090 Artiza Networks
 00600D Digital Logic GmbH
@@ -4978,66 +4957,66 @@ D4C766 Acentic GmbH
 00A016 Micropolis
 00A048 Questech
 00A003 Siemens Switzerland, I B T HVP
-00A0F9 Bintec Communications Gmbh
+00A0F9 Bintec Communications GMBH
 00A0F5 Radguard
 00A0CA Fujitsu Denso
 00A022 Centre FOR Development OF Advanced Computing
 00A0B6 Sanritz Automation
-00A079 Alps Electric (usa)
-00A0C0 Digital Link
+00A079 ALPS Electric (usa)
+00A0C0 Digital LINK
 00A01E EST
 00A0AE Nucom Systems
 00A062 AES Prodata
 00A076 Cardware LAB
-00A0A1 Epic Data
+00A0A1 EPIC DATA
 00A044 NTT IT
 00A011 Mutoh Industries
 00A0BA Patton Electronics
 00A0B5 3H Technology
 00A04D EDA Instruments
-00A086 Amber Wave Systems
+00A086 Amber WAVE Systems
 00A0AF WMS Industries
-00A057 Lancom Systems Gmbh
+00A057 Lancom Systems GmbH
 00A030 Captor Nv/sa
 00A0DE Yamaha
 00A084 Dataplex
 00A049 Digitech Industries
 00A09D Johnathon Freeman Technologies
-00A06B DMS Dorsch Mikrosystem Gmbh
+00A06B DMS Dorsch Mikrosystem GMBH
 00A0F8 Zebra Technologies
 00A09F Commvision
 00A06E Austron
 002022 NMS Communications
-0020AE Ornet Data Communication TECH.
+0020AE Ornet DATA Communication Tech.
 0020AA Ericsson Television Limited
 0020A4 Multipoint Networks
-000267 Node Runner
+000267 NODE Runner
 0020B1 Comtech Research
 002032 Alcatel Taisel
 0020E9 Dantel
 002038 VME Microsystems International
 0020A3 Harmonic
-002059 Miro Computer Products AG
-002034 Rotec Industrieautomation Gmbh
-002079 Mikron Gmbh
+002059 MIRO Computer Products AG
+002034 Rotec Industrieautomation GMBH
+002079 Mikron GMBH
 002005 Simple Technology
 002018 CIS Technology
 002098 Hectronic AB
 0020FD ITV Technologies
 0020FA GDE Systems
-0020C1 SAXA
-002080 Synergy (uk)
+0020C1 Saxa
+002080 Synergy (UK)
 00C023 Tutankhamon Electronics
-00C08B Risq Modular Systems
+00C08B RISQ Modular Systems
 0020C4 Inet
 002074 Sungwoon Systems
 00203C Eurotime AB
-002028 West EGG Systems
+002028 WEST EGG Systems
 002068 Isdyne
 0020C8 Larscom Incorporated
 00209D Lippert Automationstechnik
 00209C Primary Access
-00206D Data RACE
+00206D DATA Race
 00203A Digital Bi0metrics
 002048 Marconi Communications
 0020DC Densitron Taiwan
@@ -5045,9 +5024,9 @@ D4C766 Acentic GmbH
 002011 Canopus
 002051 Verilink
 00203B Wisdm
-0020BA Center FOR High Performance
+0020BA Center FOR HIGH Performance
 0020F5 Pandatel AG
-00200E Nsslglobal Technologies AS
+00200E NSSLGlobal Technologies AS
 0020E7 B&W Nuclear Service Company
 0020F0 Universal Microelectronics
 002089 T3plus Networking
@@ -5055,7 +5034,7 @@ D4C766 Acentic GmbH
 00C080 Netstar
 00C0B4 Myson Technology
 00C045 Isolation Systems
-0070B3 Data Recall
+0070B3 DATA Recall
 0070B0 M/a-com Companies
 00E6D3 Nixdorf Computer
 00C0C3 Acuson Computed Sonography
@@ -5063,10 +5042,10 @@ D4C766 Acentic GmbH
 00C0E5 Gespac
 00C04D Mitec
 00C047 Unimicro Systems
-00C084 Data Link
+00C084 DATA LINK
 00C041 Digital Transmission Systems
 00C01F S.e.r.c.e.l.
-006086 Logic Replacement TECH.
+006086 Logic Replacement Tech.
 00C059 Denso
 00C0F1 Shinko Electric
 00C0A1 Tokyo Denshi Sekei
@@ -5080,11 +5059,11 @@ D4C766 Acentic GmbH
 00C0F4 Interlink System
 00C0E2 Calcomp
 00C07B Ascend Communications
-00C03C Tower Tech S.r.l.
+00C03C Tower TECH S.r.l.
 00C01D Grand Junction Networks
 00C035 Quintar Company
 00C070 Sectra Secure-transmission AB
-00C06D Boca Research
+00C06D BOCA Research
 00C0EA Array Technology
 00C009 KT Technology (S) PTE
 00C0D6 J1 Systems
@@ -5100,20 +5079,19 @@ D4C766 Acentic GmbH
 00C09A Photonics
 00C01A Corometrics Medical Systems
 00C068 HME Clear-Com
-00C0D8 Universal Data Systems
-004036 Zoom Telephonics
+00C0D8 Universal DATA Systems
 004016 ADC - Global Connectivity Solutions Division
 00406A Kentek Information Systems
 00400A Pivotal Technologies
 004099 Newgen Systems
 004011 Andover Controls
-0040A1 Ergo Computing
-004081 Mannesmann Scangraphic Gmbh
+0040A1 ERGO Computing
+004081 Mannesmann Scangraphic GMBH
 00C08C Performance Technologies
-00C007 Pinnacle Data Systems
+00C007 Pinnacle DATA Systems
 00C098 Chuntex Electronic
 00C0BE Alcatel - SEL
-00C06E Haft Technology
+00C06E HAFT Technology
 00C08A Lauterbach GmbH
 00C0F7 Engage Communication
 0040B7 Stealth Computer Systems
@@ -5128,37 +5106,37 @@ D4C766 Acentic GmbH
 0040E0 Atomwide
 0040A8 IMF International
 004070 Interware
-00408A TPS Teleprocessing SYS. Gmbh
+00408A TPS Teleprocessing SYS. GMBH
 0040FD LXE
 00403F Ssangyong Computer Systems
 004082 Laboratory Equipment
-0040F1 Chuo Electronics
+0040F1 CHUO Electronics
 0040A9 Datacom
-0040E3 Quin Systems
+0040E3 QUIN Systems
 004091 Procomp Industria Eletronica
-0040EA Plain Tree Systems
+0040EA Plain TREE Systems
 0040A7 Itautec Philco
 004064 KLA Instruments
 004043 Nokia Siemens Networks GmbH & KG.
-00405A Goldstar Information & COMM.
-004013 NTT Data COMM. Systems
+00405A Goldstar Information & Comm.
+004013 NTT DATA Comm. Systems
 00400C General Micro Systems
 00405E North Hills Israel
 0040FA Microboards
-004014 Comsoft Gmbh
+004014 Comsoft GMBH
 004000 PCI Componentes DA Amzonia
 00406C Copernique
 004075 Tattile SRL
 004053 Ampro Computers
-008038 Data Research & Applications
+008038 DATA Research & Applications
 00805E LSI Logic
 008060 Network Interface
-0080C3 Bicc Information Systems & SVC
+0080C3 BICC Information Systems & SVC
 008044 Systech Computer
 008006 Compuadd
 00809B Justsystem
 0080DF ADC Codenoll Technology
-008028 Tradpost (hk)
+008028 Tradpost (HK)
 008061 Litton Systems
 0080F5 Quantel
 0080B9 Arche Technoligies
@@ -5166,8 +5144,8 @@ D4C766 Acentic GmbH
 00808A Summit Microsystems
 0080A7 Honeywell International
 008066 Arcom Control Systems
-0080CB Falco Data Products
-008007 Dlog Nc-systeme
+0080CB Falco DATA Products
+008007 DLOG Nc-systeme
 008062 Interface
 00801E Xinetron
 0080E2 T.d.i.
@@ -5177,15 +5155,15 @@ D4C766 Acentic GmbH
 0080BC Hitachi Engineering
 008036 Reflex Manufacturing Systems
 008083 Amdahl
-0080B8 DMG Mori B.u.g.
+0080B8 DMG MORI B.u.g.
 00804D Cyclone Microsystems
 0080D4 Chase Research
 00803D Surigiken
 00808B Dacoll Limited
 0080B2 Network Equipment Technologies
-008076 Mcnc
+008076 MCNC
 00800B CSK
-008018 Kobe Steel
+008018 KOBE Steel
 008068 Yamatech Scientific
 0080A8 Vitacom
 008033 EMS Aviation
@@ -5193,9 +5171,8 @@ D4C766 Acentic GmbH
 008091 Tokyo Electric
 00008E Solbourne Computer
 0000DC Hayes Microcomputer Products
-000063 Barco Control Rooms Gmbh
+000063 Barco Control Rooms GMBH
 00004E Ampex
-0000BD Mitsubishi Cable Industries, / Ryosei Systems
 00002E Societe Evira
 00003F Syntrex
 00809D Commscraft
@@ -5205,7 +5182,7 @@ D4C766 Acentic GmbH
 0080DD GMX/gimix
 0080FB BVM Limited
 0080B4 Sophia Systems
-00807F Dy-4 Incorporated
+00807F DY-4 Incorporated
 00802D Xylogics
 000061 Gateway Communications
 0000EA Upnod AB
@@ -5216,7 +5193,7 @@ D4C766 Acentic GmbH
 0000E5 Sigmex
 000089 Cayman Systems
 0000FF Camtec Electronics
-0000B7 Dove Computer
+0000B7 DOVE Computer
 0000F2 Spider Communications
 0000CC Densan
 0000A4 Acorn Computers Limited
@@ -5226,17 +5203,17 @@ D4C766 Acentic GmbH
 000077 Interphase
 0000A2 Bay Networks
 0000EC Microprocess
-0000C2 Information Presentation TECH.
+0000C2 Information Presentation Tech.
 0000FC Meiko
-00006D Cray Communications
-0000DA Atex
+00006D CRAY Communications
+0000DA ATEX
 0000DD TCL Incorporated
 0000AE Dassault Electronique
 0000A0 Sanyo Electric
 0000C0 Western Digital
-000033 Egan Machinery Company
+000033 EGAN Machinery Company
 00009D Locus Computing
-0000FD High Level Hardware
+0000FD HIGH Level Hardware
 000065 Network General
 000011 Normerel Systemes
 000010 Sytek
@@ -5245,13 +5222,13 @@ D4C766 Acentic GmbH
 08007F Carnegie-mellon University
 000099 MTX
 0000C4 Waters DIV. OF Millipore
-0000EB Matsushita COMM. IND.
+0000EB Matsushita Comm. IND.
 000028 Prodigy Systems
 08003B Torus Systems Limited
-08003C Schlumberger Well Services
+08003C Schlumberger WELL Services
 080034 Filenet
 080036 Intergraph
-080033 Bausch & Lomb
+080033 Bausch & LOMB
 080048 Eurotherm Gauging Systems
 080043 Pixel Computer
 080045 Concurrent Computer
@@ -5265,7 +5242,7 @@ D4C766 Acentic GmbH
 080050 Daisy Systems
 08005E Counterpoint Computer
 080076 PC LAN Technologies
-080075 Dansk Data Electronik
+080075 Dansk DATA Electronik
 08002B Digital Equipment
 080029 Megatek
 0270B0 M/a-com Companies
@@ -5301,7 +5278,7 @@ D44F68 Eidetic Communications
 8CC84B Chongqing Fugui Electronics
 0C2FB0 Samsung Electronics
 B40216 Cisco Systems
-54A493 Ieee Registration Authority
+54A493 IEEE Registration Authority
 6C1C71 Zhejiang Dahua Technology
 CC6A10 The Chamberlain Group
 F03F95 Huawei Technologies
@@ -5309,7 +5286,7 @@ F03F95 Huawei Technologies
 9C69D1 Huawei Technologies
 185A58 Dell
 C43A35 Fn-link Technology Limited
-04D16E Ieee Registration Authority
+04D16E IEEE Registration Authority
 040E3C HP
 C4E0DE Zhengzhou XindaJiean Information Technology
 901A4F EM Microelectronic
@@ -5321,14 +5298,14 @@ D88ADC Huawei Device
 7C48B2 Vida Resources Lte
 2CAB33 Texas Instruments
 B887C6 Prudential Technology
-EC9C32 SichuanAI-LinkTechnologyCo.
+EC9C32 Sichuan AI-Link Technology
 4CADA8 Panoptics
 FC1CA1 Nokia
 D42DC5 Panasonic i-PRO Sensing Solutions
 E8D03C Shenzhen Jingxun Software Telecommunication Technology
 1C1ADF Microsoft
 D4F547 Google
-981BB5 Assa Abloy Korea, Irevo
+981BB5 ASSA Abloy Korea, iRevo
 34CB1A Procter & Gamble Company
 F0B107 Ericsson AB
 784F9B Juniper Networks
@@ -5345,14 +5322,14 @@ B035B5 Apple
 F072EA Google
 B87BC5 Apple
 F05136 TCT mobile
-B8C9B5 Guangdong Oppo Mobile Telecommunications
+B8C9B5 Guangdong OPPO Mobile Telecommunications
 88ACC0 Zyxel Communications
 90FD73 zte
-1C1E38 Pccw Global
+1C1E38 PCCW Global
 3C410E Cisco Systems
 88D98F Juniper Networks
 0045E2 CyberTAN Technology
-006967 Ieee Registration Authority
+006967 IEEE Registration Authority
 F86FDE Shenzhen Goodix Technology
 646624 Sagemcom Broadband SAS
 B0F530 Hitron Technologies.
@@ -5362,7 +5339,7 @@ B4A898 Huawei Device
 BC1AE4 Huawei Device
 043F72 Mellanox Technologies
 1C4D66 Amazon Technologies
-502CC6 Gree Electric Appliances, OF Zhuhai
+502CC6 GREE Electric Appliances, OF Zhuhai
 F4FEFB Samsung Electronics
 984914 Wistron Neweb
 0CEE99 Amazon Technologies
@@ -5389,8 +5366,7 @@ E02AE6 Fiberhome Telecommunication Technologies
 641236 Technicolor CH USA
 788B2A Zhen Shi Information Technology (Shanghai)
 AC64CF Fn-link Technology Limited
-F06728 Guangdong Oppo Mobile Telecommunications
-BCD767 Private
+F06728 Guangdong OPPO Mobile Telecommunications
 9CE176 Cisco Systems
 102959 Apple
 E47684 Apple
@@ -5402,11 +5378,11 @@ F80DF0 zte
 5C17CF OnePlus Technology (Shenzhen)
 A4FA76 New H3C Technologies
 70EA5A Apple
-3CFAD3 Ieee Registration Authority
+3CFAD3 IEEE Registration Authority
 8C6078 Swissbit AG
 00DD25 Shenzhen hechengdong Technology
-8020E1 Bvba Dptechnics
-0445A1 Nirit- Xinwei  Telecom Technology
+8020E1 BVBA DPTechnics
+0445A1 Nirit- Xinwei Telecom Technology
 8C97EA Freebox SAS
 30AB6A Samsung Electro-mechanics(thailand)
 749BE8 Hitron Technologies.
@@ -5436,9 +5412,9 @@ F07CC7 Juniper Networks
 D45EEC Beijing Xiaomi Electronics
 74C929 Zhejiang Dahua Technology
 D4CFF9 Shenzhen SEI Robotics
-5CB29E Asco Power Technologies
+5CB29E ASCO Power Technologies
 9CC9EB Netgear
-94CC04 Ieee Registration Authority
+94CC04 IEEE Registration Authority
 90EC77 silicom
 88C397 Beijing Xiaomi Mobile Software
 F0F6C1 Sonos
@@ -5463,13 +5439,12 @@ A416E7 Huawei Technologies
 8C83DF Nokia
 AC4B1E Integri-Sys.Com
 B0E4D5 Google
-D4DACD BSkyB
 6869CA Hitachi
 AC4A56 Cisco Systems
 F4EAB5 Extreme Networks
 001977 Extreme Networks
 08EA44 Extreme Networks
-B0B5C3 Guangdong Oppo Mobile Telecommunications
+B0B5C3 Guangdong OPPO Mobile Telecommunications
 704A0E Ampak Technology
 08306B Palo Alto Networks
 00869C Palo Alto Networks
@@ -5485,7 +5460,7 @@ B87CF2 Extreme Networks
 2462CE Aruba, a Hewlett Packard Enterprise Company
 68E209 Huawei Technologies
 400589 T-Mobile
-C09BF4 Ieee Registration Authority
+C09BF4 IEEE Registration Authority
 F4308B Xiaomi Communications
 DC6B12 worldcns
 70039F Espressif
@@ -5520,7 +5495,7 @@ DC7385 Huawei Device
 184593 Taicang T&W Electronics
 CC9ECA HMD Global Oy
 3C306F Huawei Technologies
-34EAE7 Shanghai High-Flying Electronics  Technology
+34EAE7 Shanghai High-Flying Electronics Technology
 D4ABCD Hui Zhou Gaoshengda Technology
 80E1BF Huawei Technologies
 482CD0 Huawei Technologies
@@ -5594,7 +5569,7 @@ C45444 Quanta Computer
 001B24 Quanta Computer
 C80AA9 Quanta Computer
 60EB69 Quanta Computer
-C08F20 Shenzhen Skyworth  Digital  Technology
+C08F20 Shenzhen Skyworth Digital Technology
 74F7F6 Shanghai Sunmi Technology
 241AE6 Huawei Device
 60B76E Google
@@ -5610,7 +5585,7 @@ F88200 CaptionCall
 340F66 Web Sensing
 5865E6 infomark
 0050F1 Maxlinear
-F4E578 LLC Proizvodstvennaya Kompania TransService
+F4E578 LLC Proizvodstvennaya Kompania "TransService"
 0854BB Shenzhen Chuangwei-rgb Electronics
 60EB5A Asterfusion Data Technologies
 E4D373 Huawei Technologies
@@ -5657,7 +5632,7 @@ F81093 Apple
 5CD89E Huawei Device
 0405DD Shenzhen Cultraview Digital Technology
 3897A4 Elecom
-E433AE Guangdong Oppo Mobile Telecommunications
+E433AE Guangdong OPPO Mobile Telecommunications
 DCE994 Cloud Network Technology Singapore PTE.
 387A3C Fiberhome Telecommunication Technologies
 8CCE4E Espressif
@@ -5680,7 +5655,7 @@ F0F7E7 Huawei Technologies
 98F181 New H3C Technologies
 90808F Huawei Device
 40A9CF Amazon Technologies
-5895D8 Ieee Registration Authority
+5895D8 IEEE Registration Authority
 0838E6 Motorola (Wuhan) Mobility Technologies Communication
 E8C2DD Infinix mobility limited
 48D890 Fn-link Technology Limited
@@ -5701,14 +5676,14 @@ ECCE13 Cisco Systems
 8CFDDE Sagemcom Broadband SAS
 A468BC Oakley
 607EA4 Shanghai Imilab TechnologyLtd
-7895EB Itel Mobile Limited
-1C9F4E Coosea Group (hk) Company Limited
+7895EB ITEL Mobile Limited
+1C9F4E Coosea Group (HK) Company Limited
 14AB02 Huawei Technologies
 BC5BD5 Arris Group
 085531 Routerboard.com
 3C6105 Espressif
-2406AA Guangdong Oppo Mobile Telecommunications
-843095 Hon Hai Precision IND.CO.
+2406AA Guangdong OPPO Mobile Telecommunications
+843095 Hon Hai Precision Ind.co.
 0865F0 JM Zengge
 AC471B Huawei Device
 003192 TP-Link Limited
@@ -5722,8 +5697,6 @@ B456E3 Apple
 4C20B8 Apple
 1488E6 Apple
 BC0F9A D-Link International
-B04530 BSkyB
-6CA0B4 BSkyB
 947BBE Ubicquia
 24649F Huawei Device
 0C1773 Huawei Device
@@ -5741,7 +5714,7 @@ E81E92 Huawei Device
 BC428C Alpsalpine
 7495EC Alpsalpine
 98ED7E eero
-8CAE49 Ieee Registration Authority
+8CAE49 IEEE Registration Authority
 00214F Alpsalpine
 78CF2F Huawei Technologies
 A83B5C Huawei Technologies
@@ -5767,10 +5740,9 @@ F0FEE7 Huawei Device
 DCA120 Nokia
 50523B Nokia
 DCCD74 Japan E.M.Solutions
-001293 ABB Power Protection (CH)
 A03B01 Kyung In Electronics
 18188B Fujitsu Connected Technologies Limited
-145E69 Guangdong Oppo Mobile Telecommunications
+145E69 Guangdong OPPO Mobile Telecommunications
 484C29 Huawei Technologies
 C4D438 Huawei Technologies
 C0280B Honor Device
@@ -5788,10 +5760,9 @@ A0A3F0 D-Link International
 9C823F Huawei Device
 54F607 Huawei Device
 687848 Westunitis
-08FF24 Shenzhen Skyworth  Digital  Technology
+08FF24 Shenzhen Skyworth Digital Technology
 50558D China Mobile IOT Company Limited
 642656 Shenzhen Fanweitai Technology Service
-E06C4E Shenzhen Tinno Mobile Technology
 F0258E Huawei Technologies
 9C746F Huawei Technologies
 64E003 Hui Zhou Gaoshengda Technology
@@ -5834,11 +5805,11 @@ A8F266 Huawei Device
 D8EC5E Belkin International
 84FD27 Silicon Laboratories
 CC9C3E Cisco Meraki
-4829E4 ZAO NPK Rotek
+4829E4 ZAO "NPK Rotek"
 FCA9DC Renesas Electronics (Penang) Sdn. Bhd.
 FC584A xiamenshi c-chip technology
 78653B Shaoxing Ourten Electronics
-E0E656 Nethesis  srl
+E0E656 Nethesis srl
 9023B4 New H3C Technologies
 882A5E New H3C Technologies
 841EA3 Sagemcom Broadband SAS
@@ -5850,7 +5821,7 @@ F40223 PAX Computer Technology(Shenzhen)
 1CD1E0 Cisco Systems
 24456B Huawei Device
 483871 Huawei Device
-44BDDE Bhtc Gmbh
+44BDDE BHTC GmbH
 8C2A8E DongGuan Ramaxel Memory Technology
 4044FD Realme Chongqing Mobile Telecommunications
 E8FD35 Huawei Device
@@ -5876,8 +5847,8 @@ CC3331 Texas Instruments
 C89BAD Honor Device
 C45BBE Espressif
 889009 Juniper Networks
-90B67A Shenzhen Skyworth  Digital  Technology
-7CD9F4 UAB Teltonika Telematics
+90B67A Shenzhen Skyworth Digital Technology
+7CD9F4 UAB "Teltonika Telematics"
 C8C64A Flextronics Tech.(Ind) Pvt
 FC4EA4 Apple
 F4BEEC Apple
@@ -5901,7 +5872,6 @@ A4056E Tiinlab
 C87B23 Bose
 78D9E9 Momentum IOT
 2C0823 Sercomm France Sarl
-308E7A Shenzhen iComm Semiconductor
 9C1C37 AltoBeam (China)
 8CE748 Hangzhou Hikvision Digital Technology
 984265 Sagemcom Broadband SAS
@@ -5931,8 +5901,8 @@ F8BAE6 Nokia
 40C48C N-iTUS
 482218 Shenzhen Yipingfang Network Technology
 30A176 Fiberhome Telecommunication Technologies
-E40CFD Guangdong Oppo Mobile Telecommunications
-58D697 Guangdong Oppo Mobile Telecommunications
+E40CFD Guangdong OPPO Mobile Telecommunications
+58D697 Guangdong OPPO Mobile Telecommunications
 5437BB Taicang T&W Electronics
 60F8F2 Synaptec
 AC74B1 Intel Corporate
@@ -5940,7 +5910,7 @@ AC74B1 Intel Corporate
 F4E451 Huawei Technologies
 6026EF Aruba, a Hewlett Packard Enterprise Company
 F46077 Texas Instruments
-249AC8 Shenzhen Skyworth  Digital  Technology
+249AC8 Shenzhen Skyworth Digital Technology
 C03C04 Sagemcom Broadband SAS
 A4D73C Seiko Epson
 6C108B WeLink Communications
@@ -5949,12 +5919,12 @@ F88EA1 Edgecore Networks
 F463E7 Nanjing Maxon O.E. Tech.
 2428FD Hangzhou Hikvision Digital Technology
 88AEDD EliteGroup Computer Systems
-64D02D Next Generation Integration Limited (ngi)
+64D02D NEXT Generation Integration Limited (ngi)
 A0E70B Intel Corporate
 B0D888 Panasonic Automotive
 04EEEE Laplace System
 68966A Ohsung
-902E16 Lcfc(hefei) Electronics Technology
+902E16 LCFC(HeFei) Electronics Technology
 7806C9 Huawei Device
 E8A6CA Huawei Device
 CCFA66 Huawei Device
@@ -5965,7 +5935,7 @@ E030F9 Juniper Networks
 24085D Continental Aftermarket & Services GmbH
 34243E zte
 38453B Ruckus Wireless
-781305 Ieee Registration Authority
+781305 IEEE Registration Authority
 205476 Sony
 3017C8 Sony
 6C23B9 Sony
@@ -5995,7 +5965,7 @@ E4DC5F Cofractal
 CC896C GN Hearing A/S
 48F3F3 Baidu Online Network Technology (Beijing)
 D47350 DBG Commnunications Technology
-3C7AF0 Itel Mobile Limited
+3C7AF0 ITEL Mobile Limited
 70DA17 Austrian Audio GmbH
 50411C Ampak Technology
 8C1ED9 Beijing Unigroup Tsingteng Microsystem
@@ -6022,12 +5992,12 @@ A45590 Xiaomi Communications
 081C6E Xiaomi Communications
 84AC16 Apple
 2CBC87 Apple
-44A92C Ieee Registration Authority
+44A92C IEEE Registration Authority
 D88083 Cloud Network Technology Singapore PTE.
 ACB92F Hangzhou Hikvision Digital Technology
 187758 Audoo Limited (UK)
 90E868 AzureWave Technology
-4C50F1 Guangdong Oppo Mobile Telecommunications
+4C50F1 Guangdong OPPO Mobile Telecommunications
 FC4265 Zhejiang Tmall Technology
 B4E454 Amazon Technologies
 0C43F9 Amazon Technologies
@@ -6052,7 +6022,7 @@ E0B9E5 Technicolor Delivery Technologies Belgium NV
 504B9E Huawei Device
 047AAE Huawei Device
 3C93F4 Huawei Technologies
-6433B5 Ieee Registration Authority
+6433B5 IEEE Registration Authority
 8C4B14 Espressif
 D4E853 Hangzhou Hikvision Digital Technology
 18E215 Nokia
@@ -6064,7 +6034,7 @@ BC6AD1 Xiaomi Communications
 64B623 Schrack Seconet Care Communication GmbH
 0845D1 Cisco Systems
 9C40CD Synclayer
-785EE8 Ieee Registration Authority
+785EE8 IEEE Registration Authority
 CCBCE3 Huawei Technologies
 089E84 Huawei Technologies
 1082D7 Realme Chongqing Mobile Telecommunications
@@ -6088,7 +6058,7 @@ EC1C5D Siemens AG
 701AB8 Intel Corporate
 5CDF89 Ruckus Wireless
 70B64F Guangzhou V-solution Electronic Technology
-B4205B Guangdong Oppo Mobile Telecommunications
+B4205B Guangdong OPPO Mobile Telecommunications
 187A3B Aruba, a Hewlett Packard Enterprise Company
 70B9BB Shenzhen Hankvision Technology
 A4C69A Samsung Electronics
@@ -6112,22 +6082,359 @@ A022DE vivo Mobile Communication
 207454 vivo Mobile Communication
 BC2228 D-Link International
 103C59 zte
-A0B4BF Infinet-EKB
 C4CA2B Arista Networks
 002469 Fasttel - Smart Doorphones
 B43D08 GX International BV
 7089F5 Dongguan Lingjie IOT
 88DC96 EnGenius Technologies
 40B0A1 Valcom
-B8208E Panasonic  Connected Solutions Company
 90380C Espressif
 847B57 Intel Corporate
 64CBE9 LG Innotek
-24D81E MirWifi,Joint-Stock Company
+9C756E Ajax Systems DMCC
+F06C73 Nokia
 E8F9D4 Huawei Technologies
 B0C787 Huawei Technologies
 0C4F9B Huawei Technologies
+7C214A Intel Corporate
+508492 Intel Corporate
 482FD7 Huawei Technologies
+24D81E MirWifi,Joint-Stock Company
+9880BB IEEE Registration Authority
+D8B053 Xiaomi Communications
+6CF784 Xiaomi Communications
+042B58 Shenzhen Hanzsung Technology
+28C01B Shenzhen Skyworth Digital Technology
+B812DA Lvswitches
+A0D7F3 Samsung Electronics
+E86D6E voestalpine Signaling UK
+282A87 ITEL Mobile Limited
+A8B57C Roku
+78C6BB Analog Devices
+2426BA Shenzhen Toptel Technology
+546CEB Intel Corporate
+009337 Intel Corporate
+7890A2 zte
+602232 Ubiquiti Networks
+ACBCD9 Cisco Systems
+58CE2A Intel Corporate
+10A51D Intel Corporate
+088E90 Intel Corporate
+C04442 Apple
+D468AA Apple
+98DD60 Apple
+F8C3CC Apple
+301A28 Mako Networks
+305A99 Sichuan Tianyi Comheart Telecom
+604DE1 Huawei Technologies
+704E6B Huawei Technologies
+70C6DD New H3C Technologies
+185B00 Nokia
+6CC49F Aruba, a Hewlett Packard Enterprise Company
+603D29 Huawei Technologies
+54C480 Huawei Technologies
+A861DF China Mobile Group Device
+7CA62A Hewlett Packard Enterprise
+1C4586 Nintendo
+507C6F Intel Corporate
+589B4A DWnet Technologies(Suzhou)
+5C83CD New platforms
+384B24 Siemens AG
+F0AE66 Cosonic Intelligent Technologies
+208097 Shenzhen OXO Technology limited
+7C1689 Sagemcom Broadband SAS
+4011C3 Samsung Electronics
+C47D9F Samsung Electronics
+9C5440 Private
+3CA916 Huawei Device
+C41C07 Samsung Electronics
+58FCC6 TOZO
+004036 Minim
+448502 Shenzhen SuperElectron Technology
+A4EF15 AltoBeam (China)
+D49400 Huawei Technologies
+8415D3 Huawei Technologies
+A06C65 Texas Instruments
+F4A454 IEEE Registration Authority
+10E8A7 Wistron Neweb
+D42C46 Buffalo.inc
+1091A8 Espressif
+6C3A36 Glowforge
+806A00 Cisco Systems
+D46C6D Arris Group
+A0E7AE Arris Group
+EC50AA Aruba, a Hewlett Packard Enterprise Company
+B44506 Dell
+CCA3BD ITEL Mobile Limited
+D4354A Alaxala Networks
+40E99B Samsung Electro-mechanics(thailand)
+78047A Edge Networks
+BCAF87 smartAC.com
+C02B31 Phytium Technology
+58CF79 Espressif
+4CC449 Icotera A/S
+BC455B Samsung Electronics
+B03CDC Intel Corporate
+0009B0 Onkyo Technology K.K.
+08F80D IEEE Registration Authority
+786299 Bitstream sp. z o.o.
+CC5B31 Nintendo
+0C1EF7 Omni-ID
+E06D18 Pioneercorporation
+8CF8C5 Intel Corporate
+345D9E Sagemcom Broadband SAS
+A45FB9 DreamBig Semiconductor
+B4D286 Telechips
+000F32 Lootom Telcovideo Network (Wuxi)
+18C23C Lumi United Technology
+0475F9 Taicang T&W Electronics
+E85177 Qingdao Intelligent&Precise Electronics
+388A21 UAB "Teltonika Telematics"
+A05950 Intel Corporate
+50874D Guangdong OPPO Mobile Telecommunications
+5089D1 Huawei Device
+00620B Broadcom Limited
+A41752 Hifocus Electronics India Private Limited
+40FE95 New H3C Technologies
+BCD074 Apple
+F061C0 Aruba, a Hewlett Packard Enterprise Company
+DCCCE6 Samsung Electronics
+F065AE Samsung Electronics
+1C70C9 Jiangsu Aisida Electronic
+9CB8B4 Ampak Technology
+004084 Honeywell
+A05394 Shenzhen zediel
+04EEE8 IEEE Registration Authority
+3CF7D1 Omron
+84B4DB Silicon Laboratories
+38C804 Hui Zhou Gaoshengda Technology
+E007C2 Fujian Star-net Communication
+2CFDB4 Shenzhen Jingxun Software Telecommunication Technology
+B4F267 Compal Broadband Networks
+C0BAE6 Application Solutions (Safety and Security)
+18D793 IEEE Registration Authority
+0009E5 Hottinger Brüel & Kjaer GmbH
+D8B673 Texas Instruments
+9850A3 Signaltek JSC
+C0FBC1 ITEL Mobile Limited
+E817FC Fujitsu Cloud Technologies Limited
+B0DD74 Heimgard Technologies AS
+DC3643 IEEE Registration Authority
+102C8D GD Midea Air-Conditioning Equipment
+94E686 Espressif
+F828C9 Huawei Technologies
+50B3B4 Shenzhen Furuilian Electronic
+B48C9D AzureWave Technology
+FC1193 Huawei Technologies
+E43883 Ubiquiti Networks
+34B883 Cisco Systems
+C07982 TCL King Electrical Appliances(Huizhou)Co.
+D0EDFF ZF CVCS
+F8A91F Zvision Technologies
+4CBAD7 LG Innotek
+7CC95E Dongguan Liesheng Electronic
+7CCCFC Quectel Wireless Solutions
+988FE0 IEEE Registration Authority
+34D737 IBG Industriebeteiligungsgesellschaft mbH &b KG
+2C3341 China Mobile IOT Company Limited
+AC567B Sunnovo International Limited
+9CC12D GD Midea Air-Conditioning Equipment
+80657C Apple
+DC8084 Apple
+8CC7C3 Netlink ICT
+7C35F8 Zhejiang Tmall Technology
+7426FF zte
+C42728 zte
+C85895 Motorola Mobility, a Lenovo Company
+E4DADF Taicang T&W Electronics
+A8537D Mist Systems
+303422 eero
+08E021 Honor Device
+B05C16 Fiberhome Telecommunication Technologies
+E8D322 Cisco Systems
+8C1553 Beijing Memblaze Technology
+D4BD4F Ruckus Wireless
+5CC9C0 Renesas Electronics (Penang) Sdn. Bhd.
+6CB158 Tp-link Technologies
+E881AB Beijing Sankuai Online Technology
+1C47F6 Zhidao Network Technology(Shenzhen)
+A0B4BF InfiNet
+E8EBD3 Mellanox Technologies
+302BDC Top-Unum Electronics
+90F7B2 New H3C Technologies
+04E31A Sagemcom Broadband SAS
+C0060C Huawei Technologies
+B0A4F0 Huawei Technologies
+24753A Guangdong OPPO Mobile Telecommunications
+6C999D Amazon Technologies
+6C9308 IEEE Registration Authority
+7C6A60 China Mobile Group Device
+6818D9 Hill AFB - Capre Group
+18BC57 ADVA Optical Networking
+D8E2DF Microsoft
+1C61B4 TP-Link Limited
+9CA2F4 TP-Link Limited
+B4695F TCT mobile
+388F30 Samsung Electronics
+A04466 Intellics
+446D7F Amazon Technologies
+84C692 Texas Instruments
+6CB2FD Texas Instruments
+6C0F61 Hypervolt
+2406F2 Sichuan Tianyi Comheart Telecom
+C06DED Hangzhou Hikvision Digital Technology
+90935A Arris Group
+AC8FA9 Nokia Solutions and Networks GmbH & KG
+4C734F Juniper Networks
+C0C170 Shenzhen SuperElectron Technology
+504289 zte
+44291E AltoBeam (China)
+24EBED Huawei Technologies
+308E7A Shenzhen iComm Semiconductor
+2CDD5F Shenzhen iComm Semiconductor
+AC51AB Huawei Technologies
+48CDD3 Huawei Technologies
+CC6618 Adtran
+E0276C Guangzhou Shiyuan Electronic Technology Company Limited
+DC8E95 Silicon Laboratories
+28BE43 vivo Mobile Communication
+2CFC8B Guangdong OPPO Mobile Telecommunications
+F8AD24 Realme Chongqing Mobile Telecommunications
+B01F8C Aruba, a Hewlett Packard Enterprise Company
+A8C98A New H3C Technologies
+002604 WorldCast Systems
+7CEF40 Nextorage
+1CAF4A Samsung Electronics
+C8120B Samsung Electronics
+2874F5 Nokia Solutions and Networks GmbH & KG
+C0E01C IoT Security Group
+0000BD Ryosei
+00CB7A Technicolor CH USA
+ACCCFC Amazon Technologies
+902CFB CanTops
+F8AB82 Xiaomi Communications
+EC30B3 Xiaomi Communications
+9C57BC eero
+142D4D Apple
+EC42CC Apple
+B8211C Apple
+B03F64 Apple
+D45A3F Juniper Networks
+E8DC6C Cisco Systems
+A8A237 Arcadyan
+2C8217 Apple
+08E63B zte
+88C174 zte
+C89E61 Lyngsoe Systems
+E028B1 Shenzhen Skyworth Digital Technology
+C08D51 Amazon Technologies
+44B4B2 Amazon Technologies
+48B4C3 Aruba, a Hewlett Packard Enterprise Company
+6C1524 IEEE Registration Authority
+78034F Nokia
+C0E911 Private
+14F592 Shenzhen SDG Donzhi Technology
+4C09FA Frontier Smart Technologies
+68A7B4 Honor Device
+803C20 Huawei Technologies
+A4DD58 Huawei Technologies
+242CFE Zhejiang Tmall Technology
+E8D87E Amazon Technologies
+001293 ABB Switzerland
+9C1FCA Hangzhou AlmightyDigit Technology
+2CDC78 Descartes Systems (usa)
+A042D1 Huawei Device
+58879F Huawei Device
+E06C4E Shenzhen Tinno Mobile Technology
+806AB0 Shenzhen Tinno Mobile Technology
+8470D7 eero
+10B232 Qingdao Intelligent&Precise Electronics
+149BF3 Guangdong OPPO Mobile Telecommunications
+10071D Fiberhome Telecommunication Technologies
+F4B3B1 Silicon Laboratories
+B850D8 Beijing Xiaomi Mobile Software
+581DD8 Sagemcom Broadband SAS
+04698F Juniper Networks
+5C53C3 Ubee Interactive, Limited
+AC5AF0 LG Electronics
+ECA62F Huawei Technologies
+C09F51 Sernet (suzhou) Technologies
+8002F4 IEEE Registration Authority
+A0CDF3 Murata Manufacturing
+242934 Google
+380A4F Prachi Enterprises
+C83A1B Toshiba TEC
+B48A0A Espressif
+801970 Samsung Electronics
+E0F728 Amazon Technologies
+1C0ED3 Sichuan Tianyi Comheart Telecom
+2432AE Hangzhou Hikvision Digital Technology
+3822F4 Huawei Device
+0CBEF1 Huawei Device
+AC936A Huawei Device
+38A44B Huawei Device
+7C4CA5 SKY UK Limited
+C03E0F SKY UK Limited
+0CF9C0 SKY UK Limited
+7050AF SKY UK Limited
+D058FC SKY UK Limited
+900218 SKY UK Limited
+D4DACD SKY UK Limited
+B04530 SKY UK Limited
+6CA0B4 SKY UK Limited
+3C9EC7 SKY UK Limited
+A4AE11 Hon Hai Precision Industry
+7CDE78 New H3C Technologies
+3CE064 Texas Instruments
+E0928F Texas Instruments
+CC037B Texas Instruments
+581CF8 Intel Corporate
+AC198E Intel Corporate
+C85EA9 Intel Corporate
+B8FBAF Xiamen IPRT Technology
+348518 Espressif
+ECE6A2 Fiberhome Telecommunication Technologies
+04E8B9 Intel Corporate
+E02E0B Intel Corporate
+CC29BD zte
+385CFB Silicon Laboratories
+C43D1A Intel Corporate
+68539D EM Microelectronic
+C8BF4C Beijing Xiaomi Mobile Software
+E46564 Shenzhen KTC Technology
+E051D8 China Dragon Technology Limited
+BCF88B zte
+5C60BA HP
+E0EF02 Chengdu Quanjing Intelligent Technology
+4CA3A7 Tecno Mobile Limited
+A8ABB5 Apple
+5864C4 Apple
+40A53B Nokia
+74803F Renesas Electronics (Penang) Sdn. Bhd.
+0443FD Sichuan Tianyi Comheart Telecom
+A4897E Guangzhou Yuhong Technology
+E8CC8C Chengdu Jiarui Hualian Communication Technology
+5C5284 Apple
+C0956D Apple
+3C39C8 Apple
+209CB4 Aruba, a Hewlett Packard Enterprise Company
+ECA138 Amazon Technologies
+B067B5 Apple
+900A62 Inventus Power Eletronica do Brasil LTDA
+7054B4 Vestel Elektronik San ve Tic. A.S.
+04BF1B Dell
+081A1E Shenzhen iComm Semiconductor
+505FB5 Askey Computer
+88DE7C Askey Computer
+AC3184 Huawei Device
+503F50 Huawei Device
+481CB9 SZ DJI Technology
+B8208E Panasonic Connect
+3CA7AE zte
+80646F Espressif
+045747 GoPro
+EC1D9E Quectel Wireless Solutions
+BCD767 BAE Systems Apllied Intelligence
 9CFFC2 AVI Systems GmbH
 44D878 Hui Zhou Gaoshengda Technology
 A0D807 Huawei Device
@@ -6136,7 +6443,7 @@ A0D807 Huawei Device
 98F4AB Espressif
 D8BFC0 Espressif
 202681 Tecno Mobile Limited
-F4D620 Guangdong Oppo Mobile Telecommunications
+F4D620 Guangdong OPPO Mobile Telecommunications
 64FB92 PPC Broadband
 141346 Skyworth Digital Technology(Shenzhen)
 949034 Shenzhen Chuangwei-rgb Electronics
@@ -6145,7 +6452,7 @@ F4D620 Guangdong Oppo Mobile Telecommunications
 98F781 Arris Group
 7897C3 Dingxin Information Technology
 4C90DB JL Audio
-B899AE Shenzhen MiaoMing  Intelligent Technology
+B899AE Shenzhen MiaoMing Intelligent Technology
 E8D0B9 Taicang T&W Electronics
 3C8F06 Shenzhen Libtor Technology
 B00875 Huawei Technologies
@@ -6157,18 +6464,18 @@ A8C0EA Pepwave Limited
 182AD3 Juniper Networks
 80B07B zte
 C85A9F zte
-44AEAB Guangdong Oppo Mobile Telecommunications
-A4F05E Guangdong Oppo Mobile Telecommunications
+44AEAB Guangdong OPPO Mobile Telecommunications
+A4F05E Guangdong OPPO Mobile Telecommunications
 1C687E Shenzhen Qihu Intelligent Technology Company Limited
 C03656 Fiberhome Telecommunication Technologies
 5885A2 Realme Chongqing MobileTelecommunications
 2CF89B Cisco Systems
-00071C At&t
+00071C AT&T
 E0E8E6 Shenzhen C-Data Technology
 500291 Espressif
 001DDF Sunitec Enterprise
 8C0FFA Hutec
-ACFE05 Itel Mobile Limited
+ACFE05 ITEL Mobile Limited
 782A79 Integrated Device Technology (Malaysia) Sdn. Bhd.
 786559 Sagemcom Broadband SAS
 50D2F5 Beijing Xiaomi Mobile Software
@@ -6176,19 +6483,17 @@ ACFE05 Itel Mobile Limited
 20DFB9 Google
 5CCAD3 Chipsea Technologies (shenzhen)
 28167F Xiaomi Communications
-B03E51 BSkyB
 5CE883 Huawei Technologies
 100177 Huawei Technologies
 44A191 Huawei Technologies
-6023A4 SichuanAI-LinkTechnologyCo.
+6023A4 Sichuan AI-Link Technology
 A4530E Cisco Systems
 00403A Impact Technologies
 F887F1 Apple
 9C28BF Continental Automotive Czech Republic s.r.o.
-807215 BSkyB
 74D637 Amazon Technologies
-D05F64 Ieee Registration Authority
-BCC31B Kygo Life A
+D05F64 IEEE Registration Authority
+BCC31B Kygo Life
 64DF10 JingLue Semiconductor(SH)
 C463FB Neatframe AS
 0C8126 Juniper Networks
@@ -6203,7 +6508,7 @@ B8F12A Apple
 04A222 Arcadyan
 489BD5 Extreme Networks
 3C8C93 Juniper Networks
-28FE65 DongGuan Siyoto Electronics,
+28FE65 DongGuan Siyoto Electronics
 1806F5 RAD Data Communications
 7484E1 Dongguan Haoyuan Electronics
 44FB5A zte
@@ -6234,15 +6539,15 @@ D89B3B Huawei Technologies
 88403B Huawei Technologies
 FC8743 Huawei Technologies
 807693 Newag SA
-BC9740 Ieee Registration Authority
+BC9740 IEEE Registration Authority
 04885F Huawei Technologies
 C850CE Huawei Technologies
 50F8A5 eWBM
 1449BC DrayTek
 20F478 Xiaomi Communications
 90735A Motorola Mobility, a Lenovo Company
-1C8259 Ieee Registration Authority
-0004DF Teracom Telematica S.A
+1C8259 IEEE Registration Authority
+0004DF Teracom Telematica
 7438B7 Canon
 8C04BA Dell
 00FA21 Samsung Electronics
@@ -6254,15 +6559,14 @@ D49DC0 Samsung Electronics
 D0196A Ciena
 4413D0 zte
 2462AB Espressif
-88B436 Private
 6CAB05 Cisco Systems
 000BE4 Hosiden
 60D248 Arris Group
 485DEB Just Add Power
-501395 SichuanAI-LinkTechnologyCo.
+501395 Sichuan AI-Link Technology
 18D9EF Shuttle
 88DA33 Beijing Xiaoyuer Network Technology
-5041B9 I-O Data Device
+5041B9 I-O DATA Device
 80DABC Megafone Limited
 C09FE1 zte
 184644 Home Control Singapore Pte
@@ -6275,10 +6579,9 @@ F848FD China Mobile Group Device
 C821DA Shenzhen Youhua Technology
 E0B655 Beijing Xiaomi Electronics
 002175 Pacific Satellite International
-889746 SichuanAI-LinkTechnologyCo.
+889746 Sichuan AI-Link Technology
 1CDE57 Fiberhome Telecommunication Technologies
 E0DCFF Xiaomi Communications
-608CDF Private
 00778D Cisco Systems
 000E8C Siemens AG
 008764 Cisco Systems
@@ -6290,7 +6593,7 @@ C468D0 VTech Telecommunications
 DCB808 Extreme Networks
 B0E71D Shanghai Maigantech
 F8BBBF eero
-846FCE Guangdong Oppo Mobile Telecommunications
+846FCE Guangdong OPPO Mobile Telecommunications
 20658E Huawei Technologies
 183D5E Huawei Technologies
 DC7137 zte
@@ -6298,12 +6601,12 @@ DC7137 zte
 3441A8 ER-Telecom
 34DB9C Sagemcom Broadband SAS
 7440BE LG Innotek
-04D4C4 Asustek Computer
+04D4C4 ASUSTek Computer
 F0D4E2 Dell
 A8E2C3 Shenzhen Youhua Technology
 9020C2 Aruba, a Hewlett Packard Enterprise Company
 0CA06C Industrial Cyber Sensing
-FCD2B6 Ieee Registration Authority
+FCD2B6 IEEE Registration Authority
 804A14 Apple
 703C69 Apple
 AC2DA9 Tecno Mobile Limited
@@ -6328,23 +6631,23 @@ ACBB61 YSTen Technology
 2479F8 Kupson spol. s r.o.
 7CFD82 Guangdong Genius Technology
 180D2C Intelbras
-042DB4 First Property (beijing), Modern Moma Branch
+042DB4 First Property (Beijing), Modern MOMA Branch
 04E0B0 Shenzhen Youhua Technology
 08ECF5 Cisco Systems
-D07650 Ieee Registration Authority
+D07650 IEEE Registration Authority
 60D0A9 Samsung Electronics
 88CEFA Huawei Technologies
 002706 Yoisys
 00CB51 Sagemcom Broadband SAS
 C464B7 Fiberhome Telecommunication Technologies
-EC4118 Xiaomi Electronics,co.
-D8860B Ieee Registration Authority
+EC4118 Xiaomi Electronics,CO.
+D8860B IEEE Registration Authority
 342003 Shenzhen Feitengyun Technology
 F07D68 D-Link
 40E3D6 Aruba, a Hewlett Packard Enterprise Company
 B45D50 Aruba, a Hewlett Packard Enterprise Company
 78DAA2 Cynosure Technologies
-38B19E Ieee Registration Authority
+38B19E IEEE Registration Authority
 38E26E ShenZhen Sweet Rain Electronics
 00D050 Iskratel d.o.o.
 70C9C6 Cisco Systems
@@ -6364,7 +6667,7 @@ F46E95 Extreme Networks
 C80873 Ruckus Wireless
 701BFB Integrated Device Technology (Malaysia) Sdn. Bhd.
 001BB5 Cherry GmbH
-D05157 Leax Arkivator Telecom
+D05157 LEAX Arkivator Telecom
 288088 Netgear
 64CE6E Sierra Wireless
 1C3477 Innovation Wireless
@@ -6373,7 +6676,6 @@ BC3E07 Hitron Technologies.
 001697 NEC
 003013 NEC
 049DFE Hivesystem
-0CEC84 Shenzhen Tinno Mobile Technology
 9CDB07 Thum+Mahr GmbH
 DCEB69 Technicolor CH USA
 004E35 Hewlett Packard Enterprise
@@ -6398,7 +6700,6 @@ B4C62E Molex CMS
 B8259A Thalmic Labs
 282536 Shenzhen Holatek
 B8A175 Roku
-CCD3C1 Vestel Elektronik San ve Tic. A..
 0CD0F8 Cisco Systems
 745F90 LAM Technologies
 A42655 LTI Motion (Shanghai)
@@ -6406,7 +6707,7 @@ A42655 LTI Motion (Shanghai)
 3C9BD6 Vizio
 F85B9C SB Systems
 6CA928 HMD Global Oy
-00D861 Micro-star Intl
+00D861 Micro-Star INTL
 74C17D Infinix mobility limited
 8871B1 Arris Group
 F0AF85 Arris Group
@@ -6425,14 +6726,13 @@ F4DD9E GoPro
 D4D919 GoPro
 141114 Tecno Mobile Limited
 A45046 Xiaomi Communications
-1C24CD Askey Computer
 007C2D Samsung Electronics
 B47748 Shenzhen Neoway Technology
 F8501C Tianjin Geneuo Technology
 44070B Google
 F8C249 Private
 B831B5 Microsoft
-ECF6BD Sncf Mobilits
+ECF6BD SNCF Mobilités
 38B4D3 BSH Hausgeraete GmbH
 C84782 Areson Technology
 E89363 Nokia
@@ -6450,12 +6750,12 @@ CCBBFE Huawei Technologies
 A4D931 Apple
 BCFED9 Apple
 808223 Apple
-300A60 Ieee Registration Authority
+300A60 IEEE Registration Authority
 80D065 CKS
 283166 vivo Mobile Communication
 C04004 Medicaroid
 20AD56 Continental Automotive Systems
-5029F5 Guangdong Oppo Mobile Telecommunications
+5029F5 Guangdong OPPO Mobile Telecommunications
 CC08FB Tp-link Technologies
 BCAF91 TE Connectivity Sensor Solutions
 F0D7DC Wesine (Wuhan) Technology
@@ -6464,24 +6764,24 @@ F0D7DC Wesine (Wuhan) Technology
 1459C0 Netgear
 8C61A3 Arris Group
 A81087 Texas Instruments
-A02833 Ieee Registration Authority
+A02833 IEEE Registration Authority
 C8C2F5 Flextronics Manufacturing(zhuhai)co.
 F05849 CareView Communications
 34E5EC Palo Alto Networks
-A4ED43 Ieee Registration Authority
+A4ED43 IEEE Registration Authority
 94298D Shanghai AdaptComm Technology
 00AA6E Cisco Systems
 6843D7 Agilecom Photonics Solutions Guangdong Limited
 20D80B Juniper Networks
 8C8F8B China Mobile Chongqing branch
 B86A97 Edgecore Networks
-000A5E 3com
-00105A 3com
-006097 3com
-006008 3com
+000A5E 3COM
+00105A 3COM
+006097 3COM
+006008 3COM
 001B6E Keysight Technologies
-00040B 3com Europe
-000102 3com
+00040B 3COM Europe
+000102 3COM
 8CFE74 Ruckus Wireless
 A8016D Aiwa
 0440A9 New H3C Technologies
@@ -6489,7 +6789,6 @@ A8016D Aiwa
 E43493 Huawei Technologies
 342912 Huawei Technologies
 604BAA Magic Leap
-4C364E Panasonic  Connected Solutions Company
 BCA58B Samsung Electronics
 80CEB9 Samsung Electronics
 D0D3FC Mios
@@ -6507,7 +6806,7 @@ B8BEF4 devolo AG
 58FDBE Shenzhen Taikaida Technology
 F4F197 Emtake
 6CED51 Nexcontrol
-04C3E6 Ieee Registration Authority
+04C3E6 IEEE Registration Authority
 286336 Siemens AG
 14D169 Huawei Technologies
 1062E5 Hewlett Packard
@@ -6529,9 +6828,9 @@ F8272E Mercku
 F89910 Integrated Device Technology (Malaysia) Sdn. Bhd.
 50E0EF Nokia
 848A8D Cisco Systems
-1CC3EB Guangdong Oppo Mobile Telecommunications
-504C7E THE 41st Institute OF Cetc
-001413 Trebing & Himstedt Prozeautomation GmbH & KG
+1CC3EB Guangdong OPPO Mobile Telecommunications
+504C7E THE 41ST Institute OF CETC
+001413 Trebing & Himstedt Prozeßautomation GmbH & KG
 000799 Tipping Point Technologies
 D01CBB Beijing Ctimes Digital Technology
 7487BB Ciena
@@ -6546,7 +6845,7 @@ A83E0E HMD Global Oy
 00111E Ethernet Powerlink Standarization Group (epsg)
 00409D DigiBoard
 CC50E3 Espressif
-DCE305 ZAO NPK Rotek
+DCE305 ZAO "NPK Rotek"
 A4DA32 Texas Instruments
 000EEE Muco Industrie BV
 7C1C4E LG Innotek
@@ -6561,7 +6860,7 @@ E06066 Sercomm
 DCE0EB Nanjing Aozheng Information TechnologyLtd
 EC8C9A Huawei Technologies
 B48655 Huawei Technologies
-2C4759 Beijing Mega Preponderance Science & Technology
+2C4759 Beijing MEGA preponderance Science & Technology
 A41566 Weifang Goertek Electronics
 1C965A Weifang Goertek Electronics
 401B5F Weifang Goertek Electronics
@@ -6578,19 +6877,19 @@ B88AEC Nintendo
 D0D783 Huawei Technologies
 AC3B77 Sagemcom Broadband SAS
 B0FC0D Amazon Technologies
-CCC92C Schindler - Port Technology
+CCC92C Schindler - PORT Technology
 001E39 Comsys Communication
 78725D Cisco Systems
 FCE66A Industrial Software
-7836CC Guangdong Oppo Mobile Telecommunications
-8CCF5C Befega Gmbh
+7836CC Guangdong OPPO Mobile Telecommunications
+8CCF5C Befega GmbH
 70C833 Wirepas Oy
-0C73EB Ieee Registration Authority
+0C73EB IEEE Registration Authority
 048AE1 Flextronics Manufacturing(zhuhai)co.
 F0B5D1 Texas Instruments
 00E000 Fujitsu Limited
-90848B HDR10+ Technologies
-C8D779 Qing DAO Haier Telecom
+90848B Hdr10+ Technologies
+C8D779 QING DAO Haier Telecom
 10B36F Bowei Technology Company Limited
 FC9BC6 Sumavision Technologies
 C8292A Barun Electronics
@@ -6613,7 +6912,7 @@ BCE143 Apple
 C8D083 Apple
 0C6ABC Fiberhome Telecommunication Technologies
 0080BA Specialix (asia) PTE
-480BB2 Ieee Registration Authority
+480BB2 IEEE Registration Authority
 CCC079 Murata Manufacturing
 E019D8 BH Technologies
 6030D4 Apple
@@ -6629,21 +6928,21 @@ A438CC Nintendo
 8C4CDC Planex Communications
 5065F3 Hewlett Packard
 3C9509 Liteon Technology
-BCAB7C Trnp Korea
-64CB5D SIA TeleSet
-5821E9 Twpi
+BCAB7C TRnP Korea
+64CB5D SIA "TeleSet"
+5821E9 TWPI
 C49F4C Huawei Technologies
 0C704A Huawei Technologies
 F0E3DC Tecon MT
 A8DA01 Shenzhen Nuolijia Digital Technology
 7C2586 Juniper Networks
-F041C8 Ieee Registration Authority
+F041C8 IEEE Registration Authority
 CC9916 Integrated Device Technology (Malaysia) Sdn. Bhd.
 EC7FC6 Eccel SAS
 4CABFC zte
 0010D8 Calista
 002194 Ping Communication
-5C5AEA Ford
+5C5AEA FORD
 000B7B Test-Um
 30FD38 Google
 001386 ABB/Totalflow
@@ -6655,7 +6954,7 @@ BCDDC2 Espressif
 7CFF4D AVM Audiovisuelles Marketing und Computersysteme GmbH
 C88F26 Skyworth Digital Technology(Shenzhen)
 703A73 Shenzhen Sundray Technologies Company Limited
-10F9EB Industria Fueguina de Relojera Electrnica
+10F9EB Industria Fueguina de Relojería Electrónica
 80AD16 Xiaomi Communications
 044EAF LG Innotek
 1894C6 ShenZhen Chenyee Technology
@@ -6715,9 +7014,9 @@ BCFFEB Motorola Mobility, a Lenovo Company
 FC0A81 Extreme Networks
 F045DA Texas Instruments
 B80716 vivo Mobile Communication
-A8EEC6 Muuselabs NV/SA
+A8EEC6 Muuselabs Nv/sa
 E4F042 Google
-4048FD Ieee Registration Authority
+4048FD IEEE Registration Authority
 20B399 Enterasys
 CC2D21 Tenda Technology,Ltd.Dongguan branch
 004097 Datex Division OF
@@ -6747,7 +7046,7 @@ A89FEC Arris Group
 00BE9E Fiberhome Telecommunication Technologies
 54C57A Sunnovo International Limited
 58C17A Cambium Networks Limited
-38019F Shenzhen Fast Technologies
+38019F Shenzhen FAST Technologies
 245CCB AXIe Consortium
 609BC8 Hipad Intelligent Technology
 406A8E Hangzhou Puwell OE Tech
@@ -6758,7 +7057,7 @@ A89FEC Arris Group
 001C73 Arista Networks
 2C8A72 HTC
 38AD8E New H3C Technologies
-34D0B8 Ieee Registration Authority
+34D0B8 IEEE Registration Authority
 D06726 Hewlett Packard Enterprise
 ECFAF4 SenRa Tech Pvt.
 D88F76 Apple
@@ -6769,13 +7068,13 @@ C8E7F0 Juniper Networks
 B0935B Arris Group
 F449EF Emstone
 54DF24 Fiberhome Telecommunication Technologies
-AC1DDF Ieee Registration Authority
+AC1DDF IEEE Registration Authority
 E8D819 AzureWave Technology
-782D7E Trendnet
-741AE0 Ieee Registration Authority
+782D7E TRENDnet
+741AE0 IEEE Registration Authority
 24B209 Avaya
 FC65DE Amazon Technologies
-B06EBF Asustek Computer
+B06EBF ASUSTek Computer
 603D26 Technicolor CH USA
 BC903A Robert Bosch GmbH
 D0B128 Samsung Electronics
@@ -6783,8 +7082,8 @@ BC5451 Samsung Electronics
 74860B Cisco Systems
 182D98 Jinwoo Industrial system
 D8A534 Spectronix
-EC51BC Guangdong Oppo Mobile Telecommunications
-F079E8 Guangdong Oppo Mobile Telecommunications
+EC51BC Guangdong OPPO Mobile Telecommunications
+F079E8 Guangdong OPPO Mobile Telecommunications
 601803 Daikin Air-conditioning (Shanghai)
 00A096 Mitsumi Electric
 78617C Mitsumi Electric
@@ -6795,7 +7094,7 @@ B4D64E Caldero Limited
 F89DBB Tintri
 D8A01D Espressif
 C4F312 Texas Instruments
-904E91 Ieee Registration Authority
+904E91 IEEE Registration Authority
 5CE8B7 Oraimo Technology Limited
 3C11B2 Fraunhofer FIT
 104B46 Mitsubishi Electric
@@ -6805,7 +7104,7 @@ D067E5 Dell
 CC66B2 Nokia
 9C65EE Dasan Network Solutions
 78CA04 Nokia
-34298F Ieee Registration Authority
+34298F IEEE Registration Authority
 5CEA1D Hon Hai Precision Ind.
 181456 Nokia
 0017C8 Kyocera Display
@@ -6816,10 +7115,10 @@ E048D3 Mobiwire Mobiles (ningbo)
 58E28F Apple
 787B8A Apple
 4C16FC Juniper Networks
-48BCA6 asung Techno
+48BCA6 ​asung Techno
 B009DA Ring Solutions
 00054F Garmin International
-005C86 Shenzhen Fast Technologies
+005C86 Shenzhen FAST Technologies
 30053F JTI
 B8DB1C Integrated Device Technology (Malaysia) Sdn. Bhd.
 3C10E6 Phazr
@@ -6846,13 +7145,12 @@ FC7F56 CoSyst Control Systems GmbH
 84AA9C MitraStar Technology
 F0EFD2 TF Payment Service
 24B2DE Espressif
-F4939F Hon Hai Precision Ind.
 000726 Shenzhen Gongjin Electronics
 FC8B97 Shenzhen Gongjin Electronics
 2CAB25 Shenzhen Gongjin Electronics
 1CA532 Shenzhen Gongjin Electronics
-000C03 Hdmi Licensing
-7CBACC Ieee Registration Authority
+000C03 HDMI Licensing
+7CBACC IEEE Registration Authority
 94F128 Hewlett Packard Enterprise
 101B54 Huawei Technologies
 A80C63 Huawei Technologies
@@ -6863,12 +7161,12 @@ C4017C Ruckus Wireless
 540237 Teltronic AG
 4CB008 Shenzhen Gwelltimes Technology
 E86FF2 Actiontec Electronics
-005018 AMIT
+005018 Amit
 70DEF9 FAI WAH International (hong Kong) Limited
 B0EABC Askey Computer
 94C691 EliteGroup Computer Systems
-3CF591 Guangdong Oppo Mobile Telecommunications
-602101 Guangdong Oppo Mobile Telecommunications
+3CF591 Guangdong OPPO Mobile Telecommunications
+602101 Guangdong OPPO Mobile Telecommunications
 7CEB7F Dmet Products
 8C8580 Smart Innovation
 404229 Layer3TV
@@ -6884,7 +7182,7 @@ DCBE7A Zhejiang Nurotron Biotechnology
 3438B7 Humax
 CC0677 Fiberhome Telecommunication Technologies
 784501 Biamp Systems
-309C23 Micro-star Intl
+309C23 Micro-Star INTL
 54D751 Proximus
 14780B Varex Imaging Deutschland AG
 ACAFB9 Samsung Electronics
@@ -6893,9 +7191,8 @@ ACAFB9 Samsung Electronics
 D4258B Intel Corporate
 041B6D LG Electronics (Mobile Communications)
 F44156 Arrikto
-0080C2 Ieee 802.1 Working Group
 688DB6 Aetek
-ECF342 Guangdong Oppo Mobile Telecommunications
+ECF342 Guangdong OPPO Mobile Telecommunications
 50FF20 Keenetic Limited
 E45740 Arris Group
 F894C2 Intel Corporate
@@ -6911,7 +7208,7 @@ B03D96 Vision Valley FZ
 30D386 zte
 70DB98 Cisco Systems
 B42A0E Technicolor CH USA
-9CC8AE Becton, Dickinson  and Company
+9CC8AE Becton, Dickinson and Company
 B0359F Intel Corporate
 C0D962 Askey Computer
 F80BCB Cisco Systems
@@ -6925,7 +7222,7 @@ B83A08 Tenda Technology,Ltd.Dongguan branch
 A49BF5 Hybridserver Tec GmbH
 503DA1 Samsung Electronics
 F097E5 Tamio
-4C1A3D Guangdong Oppo Mobile Telecommunications
+4C1A3D Guangdong OPPO Mobile Telecommunications
 08028E Netgear
 E8E732 Alcatel-Lucent Enterprise
 B47C9C Amazon Technologies
@@ -6938,15 +7235,15 @@ B0481A Apple
 B49CDF Apple
 48BF6B Apple
 2C1DB8 Arris Group
-58821D H. Schomcker GmbH
+58821D H. Schomäcker GmbH
 D8A105 Syslane,
 BCA042 Shanghai Flyco Electrical Appliance
 3C0518 Samsung Electronics
 900628 Samsung Electronics
-B4A9FE Ghia Technology (shenzhen)
+B4A9FE GHIA Technology (Shenzhen)
 08B258 Juniper Networks
 9C84BF Apple
-1CA0D3 Ieee Registration Authority
+1CA0D3 IEEE Registration Authority
 9CFCD1 Aetheris Technology (Shanghai)
 CCCE1E AVM Audiovisuelles Marketing und Computersysteme GmbH
 0CF4D5 Ruckus Wireless
@@ -6970,8 +7267,8 @@ C4836F Ciena
 A80CCA Shenzhen Sundray Technologies Company Limited
 38AA3C Samsung Electro Mechanics
 000302 Charles Industries
-50A4D0 Ieee Registration Authority
-800010 At&t
+50A4D0 IEEE Registration Authority
+800010 AT&T
 0024F1 Shenzhen Fanhai Sanjiang Electronics
 142FFD LT Security
 0C3CCD Universal Global Scientific Industrial
@@ -6985,7 +7282,7 @@ CC9F7A Chiun Mai Communication Systems
 78F29E Pegatron
 64777D Hitron Technologies.
 9C50EE Cambridge Industries(Group)
-40ED98 Ieee Registration Authority
+40ED98 IEEE Registration Authority
 C891F9 Sagemcom Broadband SAS
 ACDCE5 Procter & Gamble Company
 00B362 Apple
@@ -7000,8 +7297,8 @@ F48C50 Intel Corporate
 DCD255 Kinpo Electronics
 A02C36 Fn-link Technology Limited
 000320 Xpeed
-508A0F Shenzhen Fise Technology Holding
-7CCBE2 Ieee Registration Authority
+508A0F Shenzhen FISE Technology Holding
+7CCBE2 IEEE Registration Authority
 A8A5E2 MSF-Vathauer Antriebstechnik GmbH & KG
 BCA8A6 Intel Corporate
 74FF4C Skyworth Digital Technology(Shenzhen)
@@ -7019,7 +7316,7 @@ D46A6A Hon Hai Precision Ind.
 002590 Super Micro Computer
 AC1F6B Super Micro Computer
 000B2E Cal-Comp Electronics & Communications Company
-4865EE Ieee Registration Authority
+4865EE IEEE Registration Authority
 D0F73B Helmut Mauell GmbH Werk Weida
 180675 Dilax Intelcom GmbH
 000FC2 Uniwell
@@ -7042,7 +7339,7 @@ C8D3FF Hewlett Packard
 C4BE84 Texas Instruments
 F4F524 Motorola Mobility, a Lenovo Company
 00BBC1 Canon
-24C1BD Crrc Dalian R&D
+24C1BD CRRC Dalian R&D
 00A2EE Cisco Systems
 0059DC Cisco Systems
 00FD45 Hewlett Packard Enterprise
@@ -7051,8 +7348,8 @@ B4D135 Cloudistics
 0013A5 General Solutions
 9C3DCF Netgear
 248894 shenzhen lensun Communication Technology
-B04BBF PT HAN Sung Electoronics Indonesia
-CC2D83 Guangdong Oppo Mobile Telecommunications
+B04BBF PT HAN SUNG Electoronics Indonesia
+CC2D83 Guangdong OPPO Mobile Telecommunications
 D46E0E Tp-link Technologies
 88366C EFM Networks
 48DA96 Eddy Smart Home Solutions
@@ -7063,17 +7360,17 @@ EC107B Samsung Electronics
 1C232C Samsung Electronics
 E00DB9 Cree
 DC0D30 Shenzhen Feasycom Technology
-F0ACD7 Ieee Registration Authority
+F0ACD7 IEEE Registration Authority
 9495A0 Google
 00A6CA Cisco Systems
-38D547 Asustek Computer
+38D547 ASUSTek Computer
 FC83C6 N-Radio Technologies
 30B64F Juniper Networks
 1C9D3E Integrated Device Technology (Malaysia) Sdn. Bhd.
 F02FA7 Huawei Technologies
 18DED7 Huawei Technologies
 C83DD4 CyberTAN Technology
-E0B94D Shenzhen Bilian Electronicltd
+E0B94D Shenzhen Bilian Electronic，ltd
 D8452B Integrated Device Technology (Malaysia) Sdn. Bhd.
 E4186B Zyxel Communications
 008731 Cisco Systems
@@ -7166,7 +7463,7 @@ AC482D Ralinwi Nanjing Electronic Technology
 009058 Ultra Electronics Command & Control Systems
 001CFD Universal Electronics
 080087 Xyplex
-DC1A01 Ecoliv Technology ( Shenzhen )
+DC1A01 Ecoliv Technology ( Shenzhen
 00549F Avaya
 2824FF Wistron Neweb
 38256B Microsoft Mobile Oy
@@ -7192,7 +7489,7 @@ C09134 ProCurve Networking by HP
 203AEF Sivantos GmbH
 005979 Networked Energy Services
 207C8F Quanta Microsystems
-000B34 ShangHai Broadband TechnologiesLTD
+000B34 ShangHai Broadband Technologiesltd
 74B57E zte
 B8BB23 Guangdong Nufront CSC
 34EA34 HangZhou Gubei Electronics Technology
@@ -7208,16 +7505,16 @@ E09DB8 Planex Communications
 8C90D3 Nokia
 0028F8 Intel Corporate
 58BC8F Cognitive Systems
-D455BE Shenzhen Fast Technologies
+D455BE Shenzhen FAST Technologies
 640DCE Shenzhen Mercury Communication Technologies
 54D272 Nuki Home Solutions GmbH
-EC26FB Tecc
+EC26FB TECC
 0020F4 Spectrix
 04EE91 x-fabric GmbH
 B47443 Samsung Electronics
 FCF647 Fiberhome Telecommunication Technologies
 18686A zte
-C44BD1 Wallys Communications  Teachnologies
+C44BD1 Wallys Communications Teachnologies
 6CB9C5 Delta Networks
 30766F LG Electronics (Mobile Communications)
 A8922C LG Electronics (Mobile Communications)
@@ -7225,8 +7522,8 @@ F80CF3 LG Electronics (Mobile Communications)
 C49A02 LG Electronics (Mobile Communications)
 001F6B LG Electronics (Mobile Communications)
 0026E2 LG Electronics (Mobile Communications)
-DC4427 Ieee Registration Authority
-BC3400 Ieee Registration Authority
+DC4427 IEEE Registration Authority
+BC3400 IEEE Registration Authority
 E8886C Shenzhen SC Technologies
 0024FF QLogic
 001E21 Qisda
@@ -7247,14 +7544,13 @@ B808D7 Huawei Technologies
 000FDB Westell Technologies
 3C0771 Sony
 80414E BBK Educational Electronics
-249442 Open Road Solutions
+249442 OPEN ROAD Solutions 
 C46413 Cisco Systems
 0010CA Telco Systems
 00E09E Quantum
-000A08 Alpine Electronics
 206A8A Wistron Infocomm (Zhongshan)
 784476 Zioncom Electronics (Shenzhen)
-001165 Znyx Networks
+001165 ZNYX Networks
 000A68 Solarflare Communications
 002186 Universal Global Scientific Industrial
 183919 Unicoi Systems
@@ -7280,17 +7576,17 @@ C0A1A2 MarqMetrix
 08D0B7 Qingdao Hisense Communications
 ECD68A Shenzhen JMicron Intelligent Technology Developmen
 5052D2 Hangzhou Telin Technologies, Limited
-90EED9 Universal DE Desarrollos Electrnicos
+90EED9 Universal DE Desarrollos Electrónicos
 606453 AOD
 009E1E Cisco Systems
 00253E Sensus Metering Systems
 C8AFE3 Hefei Radio Communication Technology
-7C574E Cobi Gmbh
+7C574E COBI GmbH
 28F10E Dell
 045604 Gionee Communication Equipment
 34C0F9 Rockwell Automation
 00FEC8 Cisco Systems
-2C5A8D Systronik Elektronik u. Systemtechnik Gmbh
+2C5A8D Systronik Elektronik u. Systemtechnik GmbH
 10BEF5 D-Link International
 E47B3F Beijing-cloud Technology
 0C8A87 AgLogica Holdings
@@ -7298,7 +7594,6 @@ E47B3F Beijing-cloud Technology
 34A2A2 Huawei Technologies
 749D8F Huawei Technologies
 945907 Shanghai Hite-belden Network Technology
-001848 Vecima Networks
 0016FB Shenzhen MTC
 A0415E Opsens Solution
 A860B6 Apple
@@ -7328,7 +7623,7 @@ BC7574 Huawei Technologies
 A4E597 Gessler GmbH
 006CBC Cisco Systems
 5C70A3 LG Electronics (Mobile Communications)
-001D08 Jiangsu Yinhe  Electronics
+001D08 Jiangsu Yinhe Electronics
 001D82 GN Netcom A/S
 001317 GN Netcom A/S
 00A0A4 Oracle
@@ -7387,7 +7682,7 @@ DC094C Huawei Technologies
 24BCF8 Huawei Technologies
 A0043E Parker Hannifin Manufacturing Germany GmbH & KG
 C84529 IMK Networks
-7C477C Ieee Registration Authority
+7C477C IEEE Registration Authority
 F877B8 Samsung Electronics
 F0D2F1 Amazon Technologies
 A8E3EE Sony Interactive Entertainment
@@ -7396,7 +7691,7 @@ A8E3EE Sony Interactive Entertainment
 20A90E TCT mobile
 EC438B Yaptv
 980CA5 Motorola (Wuhan) Mobility Technologies Communication
-441102 Edmi  Europe
+441102 EDMI Europe
 A85EE4 12Sided Technology
 182195 Samsung Electronics
 44783E Samsung Electronics
@@ -7407,12 +7702,12 @@ BC44B0 Elastifile
 F4ED5F Shenzhen KTC Technology Group
 00E0E4 Fanuc Robotics North America
 000896 Printronix
-245EBE Qnap Systems
+245EBE QNAP Systems
 0404EA Valens Semiconductor
 800DD7 Latticework
 D0B53D Sepro Robotique
 00D0EC Nakayo
-4CCC6A Micro-star Intl
+4CCC6A Micro-Star INTL
 30636B Apple
 70884D Japan Radio
 A4F1E8 Apple
@@ -7435,7 +7730,7 @@ EC9B5B Nokia
 002668 Nokia Danmark A/S
 00247D Nokia Danmark A/S
 002265 Nokia Danmark A/S
-F88096 Elsys Equipamentos Eletrnicos Ltda
+F88096 Elsys Equipamentos Eletrônicos Ltda
 A811FC Arris Group
 001DAA DrayTek
 E498D1 Microsoft Mobile Oy
@@ -7600,13 +7895,13 @@ C81F66 Dell
 0015C5 Dell
 001422 Dell
 109836 Dell
-800A80 Ieee Registration Authority
+800A80 IEEE Registration Authority
 F8DB88 Dell
 3CA348 vivo Mobile Communication
 E45AA2 vivo Mobile Communication
 CC3B3E Lester Electrical
 2082C0 Xiaomi Communications
-DC6DCD Guangdong Oppo Mobile Telecommunications
+DC6DCD Guangdong OPPO Mobile Telecommunications
 C4282D Embedded Intellect
 5846E1 Baxter International
 00173F Belkin International
@@ -7626,7 +7921,7 @@ E8F1B0 Sagemcom Broadband SAS
 2C27D7 Hewlett Packard
 984BE1 Hewlett Packard
 002926 Applied Optoelectronics, Taiwan Branch
-24BA13 Riso Kagaku
+24BA13 RISO Kagaku
 0017E5 Texas Instruments
 0017EC Texas Instruments
 0017E7 Texas Instruments
@@ -7637,14 +7932,13 @@ E8F1B0 Sagemcom Broadband SAS
 00265A D-Link
 C8BE19 D-Link International
 A4BA76 Huawei Technologies
-0050C2 Ieee Registration Authority
+0050C2 IEEE Registration Authority
 440010 Apple
 0056CD Apple
 006037 NXP Semiconductors
-DCC0EB Assa Abloy Cte Picarde
-28BC56 EMAC
+DCC0EB ASSA Abloy CÔTE Picarde
+28BC56 Emac
 00CDFE Apple
-A0F895 Shenzhen Tinno Mobile Technology
 0078CD Ignition Design Labs
 B436A9 Fibocom Wireless
 70CA4D Shenzhen lnovance Technology
@@ -7709,7 +8003,7 @@ AC2A0C CSR Zhuzhou Institute
 00234D Hon Hai Precision Ind.
 002556 Hon Hai Precision Ind.
 601888 zte
-D860B0 bioMrieux Italia
+D860B0 bioMérieux Italia
 54E6FC Tp-link Technologies
 74EA3A Tp-link Technologies
 F81A67 Tp-link Technologies
@@ -7722,7 +8016,7 @@ F431C3 Apple
 64A5C3 Apple
 28565A Hon Hai Precision Ind.
 6CB56B Humax
-BC3AEA Guangdong Oppo Mobile Telecommunications
+BC3AEA Guangdong OPPO Mobile Telecommunications
 E422A5 Plantronics
 D4C9B2 Quanergy Systems
 6021C0 Murata Manufacturing
@@ -7824,12 +8118,12 @@ D46D50 Cisco Systems
 F07816 Cisco Systems
 00223A Cisco Spvtg
 0021BE Cisco Spvtg
-14DAE9 Asustek Computer
+14DAE9 ASUSTek Computer
 F4CFE2 Cisco Systems
 A80C0D Cisco Systems
 C07BBC Cisco Systems
 24E9B3 Cisco Systems
-0011D8 Asustek Computer
+0011D8 ASUSTek Computer
 C08C60 Cisco Systems
 E8EDF3 Cisco Systems
 E4C722 Cisco Systems
@@ -7840,8 +8134,8 @@ F41FC2 Cisco Systems
 1CDEA7 Cisco Systems
 F07F06 Cisco Systems
 88F031 Cisco Systems
-0018F3 Asustek Computer
-001A92 Asustek Computer
+0018F3 ASUSTek Computer
+001A92 ASUSTek Computer
 000C41 Cisco-Linksys
 0016B6 Cisco-Linksys
 0018F8 Cisco-Linksys
@@ -7905,7 +8199,7 @@ DC86D8 Apple
 D0E140 Apple
 24A2E1 Apple
 04214C Insight Energy Ventures
-F832E4 Asustek Computer
+F832E4 ASUSTek Computer
 80EA96 Apple
 600308 Apple
 04F13E Apple
@@ -7974,7 +8268,7 @@ B857D8 Samsung Electronics
 A8C87F Roqos
 3C831E CKD
 90DFFB Homerider Systems
-305A3A Asustek Computer
+305A3A ASUSTek Computer
 2C081C OVH
 C08488 Finis
 38F557 Jolata
@@ -7987,7 +8281,7 @@ B844D9 Apple
 5CCF7F Espressif
 681295 Lupine Lighting Systems GmbH
 7011AE Music Life
-041E7A Dspworks
+041E7A DSPWorks
 84A788 Perples
 AC60B6 Ericsson AB
 14B370 Gigaset Digital Technology (Shenzhen)
@@ -7995,7 +8289,7 @@ AC60B6 Ericsson AB
 1C497B Gemtek Technology
 2CCF58 Huawei Technologies
 D09380 Ducere Technologies Pvt.
-68F956 Objetivos y Servicio de Valor Aadido
+68F956 Objetivos y Servicio de Valor Añadido
 C8A9FC Goyoo Networks
 FCFEC2 Invensys Controls UK Limited
 689AB7 Atelier Vision
@@ -8006,7 +8300,7 @@ FCFEC2 Invensys Controls UK Limited
 FC2FEF UTT Technologies
 A4C138 Telink Semiconductor (Taipei)
 20F510 Codex Digital Limited
-A8741D Phoenix Contact Electronics Gmbh
+A8741D Phoenix Contact Electronics GmbH
 F09A51 Shanghai Viroyal Electronic Technology Company Limited
 4CB82C Cambridge Mobile Telematics
 E4A32F Shanghai Artimen Technology
@@ -8031,12 +8325,12 @@ F0AB54 Mitsumi Electric
 3C3178 Qolsys
 08ECA9 Samsung Electronics
 E04B45 Hi-P Electronics Pte
-F46A92 Shenzhen Fast Technologies
+F46A92 Shenzhen FAST Technologies
 F0D657 Echosens
 9C37F4 Huawei Technologies
 3C4711 Huawei Technologies
 5CEB68 Cheerstar Technology
-AC562C Lava International(h.k) Limited
+AC562C LAVA International(h.k) Limited
 FC9AFA Motus Global
 14157C Tokyo Cosmos Electric
 20E407 Spark srl
@@ -8062,7 +8356,7 @@ F8CFC5 Motorola Mobility, a Lenovo Company
 A47B85 Ultimedia,
 5C5B35 Mist Systems
 ECBAFE Giroptic
-3C2C94 HangZhou Delan Technology
+3C2C94 杭州德澜科技有限公司（HangZhou Delan Technology
 241B44 Hangzhou Tuners Electronics
 80A85D Osterhout Design Group
 ACCAAB Virtual Electric
@@ -8074,22 +8368,22 @@ E09971 Samsung Electronics
 10D38A Samsung Electronics
 E48501 Geberit International AG
 206274 Microsoft
-E8162B Ideo Security
+E8162B IDEO Security
 B47356 Hangzhou Treebear Networking
 346895 Hon Hai Precision Ind.
 847303 Letv Mobile and Intelligent Information Technology (Beijing)
 3CC2E1 Xinhua Control Engineering
 8C873B Leica Camera AG
 44F477 Juniper Networks
-142971 Nemoa Electronics (hk)
+142971 Nemoa Electronics (HK)
 78E980 RainUs
 E0FFF7 Softiron
 3C6A9D Dexatek Technology
 349E34 Evervictory ElectronicLtd
 700FC7 Shenzhen Ikinloop Technology
 BC74D7 HangZhou JuRu Technology
-78EB14 Shenzhen Fast Technologies
-3C4937 Assmann Electronic Gmbh
+78EB14 Shenzhen FAST Technologies
+3C4937 Assmann Electronic GmbH
 844464 ServerU
 003560 Rosen Aviation
 F8BC41 Rosslare Enterprises Limited
@@ -8100,7 +8394,7 @@ D89341 General Electric Global Research
 1C9ECB Beijing Nari Smartchip Microelectronics Company Limited
 D48DD9 Meld Technology
 DCC622 Buheung System
-902CC7 C-MAX Asia Limited
+902CC7 C-max Asia Limited
 8870EF SC Professional Trading
 94C038 Tallac Networks
 6836B5 DriveScale
@@ -8157,13 +8451,13 @@ FC790B Hitachi High Technologies America
 14B484 Samsung Electronics
 F4C447 Coagent International Enterprise Limited
 C8E42F Technical Research Design and Development
-C4C9EC Gugaoo   HK Limited
+C4C9EC Gugaoo HK Limited
 34E42A Automatic Bar Controls
 3059B7 Microsoft
 20A787 Bointec Taiwan Limited
 A0FC6E Telegrafia a.s.
 2053CA Risk Technology
-A43D78 Guangdong Oppo Mobile Telecommunications
+A43D78 Guangdong OPPO Mobile Telecommunications
 04572F Sertel Electronics UK
 D8977C Grey Innovation
 BC8D0E Nokia
@@ -8188,7 +8482,7 @@ B05706 Vallox Oy
 A8A668 zte
 00EEBD HTC
 38F708 National Resource Management
-E0DB88 Open Standard Digital-if Interface for Satcom Systems
+E0DB88 Open Standard Digital-IF Interface for Satcom Systems
 A8BD3A Unionman Technology
 A824EB ZAO NPO Introtest
 C40E45 ACK Networks
@@ -8197,7 +8491,7 @@ A46CC1 LTi REEnergy GmbH
 A8B9B3 Essys
 6C09D6 Digiquest Electronics
 481842 Shanghai Winaas Equipment
-447098 Ming Hong Technology (shen Zhen) Limited
+447098 MING HONG Technology (shen Zhen) Limited
 9CBD9D SkyDisk
 74C621 Zhejiang Hite Renewable Energy
 D4319D Sinwatec
@@ -8221,7 +8515,7 @@ B843E4 Vlatacom
 B898F7 Gionee Communication Equipment,Ltd.ShenZhen
 848336 Newrun
 182012 Aztech Associates
-B8266C Anov France
+B8266C ANOV France
 3C300C Dewar Electronics
 98FFD0 Lenovo Mobile Communication Technology
 A875E2 Aventura Technologies
@@ -8253,7 +8547,7 @@ E47723 zte
 18AA45 Fon Technology
 902083 General Engine Management Systems
 14B126 Industrial Software
-D850E6 Asustek Computer
+D850E6 ASUSTek Computer
 DC3EF8 Nokia
 A49F89 Shanghai Rui Rui Communication TechnologyLtd.
 7060DE LaVision GmbH
@@ -8264,7 +8558,7 @@ FCFE77 Hitachi Reftechno
 644214 Swisscom Energy Solutions AG
 0CA694 Sunitec Enterprise
 184462 Riava Networks
-C03580 A&R Tech
+C03580 A&R TECH
 D08A55 Skullcandy
 344F3F IO-Power Technology
 146080 zte
@@ -8277,13 +8571,12 @@ CC720F Viscount Systems
 C0A0BB D-Link International
 2CCD69 Aqavi.com
 F45F69 Matsufu Electronics distribution Company
-28A1EB Etek Technology (shenzhen)
+28A1EB ETEK Technology (shenzhen)
 B8F828 Changshu Gaoshida Optoelectronic Technology
 3C1A57 Cardiopulmonary
 541B5D Techno-Innov
 9CE7BD Winduskorea
 3842A6 Ingenieurbuero Stahlkopf
-2C553C Gainspeed
 248000 Westcontrol AS
 1C4BB9 SMG Enterprise
 346178 The Boeing Company
@@ -8306,11 +8599,11 @@ ACE42E SK hynix
 9876B6 Adafruit
 503CC4 Lenovo Mobile Communication Technology
 2C7B84 OOO Petr Telegin
-A4C0C7 ShenZhen Hitom Communication TechnologyLTD
+A4C0C7 ShenZhen Hitom Communication Technology.LTD
 306112 PAV GmbH
-789F4C Hoerbiger Elektronik Gmbh
+789F4C Hoerbiger Elektronik GmbH
 18104E Cedint-upm
-9C1465 Edata Elektronik San. ve Tic. A..
+9C1465 Edata Elektronik San. ve Tic. A.Ş.
 4C55CC Zentri
 00C5DB Datatech Sistemas Digitales Avanzados SL
 8CF945 Power Automation pte
@@ -8318,7 +8611,7 @@ F842FB Yasuda Joho
 887398 K2E Tekpoint
 2C922C Kishu Giken Kogyou Company
 D8FEE3 D-Link International
-58F387 Hccp
+58F387 HCCP
 3C977E IPS Technology Limited
 A4FB8D Hangzhou Dunchong TechnologyLtd
 F4CD90 Vispiron Rotec GmbH
@@ -8326,10 +8619,10 @@ F4CD90 Vispiron Rotec GmbH
 043D98 ChongQing QingJia Electronics
 E03E4A Cavanagh Group International
 041B94 Host Mobility AB
-A0CEC8 CE Link Limited
+A0CEC8 CE LINK Limited
 907A28 Beijing Morncloud Information And Technology
 1001CA Ashley Butterworth
-246AAB IT-IS International
+246AAB It-is International
 FC4BBC Sunplus Technology
 50A0BF Alba Fiber Systems
 B836D8 Videoswitch
@@ -8357,7 +8650,7 @@ DC825B Janus, spol. s r.o.
 C04301 Epec Oy
 E07C62 Whistle Labs
 F07F0C Leopold Kostal GmbH &Co. KG
-4C6255 Sanmina-sci System DE Mexico S.A. DE C.V.
+4C6255 Sanmina-sci System DE Mexico DE C.V.
 082719 APS systems/electronic AG
 505AC6 Guangdong Super Telecom
 9C79AC Suntec Software(Shanghai)
@@ -8366,25 +8659,25 @@ B863BC Robotis,
 980D2E HTC
 C419EC Qualisys AB
 604A1C Suyin
-D464F7 Chengdu Usee Digital Technology
-74D02B Asustek Computer
+D464F7 Chengdu USEE Digital Technology
+74D02B ASUSTek Computer
 601E02 EltexAlatau
 E0C6B3 MilDef AB
 6472D8 GooWi Technology,Limited
 60601F SZ DJI Technology
 5C8486 Brightsource Industries Israel
 50CD32 NanJing Chaoran Science & Technology
-BCBAE1 Arec
+BCBAE1 AREC
 18FA6F ISC applied systems
 A01C05 Nimax Telecom
 60E00E Shinsei Electronics
 545414 Digital RF Corea
-24EB65 Saet I.S. S.r.l.
+24EB65 SAET I.S. S.r.l.
 D0F27F SteadyServ Technoligies
 E894F6 Tp-link Technologies
 188410 CoreTrust
 FC229C Han Kyung I Net
-1832A2 Laon Technology
+1832A2 LAON Technology
 D4A499 InView Technology
 08482C Raycore Taiwan
 DC2BCA Zera GmbH
@@ -8394,7 +8687,7 @@ B4DD15 ControlThings Oy Ab
 DC1DD4 Microstep-MIS spol. s r.o.
 FCDD55 Shenzhen WeWins wireless
 B01743 Edison Global Circuits
-D0BE2C Cnslink
+D0BE2C CNSLink
 40516C Grandex International
 C0885B SnD Tech
 3CFB96 Emcraft Systems
@@ -8412,7 +8705,7 @@ C04A00 Tp-link Technologies
 94C962 Teseq AG
 DC2A14 Shanghai Longjing Technology
 6886E7 Orbotix
-C05E6F V. Stonkaus firma Kodinis Raktas
+C05E6F V. Stonkaus firma "Kodinis Raktas"
 C0B8B1 BitBox
 F82EDB RTW GmbH & KG
 808B5C Shenzhen Runhuicheng Technology
@@ -8448,17 +8741,17 @@ ECE915 STI
 303D08 Glintt TES
 A81FAF Krypton Polska
 30D357 Logosol
-BC39A6 Csun System Technology
-ECB541 Shinano E and Eltd.
+BC39A6 CSUN System Technology
+ECB541 Shinano E and ELtd.
 D410CF Huanshun Network Science and Technology
 6CB311 Shenzhen Lianrui Electronics
 10A743 SK Mtek Limited
-547FA8 Telco Systems, S.r.o.
+547FA8 Telco systems, s.r.o.
 5474E6 Webtech Wireless
 C46DF1 DataGravity
-304449 Plath Gmbh
+304449 Plath GmbH
 94FD2E Shanghai Uniscope Technologies
-E4C146 Objetivos y Servicios de Valor A
+E4C146 Objetivos y Servicios de Valor
 D40057 MC Technologies GmbH
 5CE0F6 NIC.br- Nucleo de Informacao e Coordenacao do Ponto BR
 C83D97 Nokia
@@ -8466,16 +8759,16 @@ C83D97 Nokia
 600F77 SilverPlus
 B0358D Nokia
 F8E4FB Actiontec Electronics
-8C4AEE Giga TMS
+8C4AEE GIGA TMS
 34C99D Eidolon Communications Technology
 ACE64B Shenzhen Baojia Battery Technology
 789F87 Siemens AG I IA PP PRM
 08E5DA Nanjing Fujitsu Computer Products
-5884E4 IP500 Alliance e.V.
+5884E4 Ip500 Alliance e.V.
 044BFF GuangZhou Hedy Digital Technology
 E8718D Elsys Equipamentos Eletronicos Ltda
-D0738E Dong OH Precision
-64C944 Lark Technologies
+D0738E DONG OH Precision
+64C944 LARK Technologies
 0C93FB BNS Solutions
 E44F5F EDS Elektronik Destek San.Tic.Ltd.Sti
 E86D54 Digit Mobile
@@ -8485,8 +8778,8 @@ E86D54 Digit Mobile
 5C38E0 Shanghai Super Electronics Technology
 08AF78 Totus Solutions
 C8C791 Zero1.tv GmbH
-ECD925 Rami
-1C9492 Ruag Schweiz AG
+ECD925 RAMI
+1C9492 RUAG Schweiz AG
 B889CA Iljin Electric
 64F50E Kinion Technology Company Limited
 D04CC1 Sintrones Technology
@@ -8496,7 +8789,7 @@ D04CC1 Sintrones Technology
 1848D8 Fastback Networks
 F0D3E7 Sensometrix SA
 B01266 Futaba-Kikaku
-7CC8D0 Tianjin Yaan Technology
+7CC8D0 Tianjin YAAN Technology
 88E917 Tamaggo
 88615A Siano Mobile Silicon
 70E24C SAE IT-systems GmbH & KG
@@ -8569,22 +8862,22 @@ B4E1EB Private
 A06D09 Intelcan Technosystems
 60F3DA Logic Way GmbH
 FC5090 Simex Sp. z o.o.
-60B982 RO.VE.R. Laboratories
+60B982 Ro.ve.r. Laboratories
 B46238 Exablox
 C8BBD3 Embrane
 8C604F Cisco Systems
-A4B980 Parking Boxx
+A4B980 Parking BOXX
 A47C14 ChargeStorm AB
 8020AF Trade Fides
 2C750F Shanghai Dongzhou-Lawton Communication Technology
 5C5015 Cisco Systems
 980284 Theobroma Systems GmbH
 1CD40C Kriwan Industrie-Elektronik GmbH
-002D76 Titech Gmbh
+002D76 Titech GmbH
 F8DB4C PNY Technologies
 0C9D56 Consort Controls
 3CB87A Private
-AC1461 Ataw
+AC1461 ATAW
 E4C6E6 Mophie
 502D1D Nokia
 F48E09 Nokia
@@ -8597,7 +8890,7 @@ F48E09 Nokia
 200505 Radmax Communication Private Limited
 C035BD Velocytech Aps
 287184 Spire Payments
-7CB03E Osram Gmbh
+7CB03E Osram GmbH
 3C9F81 Shenzhen Catic Bit Communications Technology
 445F7A Shihlin Electric & Engineering
 441319 WKK Technology
@@ -8608,7 +8901,7 @@ C84544 Asia Pacific CIS (Wuxi)
 E0EF25 Lintes Technology
 50ED94 Egatel SL
 48A22D Shenzhen Huaxuchang Telecom Technology
-C86000 Asustek Computer
+C86000 ASUSTek Computer
 AC0DFE Ekon GmbH - myGEKKO
 FC5B26 MikroBits
 40F407 Nintendo
@@ -8626,7 +8919,7 @@ BCE59F Waterworld Technology
 DCA8CF New Spin Golf
 A849A5 Lisantech
 A05E6B Melper
-D878E5 Kuhn SA
+D878E5 KUHN SA
 D824BD Cisco Systems
 3497FB Advanced RF Technologies
 F03A55 Omega Elektronik AS
@@ -8638,24 +8931,24 @@ C467B5 Libratone A/S
 4C3910 Newtek Electronics
 903AA0 Nokia
 B06CBF 3ality Digital Systems GmbH
-54D0ED Axim Communications
+54D0ED AXIM Communications
 843611 hyungseul publishing networks
 3440B5 IBM
 D4D748 Cisco Systems
 344F69 Ekinops SAS
 F8313E endeavour GmbH
 143605 Nokia
-C81AFE Dlogic Gmbh
+C81AFE Dlogic GmbH
 EC63E5 ePBoard Design
 94DB49 Sitcorp
 F0620D Shenzhen Egreat Tech
 2C67FB ShenZhen Zhengjili Electronics
-3CE5B4 Kidasen Industria E Comercio DE Antenas Ltda
+3CE5B4 Kidasen Industria E Comercio DE Antenas LTDA
 08D09F Cisco Systems
 644BF0 CalDigit
 64ED62 Woori Systems
 2C002C Unowhy
-5CC9D3 Palladium Energy Eletronica DA Amazonia Ltda
+5CC9D3 Palladium Energy Eletronica DA Amazonia LTDA
 C87CBC Valink
 B81413 Keen High Holding(HK)
 B4944E WeTelecom
@@ -8669,7 +8962,7 @@ CC6BF1 Sound Masking
 70CA9B Cisco Systems
 A078BA Pantech
 68BC0C Cisco Systems
-345B11 EVI Heat AB
+345B11 EVI HEAT AB
 78BAD0 Shinybow Technology
 24E6BA JSC Zavod im. Kozitsky
 CCA374 Guangdong Guanglian Electronic TechnologyLtd
@@ -8680,13 +8973,13 @@ A8BD1A Honey Bee (Hong Kong) Limited
 C4C19F National Oilwell Varco Instrumentation, Monitoring, and Optimization (NOV IMO)
 000830 Cisco Systems
 C4EEAE VSS Monitoring
-F8D3A9 Axan Networks
+F8D3A9 AXAN Networks
 BC779F SBM
 406AAB RIM
 9CA3BA Sakura Internet
 8C8A6E Estun Automation Technoloy
 988217 Disruptive
-9C5C8D Firemax Indstria E Comrcio DE Produtos Eletrnicos  Ltda
+9C5C8D Firemax Indústria E Comércio DE Produtos Eletrônicos LTDA
 D4206D HTC
 7C1E52 Microsoft
 DCB4C4 Microsoft XCG
@@ -8696,12 +8989,12 @@ ACCB09 Hefcom Metering (Pty)
 CCB8F1 Eagle Kingdom Technologies Limited
 A429B7 bluesky
 48F317 Private
-CCF8F0 Xi'an Hisu Multimedia Technology
+CCF8F0 Xi'an HISU Multimedia Technology
 04888C Eifelwerk Butler Systeme GmbH
 D45AB2 Galleon Systems
 30DE86 Cedac Software S.r.l.
 18C451 Tucson Embedded Systems
-704642 Chyng Hong Electronic
+704642 Chyng HONG Electronic
 D41C1C RCF
 58920D Kinetic Avionics Limited
 AC02EF Comsis
@@ -8720,10 +9013,10 @@ A44B15 Sun Cupid Technology (HK)
 48C862 Simo Wireless
 78BEB6 Enhanced Vision
 449CB5 Alcomp
-B4FC75 Sema Electronics(hk)
+B4FC75 SEMA Electronics(HK)
 B0BF99 Wizitdongdo
-B82ADC EFR Europische Funk-Rundsteuerung GmbH
-40F14C ISE Europe Sprl
+B82ADC EFR Europäische Funk-Rundsteuerung GmbH
+40F14C ISE Europe SPRL
 E8944C Cogent Healthcare Systems
 9067F3 Alcatel Lucent
 D4F0B4 Napco Security Technologies
@@ -8731,8 +9024,8 @@ D4F0B4 Napco Security Technologies
 70B921 Fiberhome Telecommunication Technologies
 A0E295 DAT System
 A0165C Triteka
-9C417C Hame  Technology,  Limited
-9C6ABE Qees ApS.
+9C417C Hame Technology, Limited
+9C6ABE QEES ApS.
 9C934E Xerox
 044665 Murata Manufacturing
 2C2172 Juniper Networks
@@ -8763,17 +9056,17 @@ E8B4AE Shenzhen C&D Electronics
 A8E018 Nokia
 781DFD Jabil
 18AEBB Siemens Convergence Creators GmbH&Co.KG
-B0BDA1 Zaklad Elektroniczny Sims
+B0BDA1 Zaklad Elektroniczny SIMS
 70B265 Hiltron s.r.l.
 CCC62B Tri-Systems
 D8C068 Netgenetech.co.
 601199 Siama Systems
 6C81FE Mitsuba
-C027B9 Beijing National Railway Research & Design Institute  of Signal & Communication
+C027B9 Beijing National Railway Research & Design Institute of Signal & Communication
 147411 RIM
-F8A9DE Puissance Plus
+F8A9DE Puissance PLUS
 A88CEE MicroMade Galka i Drozdz sp.j.
-DC2B66 InfoBLOCK S.A. de C.V.
+DC2B66 InfoBLOCK de C.V.
 B8871E Good Mind Industries
 D4F027 Trust Power
 0455CA BriView (Xiamen)
@@ -8799,10 +9092,10 @@ C8208E Storagedata
 5C5EAB Juniper Networks
 9C807D Syscable Korea
 28E297 Shanghai InfoTM Microelectronics
-34B571 Plds
+34B571 PLDS
 3C7437 RIM
 EC9233 Eddyfi NDT
-743889 Annax Anzeigesysteme Gmbh
+743889 Annax Anzeigesysteme GmbH
 44D2CA Anvia TV Oy
 386E21 Wasion Group
 2872F0 Athena
@@ -8825,7 +9118,7 @@ B08991 LGE
 A4C0E1 Nintendo
 4C3B74 Vogtec(h.k.)
 684352 Bhuu Limited
-ECE90B Sistema Solucoes Eletronicas Ltda - Easytech
+ECE90B Sistema Solucoes Eletronicas LTDA - Easytech
 A08C9B Xtreme Technologies
 A83944 Actiontec Electronics
 74E06E Ergophone GmbH
@@ -8852,7 +9145,7 @@ F02A61 Waldo Networks
 C8A70A Verizon Business
 60DA23 Estech
 44DCCB Semindia Systems PVT
-A0DE05 JSC Irbis-T
+A0DE05 JSC "Irbis-T"
 0817F4 IBM
 CCD811 Aiconn Technology
 F43814 Shanghai Howell Electronic
@@ -8881,7 +9174,7 @@ C8D5FE Shenzhen Zowee Technology
 2C3068 Pantech
 00BD27 Exar
 5C4058 Jefferson Audio Video Systems
-58D08F Ieee 1904.1 Working Group
+58D08F IEEE 1904.1 Working Group
 6C9CE9 Nimble Storage
 CC09C8 Imaqliq
 9C4563 Dimep Sistemas
@@ -8906,7 +9199,7 @@ E06290 Jinan Jovision Science & Technology
 C46354 U-Raku
 405FBE RIM
 6854F5 enLighted
-7CB542 Aces Technology
+7CB542 ACES Technology
 905446 TES Electronic Solutions
 544A05 wenglor sensoric gmbh
 98E165 Accutome
@@ -8915,7 +9208,7 @@ C46354 U-Raku
 0CD696 Amimon
 F4DC4D Beijing CCD Digital Technology
 4013D9 Global ES
-AC4FFC Svs-vistek Gmbh
+AC4FFC Svs-vistek GmbH
 B43741 Consert
 94857A Evantage Industries
 4083DE Zebra Technologies
@@ -8932,7 +9225,7 @@ F0AD4E Globalscale Technologies
 7CA29B D.SignT GmbH & KG
 A04041 Samwonfa
 6C22AB Ainsworth Game Technology
-3018CF Deos Control Systems Gmbh
+3018CF DEOS control systems GmbH
 08FAE0 Fohhn Audio AG
 58B9E1 Crystalfontz America
 20D906 Iota
@@ -8951,11 +9244,11 @@ B0E39D CAT System
 E0589E Laerdal Medical
 0C1DC2 SeAH Networks
 5475D0 Cisco Systems
-6089B7 Kael Mhendslk Elektronk Tcaret Sanay Lmted rket
+6089B7 KAEL Mühendi̇sli̇k Elektroni̇k Ti̇caret Sanayi̇ Li̇mi̇ted Şi̇rketi̇
 30525A NST
 2CA780 True Technologies
 7C6F06 Caterpillar Trimble Control Technologies
-601283 TSB Real Time Location Systems S.L.
+601283 TSB REAL TIME Location Systems S.L.
 98DCD9 Unitec
 C0CFA3 Creative Electronics & Software
 94236E Shenzhen Junlan Electronic
@@ -8983,7 +9276,7 @@ B86491 CK Telecom
 50F003 Open Stack
 DC49C9 Casco Signal
 70D880 Upos System sp. z o.o.
-A05DC1 Tmct
+A05DC1 TMCT
 583CC6 Omneality
 B0C8AD People Power Company
 181714 Daewoois
@@ -8992,11 +9285,11 @@ F0EC39 Essec
 2046F9 Advanced Network Devices (dba:AND)
 487119 SGB Group
 04FE7F Cisco Systems
-A4B1EE H. Zander Gmbh & KG
+A4B1EE H. Zander GmbH & KG
 842141 Shenzhen Ginwave Technologies
 A0231B TeleComp R&D
 B8A3E0 BenRui Technology
-3CF52C Dspecialists Gmbh
+3CF52C Dspecialists GmbH
 EC4476 Cisco Systems
 6C1811 Decatur Electronics
 F8E968 Egker Kft.
@@ -9010,28 +9303,27 @@ ACBEB6 Visualedge Technology
 AC583B Human Assembler
 E8E776 Shenzhen Kootion Technology
 681FD8 Siemens Industry
-4001C6 3com Europe
+4001C6 3COM Europe
 9C5E73 Calibre UK
 5C1437 Thyssenkrupp Aufzugswerke GmbH
-9C55B4 I.S.E. S.r.l.
-4C63EB Application Solutions (Electronics and Vision)
+9C55B4 I.s.e. S.r.l.
 702F97 Aava Mobile Oy
 10CA81 Precia
 40A6A4 PassivSystems
-94BA31 Visiontec da Amaznia Ltda.
+94BA31 Visiontec da Amazônia Ltda.
 B894D2 Retail Innovation HTT AB
 B0E97E Advanced Micro Peripherals
 F0C24C Zhejiang FeiYue Digital Technology
 E4751E Getinge Sterilization AB
 9C5B96 NMR
-60F13D Jablocom S.r.o.
+60F13D Jablocom s.r.o.
 50252B Nethra Imaging Incorporated
 F8811A Overkiz
-3863F6 3nod Multimedia(shenzhen)co.
+3863F6 3NOD Multimedia(shenzhen)co.
 78B81A Inter Sales A/S
 CC0080 Bettini SRL
-644BC3 Shanghai Woasis Telecommunications
-942E63 Finscur
+644BC3 Shanghai WOASiS Telecommunications
+942E63 Finsécur
 AC8317 Shenzhen Furtunetel Communication
 ACD180 Crexendo Business Solutions
 CCCC4E Sun Fountainhead USA.
@@ -9051,7 +9343,7 @@ D4AAFF Micro World
 0026DC Optical Systems Design
 002700 Shenzhen Siglent Technology
 0026EC Legrand Home Systems
-0026D4 Irca SpA
+0026D4 IRCA SpA
 002663 Shenzhen Huitaiwei Tech.
 002661 Irumtek
 00265B Hitron Technologies.
@@ -9077,7 +9369,7 @@ D4AAFF Micro World
 0026A1 Megger
 002644 Thomson Telecom Belgium
 002646 Shenyang Tongfang Multimedia Technology Company Limited
-00263F Lios Technology Gmbh
+00263F LIOS Technology GmbH
 00263B Onbnetech
 002658 T-Platforms (Cyprus) Limited
 00264C Shanghai DigiVision Technology
@@ -9085,7 +9377,7 @@ D4AAFF Micro World
 002631 Commtact
 0025FB Tunstall Healthcare A/S
 0025F4 KoCo Connector AG
-002606 Raumfeld Gmbh
+002606 Raumfeld GmbH
 002607 Enabling Technology
 002624 Thomson
 002605 CC Systems AB
@@ -9104,13 +9396,12 @@ D4AAFF Micro World
 0025C2 RingBell
 0025A7 itron
 0025A9 Shanghai Embedway Information Technologies
-0025CA LS Research
 0025B4 Cisco Systems
-0025B2 Mbda Deutschland Gmbh
-0025EF I-TEC
+0025B2 MBDA Deutschland GmbH
+0025EF I-tec
 002528 Daido Signal
 002526 Genuine Technologies
-00256B Atenix E.E. S.r.l.
+00256B Atenix E.E. s.r.l.
 00256E Van Breda
 002565 Vizimax
 00255E Shanghai Dare Technologies
@@ -9120,16 +9411,15 @@ D4AAFF Micro World
 002584 Cisco Systems
 002579 J & F Labs
 00257F CallTechSolution
-002577 D-BOX Technologies
+002577 D-box Technologies
 002572 Nemo-Q International AB
-002529 Comelit Group S.P.A
+002529 Comelit Group
 00252A Chengdu GeeYa Technology
 00258A Pole/Zero
 00255F SenTec AG
 0024EC United Information Technology
 0024E6 In Motion Technology
 0024E7 Plaster Networks
-0024E4 Withings
 0024DE Global Technology
 0024DC Juniper Networks
 0024DB Alcohol Monitoring Systems
@@ -9149,7 +9439,7 @@ D4AAFF Micro World
 00249E ADC-Elektronik GmbH
 00249F RIM Testing Services
 0024C2 Asumo
-0024BF Ciat
+0024BF CIAT
 0024C0 NTI Comodo
 0024BB Central
 0024BC HuRob
@@ -9199,23 +9489,23 @@ D4AAFF Micro World
 00236F DAQ System
 002330 Dizipia
 002369 Cisco-Linksys
-0022F8 Pima Electronic Systems
+0022F8 PIMA Electronic Systems
 00231C Fourier Systems
 00231D Deltacom Electronics
 0022D7 Nintendo
 0022D6 Cypak AB
 0022D0 Polar Electro Oy
-00230A Arburg Gmbh & KG
+00230A Arburg GmbH & KG
 0022C3 Zeeport Technology
 002316 Kisan Electronics
 00230F Hirsch Electronics
 00232D SandForce
 002323 Zylin AS
-0022DE Oppo Digital
+0022DE OPPO Digital
 0022F1 Private
 0022A2 Xtramus Technologies
 00229E Social Aid Research
-002285 Nomus Comm Systems
+002285 Nomus COMM Systems
 002281 Daintree Networks
 002255 Cisco Systems
 00224E SEEnergy
@@ -9234,11 +9524,11 @@ D4AAFF Micro World
 002232 Design Design Technology
 00222B Nucomm
 002226 Avaak
-002221 Itoh Denki
+002221 ITOH Denki
 00221D Freegene Technology
 002224 Good Will Instrument
 002245 Leine & Linde AB
-002249 Home Multienergy SL
+002249 HOME Multienergy SL
 002240 Universal Telecom S/A
 00220F MoCA (Multimedia over Coax Alliance)
 00220A OnLive
@@ -9252,7 +9542,7 @@ D4AAFF Micro World
 0021AC Infrared Integrated Systems
 00218E Mekics
 00218F Avantgarde Acoustic Lautsprechersysteme GmbH
-00217E Telit Communication s.p.a
+00217E Telit Communication
 002187 Imacs GmbH
 002181 Si2 Microsystems Limited
 0021C2 GL Communications
@@ -9268,7 +9558,7 @@ D4AAFF Micro World
 002165 Presstek
 00211F Shinsung Deltatech
 002124 Optos Plc
-002133 Building B
+002133 Building
 002134 Brandywine Communications
 00213A Winchester Systems
 00212E dresden-elektronik
@@ -9278,7 +9568,7 @@ D4AAFF Micro World
 002142 Advanced Control Systems doo
 001FFA Coretree,
 001FF2 VIA Technologies
-002101 Aplicaciones Electronicas Quasar (AEQ)
+002101 Aplicaciones Electronicas Quasar (aeq)
 002103 GHI Electronics
 001FF8 Siemens AG, Sector Industry, Drive Technologies, Motion Control Systems
 001FD0 Giga-byte Technology
@@ -9297,7 +9587,7 @@ D4AAFF Micro World
 001F98 Daiichi-dentsu
 001F93 Xiotech
 001F51 HD Communications
-001F53 Gemac Chemnitz Gmbh
+001F53 Gemac Chemnitz GmbH
 001F50 Swissdis AG
 001F4C Roseman Engineering
 001FA9 Atlanta DTH
@@ -9312,7 +9602,7 @@ D4AAFF Micro World
 001F1D Atlas Material Testing Technology
 001F15 Bioscrypt
 001F2B Orange Logic
-001F2A Accm
+001F2A ACCM
 001F30 Travelping
 001F48 Mojix
 001F3E RP-Technik e.K.
@@ -9341,7 +9631,7 @@ D4AAFF Micro World
 001ECF Philips Electronics UK
 001E22 Arvoo Imaging Products BV
 001E1A Best Source Taiwan
-001E19 Gtri
+001E19 GTRI
 001E14 Cisco Systems
 001E44 Santec
 001E62 Siemon
@@ -9349,25 +9639,25 @@ D4AAFF Micro World
 001E5D Holosys d.o.o.
 001E78 Owitek Technology,
 001E7A Cisco Systems
-001E27 SBN Tech
+001E27 SBN TECH
 001E60 Digital Lighting Systems
 001E6C Opaque Systems
 001E2F DiMoto
-001E36 Ipte
+001E36 IPTE
 001DA7 Seamless Internet
 001DA5 WB Electronics
 001DA8 Takahata Electronics
 001DA9 Castles Technology,
-001DCB Exns Development Oy
+001DCB Exéns Development Oy
 001DCA PAV Electronics Limited
 001DC2 Xortec OY
-001E0E Maxi View Holdings Limited
+001E0E MAXI VIEW Holdings Limited
 001E0F Briot International
 001DE3 Intuicom
 001DDE Zhejiang Broadcast&Television Technology
 001DE5 Cisco Systems
 001DEC Marusys
-001DE8 Nikko Denki Tsushin(ndtc)
+001DE8 Nikko Denki Tsushin(NDTC)
 001DDA Mikroelektronika spol. s r. o.
 001DB0 FuJian HengTong Information Technology
 001DB8 Intoto
@@ -9415,11 +9705,11 @@ D4AAFF Micro World
 001CA7 International Quartz Limited
 001CAB Meyer Sound Laboratories
 001C9E Dualtech IT AB
-001CC8 Industronic Industrie-electronic Gmbh & KG
+001CC8 Industronic Industrie-Electronic GmbH & KG
 001CC6 ProStor Systems
 001CBE Nintendo
-001C94 LI-COR Biosciences
-001C8C Dial Technology
+001C94 Li-cor Biosciences
+001C8C DIAL Technology
 001CCA Shanghai Gaozhi Science & Technology Development
 001CC9 Kaise Electronic Technology
 001C93 ExaDigm
@@ -9430,7 +9720,7 @@ D4AAFF Micro World
 001C0A Shenzhen AEE Technology
 001C0D G-Technology
 001C03 Betty TV Technology AG
-001C46 Qtum
+001C46 QTUM
 001C42 Parallels
 001C3E ECKey
 001C51 Celeno Communications
@@ -9470,7 +9760,7 @@ D4AAFF Micro World
 001B7E Beckmann GmbH
 001B7A Nintendo
 001B34 Focus System
-001B3A Sims
+001B3A SIMS
 001B5F Alien Technology
 001B61 Digital Acoustics
 001B5E BPL Limited
@@ -9485,14 +9775,14 @@ D4AAFF Micro World
 001B4D Areca Technology
 001AE3 Cisco Systems
 001ADF Interactivetv Limited
-001AE1 Edge Access
+001AE1 EDGE Access
 001AE8 Unify Software and Solutions GmbH & KG
 001AE9 Nintendo
 001AE5 Mvox Technologies
 001AE4 Medicis Technologies
 001AF8 Copley Controls
 001AF5 Pentaone.
-001AED Incotec Gmbh
+001AED Incotec GmbH
 001AEE Shenztech
 001ACE Yupiteru
 001ACC Celestial Semiconductor
@@ -9508,11 +9798,11 @@ D4AAFF Micro World
 001AB7 Ethos Networks
 001AB2 Cyber Solutions
 001A97 fitivision technology
-001A90 Trpico Sistemas e Telecomunicaes da Amaznia LTDA.
+001A90 Trópico Sistemas e Telecomunicações da Amazônia Ltda.
 001A94 Votronic GmbH
 001AC7 Unipoint
 001AC0 Joybien Technologies
-001A9E Icon Digital International Limited
+001A9E ICON Digital International Limited
 001A98 Asotel Communication Limited Taiwan Branch
 001A72 Mosart Semiconductor
 001A68 Weltec Enterprise
@@ -9521,13 +9811,12 @@ D4AAFF Micro World
 001AA2 Cisco Systems
 001A9C RightHand Technologies
 001A7E LN Srithai Comm
-001A5A Korea Electric Power Data Network  (KDN)
+001A5A Korea Electric Power Data Network (kdn)
 001A5F KitWorks.fi
-001A35 Bartec Gmbh
 001A37 Lear
 001A38 Sanmina-SCI
 001A2B Ayecom Technology
-001A28 Aswt, Taiwan Branch H.K.
+001A28 ASWT, Taiwan Branch H.K.
 001A2C Satec
 001A27 Ubistar
 001A21 Brookhuis Applied Technologies BV
@@ -9536,7 +9825,7 @@ D4AAFF Micro World
 001A5D Mobinnova
 001A4D Giga-byte Technology
 001A48 Takacom
-001A0B Bona Technology
+001A0B BONA Technology
 001A06 OpVista
 001A2E Ziova Coporation
 001A32 Activa Multimedia
@@ -9552,7 +9841,7 @@ D4AAFF Micro World
 0019C4 Infocrypt
 0019BC Electro Chance SRL
 00199B Diversified Technical Systems
-001990 ELM Data
+001990 ELM DATA
 00198F Nokia Bell N.V.
 0019D8 Maxfor
 0019D5 IP Innovations
@@ -9576,9 +9865,9 @@ D4AAFF Micro World
 001981 Vivox
 001945 RF COncepts
 00191F Microlink communications
-001920 Kume Electric
+001920 KUME electric
 001926 BitsGen
-001929 2m2b Montadora de Maquinas Bahia Brasil Ltda
+001929 2M2B Montadora de Maquinas Bahia Brasil LTDA
 0018F1 Chunichi Denshi
 0018F2 Beijing Tianyu Communication Equipment
 0018EC Welding Technology
@@ -9601,7 +9890,7 @@ D4AAFF Micro World
 001891 Zhongshan General K-mate Electronics
 0018AD Nidec Sankyo
 0018AC Shanghai Jiao Da Hisys Technology
-0018AB Beijing Lhwt Microelectronics
+0018AB Beijing LHWT Microelectronics
 0018A5 ADigit Technologies
 001878 Mackware GmbH
 00186A Global Link Digital Technology
@@ -9622,7 +9911,7 @@ D4AAFF Micro World
 0017ED WooJooIT
 001843 Dawevision
 00182C Ascend Networks
-00181D Asia Electronics
+00181D ASIA Electronics
 00181F Palmmicro Communications
 00181B TaiJin Metal
 001805 Beijing InHand Networking Technology
@@ -9722,12 +10011,12 @@ D4AAFF Micro World
 0015AD Accedian Networks
 0015AC Capelon AB
 0015A9 Kwang WOO I&C
-00E0A8 SAT GmbH &
+00E0A8 SAT GmbH
 001574 Horizon Semiconductors
 00158A Surecom Technology
 00158E Plustek.INC
-001589 D-MAX Technology
-0015B4 Polymap  Wireless
+001589 D-max Technology
+0015B4 Polymap Wireless
 0015CA TeraRecon
 001598 Kolektor group
 001512 Zurich University of Applied Sciences
@@ -9736,7 +10025,7 @@ D4AAFF Micro World
 00156E A. W. Communication Systems
 001568 Dilithium Networks
 00154B Wonde Proud Technology
-001548 Cube Technologies
+001548 CUBE Technologies
 00155F GreenPeak Technologies
 00155A Dainippon Pharmaceutical
 00151D M2I
@@ -9747,7 +10036,7 @@ D4AAFF Micro World
 0014A1 Synchronous Communication
 00149E UbONE
 0014A2 Core Micro Systems
-0014AD Gassner Wiege- und Metechnik GmbH
+0014AD Gassner Wiege- und Meßtechnik GmbH
 0014AF Datasym POS
 0014A9 Cisco Systems
 0014FF Precise Automation
@@ -9788,13 +10077,13 @@ D4AAFF Micro World
 0013F0 Wavefront Semiconductor
 0013EF Kingjon Digital Technology
 0013EB Sysmaster
-0013EC Netsnapper Technologies Sarl
+0013EC Netsnapper Technologies SARL
 00142B Edata Communication
 00142C Koncept International
 001424 Merry Electrics
 0013D0 t+ Medical
-0013D2 Page Iberica
-0013D1 Kirk Telecom A/S
+0013D2 PAGE Iberica
+0013D1 KIRK telecom A/S
 00140F Federal State Unitary Enterprise Leningrad R&D Institute of
 001407 Sperian Protection Instrumentation
 001406 Go Networks
@@ -9813,15 +10102,14 @@ D4AAFF Micro World
 00135B PanelLink Cinema
 00136F PacketMotion
 001368 Saab Danmark A/S
-0013B4 Appear TV
 0013AE Radiance Technologies
 001397 Oracle
 0013C3 Cisco Systems
 0013BD Hymatom SA
-001391 Ouen
+001391 OUEN
 001323 Cap
 001314 Asiamajor
-001316 L-S-B Broadcast Technologies GmbH
+001316 L-s-b Broadcast Technologies GmbH
 001312 Amedia Networks
 001336 Tianjin 712 Communication Broadcasting
 00135E Eab/rwi/k
@@ -9836,11 +10124,11 @@ D4AAFF Micro World
 0012D8 International Games System
 00129A IRT Electronics
 00128D STB Datenservice GmbH
-0012DB Ziehl Industrie-elektronik Gmbh + KG
+0012DB Ziehl industrie-elektronik GmbH + KG
 0012D6 Jiangsu Yitong High-Tech
 0012DA Cisco Systems
 0012D3 Zetta Systems
-0012A2 Vita
+0012A2 VITA
 0012A5 Dolphin Interconnect Solutions AS
 0012A8 intec GmbH
 00129E Surf Communications
@@ -9868,11 +10156,11 @@ D4AAFF Micro World
 001292 Griffin Technology
 0011F3 NeoMedia Europe AG
 0011E9 Starnex
-0011EC Avix
+0011EC AVIX
 0011E7 Worldsat - Texas de France
 001202 Decrane Aerospace - Audio International
 0011FE Keiyo System Research
-0011FD Korg
+0011FD KORG
 0011FA Rane
 0011CE Ubisense Limited
 0011D0 Tandberg Data ASA
@@ -9902,7 +10190,7 @@ D4AAFF Micro World
 001170 GSC SRL
 00116B Digital Data Communications Asia
 001169 EMS Satcom
-001162 Star Micronics
+001162 STAR Micronics
 001181 InterEnergyLtd,
 001194 Chi Mei Communication Systems
 0011BF Aesys
@@ -9919,7 +10207,7 @@ D4AAFF Micro World
 00112E Ceicom
 001122 Cimsys
 001117 Cesnet
-001116 Coteau Vert
+001116 Coteau VERT
 001110 Maxanna Technology
 00113B Micronet Communications
 00113D KN Soltec
@@ -9927,13 +10215,13 @@ D4AAFF Micro World
 001135 Grandeye
 001121 Cisco Systems
 001149 Proliphix
-000FC0 Delcomp
+000FC0 DELCOMp
 000FBA Tevebox AB
 000FB8 CallURL
 000FB7 Cavium
 000FD3 Digium
 000FD1 Applied Wireless Identifications Group
-000FC1 Wave
+000FC1 WAVE
 001100 Schneider Electric
 000FFA Optinel Systems
 000FFD Glorytek Network
@@ -9947,8 +10235,8 @@ D4AAFF Micro World
 000FEA Giga-Byte Technology
 000FF7 Cisco Systems
 000FD8 Force
-000F8D Fast Tv-server AG
-000F85 Addo-japan
+000F8D FAST TV-Server AG
+000F85 ADDO-Japan
 000F82 Mortara Instrument
 000F49 Northover Solutions Limited
 000F4B Oracle
@@ -9956,7 +10244,7 @@ D4AAFF Micro World
 000F4A Kyushu-kyohan
 000F81 PAL Pacific
 000F7F Ubstorage
-000F95 Elecom,ltd Laneed Division
+000F95 Elecom,LTD Laneed Division
 000F55 Datawire Communication Networks
 000F56 Continuum Photonics
 000F60 Lifetron
@@ -9986,9 +10274,9 @@ D4AAFF Micro World
 000EF0 Festo AG & KG
 000EE9 WayTech Development
 000F40 Optical Internetworking Forum
-000F33 Duali
+000F33 DUALi
 000F05 3B System
-000EC9 Yoko Technology
+000EC9 YOKO Technology
 000EBD Burdick, a Quinton Compny
 000EB9 Hashimoto Electronics Industry
 000EB2 Micro-Research Finland Oy
@@ -10004,10 +10292,10 @@ D4AAFF Micro World
 000E95 Fujiya Denki Seisakusho
 000E97 Ultracker Technology
 000EA7 Endace Technology
-000E6F Iris Berhad
+000E6F IRIS Berhad
 000EB5 Ecastle Electronics
 000E50 Thomson Telecom Belgium
-000E4B atrium c and i
+000E4B atrium c and
 000E2B Safari Technologies
 000E28 Dynamic Ratings P/L
 000E24 Huwell Technology
@@ -10020,7 +10308,7 @@ D4AAFF Micro World
 000E36 Heinesys
 000E17 Private
 000E15 Tadlys
-000E01 Asip Technologies
+000E01 ASIP Technologies
 000DCB Petcomkorea
 000DCC Neosmart
 000DCE Dynavac Technology Pte
@@ -10044,7 +10332,7 @@ D4AAFF Micro World
 000D55 Sanycom Technology
 000D57 Fujitsu I-Network Systems Limited.
 000D58 Private
-000D51 Divr Systems
+000D51 DIVR Systems
 000D39 Network Electronics
 000D35 PAC International
 000D95 Opti-cell
@@ -10055,21 +10343,21 @@ D4AAFF Micro World
 000DA1 Mirae ITS
 000D80 Online Development
 000D13 Wilhelm Rutenbeck GmbH&Co.KG
-000D19 Robe Show Lighting
+000D19 ROBE Show lighting
 000D1C Amesys Defense
 000CED Real Digital Media
 000CF0 M & N GmbH
 000CF4 Akatsuki Electric Mfg.co.
-000CF3 Call Image SA
+000CF3 CALL Image SA
 000CCF Cisco Systems
-000CD8 M. K. Juchheim GmbH &
+000CD8 M. K. Juchheim GmbH
 000CC6 Ka-Ro electronics GmbH
 000D01 P&E Microcomputer Systems
 000D00 Seaway Networks
 000CF9 Xylem Water Solutions
 000CC4 Tiptel AG
 000CBA Jamex
-000CD1 Sfom Technology
+000CD1 SFOM Technology
 000CCE Cisco Systems
 000CE0 Trek Diagnostics
 000CE2 Rolls-Royce
@@ -10105,7 +10393,7 @@ D4AAFF Micro World
 000C3A Oxance
 000C35 KaVo Dental GmbH & KG
 000C56 Megatel Computer (1986)
-000C57 Mackie Engineering Services Belgium Bvba
+000C57 Mackie Engineering Services Belgium BVBA
 000C23 Beijing Lanchuan Tech.
 000C25 Allied Telesis Labs
 000C18 Zenisu Keisoku
@@ -10114,21 +10402,21 @@ D4AAFF Micro World
 000C4A Cygnus Microsystems (P) Limited
 000C54 Pedestal Networks
 000C37 Geomation
-000BE8 Aoip
-000BDC Akcp
+000BE8 AOIP
+000BDC AKCP
 000BD8 Industrial Scientific
-000BD7 Dorma Time + Access Gmbh
+000BD7 Dorma Time + Access GmbH
 000BDD Tohoku Ricoh
-000BE5 Hims International
+000BE5 HIMS International
 000BE9 Actel
 000BE3 Key Stream
 000BD3 cd3o
 000BD5 Nvergence
 000BD1 Aeronix
 000BD2 Remopro Technology
-000BC7 Icet
+000BC7 ICET
 000BB8 Kihoku Electronic
-000BC0 China Iwncomm
+000BC0 China IWNComm
 000BB0 Sysnet Telematica srl
 000BB4 RDC Semiconductor,
 000BCC Jusan
@@ -10136,7 +10424,7 @@ D4AAFF Micro World
 000BF9 Gemstone Communications
 000BFC Cisco Systems
 000BEA Zultys Technologies
-000B9F Neue Elsa Gmbh
+000B9F Neue ELSA GmbH
 000B98 NiceTechVision
 000B95 eBet Gaming Systems
 000B9E Yasing Technology
@@ -10144,8 +10432,8 @@ D4AAFF Micro World
 000B54 BiTMICRO Networks
 000B8C Flextronics
 000B8A Miteq
-000B90 Adva Optical Networking
-000B79 X-COM
+000B90 ADVA Optical Networking
+000B79 X-com
 000B4B Visiowave SA
 000B36 Productivity Systems
 000B35 Quad Bit System
@@ -10194,7 +10482,7 @@ D4AAFF Micro World
 000AC4 Daewoo Teletech
 000AC0 Fuyoh Video Industry
 000AAE Rosemount Process Analytical
-000AB3 Fa. Gira
+000AB3 Fa. GIRA
 000ABA Arcon Technology Limited
 000AB6 Compunetix
 000AAF Pipal Systems
@@ -10213,7 +10501,7 @@ D4AAFF Micro World
 000A2C Active Tchnology
 000A2A QSI Systems
 000A23 Parama Networks
-000A1F ART Ware Telecommunication
+000A1F ART WARE Telecommunication
 000A0A Sunix
 000A05 Widax
 000A34 Identicard Systems Incorporated
@@ -10238,13 +10526,13 @@ D4AAFF Micro World
 0009F5 Emerson Network Power
 0009EA YEM
 0009C5 Kingene Technology
-0009CD Hudson Soft
+0009CD Hudson SOFT
 0009C0 6wind
 0009BF Nintendo
 0009E3 Angel Iglesias
 0009B4 Kisan Telecom
 0009AE Okano Electric
-0009BA Maku Informationstechik Gmbh
+0009BA MAKU Informationstechik GmbH
 000A04 3Com
 000971 Time Management
 000974 Innopia Technologies
@@ -10260,9 +10548,9 @@ D4AAFF Micro World
 000996 RDI
 00090C Mayekawa Mfg.
 00090D Leader Electronics
-0008FE Unik C&C
+0008FE UNIK C&C
 0008FF Trilogy Communications
-000904 Mondial Electronic
+000904 Mondial electronic
 00091F A&D
 000924 Telebau GmbH
 000921 Planmeca Oy
@@ -10318,7 +10606,7 @@ D4AAFF Micro World
 00047E Siqura
 0007BC Identix
 0007A9 Novasonics
-0007A1 Viasys Healthcare Gmbh
+0007A1 Viasys Healthcare GmbH
 00079E Ilinx
 0007A0 e-Watch
 000788 Clipcomm
@@ -10334,7 +10622,7 @@ D4AAFF Micro World
 000717 Wieland Electric GmbH
 000711 Acterna
 000702 Varex Imaging
-000705 Endress & Hauser GmbH &
+000705 Endress & Hauser GmbH
 0006FF Sheba Systems
 000741 Sierra Automated Systems
 000745 Radlan Computer Communications
@@ -10353,7 +10641,7 @@ D4AAFF Micro World
 00070A Unicom Automation
 000709 Westerstrand Urfabrik AB
 0006EB Global Data
-0006D3 Alpha Telecom, U.S.A.
+0006D3 Alpha Telecom, U.s.a.
 000647 Etrali
 0006A4 Innowell
 0006D6 Cisco Systems
@@ -10368,7 +10656,7 @@ D4AAFF Micro World
 0006AC Intersoft
 000694 Mobillian
 0006C7 Rfnet Technologies Pte (S)
-0006B9 A5TEK
+0006B9 A5tek
 0006B3 Diagraph
 0006E3 Quantitative Imaging
 0006E4 Citel Technologies
@@ -10378,7 +10666,7 @@ D4AAFF Micro World
 000665 Sunny Giken
 000669 Datasound Laboratories
 00066E Delta Electronics
-00061B Notebook Development Lab.  Lenovo Japan
+00061B Notebook Development Lab. Lenovo Japan
 00060F Narad Networks
 000610 Abeona Networks
 000611 Zeus Wireless
@@ -10387,7 +10675,7 @@ D4AAFF Micro World
 00065A Strix Systems
 000652 Cisco Systems
 000656 Tactel AB
-000641 Itcn
+000641 ITCN
 000648 Seedsware
 00064C Invicta Networks
 000674 Spectrum Control
@@ -10406,7 +10694,7 @@ D4AAFF Micro World
 0005CA Hitron Technology
 0005D2 DAP Technologies
 0005B1 ASB Technology BV
-000599 DRS Test and Energy Management or DRS-TEM
+000599 DRS Test and Energy Management or Drs-tem
 00059A Cisco Systems
 0005AB Cyber Fone
 000592 Pultek
@@ -10450,7 +10738,7 @@ D4AAFF Micro World
 0004DD Cisco Systems
 008086 Computer Generation
 000504 Naray Information & Communication Enterprise
-000509 Avoc Nishimura
+000509 AVOC Nishimura
 0004FB Commtech
 0004C0 Cisco Systems
 0004BA KDD Media Will
@@ -10468,7 +10756,7 @@ D4AAFF Micro World
 000491 Technovision
 000493 Tsinghua Unisplendour
 000494 Breezecom
-000489 Yafo Networks
+000489 YAFO Networks
 00048A Temia Vertriebs GmbH
 000481 Econolite Control Products
 00046C Cyber Technology
@@ -10484,7 +10772,7 @@ D4AAFF Micro World
 000477 Scalant Systems
 000473 Photonex
 000470 ipUnplugged AB
-00045D Beka Elektronik
+00045D BEKA Elektronik
 000459 Veristar
 0004A4 NetEnabled
 000416 Parks S/A Comunicacoes Digitais
@@ -10515,7 +10803,7 @@ D4AAFF Micro World
 000396 EZ Cast
 00039A SiConnect
 000363 Miraesys
-00035F Prftechnik Condition Monitoring GmbH & KG
+00035F Prüftechnik Condition Monitoring GmbH & KG
 000360 PAC Interactive Technology
 000361 Widcomm
 000394 Connect One
@@ -10528,7 +10816,7 @@ D4AAFF Micro World
 000378 Humax
 000374 Control Microsystems
 000376 Graphtec Technology
-00037E Portech Communications
+00037E PORTech Communications
 00036D Runtop
 00036E Nicon Systems (Pty) Limited
 000371 Acomz Networks
@@ -10583,15 +10871,15 @@ D4AAFF Micro World
 0002A7 Vivace Networks
 0001B2 Digital Processing Systems
 0001B8 Netsensity
-0001B9 SKF (U.K.) Limited
+0001B9 SKF (u.k.) Limited
 0001B3 Precision Electronic Manufacturing
 0001BD Peterson Electro-Musical Products
 000209 Shenzhen SED Information Technology
 000202 Amino Communications
 000201 IFM Electronic gmbh
 000234 Imperial Technology
-000236 Init Gmbh
-00022B SAXA
+000236 INIT GmbH
+00022B Saxa
 000224 C-cor
 00021F Aculab PLC
 00021A Zuma Networks
@@ -10600,7 +10888,7 @@ D4AAFF Micro World
 000222 Chromisys
 000213 S.d.e.l.
 0001DB Freecom Technologies GmbH
-0001DF Isdn Communications
+0001DF ISDN Communications
 0001EF Camtel Technology
 00020A Gefran Spa
 000206 Telital R&D Denmark A/S
@@ -10609,7 +10897,7 @@ D4AAFF Micro World
 00014E WIN Enterprises
 003073 International Microsystems
 00303F TurboComm Tech
-000184 Sieb & Meyer AG
+000184 SIEB & Meyer AG
 000195 Sena Technologies
 0001A4 Microlink
 00018E Logitec
@@ -10635,7 +10923,7 @@ D4AAFF Micro World
 00B0AE Symmetricom
 00B0E7 British Federal
 00B08E Cisco Systems
-00305C Smar Laboratories
+00305C SMAR Laboratories
 003004 Leadtek Research
 0030F9 Sollae Systems
 000118 EZ Digital
@@ -10673,7 +10961,7 @@ D4AAFF Micro World
 0030B4 Intersil
 0030B1 TrunkNet
 003060 Powerfile
-0030A0 Tyco Submarine Systems
+0030A0 TYCO Submarine Systems
 003015 CP Clare
 00301F Optical Networks
 0030FA Telica
@@ -10684,8 +10972,8 @@ D4AAFF Micro World
 003043 Idream Technologies, PTE.
 003000 Allwell Technology
 003011 HMS Industrial Networks
-003068 Cybernetics TECH.
-003091 Taiwan First Line ELEC.
+003068 Cybernetics Tech.
+003091 Taiwan First LINE Elec.
 0030CD Conexant Systems
 00301A Smartbridges PTE.
 003029 Opicom
@@ -10703,15 +10991,15 @@ D4AAFF Micro World
 00305B Toko
 00D049 Impresstek
 00D05B Acroloop Motion Control
-00D042 Mahlo Gmbh & UG
+00D042 Mahlo GMBH & UG
 00D031 Industrial Logic
 00D038 Fivemere
 00D0C6 Thomas & Betts
 00D077 Lucent Technologies
 00D03E Rocketchips
-00D093 TQ - Components Gmbh
+00D093 TQ - Components GMBH
 00D03F American Communication
-00D0F7 Next Nets
+00D0F7 NEXT NETS
 00D06F KMC Controls
 00D0FC Granite Microsystems
 00D0A6 Lanbird Technology
@@ -10719,8 +11007,8 @@ D4AAFF Micro World
 00D0D2 Epilog
 00D0F9 Acute Communications
 00D0CE iSystem Labs
-00D018 QWES. COM
-0001A7 Unex Technology
+00D018 Qwes. COM
+0001A7 UNEX Technology
 00D08C Genoa Technology
 00D059 Ambit Microsystems
 00D0FD Optima Tele.com
@@ -10738,9 +11026,9 @@ D4AAFF Micro World
 00D06A Linkup Systems
 00D089 Dynacolor
 00D02C Campbell Scientific
-00D0CD Atan Technology
+00D0CD ATAN Technology
 00D040 Sysmate
-00D01A Urmet  TLC
+00D01A Urmet TLC
 0050FF Hakko Electronics
 0050D2 CMC Electronics
 0050F9 Sensormatic Electronics
@@ -10758,25 +11046,25 @@ D4AAFF Micro World
 00502B Genrad
 00502E Cambex
 00506E Corder Engineering
-00502C Soyo Computer
+00502C SOYO Computer
 005077 Prolific Technology
 005033 Mayan Networks
 00500E Chromatis Networks
-00D0CC Technologies Lyre
+00D0CC Technologies LYRE
 0050EC Olicom A/S
 0050C9 Maspro Denkoh
 0050BB CMS Technologies
-005062 Kouwell Electronics  **
+005062 Kouwell Electronics **
 0050D5 AD Systems
 0050F3 Global NET Information
-0050BE Fast Multimedia AG
+0050BE FAST Multimedia AG
 00506F G-connect
 0050F8 Entrega Technologies
 005042 SCI Manufacturing Singapore PTE
 0050C0 Gatan
 005051 Iwatsu Electric
 00507D IFP
-005097 Mmc-embedded Computertechnik Gmbh
+005097 Mmc-embedded Computertechnik GmbH
 005010 NovaNET Learning
 00509A TAG Electronic Systems
 005022 Zonet Technology
@@ -10802,42 +11090,42 @@ D4AAFF Micro World
 009094 Osprey Technologies
 0090B3 Agranat Systems
 00903C Atlantic Network Systems
-00905D Netcom Sicherheitstechnik Gmbh
+00905D Netcom Sicherheitstechnik GMBH
 0090D1 Leichu Enterprise
 009046 Dexdyne
 0090DA Dynarc
 0090E0 Systran
 0090D0 Thomson Telecom Belgium
 00909B Markem-imaje
-009022 Ivex
+009022 IVEX
 009016 ZAC
 0090A7 Clientec
 009053 Daewoo Electronics
-0090DC Teco Information Systems
+0090DC TECO Information Systems
 0090E2 Distributed Processing Technology
 009085 Golden Enterprises
-0090C7 Icom
+0090C7 ICOM
 009035 Alpha Telecom
 00900F Kawasaki Heavy Industries
 0090EA Alpha Technologies
 009077 Advanced Fibre Communications
 009099 Allied Telesis
 0010AD Softronics USB
-0010A7 Unex Technology
+0010A7 UNEX Technology
 0010D5 Imasde Canarias
 001055 Fujitsu Microelectronics
 00907A Spectralink
 0090F0 Harmonic Video Systems
 009020 Philips Analytical X-ray
 0010A3 Omnitronix
-00905C Edmi
-0090E3 Avex Electronics
+00905C EDMI
+0090E3 AVEX Electronics
 0090A9 Western Digital
 0090F3 Aspect Communications
 00904F ABB Power T&D Company
 009060 System Create
 009013 Samsan
-001052 Mettler-toledo (albstadt) Gmbh
+001052 Mettler-toledo (albstadt) GMBH
 00106B Sonus Networks
 0010C3 Csi-control Systems
 009055 Parker Hannifin Compumotor Division
@@ -10855,7 +11143,7 @@ D4AAFF Micro World
 00101B Cornet Technology
 0010DC Micro-star International
 00100A Williams Communications Group
-001032 Alta Technology
+001032 ALTA Technology
 001080 Metawave Communications
 0010F4 Vertical Communications
 001077 SAF Drive Systems
@@ -10869,12 +11157,12 @@ D4AAFF Micro World
 00E086 Emerson Network Power, Avocent Division
 00E01B Sphere Communications
 00E059 Controlled Environments
-00E0C5 Bcom Electronics
+00E0C5 BCOM Electronics
 00E0EE Marel HF
 00E08E Utstarcom
 00E03F Jaton
 00E0D4 Excellent Computer
-00E07F Logististem S.r.l.
+00E07F Logististem s.r.l.
 00E013 Eastern Electronic
 00E0FD A-trend Technology
 00E0BD Interface Systems
@@ -10885,9 +11173,9 @@ D4AAFF Micro World
 00E0C9 AutomatedLogic
 00E038 Proxima
 00E09C MII
-00E0E9 Data LABS
+00E0E9 DATA Labs
 00E00C Motorola
-00E00A DIBA
+00E00A Diba
 00E0C4 Horner Electric
 00E069 Jaycor
 00E0A4 Esaote
@@ -10895,13 +11183,13 @@ D4AAFF Micro World
 00E0A5 ComCore Semiconductor
 00E015 Heiwa
 00E0E8 Gretacoder Data Systems AG
-00E016 Rapid City Communications
+00E016 Rapid CITY Communications
 00E005 Technical
 00E0C1 Memorex Telex Japan
 00E0A9 Funai Electric
 00E084 Compulite R&D
 00E096 Shimadzu
-00E017 Exxact Gmbh
+00E017 Exxact GmbH
 00607F Aurora Technologies
 00E029 Standard Microsystems
 006074 QSC
@@ -10910,32 +11198,32 @@ D4AAFF Micro World
 006027 Superior Modular Products
 0060BC KeunYoung Electronics & Communication
 0060A5 Performance Telecom
-006005 Feedback Data
+006005 Feedback DATA
 00602E Cyclades
-0060B6 Land Computer
+0060B6 LAND Computer
 00606C Arescom
 0060E3 Arbin Instruments
 006071 Midas LAB
 006061 Whistle Communications
-00601B Mesa Electronics
+00601B MESA Electronics
 0060C5 Ancot
 0060A9 Gesytec MBH
 0060F2 Lasergraphics
 0060C3 Netvision
-006029 Cary Peripherals
+006029 CARY Peripherals
 0060A8 Tidomat AB
 0060FC Conservation Through Innovation
 006018 Stellar ONE
-00600A Sord Computer
+00600A SORD Computer
 0060A4 GEW Technologies (PTY)Ltd
 006064 Netcomm Limited
-0060F9 Diamond Lane Communications
+0060F9 Diamond LANE Communications
 0060EA StreamLogic
 006082 Novalink Technologies
 0060E7 Randata
 0060D9 Transys Networks
 00601F Stallion Technologies
-006054 Controlware Gmbh
+006054 Controlware GMBH
 0060C2 MPL AG
 0060D4 Eldat Communication
 00A04E Voelker Technologies
@@ -10959,7 +11247,7 @@ D4AAFF Micro World
 00A020 Citicorp/tti
 00A0CE Ecessa
 00A028 Conner Peripherals
-00A09E Ictv
+00A09E ICTV
 00A099 K-net
 00A0EC Transmitton
 00A067 Network Services Group
@@ -10969,9 +11257,9 @@ D4AAFF Micro World
 00A002 Leeds & Northrup Australia
 00A0E4 Optiquest
 00A0EE Nashoba Networks
-00A0C3 Unicomputer Gmbh
+00A0C3 Unicomputer GMBH
 00A00A Airspan
-00A0E7 Central Data
+00A0E7 Central DATA
 00A080 Tattile SRL
 00A02B Transitions Research
 00A0E8 Reuters Holdings PLC
@@ -10982,11 +11270,11 @@ D4AAFF Micro World
 00A009 Whitetree Network
 00A00C Kingmax Technology
 00A066 ISA
-00A0AB Netcs Informationstechnik Gmbh
+00A0AB Netcs Informationstechnik GMBH
 00A0D8 Spectra - TEK
 00A0FA Marconi Communication GmbH
 00A0CB ARK Telecommunications
-00A034 Axel
+00A034 AXEL
 00A001 DRS Signal Solutions
 0020B2 GKD Gesellschaft Fur Kommunikation Und Datentechnik
 002052 Ragula Systems
@@ -10994,9 +11282,9 @@ D4AAFF Micro World
 0020FE Topware / Grand Computer
 002073 Fusion Systems
 002035 IBM
-00A017 J B M
-00A025 Redcom Labs
-00A0BB Hilan Gmbh
+00A017 J B
+00A025 Redcom LABS
+00A0BB Hilan GMBH
 00A091 Applicom International
 00A0A5 Teknor Microsysteme
 0020B7 Namaqua Computerware
@@ -11006,7 +11294,6 @@ D4AAFF Micro World
 00208D CMD Technology
 0020DD Cybertec
 0020E6 Lidkoping Machine Tools AB
-00A0A2 Digicom
 002086 Microtech Electronics Limited
 002023 T.C. Technologies
 00A054 Private
@@ -11015,7 +11302,7 @@ D4AAFF Micro World
 00201D Katana Products
 002003 Pixel Power
 002046 Ciprico
-00209B Ersat Electronic Gmbh
+00209B Ersat Electronic GMBH
 00201C Excel
 00207F Kyoei Sangyo
 0020C9 Victron BV
@@ -11028,14 +11315,14 @@ D4AAFF Micro World
 002065 Supernet Networking
 00202A N.V. Dzine
 002083 Presticom Incorporated
-002019 Ohler Gmbh
+002019 Ohler GMBH
 00209E Brown's Operating System Services
 00208E Chevin Software ENG.
 002097 Applied Signal Technology
 00C00B Norcontrol A.S.
 0020B0 Gateway Devices
 00205B Kentrox
-0020F6 NET TEK  AND Karlnet
+0020F6 NET TEK AND Karlnet
 0020C6 Nectec
 002008 Cable & Computer Technology
 0020D3 OST (ouest Standard Telematiqu
@@ -11045,12 +11332,12 @@ D4AAFF Micro World
 00C09C Hioki E.E.
 00C0AA Silicon Valley Computer
 00C066 Docupoint
-00C02D Fuji Photo Film
+00C02D FUJI Photo FILM
 00C0F2 Transition Networks
-00C0BD Inex Technologies
-00C088 EKF Elektronik Gmbh
+00C0BD INEX Technologies
+00C088 EKF Elektronik GMBH
 00C011 Interactive Computing Devices
-00C03E FA. GEBR. Heller Gmbh
+00C03E FA. Gebr. Heller GMBH
 00C0FD Prosum
 00C014 Telematics Calabasas Int'l
 00AA3C Olivetti Telecom SPA (olteco)
@@ -11065,12 +11352,12 @@ D4AAFF Micro World
 00C09E Cache Computers
 00C0AC Gambit Computer Communications
 00C034 Transaction Network
-00C093 Alta Research
+00C093 ALTA Research
 0040E7 Arnos Instruments & Computer
 004087 Ubitrex
 004007 Telmat Informatique
 00407B Scientific Atlanta
-00402C Isis Distributed Systems
+00402C ISIS Distributed Systems
 00C0DF KYE Systems
 00C0F5 Metacomp
 00C091 Jabil Circuit
@@ -11084,28 +11371,28 @@ D4AAFF Micro World
 00C054 Network Peripherals
 00C022 Lasermaster Technologies
 00C025 Dataproducts
-0040CF Strawberry TREE
+0040CF Strawberry Tree
 004077 Maxton Technology
 00C02C Centrum Communications
-00C0FB Advanced Technology Labs
+00C0FB Advanced Technology LABS
 00C02B Gerloff Gesellschaft FUR
 004074 Cable AND Wireless
-0040B8 Idea Associates
-0040E8 Charles River Data Systems
+0040B8 IDEA Associates
+0040E8 Charles River DATA Systems
 0040C0 Vista Controls
 00C0A0 Advance Micro Research
 00C010 Hirakawa Hewtech
 00C037 Dynatem
 004083 TDA Industria DE Produtos
 00405B Funasset Limited
-004073 Bass Associates
+004073 BASS Associates
 00407D Extension Technology
 0080D7 Fantum Engineering
 00807A Aitech Systems
 0080DC Picker International
 00404D Telecommunications Techniques
-00400D Lannet Data Communications
-004019 Aeon Systems
+00400D Lannet DATA Communications
+004019 AEON Systems
 0040BE Boeing Defense & Space
 00406E Corollary
 004076 Sun Conversion Technologies
@@ -11114,15 +11401,15 @@ D4AAFF Micro World
 00401E ICC
 00409A Network Express
 004094 Shographics
-004055 Metronix Gmbh
+004055 Metronix GMBH
 004027 SMC Massachusetts
 00408B Raylan
 0040EF Hypercom
 004093 Paxdata Networks
-004085 Saab Instruments AB
+004085 SAAB Instruments AB
 004023 Logic
-0040A4 Rose Electronics
-004008 A Plus Info
+0040A4 ROSE Electronics
+004008 A PLUS INFO
 0040B5 Video Technology Computers
 004012 Windata
 0040D5 Sartorius Mechatronics T&H GmbH
@@ -11130,11 +11417,11 @@ D4AAFF Micro World
 0040CA First Internat'l Computer
 0040C4 Kinkei System
 00405D Star-tek
-0040E2 Mesa Ridge Technologies
-00408C Axis Communications AB
+0040E2 MESA Ridge Technologies
+00408C AXIS Communications AB
 004045 Twinhead
 004028 Netcomm Limited
-0040DD Hong Technologies
+0040DD HONG Technologies
 0040CB Lanwan Technologies
 0040B2 Systemforschung
 0040E6 C.a.e.n.
@@ -11145,10 +11432,10 @@ D4AAFF Micro World
 0080AE Hughes Network Systems
 00803A Varityper
 00801C Newport Systems Solutions
-008056 Sphinx Electronics Gmbh & KG
+008056 Sphinx Electronics GmbH & KG
 008031 Basys
 0080DB Graphon
-008082 PEP Modular Computers Gmbh
+008082 PEP Modular Computers GMBH
 008039 Alcatel STC Australia
 008023 Integrated Business Networks
 00806B Schmid Telecommunication
@@ -11156,11 +11443,11 @@ D4AAFF Micro World
 008041 VEB Kombinat Robotron
 008080 Datamedia
 00803F Tatung Company
-0080E6 Peer Networks
+0080E6 PEER Networks
 0080E0 XTP Systems
 008088 Victor Company OF Japan
 0080D8 Network Peripherals
-00809E Datus Gmbh
+00809E Datus GMBH
 00802B Integrated Marketing
 008001 Periphonics
 008097 Centralp Automatismes
@@ -11170,7 +11457,7 @@ D4AAFF Micro World
 0080D5 Cadre Technologies
 00801B Kodiak Technology
 0080D3 Shiva
-0080B3 Aval Data
+0080B3 AVAL DATA
 008020 Network Products
 008070 Computadoras Micron
 008008 Dynatech Computer Systems
@@ -11196,14 +11483,14 @@ D4AAFF Micro World
 000094 Asante Technologies
 000090 Microcom
 000047 Nicolet Instruments
-000021 Sureman COMP. & Commun.
+000021 Sureman Comp. & Commun.
 000030 VG Laboratory Systems
 000035 Spectragraphics
 000026 Sha-ken
 0000B6 Micro-matic Research
 000082 Lectra Systemes SA
 00002B Crisp Automation
-000051 HOB Electronic Gmbh & KG
+000051 HOB Electronic GMBH & KG
 0000A7 Network Computing Devices
 000098 Crosscomm
 0000C6 EON Systems
@@ -11211,10 +11498,10 @@ D4AAFF Micro World
 00008F Raytheon
 0000F1 Magna Computer
 000054 Schneider Electric
-000020 Dataindustrier Diab AB
-00007A Dana Computer
-000045 Ford Aerospace & COMM.
-00009C Rolm Mil-spec Computers
+000020 Dataindustrier DIAB AB
+00007A DANA Computer
+000045 FORD Aerospace & Comm.
+00009C ROLM Mil-spec Computers
 00007C Ampere Incorporated
 000068 Rosemount Controls
 0000E9 Isicad
@@ -11226,7 +11513,7 @@ D4AAFF Micro World
 00008D Cryptek
 00003B i Controls
 0000B3 Cimlinc Incorporated
-0000D3 Wang Laboratories
+0000D3 WANG Laboratories
 0000D0 Develcon Electronics
 000093 Proteon
 00008B Infotron
@@ -11241,18 +11528,18 @@ D4AAFF Micro World
 08002D Lan-tec
 00DD00 Ungermann-bass
 0000AA Xerox
-040AE0 Xmit AG Computer Networks
+040AE0 XMIT AG Computer Networks
 080011 Tektronix
-080026 Norsk Data A.S.
-080025 Control Data
+080026 Norsk DATA A.S.
+080025 Control DATA
 100000 Private
 0000D7 Dartmouth College
 AA0004 Digital Equipment
 08000C Miklyn Development
 00DD05 Ungermann-bass
-08001D Able Communications
+08001D ABLE Communications
 00DD0B Ungermann-bass
-080003 Advanced Computer COMM.
+080003 Advanced Computer Comm.
 00DD03 Ungermann-bass
 00DD0F Ungermann-bass
 000001 Xerox
@@ -11264,13 +11551,12 @@ AA0004 Digital Equipment
 F854B8 Amazon Technologies
 781735 Nokia Shanghai Bell
 3C894D Dr. Ing. h.c. F. Porsche AG
-84C807 Adva Optical Networking
-B43939 Shenzhen Tinno Mobile Technology
+84C807 ADVA Optical Networking
 A0AB51 Weifang Goertek Electronics
 64C901 Inventec
 749EF5 Samsung Electronics
 68BFC4 Samsung Electronics
-A85E45 Asustek Computer
+A85E45 ASUSTek Computer
 04B1A1 Samsung Electronics
 CC464E Samsung Electronics
 F8893C Inventec Appliances
@@ -11285,15 +11571,14 @@ C4AD34 Routerboard.com
 D89E61 Huawei Device
 347E00 Huawei Device
 003092 Kontron Electronics AG
-80751F BSkyB
 E85A8B Xiaomi Communications
 442295 China Mobile Iot Limited company
 5C710D Cisco Systems
 00AB48 eero
 F855CD Visteon
 441847 Hunan Scrown Electronic Information Tech.co.
-1CC1BC YichipMicroelectronics (Hangzhou)
-AC61B9 Wama Technology Limited
+1CC1BC Yichip Microelectronics (Hangzhou)
+AC61B9 WAMA Technology Limited
 C4D8F3 iZotope
 003056 HMS Industrial Networks
 680AE2 Silicon Laboratories
@@ -11309,7 +11594,7 @@ C8F319 LG Electronics (Mobile Communications)
 4CF55B Huawei Technologies
 E83F67 Huawei Device
 3446EC Huawei Device
-643139 Ieee Registration Authority
+643139 IEEE Registration Authority
 A44BD5 Xiaomi Communications
 64956C LG Electronics
 14876A Apple
@@ -11321,19 +11606,18 @@ E0EB40 Apple
 B4ECF2 Shanghai Listent Medical Tech
 4077A9 New H3C Technologies
 F83331 Texas Instruments
-C4954D Ieee Registration Authority
+C4954D IEEE Registration Authority
 C49878 Shanghai Moaan Intelligent Technology
 6C639C Arris Group
 A4BB6D Dell
 6C06D6 Huawei Device
 0C8E29 Arcadyan
-A0224E Ieee Registration Authority
-3027CF Private
+A0224E IEEE Registration Authority
 3843E5 Grotech
 CC593E Sensium Healthcare Limited
 5C68D0 Aurora Innovation
 10364A Boston Dynamics
-00B810 YichipMicroelectronics (Hangzhou)
+00B810 Yichip Microelectronics (Hangzhou)
 A4B239 Cisco Systems
 001BB0 Bharat Electronics Limited
 68AFFF Shanghai Cambricon Information Technology
@@ -11344,10 +11628,10 @@ FC1BD1 Huawei Technologies
 D01C3C Tecno Mobile Limited
 18C04D Giga-byte Technology
 8CAAB5 Espressif
-402C76 Ieee Registration Authority
+402C76 IEEE Registration Authority
 44C7FC Huawei Device
 7885F4 Huawei Device
-F44955 Mimo Tech
+F44955 MIMO TECH
 0809C7 Zhuhai Unitech Power Technology
 88541F Google
 900CC8 Google
@@ -11375,19 +11659,19 @@ D446E1 Apple
 FCF29F China Mobile Iot Limited company
 F81F32 Motorola Mobility, a Lenovo Company
 B00AD5 zte
-20114E MeteRSit S.R.L.
+20114E MeteRSit S.r.l.
 2C5741 Cisco Systems
 A84D4A Audiowise Technology
 7894E8 Radio Bridge
 484EFC Arris Group
-B0B353 Ieee Registration Authority
+B0B353 IEEE Registration Authority
 547FBC iodyne
 7CDFA1 Espressif
 98006A zte
 002674 Hunter Douglas
 1C97C5 Ynomia
 5CC1D7 Samsung Electronics
-380146 Shenzhen Bilian Electronicltd
+380146 Shenzhen Bilian Electronic，ltd
 889655 Zitte
 F4A4D6 Huawei Technologies
 FCE14F BRK Brands
@@ -11410,12 +11694,12 @@ CC7F75 Cisco Systems
 D03FAA Apple
 0CB937 Ubee Interactive, Limited
 D4DC09 Mist Systems
-0088BA Nc&c
+0088BA NC&C
 F47335 Logitech Far East
 90ADFC Telechips
 5CA62D Cisco Systems
 402B69 Kumho Electric
-E8E98E Solar Controls S.r.o.
+E8E98E Solar controls s.r.o.
 64F6BB Fibocom Wireless
 BC1695 zte
 DC35F1 Positivo Tecnologia
@@ -11427,7 +11711,7 @@ A4CFD2 Ubee Interactive, Limited
 A8A097 ScioTeq bvba
 086BD1 Shenzhen SuperElectron Technology
 AC3A67 Cisco Systems
-3CB53D Hunan Goke Microelectronics
+3CB53D Hunan GOKE Microelectronics
 980D51 Huawei Device
 00ADD5 Huawei Device
 905D7C New H3C Technologies
@@ -11466,7 +11750,7 @@ C4A402 Huawei Technologies
 70617B Cisco Systems
 985949 Luxottica Group
 AC67B2 Espressif
-9CBD6E Dera
+9CBD6E DERA
 4C3329 Sweroam
 64E172 Shenzhen Qihoo Intelligent Technology
 488F5A Routerboard.com
@@ -11503,14 +11787,14 @@ A84025 Oxide Computer Company
 C85BA0 Shenzhen Qihu Intelligent Technology Company Limited
 E0BE03 Lite-On Network Communication (Dongguan) Limited
 5C9012 Owl Cyber Defense Solutions
-38F7CD Ieee Registration Authority
+38F7CD IEEE Registration Authority
 98CBA4 Benchmark Electronics
 0012E3 Agat Soft
 001351 Niles Audio
 183CB7 Huawei Device
 A48873 Cisco Systems
 B8804F Texas Instruments
-FCA5D0 Guangdong Oppo Mobile Telecommunications
+FCA5D0 Guangdong OPPO Mobile Telecommunications
 04CB88 Shenzhen Jingxun Software Telecommunication Technology
 A06260 Private
 A4BDC4 Huawei Technologies
@@ -11518,14 +11802,13 @@ A4BDC4 Huawei Technologies
 481693 Lear GmbH
 B47947 Nutanix
 04F8F8 Edgecore Networks
-38F0C8 Mevo
 5CFE9E Wiwynn Tainan Branch
-881C95 Itel Mobile Limited
+881C95 ITEL Mobile Limited
 F46942 Askey Computer
 241407 Xiamen Sigmastar Technology
 08E9F6 Ampak Technology
 F02E51 Casa Systems
-CCC261 Ieee Registration Authority
+CCC261 IEEE Registration Authority
 7470FD Intel Corporate
 7C2A31 Intel Corporate
 B46BFC Intel Corporate
@@ -11552,7 +11835,7 @@ A87EEA Intel Corporate
 40EC99 Intel Corporate
 BC542F Intel Corporate
 34CFF6 Intel Corporate
-C87EA1 TCL Moka International Limited
+C87EA1 TCL MOKA International Limited
 A0510B Intel Corporate
 DCFB48 Intel Corporate
 84FDD1 Intel Corporate
@@ -11580,7 +11863,7 @@ FC1499 Aimore Acoustics Incorporation
 ACF108 LG Innotek
 08ED9D Tecno Mobile Limited
 E86DCB Samsung Electronics
-304950 Ieee Registration Authority
+304950 IEEE Registration Authority
 0005C9 LG Innotek
 0CDC7E Espressif
 2098D8 Shenzhen Yingdakang Technology
@@ -11590,18 +11873,17 @@ A0CFF5 zte
 3CA62F AVM Audiovisuelles Marketing und Computersysteme GmbH
 98B3EF Huawei Device
 50F958 Huawei Device
-C0A36E BSkyB
 6032B1 Tp-link Technologies
 E41F7B Cisco Systems
 182649 Intel Corporate
-8803E9 Guangdong Oppo Mobile Telecommunications
+8803E9 Guangdong OPPO Mobile Telecommunications
 345840 Huawei Technologies
 5C647A Huawei Technologies
 BC7F7B Huawei Device
 F0FAC7 Huawei Device
 DCEF80 Huawei Technologies
 B46F2D Wahoo Fitness
-5C857E Ieee Registration Authority
+5C857E IEEE Registration Authority
 846B48 ShenZhen EepuLink
 B460ED Beijing Xiaomi Mobile Software
 30CC21 zte
@@ -11617,7 +11899,7 @@ D4F337 Xunison
 C0B8E6 Ruijie Networks
 8C941F Cisco Systems
 687DB4 Cisco Systems
-58E873 Hangzhou Dangbei Network Tech.co.
+58E873 Hangzhou Dangbei Network TECH.Co.
 B030C8 Teal Drones
 DC41A9 Intel Corporate
 088F2C Amber Technology
@@ -11637,14 +11919,13 @@ E45AD4 Eltex Enterprise
 842AFD HP
 1CFE2B Amazon Technologies
 CC483A Dell
-A4AE12 Hon Hai Precision Ind.
 DCA3A2 Feng mi(Beijing)technology
 7C25DA Fn-link Technology Limited
 A8698C Oracle
 EC570D AFE
 A4AC0F Huawei Device
 CCFF90 Huawei Device
-5405DB Lcfc(hefei) Electronics Technology
+5405DB LCFC(HeFei) Electronics Technology
 D4D51B Huawei Technologies
 2491BB Huawei Technologies
 645E10 Huawei Technologies
@@ -11672,8 +11953,7 @@ B4FBE3 AltoBeam (China)
 6C09BF Fiberhome Telecommunication Technologies
 FC6DD1 Apresia Systems
 80C955 Redpine Signals
-CC4F5C Ieee Registration Authority
-30B216 Hitachi ABB Power Grids  Grid Automation
+CC4F5C IEEE Registration Authority
 4C6D58 Juniper Networks
 5CED8C Hewlett Packard Enterprise
 30D042 Dell
@@ -11683,7 +11963,7 @@ C4278C Huawei Device
 808FE8 Intelbras
 7C73EB Huawei Device
 E48F1D Huawei Device
-FCCD2F Ieee Registration Authority
+FCCD2F IEEE Registration Authority
 94B271 Huawei Technologies
 78058C mMax Communications
 C4A72B Shenzhen Chuangwei-rgb Electronics
@@ -11720,7 +12000,7 @@ C4DE7B Huawei Device
 6C1A75 Huawei Device
 6C7637 Huawei Device
 18EE86 Novatel Wireless Solutions
-A09F10 Shenzhen Bilian Electronicltd
+A09F10 Shenzhen Bilian Electronic，ltd
 201B88 Dongguan Liesheng Electronic
 249493 FibRSol Global Network Limited
 28D044 Shenzhen Xinyin technology company
@@ -11729,7 +12009,7 @@ FC4B57 Peerless Instrument Division of Curtiss-Wright
 5C10C5 Samsung Electronics
 E8EB34 Cisco Systems
 5860D8 Arris Group
-9C9AC0 Lego System A/S
+9C9AC0 LEGO System A/S
 3CBDC5 Arcadyan
 A8DA0C Servercom (india) Private Limited
 F85329 Huawei Technologies
@@ -11752,7 +12032,7 @@ E01FED Nokia Shanghai Bell
 146B9A zte
 78321B D-Link International
 04E77E We
-4C52EC Solarwatt Gmbh
+4C52EC Solarwatt GmbH
 30D941 Raydium Semiconductor
 687627 Zhuhai Dingzhi Electronic Technology
 200BCF Nintendo
@@ -11792,7 +12072,6 @@ C0E018 Huawei Technologies
 5CE747 Huawei Technologies
 A8FFBA Huawei Technologies
 AC78D1 Juniper Networks
-ECBE5F Vestel Elektronik San ve Tic. A..
 A4423B Intel Corporate
 70CF49 Intel Corporate
 4851C5 Intel Corporate
@@ -11801,7 +12080,7 @@ EC7CB6 Samsung Electronics
 58A639 Samsung Electronics
 A4E57C Espressif
 04F993 Infinix mobility limited
-BCBD9E Itel Mobile Limited
+BCBD9E ITEL Mobile Limited
 F42A7D Tp-link Technologies
 8C0FC9 Huawei Device
 304E1B Huawei Device
@@ -11823,8 +12102,7 @@ D4A651 Tuya Smart
 88C3E5 Betop Techonologies
 E428A4 Prama India Private Limited
 943A91 Amazon Technologies
-000FA0 Canon Korea Business Solutions
-408C1F Guangdong Oppo Mobile Telecommunications
+408C1F Guangdong OPPO Mobile Telecommunications
 2C3F0B Cisco Meraki
 80C501 OctoGate IT Security Systems GmbH
 04F03E Huawei Device
@@ -11841,7 +12119,7 @@ C0D026 Huawei Device
 C4D0E3 Intel Corporate
 E4FD45 Intel Corporate
 184CAE Continental
-98387D Itronic  Technology .
+98387D Itronic Technology . 
 C8D884 Universal Electronics
 B4A25C Cambium Networks Limited
 2C71FF Amazon Technologies
@@ -11861,7 +12139,6 @@ F021E0 eero
 504348 ThingsMatrix
 D85982 Huawei Technologies
 48B25D Huawei Technologies
-2CFDB3 TCL Technoly Electronics(Huizhou).
 A41B34 China Mobile Group Device
 8045DD Intel Corporate
 C0D46B Huawei Device
@@ -11870,7 +12147,7 @@ C0D46B Huawei Device
 A47B1A Huawei Device
 147D05 Sercomm Philippines
 787A6F Juice Technology AG
-E86CC7 Ieee Registration Authority
+E86CC7 IEEE Registration Authority
 4024B2 Sichuan AI-Link Technology
 640D22 LG Electronics (Mobile Communications)
 20A7F9 Shenzhen Olanboa Technology
@@ -11907,7 +12184,7 @@ F04A02 Cisco Systems
 7409AC Quext
 F0016E Tianyi Telecom Terminals Company Limited
 EC0BAE Hangzhou BroadLink Technology
-802511 Itel Mobile Limited
+802511 ITEL Mobile Limited
 E8A660 Huawei Technologies
 CC242E Shenzhen SuperElectron Technology
 082FE9 Huawei Technologies
@@ -11924,13 +12201,13 @@ C8BFFE Huawei Device
 5C625A Canon
 7C0A3F Samsung Electronics
 08AA89 zte
-A4352D Triz Networks
+A4352D TRIZ Networks
 04D60E Funai Electric
 049F81 Netscout Systems
 00808C Netscout Systems
 001F92 Motorola Solutions
 0023BB Accretech SBS
-B0C952 Guangdong Oppo Mobile Telecommunications
+B0C952 Guangdong OPPO Mobile Telecommunications
 F4419E Huawei Device
 90F9B7 Huawei Technologies
 F44588 Huawei Technologies
@@ -11938,7 +12215,7 @@ C8BB81 Huawei Device
 1C472F Huawei Device
 205E64 Huawei Device
 60577D eero
-C8138B Shenzhen Skyworth  Digital  Technology
+C8138B Shenzhen Skyworth Digital Technology
 78F235 Sichuan AI-Link Technology
 F44EE3 Intel Corporate
 D0E042 Cisco Systems
@@ -12001,7 +12278,7 @@ D01E1D SaiNXT Technologies LLP
 608A10 Microchip Technology
 A82316 Nokia
 38E39F Motorola Mobility, a Lenovo Company
-446752 Wistron Infocomm (zhongshan)
+446752 Wistron Infocomm (Zhongshan)
 78BB88 Maxio Technology (Hangzhou)
 A864F1 Intel Corporate
 106FD9 Cloud Network Technology Singapore PTE.
@@ -12016,7 +12293,6 @@ D8BE65 Amazon Technologies
 60E32B Intel Corporate
 ACEC85 eero
 ECA81F Technicolor CH USA
-90B57F Shenzhen iComm Semiconductor
 C0F827 Rapidmax Technology
 B4527E Sony
 7086CE GD Midea Air-Conditioning Equipment
@@ -12058,8 +12334,8 @@ FC2E19 China Mobile Group Device
 000E82 Infinity Tech
 F0B61E Intel Corporate
 C84D44 Shenzhen Jiapeng Huaxiang Technology
-B04692 Guangdong Oppo Mobile Telecommunications
-AC764C Guangdong Oppo Mobile Telecommunications
+B04692 Guangdong OPPO Mobile Telecommunications
+AC764C Guangdong OPPO Mobile Telecommunications
 5C58E6 Palo Alto Networks
 EC94CB Espressif
 40406B Icomera
@@ -12083,14 +12359,13 @@ E0C58F China Mobile IOT Company Limited
 2C0547 Shenzhen Phaten Tech.
 2C1A05 Cisco Systems
 9C50D1 Murata Manufacturing
-140020 LongSung Technology (Shanghai),Ltd.
+140020 LongSung Technology (Shanghai)
 441793 Espressif
-00A388 BSkyB
 503DEB Zhejiang Tmall Technology
 30B930 zte
 949869 zte
-7C66EF Hon Hai Precision IND.CO.
-785005 Moko Technology
+7C66EF Hon Hai Precision Ind.co.
+785005 MOKO Technology
 F87FA5 Greatek
 18E1DE Chengdu ChipIntelli Technology
 8CF681 Silicon Laboratories
@@ -12109,18 +12384,18 @@ E0A258 Wanbang Digital Energy
 4CBCE9 LG Innotek
 745CFA Shenzhen Shunrui Gaojie Technology
 94A408 Shenzhen Trolink Technology
-D0F865 Itel Mobile Limited
+D0F865 ITEL Mobile Limited
 385C76 Plantronics
 7CC177 Ingram Micro Services
 7876D9 Exara Group
-84A938 Lcfc(hefei) Electronics Technology
+84A938 LCFC(HeFei) Electronics Technology
 3C9FC3 Beijing Sinead Technology
 608FA4 Nokia Solutions and Networks GmbH & KG
 38FDF8 Cisco Systems
 208C47 Tenstorrent
 5C2AEF r2p Asia-Pacific
-E4936A Guangdong Oppo Mobile Telecommunications
-4877BD Guangdong Oppo Mobile Telecommunications
+E4936A Guangdong OPPO Mobile Telecommunications
+4877BD Guangdong OPPO Mobile Telecommunications
 F856C3 zte
 7CFC16 Apple
 88B945 Apple
@@ -12131,7 +12406,7 @@ DCF4CA Apple
 18EF3A Sichuan AI-Link Technology
 A0FF22 Shenzhen Apical Technology
 00041B Bridgeworks
-6CD3EE Zimi
+6CD3EE ZIMI
 E42805 Pivotal Optics
 5C0214 Beijing Xiaomi Mobile Software
 785EA2 Sunitec Enterprise
@@ -12148,7 +12423,7 @@ C4BDE5 Intel Corporate
 649E31 Beijing Xiaomi Mobile Software
 F820A9 Huawei Device
 24CD8D Murata Manufacturing
-34AA31 Shenzhen Skyworth  Digital  Technology
+34AA31 Shenzhen Skyworth Digital Technology
 48BD4A Huawei Technologies
 A8D4E0 Huawei Technologies
 A0406F Huawei Technologies
@@ -12170,16 +12445,348 @@ DC8C1B vivo Mobile Communication
 6CD94C vivo Mobile Communication
 541F8D zte
 2CF1BB zte
-CC7190 Vietnam Post AND Telecommunication Industry Technology Joint Stock Company
+CC7190 Vietnam POST AND Telecommunication Industry Technology Joint Stock Company
 B0F7C4 Amazon Technologies
 18A9A6 Nebra
 8C5646 LG Electronics
 DC2C6E Routerboard.com
 1400E9 Mitel Networks
-D4B7D0 Ciena
-6C0F0B China Mobile Group Device
 ACACE2 Changhong (hongkong) Trading Limited
 4C8D53 Huawei Technologies
+547D40 Powervision Tech
+C0D7AA Arcadyan
+6C0F0B China Mobile Group Device
+D4B7D0 Ciena
+202027 Shenzhen Sundray Technologies Company Limited
+C8418A Samsung Electronics.
+4CABF8 Askey Computer
+F89E94 Intel Corporate
+1848BE Amazon Technologies
+68228E Juniper Networks
+686725 Espressif
+80B745 The Silk Technologies ILC
+C403A8 Intel Corporate
+644212 Shenzhen Water World Information
+886EE1 Erbe Elektromedizin GmbH
+AC8BA9 Ubiquiti Networks
+C475AB Intel Corporate
+0CB088 AITelecom
+DC973A Verana Networks
+2066FD Constell8 NV
+9C00D3 Shenzhen IK World Technology
+282D06 Ampak Technology
+202B20 Cloud Network Technology Singapore PTE.
+884D7C Apple
+A8FE9D Apple
+A0A309 Apple
+5C50D9 Apple
+000A08 Alps Alpine
+E8CAC8 Hui Zhou Gaoshengda Technology
+D419F6 NXP Semiconductor (Tianjin)
+A04C0C Shenzhen Skyworth Digital Technology
+40ACBF Hangzhou Hikvision Digital Technology
+64BF6B Huawei Technologies
+30499E Huawei Technologies
+FC7692 Semptian
+FCAFBE TireCheck GmbH
+9CEC61 Huawei Device
+B03366 vivo Mobile Communication
+7CC225 Samsung Electronics
+747069 Huawei Device
+14FB70 Huawei Device
+84D3D5 Huawei Device
+D413F8 Peplink International
+C85ACF HP
+9C1C6D Hefei Datang Storage Technology
+FC29E3 Infinix mobility limited
+88C227 Huawei Technologies
+8054D9 Huawei Technologies
+48B423 Amazon Technologies
+7070AA Amazon Technologies
+9C8566 Wingtech Mobile Communications
+94A9A8 Texas Instruments
+642FC7 New H3C Technologies
+6026AA Cisco Systems
+5C3192 Cisco Systems
+A83A48 Ubiqcom India Pvt
+F41399 Aerospace new generation communications
+641ABA Dryad Networks GmbH
+349454 Espressif
+A4438C Arris Group
+94DEB8 Silicon Laboratories
+040D84 Silicon Laboratories
+4C195D Sagemcom Broadband SAS
+0080C2 IEEE 802.1 Chair
+480286 Realme Chongqing Mobile Telecommunications
+D84A2B zte
+D0F99B zte
+98672E Skullcandy
+D43538 Beijing Xiaomi Mobile Software
+10CE02 Amazon Technologies
+D8539A Juniper Networks
+54F82A u-blox AG
+64CF13 Weigao Nikkiso(Weihai)Dialysis Equipment
+8C497A Extreme Networks
+40329D Union Image
+4C7713 Renesas Electronics (Penang) Sdn. Bhd.
+6C4BB4 Humax
+589BF7 Hefei Radio Communication Technology
+50E9DF Quectel Wireless Solutions
+441B88 Apple
+80045F Apple
+9C3E53 Apple
+C889F3 Apple
+E8FA23 Huawei Device
+EC3A52 Huawei Device
+60109E Huawei Technologies
+44EA30 Samsung Electronics
+9C2F9D Liteon Technology
+A4F33B zte
+30E7BC Guangdong OPPO Mobile Telecommunications
+7CB566 Intel Corporate
+901195 Amazon Technologies
+10B9C4 Apple
+CC7D5B Telink Semiconductor (Shanghai)
+749552 Xuzhou WIKA Electronics Control Technology
+A81306 vivo Mobile Communication
+1C34F1 Silicon Laboratories
+B43161 Realme Chongqing Mobile Telecommunications
+4CFE2E DongGuan Siyoto Electronics
+845F04 Samsung Electronics
+F8C116 Juniper Networks
+EC9B2D China Mobile Group Device
+AC93C4 GD Midea Air-Conditioning Equipment
+48CAC6 Unionman Technology
+4C63EB Application Solutions (Electronics and Vision)
+608CDF Beamtrail-Sole Proprietorship
+D01B1F Ohsung
+0C4EC0 Maxlinear
+FC38C4 China Grand Communications
+5CF51A Zhejiang Dahua Technology
+D8AA59 Tonly Technology
+2CFDB3 Tonly Technology
+CC8CBF Tuya Smart
+04CF4B Intel Corporate
+C01803 HP
+2C784C Iton Technology
+488759 Xiaomi Communications
+AC1E9E Xiaomi Communications
+E0AEA2 Huawei Technologies
+44456F Shenzhen Onega Technology
+34976F Rootech
+E8FDF8 Shanghai High-Flying Electronics Technology
+6C6C0F Huawei Technologies
+F897A9 Ericsson AB
+30B216 Hitachi Energy
+98CA20 Shanghai Simcom
+DC152D China Mobile Group Device
+00D8A2 Huawei Device
+DC6B1B Huawei Device
+342840 Apple
+18E7B0 Apple
+50578A Apple
+D49FDD Huawei Device
+D06DC9 Sagemcom Broadband SAS
+0857FB Amazon Technologies
+D4FB8E Apple
+B0DE28 Apple
+7C131D Sernet (suzhou) Technologies
+D833B7 Sagemcom Broadband SAS
+440CEE Robert Bosch Elektronika Kft
+D850A1 Hunan Danuo Technology
+441AAC Elektrik Uretim AS EOS
+4851D0 Jiangsu Xinsheng Intelligent Technology
+8077A4 Tecno Mobile Limited
+B42875 Futecho Solutions Private Limited
+302364 Nokia Shanghai Bell
+0C1C1A eero
+00C30A Xiaomi Communications
+8852EB Xiaomi Communications
+7C6CF0 Shenzhen Tinno Mobile Technology
+00A0A2 B810 S.r.l.
+3868BE Sichuan Tianyi Comheart Telecom
+DC9A7D Hisense Visual Technology
+28A53F vivo Mobile Communication
+8C49B6 vivo Mobile Communication
+84F1D0 Ehoome IOT Private Limited
+208BD1 NXP Semiconductor (Tianjin)
+000FA0 Canon Korea
+30BB7D OnePlus Technology (Shenzhen)
+6C67EF Huawei Technologies
+88693D Huawei Technologies
+00991D Huawei Technologies
+B83FD2 Mellanox Technologies
+283E0C Preferred Robotics
+30CB36 Belden Singapore Pte.
+8C1759 Intel Corporate
+04BC9F Calix
+BC6E6D EM Microelectronic
+B04A6A Samsung Electronics
+A8798D Samsung Electronics
+5CEDF4 Samsung Electronics
+3492C2 Square Route
+283DC2 Samsung Electronics
+00D49E Intel Corporate
+6CA401 essensys plc
+CCF305 Shenzhen TIAN XING Chuang ZHAN Electronic
+34BD20 Hangzhou Hikrobot Technology
+64C269 eero
+AC2AA1 Cisco Systems
+F8E94F Cisco Systems
+30894A Intel Corporate
+B8D61A Espressif
+BCF4D4 Cloud Network Technology Singapore PTE.
+D89C8E Comcast Cable
+74563C Giga-byte Technology
+EC551C Huawei Technologies
+8C6BDB Huawei Device
+10DA49 Huawei Device
+60183A Huawei Device
+18C007 Huawei Device
+E06CC5 Huawei Device
+30963B Huawei Device
+90B57F Shenzhen iComm Semiconductor
+98597A Intel Corporate
+64497D Intel Corporate
+B48351 Intel Corporate
+0025CA Laird Connectivity
+04B97D AiVIS
+C4C063 New H3C Technologies
+5443B2 Espressif
+C0DD8A Facebook Technologies
+E0798D Silicon Laboratories
+34AD61 Celestica
+10961A Chipsea Technologies (shenzhen)
+BCE9E2 Brocade Communications Systems
+ACBF71 Bose
+18A59C IEEE Registration Authority
+ACD31D Cisco Meraki
+748469 Nintendo
+74718B Apple
+70317F Apple
+A4CF99 Apple
+4C2EB4 Apple
+B41974 Apple
+04E892 Shennan Circuits
+001848 Vecima Networks
+2C553C Vecima Networks
+6095BD Apple
+001A35 Bartec GmbH
+8CCBDF Foxconn Interconnect Technology
+98F112 Hangzhou Hikvision Digital Technology
+846993 HP
+746F88 zte
+98C81C Baytec Limited
+D0989C ConMet
+2426D6 Huawei Technologies
+EC819C Huawei Technologies
+1CA410 Amlogic
+200B16 Texas Instruments
+8801F9 Texas Instruments
+F85548 Texas Instruments
+68E74A Texas Instruments
+70A6BD Honor Device
+4C9E6C Broadex Technologiesltd
+542F04 Shanghai Longcheer Technology
+E4B633 Wuxi Stars Microsystem Technology
+085104 Huawei Device
+785B64 Huawei Device
+54E15B Huawei Device
+ACC4BD Guangdong OPPO Mobile Telecommunications
+ACA32F Solidigm Technology
+C4A10E IEEE Registration Authority
+AC712E Fortinet
+0CEC84 Shenzhen Tinno Mobile Technology
+B43939 Shenzhen Tinno Mobile Technology
+8C9806 Shenzhen SEI Robotics
+200889 zte
+7070FC Gold&water Industrial Limited
+98D93D Demant Enterprise A/S
+B4A678 Zhejiang Tmall Technology
+88F2BD GD Midea Air-Conditioning Equipment
+A0F895 Shenzhen Tinno Mobile Technology
+6C0831 Analog Systems
+2C07F6 SKG Health Technologies
+0024E4 Withings
+A47EFA Withings
+7891DE Guangdong Aciga Science&Technology
+E0806B Xiaomi Communications
+70AC08 Silicon Laboratories
+7050E7 IEEE Registration Authority
+0013B4 Appear AS
+38127B Crenet Labs
+B0E45C Samsung Electronics
+3C26E4 Cisco Systems
+3891B7 Cisco Systems
+345DA8 Cisco Systems
+BC4CA0 Huawei Technologies
+74342B Huawei Technologies
+687FF0 TP-Link Limited
+DC360C Hitron Technologies.
+38FDF5 Renesas Electronics (Penang) Sdn. Bhd.
+C412EC Huawei Technologies
+60CF69 meerecompany
+4C627B SmartCow AI Technologies Taiwan
+BC7B72 Huawei Device
+F82B7F Huawei Device
+40C3BC Huawei Device
+34FE1C Choung HWA TECH
+D868A0 Samsung Electronics
+04292E Samsung Electronics
+6CC242 Shenzhen Skyworth Digital Technology
+2853E0 Sintela
+F4939F Hon Hai Precision Industry
+AC4E65 Fiberhome Telecommunication Technologies
+BC5DA3 Sichuan Tianyi Comheart Telecom
+807215 SKY UK Limited
+B03E51 SKY UK Limited
+80751F SKY UK Limited
+A4AE12 Hon Hai Precision Industry
+C0A36E SKY UK Limited
+00A388 SKY UK Limited
+38F0C8 Logitech
+1CEF03 Guangzhou V-solution Electronic Technology
+58B03E Nintendo
+7413EA Intel Corporate
+187A3E Silicon Laboratories
+300505 Intel Corporate
+B0DCEF Intel Corporate
+28BC05 BLU Products
+2CA774 Texas Instruments
+184E03 HMD Global Oy
+E00871 Dongguan Liesheng Electronic
+9C956E Microchip Technology
+DC0B09 Cisco Systems
+08F3FB Cisco Systems
+DCF31C Texas Instruments
+544538 Texas Instruments
+78C213 Sagemcom Broadband SAS
+4022D8 Espressif
+A036BC ASUSTek Computer
+1073EB Infiniti Electro-Optics
+840BBB MitraStar Technology
+04D9C8 Hon Hai Precision Industry
+A0FB83 Honor Device
+9C924F Apple
+200E2B Apple
+F0D793 Apple
+70B306 Apple
+B8496D Apple
+906560 EM Microelectronic
+880AA3 Juniper Networks
+303D51 IEEE Registration Authority
+CCD3C1 Vestel Elektronik San ve Tic. A.S.
+ECBE5F Vestel Elektronik San ve Tic. A.S.
+F4BBC7 vivo Mobile Communication
+4C364E Panasonic Connect
+986610 zte
+447147 Beijing Xiaomi Electronics
+A8DC5A Digital Watchdog
+1C24CD Askey Computer
+DCAA43 Shenzhen Terca Information Technology
+00FBF9 Axiado
+88B436 Fujifilm
+3027CF Canopy Growth
 848094 Meter
 10B3D5 Cisco Systems
 30A2C2 Huawei Device
@@ -12189,7 +12796,7 @@ ACA88E Sharp
 705425 Arris Group
 5C0BCA Tunstall Nordic AB
 283334 Huawei Device
-50A132 Shenzhen MiaoMing  Intelligent Technology
+50A132 Shenzhen MiaoMing Intelligent Technology
 807871 Askey Computer
 4CB1CD Ruckus Wireless
 F49C12 Structab AB
@@ -12205,7 +12812,7 @@ B8F653 Shenzhen Jingxun Software Telecommunication Technology
 60AB14 LG Innotek
 BC62D2 Genexis International
 6C9E7C Fiberhome Telecommunication Technologies
-44D5F2 Ieee Registration Authority
+44D5F2 IEEE Registration Authority
 000C86 Cisco Systems
 F83CBF Botato Electronics SDN BHD
 FC589A Cisco Systems
@@ -12213,9 +12820,9 @@ F08620 Arcadyan
 DCCC8D Integrated Device Technology (Malaysia) Sdn. Bhd.
 F05C77 Google
 111111 Private
-6CD71F Guangdong Oppo Mobile Telecommunications
+6CD71F Guangdong OPPO Mobile Telecommunications
 F06865 Taicang T&W Electronics
-A463A1 Inventus Power Eletronica do Brasil Ltda
+A463A1 Inventus Power Eletronica do Brasil LTDA
 3C9D56 Huawei Technologies
 70FD45 Huawei Technologies
 446747 Huawei Technologies
@@ -12226,7 +12833,7 @@ F4B5BB Ceragon Networks
 8C861E Apple
 542B8D Apple
 001D29 Doro AB
-ECA5DE Onyx Wifi
+ECA5DE ONYX WIFI
 1033BF Technicolor CH USA
 347563 Shenzhen Rf-link Technology
 142E5E Sercomm
@@ -12241,18 +12848,18 @@ D82FE6 Zhejiang Tmall Technology
 140F42 Nokia
 006D61 Guangzhou V-solution Electronic Technology
 C4AC59 Murata Manufacturing
-FCA47A Ieee Registration Authority
+FCA47A IEEE Registration Authority
 E419C1 Huawei Technologies
 B86685 Sagemcom Broadband SAS
 381A52 Seiko Epson
 000A17 Nestar Communications
-D8AF81 ZAO NPK Rotek
+D8AF81 ZAO "NPK Rotek"
 E4FDA1 Huawei Technologies
 B452A9 Texas Instruments
 54EF44 Lumi United Technology
 402B50 Arris Group
 78CC2B Sinewy Technology
-D0C857 Ieee Registration Authority
+D0C857 IEEE Registration Authority
 FCBCD1 Huawei Technologies
 7460FA Huawei Technologies
 38EFE3 Ingenico Terminals SAS
@@ -12266,7 +12873,7 @@ E4AB89 MitraStar Technology
 78C313 China Mobile Group Device
 7434AE this is engineering
 74ADB7 China Mobile Group Device
-6095CE Ieee Registration Authority
+6095CE IEEE Registration Authority
 8CE5C0 Samsung Electronics
 F08A76 Samsung Electronics
 ECAA25 Samsung Electronics
@@ -12284,7 +12891,7 @@ D0C65B Huawei Technologies
 B4CFE0 Sichuan tianyi kanghe communications
 BC7FA4 Xiaomi Communications
 FC492D Amazon Technologies
-74EE2A Shenzhen Bilian Electronicltd
+74EE2A Shenzhen Bilian Electronic，ltd
 087E64 Technicolor CH USA
 080039 Spider Systems Limited
 90473C China Mobile Group Device
@@ -12318,13 +12925,13 @@ F8DFE1 MyLight Systems
 60D2DD Shenzhen Baitong Putian Technology
 788C77 Lexmark International
 3C0C7D Tiny Mesh AS
-3476C5 I-O Data Device
+3476C5 I-O DATA Device
 24DA33 Huawei Technologies
 FCAB90 Huawei Technologies
 5893D8 Texas Instruments
 5051A9 Texas Instruments
 A4975C VTech Telecommunications
-B02A1F Wingtech Group (HongKongLimited
+B02A1F Wingtech Group (HongKong）Limited
 DC680C Hewlett Packard Enterprise
 F40270 Dell
 1C2704 zte
@@ -12335,7 +12942,7 @@ E0CC7A Huawei Technologies
 60AB67 Xiaomi Communications
 AC710C China Mobile Group Device
 A8DB03 Samsung Electro-mechanics(thailand)
-308944 Deva Broadcast
+308944 DEVA Broadcast
 F47960 Huawei Technologies
 145290 KNS Group (yadro Company)
 5C32C5 Teracom
@@ -12343,8 +12950,8 @@ ACEE70 Fontem Ventures BV
 ACE2D3 Hewlett Packard
 00FD22 Cisco Systems
 4418FD Apple
-00B600 Voim
-98FA9B Lcfc(hefei) Electronics Technology
+00B600 VOIM
+98FA9B LCFC(HeFei) Electronics Technology
 005B94 Apple
 E0897E Apple
 B00CD1 Hewlett Packard
@@ -12361,14 +12968,14 @@ ACD564 Chongqing Fugui Electronics
 94D075 CIS Crypto
 28B4FB Sprocomm Technologies
 40F9D5 Tecore Networks
-CC2C83 DarkMatter L.L.C
+CC2C83 DarkMatter
 DCED84 Haverford Systems
 7C573C Aruba, a Hewlett Packard Enterprise Company
 2C01B5 Cisco Systems
-C05336 Beijing National Railway Research & Design Institute of Signal & Communication GroupLtd.
-606ED0 Seal AG
+C05336 Beijing National Railway Research & Design Institute of Signal & Communication Group.Ltd.
+606ED0 SEAL AG
 2CCCE6 Skyworth Digital Technology(Shenzhen)
-E44CC7 Ieee Registration Authority
+E44CC7 IEEE Registration Authority
 D4E880 Cisco Systems
 A8346A Samsung Electronics
 3C20F6 Samsung Electronics
@@ -12382,12 +12989,12 @@ A4817A CIG Shanghai
 905851 Technicolor CH USA
 9809CF OnePlus Technology (Shenzhen)
 B8DE5E Longcheer Telecommunication Limited
-885A06 Guangdong Oppo Mobile Telecommunications
-5447D3 Tsat AS
+885A06 Guangdong OPPO Mobile Telecommunications
+5447D3 TSAT AS
 CCEDDC MitraStar Technology
 CCD81F Maipu Communication Technology
 688B0F China Mobile IOT Company Limited
-F82F6A Itel Mobile Limited
+F82F6A ITEL Mobile Limited
 B068E6 Chongqing Fugui Electronics
 A4E7E4 Connex GmbH
 B8EF8B Shenzhen Cannice Technology
@@ -12411,7 +13018,7 @@ BCE67C Cambium Networks Limited
 F0B31E Universal Electronics
 F89173 Aedle SAS
 C84F86 Sophos
-6429ED AO PKK Milandr
+6429ED AO "PKK Milandr"
 443C88 Ficosa Maroc International
 841C70 zte
 544741 Xcheng Holding
@@ -12422,14 +13029,14 @@ C8F742 HangZhou Gubei Electronics Technology
 30DF8D Shenzhen Gongjin Electronics
 D4C93C Cisco Systems
 78DD12 Arcadyan
-2C5D34 Guangdong Oppo Mobile Telecommunications
+2C5D34 Guangdong OPPO Mobile Telecommunications
 9C1463 Zhejiang Dahua Technology
 646038 Hirschmann Automation and Control GmbH
 7018A7 Cisco Systems
-CCD39D Ieee Registration Authority
-D425CC Ieee Registration Authority
+CCD39D IEEE Registration Authority
+D425CC IEEE Registration Authority
 8C6DC4 Megapixel VR
-D4B761 SichuanAI-LinkTechnologyCo.
+D4B761 Sichuan AI-Link Technology
 7C035E Xiaomi Communications
 44FE3B Arcadyan
 D83AF5 Wideband Labs
@@ -12441,12 +13048,12 @@ B0E7DE Homa Technologies JSC
 4C962D Fresh AB
 00D279 Vingroup Joint Stock Company
 484A30 George Robotics Limited
-4861A3 Concern Axion JSC
+4861A3 Concern "Axion" JSC
 304A26 Shenzhen Trolink Technology
 4CE5AE Tianjin Beebox Intelligent Technology
-D467D3 Guangdong Oppo Mobile Telecommunications
-A41232 Guangdong Oppo Mobile Telecommunications
-48E3C3 Jenoptik Advanced Systems Gmbh
+D467D3 Guangdong OPPO Mobile Telecommunications
+A41232 Guangdong OPPO Mobile Telecommunications
+48E3C3 Jenoptik Advanced Systems GmbH
 CC355A SecuGen
 80546A Shenzhen Gongjin Electronics
 B447F5 Earda Technologies
@@ -12473,7 +13080,7 @@ A0A3B8 Wiscloud
 FC183C Apple
 A40C66 Shenzhen Colorful Yugong Technology and Development
 4455B1 Huawei Technologies
-98F9C7 Ieee Registration Authority
+98F9C7 IEEE Registration Authority
 700B4F Cisco Systems
 E4388C Digital Products Limited
 184BDF Caavo
@@ -12497,7 +13104,7 @@ D8A98B Texas Instruments
 10B9F7 Niko-Servodan
 14EFCF Schreder
 3830F9 LG Electronics (Mobile Communications)
-A83FA1 Ieee Registration Authority
+A83FA1 IEEE Registration Authority
 6C9BC0 Chemoptics
 F4DBE6 Cisco Systems
 248498 Beijing Jiaoda Microunion Tech.Co.
@@ -12516,31 +13123,31 @@ D81C79 Apple
 44E4EE Wistron Neweb
 DC41E5 Shenzhen Zhixin Data Service
 00A5BF Cisco Systems
-C8BAE9 Qdis
+C8BAE9 QDIS
 1801F1 Xiaomi Communications
 C44F33 Espressif
 546AD8 Elster Water Metering
 C0847D Ampak Technology
 0409A5 HFR
 94917F Askey Computer
-9C0CDF Guangdong Oppo Mobile Telecommunications
+9C0CDF Guangdong OPPO Mobile Telecommunications
 242124 Nokia
 949B2C Extreme Networks
 7CD30A Inventec
 001E33 Inventec
 FC1D84 Autobase
-18AC9E Itel Mobile Limited
+18AC9E ITEL Mobile Limited
 EC84B4 CIG Shanghai
-00D096 3com Europe
-002654 3com
-0050DA 3com
-000476 3com
-000475 3com
+00D096 3COM Europe
+002654 3COM
+0050DA 3COM
+000476 3COM
+000475 3COM
 4422F1 S.fac
-3009F9 Ieee Registration Authority
+3009F9 IEEE Registration Authority
 B4DDD0 Continental Automotive Hungary Kft
 48F027 Chengdu newifi
-14C697 Guangdong Oppo Mobile Telecommunications
+14C697 Guangdong OPPO Mobile Telecommunications
 7C03AB Xiaomi Communications
 DC16B2 Huawei Technologies
 24FB65 Huawei Technologies
@@ -12550,7 +13157,7 @@ B42E99 Giga-byte Technology
 14E9B2 Fiberhome Telecommunication Technologies
 C8544B Zyxel Communications
 D07FA0 Samsung Electronics
-009093 Eizo
+009093 EIZO
 4C1159 Vision Information & Communications
 00049F Freescale Semiconductor
 00D07B Comcam International
@@ -12576,7 +13183,7 @@ AC6417 Siemens AG
 0C1C57 Texas Instruments
 806FB0 Texas Instruments
 883F99 Siemens AG
-EC6F0B FADU
+EC6F0B Fadu
 0006EC Harris
 7C6DA6 Superwave Group
 D016B4 Huawei Technologies
@@ -12600,7 +13207,7 @@ EC58EA Ruckus Wireless
 A42618 Integrated Device Technology (Malaysia) Sdn. Bhd.
 A46191 NamJunSa
 84A24D Birds Eye Systems Private Limited
-7C6B9C Guangdong Oppo Mobile Telecommunications
+7C6B9C Guangdong OPPO Mobile Telecommunications
 0017B6 Aquantia
 105917 Tonal
 D0EFC1 Huawei Technologies
@@ -12622,10 +13229,9 @@ A89969 Dell
 A4EA8E Extreme Networks
 882D53 Baidu Online Network Technology (Beijing)
 00D0B5 IPricot formerly DotCom
-746BAB Guangdong Enok Communication
+746BAB Guangdong ENOK Communication
 7829ED Askey Computer
 5061BF Cisco Systems
-0009DF Vestel Elektronik San ve Tic. A..
 F4032F Reduxio Systems
 944A0C Sercomm
 000FA2 2xWireless
@@ -12642,14 +13248,14 @@ FC6BF0 Topwell International Holdinds Limited
 54B203 Pegatron
 3868DD Inventec
 B8B7F1 Wistron Neweb
-8050F6 Itel Mobile Limited
+8050F6 ITEL Mobile Limited
 A8CAB9 Samsung Electro Mechanics
 203956 HMD Global Oy
-78AFE4 Comau S.p.A
+78AFE4 Comau
 90A137 Beijing Splendidtel Communication Technology
 80029C Gemtek Technology
 D0C5D3 AzureWave Technology
-14169E Wingtech Group (HongKongLimited
+14169E Wingtech Group (HongKong）Limited
 F8C39E Huawei Technologies
 E8D099 Fiberhome Telecommunication Technologies
 107BA4 Olive & Dove
@@ -12665,10 +13271,10 @@ C88629 Shenzhen Duubee Intelligent Technologies
 CCC2E0 Raisecom Technology
 300AC5 Ruio telecommunication technologies, Limited
 00E065 Optical Access International
-4466FC Guangdong Oppo Mobile Telecommunications
+4466FC Guangdong OPPO Mobile Telecommunications
 A028ED HMD Global Oy
 AC5474 China Mobile IOT Company Limited
-8C1CDA Ieee Registration Authority
+8C1CDA IEEE Registration Authority
 0007A8 Haier Group Technologies
 9814D2 Avonic
 1409DC Huawei Technologies
@@ -12683,8 +13289,8 @@ C0EEB5 Enice Network.
 88964E Arris Group
 883F4A Texas Instruments
 9CA615 Tp-link Technologies
-E44E76 Championtech  Enterprise (shenzhen)
-004098 Dressler Gmbh &
+E44E76 Championtech Enterprise (shenzhen)
+004098 Dressler GMBH
 001DFA Fujian Landi Commercial Equipment
 9CE65E Apple
 C49880 Apple
@@ -12701,7 +13307,7 @@ F01898 Apple
 B841A4 Apple
 00165C Trackflow
 641CAE Samsung Electronics
-F8E44E Mcot
+F8E44E MCOT
 40CD7A Qingdao Hisense Communications
 DC4EF4 Shenzhen MTN Electronics
 F08173 Amazon Technologies
@@ -12715,7 +13321,7 @@ F4BC97 Shenzhen Crave Communication
 E8986D Palo Alto Networks
 144E34 Remote Solution
 00508B Hewlett Packard
-146B9C Shenzhen Bilian Electronicltd
+146B9C Shenzhen Bilian Electronic，ltd
 948DEF Oetiker Schweiz AG
 2CD974 Hui Zhou Gaoshengda Technology
 D4F786 Fiberhome Telecommunication Technologies
@@ -12730,7 +13336,7 @@ E0E62E TCT mobile
 E42D7B China Mobile IOT Company Limited
 C464E3 Texas Instruments
 8817A3 Integrated Device Technology (Malaysia) Sdn. Bhd.
-88A9A7 Ieee Registration Authority
+88A9A7 IEEE Registration Authority
 EC8914 Huawei Technologies
 B89436 Huawei Technologies
 501479 iRobot
@@ -12750,8 +13356,8 @@ CC3B58 Curiouser Products
 F89066 Nain
 7006AC Eastcompeace Technology
 2802D8 Samsung Electronics
-DCE533 Ieee Registration Authority
-D8445C DEV Tecnologia Ind Com Man Eq Ltda
+DCE533 IEEE Registration Authority
+D8445C DEV Tecnologia Ind Com Man Eq LTDA
 509551 Arris Group
 804126 Huawei Technologies
 ACF970 Huawei Technologies
@@ -12760,7 +13366,7 @@ ACF970 Huawei Technologies
 48C796 Samsung Electronics
 F4C248 Samsung Electronics
 F47190 Samsung Electronics
-C4FFBC Ieee Registration Authority
+C4FFBC IEEE Registration Authority
 0C2369 Honeywell SPS
 04C9D9 Dish Technologies
 7055F8 Cerebras Systems
@@ -12776,7 +13382,7 @@ C477AF Advanced Digital Broadcast SA
 94290C Shenyang wisdom Foundation Technology Development
 9C32CE Canon
 20E09C Nokia
-2CFDA1 Asustek Computer
+2CFDA1 ASUSTek Computer
 3807D4 Zeppelin Systems GmbH
 04197F Grasphere Japan
 5C0038 Viasat Group
@@ -12793,7 +13399,6 @@ B85001 Extreme Networks
 5C521E Nintendo
 14444A Apollo Seiko
 3C2C99 Edgecore Networks
-88D039 TCL Technoly Electronics(Huizhou).
 683E02 Siemens AG, Digital Factory, Motion Control System
 000261 Tilgin AB
 0014C3 Seagate Technology
@@ -12801,7 +13406,7 @@ B85001 Extreme Networks
 002037 Seagate Technology
 5C81A7 Network Devices
 5C0C0E Guizhou Huaxintong Semiconductor Technology
-503CEA Guangdong Oppo Mobile Telecommunications
+503CEA Guangdong OPPO Mobile Telecommunications
 D096FB Dasan Network Solutions
 00E091 LG Electronics
 38437D Compal Broadband Networks
@@ -12855,9 +13460,9 @@ D0D2B0 Apple
 7CDD76 Suzhou Hanming Technologies
 246880 Braveridge.co.
 E8DF70 AVM Audiovisuelles Marketing und Computersysteme GmbH
-28AD3E Shenzhen Tong BO WEI Technology
+28AD3E Shenzhen TONG BO WEI Technology
 001C56 Pado Systems
-F06D78 Guangdong Oppo Mobile Telecommunications
+F06D78 Guangdong OPPO Mobile Telecommunications
 7844FD Tp-link Technologies
 707D95 Shenzhen City LinwlanTechnology
 2C431A Shenzhen Youhua Technology
@@ -12870,11 +13475,9 @@ F0BD2E H+S Polatis
 0040E4 E-M Technology
 984B4A Arris Group
 E084F3 High Grade Controls
-38A6CE BSkyB
 70708B Cisco Systems
 389F5A C-Kur TV
 D843ED Suzuken
-BC4101 Shenzhen Tinno Mobile Technology
 043A0D SM Optics S.r.l.
 448F17 Samsung Electronics, Artik
 00FC8B Amazon Technologies
@@ -12892,7 +13495,7 @@ B8D94D Sagemcom Broadband SAS
 C0742B Shenzhen Xunlong Software,limited
 5C6776 IDS Imaging Development Systems GmbH
 44EAD8 Texas Instruments
-189BA5 Ieee Registration Authority
+189BA5 IEEE Registration Authority
 1C7022 Murata Manufacturing
 CC9891 Cisco Systems
 28BF89 Fiberhome Telecommunication Technologies
@@ -12900,7 +13503,7 @@ CC9891 Cisco Systems
 002294 Kyocera
 3889DC Opticon Sensors Europe
 8C4500 Murata Manufacturing
-1CDDEA Guangdong Oppo Mobile Telecommunications
+1CDDEA Guangdong OPPO Mobile Telecommunications
 940006 jinyoung
 20040F Dell
 A43412 Thales Alenia Space
@@ -12945,7 +13548,7 @@ F0F8F2 Texas Instruments
 008BFC mixi
 A82BB5 Edgecore Networks
 E8E1E2 Energotest
-7811DC Xiaomi Electronics,co.
+7811DC Xiaomi Electronics,CO.
 D463C6 Motorola Mobility, a Lenovo Company
 F844E3 Taicang T&W Electronics
 24A534 SynTrust Tech International
@@ -12974,15 +13577,15 @@ A0423F Tyan Computer
 C08ADE Ruckus Wireless
 001D2E Ruckus Wireless
 B4E62A LG Innotek
-A0C5F2 Ieee Registration Authority
+A0C5F2 IEEE Registration Authority
 A86B7C Shenzhen Fenglian Technology
 B03956 Netgear
 3C0CDB Unionman Technology
 EC42B4 ADC
 60DA83 Hangzhou H3C Technologies, Limited
-2C5731 Wingtech Group (HongKongLimited
-CC4639 WAAV
-AC9E17 Asustek Computer
+2C5731 Wingtech Group (HongKong）Limited
+CC4639 Waav
+AC9E17 ASUSTek Computer
 641666 Nest Labs
 D8DF7A Quest Software
 145BE1 nyantec GmbH
@@ -12993,10 +13596,10 @@ A0AFBD Intel Corporate
 7C8BCA Tp-link Technologies
 B04E26 Tp-link Technologies
 B089C2 Zyptonite
-F023B9 Ieee Registration Authority
+F023B9 IEEE Registration Authority
 FC4DD4 Universal Global Scientific Industrial
-A4F4C2 Vnpt Technology
-8C147D Ieee Registration Authority
+A4F4C2 VNPT Technology
+8C147D IEEE Registration Authority
 30074D Samsung Electro-mechanics(thailand)
 1C1FD4 LifeBEAM Technologies
 009AD2 Cisco Systems
@@ -13008,22 +13611,22 @@ DC74A8 Samsung Electronics
 E83935 Hewlett Packard
 00180A Cisco Meraki
 5C6A80 Zyxel Communications
-D860B3 Guangdong Global Electronic TechnologyLTD
-64351C E-con Systems India PVT
+D860B3 Guangdong Global Electronic Technology，ltd
+64351C e-CON Systems India PVT
 60BA18 nextLAP GmbH
 44AA50 Juniper Networks
-84CD62 Shenzhen Idwell Technology
+84CD62 ShenZhen Idwell Technology
 A8D579 Beijing Chushang Science and Technology
 4448C1 Hewlett Packard Enterprise
 481063 NTT Innovation Institute
 A08E78 Sagemcom Broadband SAS
-88D50C Guangdong Oppo Mobile Telecommunications
+88D50C Guangdong OPPO Mobile Telecommunications
 D428D5 TCT mobile
-9CAF6F Itel Mobile Limited
+9CAF6F ITEL Mobile Limited
 FC539E Shanghai Wind Technologies
 605317 Sandstone Technologies
 907065 Texas Instruments
-18A958 Provision Thai
+18A958 Provision THAI
 74C9A3 Fiberhome Telecommunication Technologies
 EC8A4C zte
 D45F25 Shenzhen Youhua Technology
@@ -13042,7 +13645,6 @@ DCA904 Apple
 6CAB31 Apple
 4C74BF Apple
 04946B Tecno Mobile Limited
-A04C5B Shenzhen Tinno Mobile Technology
 488803 ManTechnology
 B436E3 Kbvision Group
 94D299 Techmation
@@ -13062,7 +13664,7 @@ E048AF Premietech Limited
 2C3311 Cisco Systems
 5082D5 Apple
 F0EE10 Samsung Electronics
-C4700B Guangzhou Chip Technologies
+C4700B Guangzhou CHIP Technologies
 3CA067 Liteon Technology
 BC024A HMD Global Oy
 949901 Shenzhen Yitoa Digital Appliance
@@ -13084,7 +13686,7 @@ B0C205 Bionime
 B81DAA LG Electronics (Mobile Communications)
 00E400 Sichuan Changhong Electric
 2C55D3 Huawei Technologies
-00C024 Eden Sistemas DE Computacao SA
+00C024 EDEN Sistemas DE Computacao SA
 7C4685 Motorola (Wuhan) Mobility Technologies Communication
 1C1EE3 Hui Zhou Gaoshengda Technology
 44032C Intel Corporate
@@ -13127,7 +13729,6 @@ C8AA55 Hunan Comtom Electronic Incorporated
 8809AF Masimo
 2CD02D Cisco Systems
 9CCC83 Juniper Networks
-24A7DC BSkyB
 64DBA0 Select Comfort
 F8983A Leeman International (HongKong) Limited
 4CECEF Soraa
@@ -13153,7 +13754,7 @@ D8197A Nuheara
 04B648 Zenner
 98F199 NEC Platforms
 1840A4 Shenzhen Trylong Smart Science and Technology
-1C48CE Guangdong Oppo Mobile Telecommunications
+1C48CE Guangdong OPPO Mobile Telecommunications
 C80CC8 Huawei Technologies
 0425C5 Huawei Technologies
 603E7B Gafachi
@@ -13162,15 +13763,14 @@ AC83F3 Ampak Technology
 CC8CDA Shenzhen Wei Da Intelligent Technology Go.
 D436DB Jiangsu Toppower Automotive Electronics
 2CDCAD Wistron Neweb
-6C5C14 Guangdong Oppo Mobile Telecommunications
+6C5C14 Guangdong OPPO Mobile Telecommunications
 E80945 Integrated Device Technology (Malaysia) Sdn. Bhd.
-B0A2E7 Shenzhen Tinno Mobile Technology
 7C2587 chaowifi.com
 2C2131 Juniper Networks
 00501E Grass Valley, A Belden Brand
 EC0D9A Mellanox Technologies
 90D7BE Wavelab Global
-244E7B Ieee Registration Authority
+244E7B IEEE Registration Authority
 30AEA4 Espressif
 3CFA43 Huawei Technologies
 145F94 Huawei Technologies
@@ -13192,7 +13792,7 @@ C0854C Ragentek Technology Group
 CC9470 Kinestral Technologies
 B439D6 ProCurve Networking by HP
 34F39A Intel Corporate
-D816C1 Dewav (hk) Electronics Limited
+D816C1 Dewav (HK) Electronics Limited
 CC61E5 Motorola Mobility, a Lenovo Company
 8C8ABB Beijing Orient View Technology
 00039B NetChip Technology
@@ -13203,9 +13803,9 @@ CC088D Apple
 38A4ED Xiaomi Communications
 B89919 7signal Solutions
 40FE0D Maxio
-AC64DD Ieee Registration Authority
+AC64DD IEEE Registration Authority
 94B819 Nokia
-787D48 Itel Mobile Limited
+787D48 ITEL Mobile Limited
 8871E5 Amazon Technologies
 BC39D9 Z-tec
 609AC1 Apple
@@ -13213,14 +13813,14 @@ BC39D9 Z-tec
 00B0EE Ajile Systems
 0418D6 Ubiquiti Networks
 20DBAB Samsung Electronics
-383A21 Ieee Registration Authority
+383A21 IEEE Registration Authority
 D8380D Shenzhen Ip-com Network
 88AD43 Pegatron
 B4EFFA Lemobile Information Technology (Beijing)
 6C71BD Ezelink Telecom
 60EFC6 Shenzhen Chima Technologies Limited
-001FC6 Asustek Computer
-B0C128 Adler Elreha Gmbh
+001FC6 ASUSTek Computer
+B0C128 Adler Elreha GmbH
 3087D9 Ruckus Wireless
 FCCAC4 LifeHealth
 F0D9B2 EXO
@@ -13228,7 +13828,7 @@ E4C801 BLU Products
 F09838 Huawei Technologies
 C80E14 AVM Audiovisuelles Marketing und Computersysteme GmbH
 AC63BE Amazon Technologies
-F81D78 Ieee Registration Authority
+F81D78 IEEE Registration Authority
 38F7B2 Seojun Electric
 101250 Integrated Device Technology (Malaysia) Sdn. Bhd.
 7802B7 ShenZhen Ultra Easy Technology
@@ -13243,7 +13843,7 @@ C87E75 Samsung Electronics
 002486 DesignArt Networks
 002478 Mag Tech Electronics Limited
 382DD1 Samsung Electronics
-001B2C Atron Electronic Gmbh
+001B2C Atron electronic GmbH
 9034FC Hon Hai Precision Ind.
 001427 JazzMutant
 001E84 Pika Technologies
@@ -13286,7 +13886,7 @@ BC851F Samsung Electronics
 5001BB Samsung Electronics
 C40142 MaxMedia Technology Limited
 8430E5 SkyHawke Technologies
-1C77F6 Guangdong Oppo Mobile Telecommunications
+1C77F6 Guangdong OPPO Mobile Telecommunications
 58E326 Compass Technologies
 001B2A Cisco Systems
 749DDC 2Wire
@@ -13319,7 +13919,7 @@ E09DFA Wanan Hongsheng ElectronicLtd
 287AEE Arris Group
 88797E Motorola Mobility, a Lenovo Company
 305890 Frontier Silicon
-708BCD Asustek Computer
+708BCD ASUSTek Computer
 00258B Mellanox Technologies
 00562B Cisco Systems
 E8FD90 Turbostor
@@ -13352,7 +13952,7 @@ D8FB68 Cloud Corner
 685388 P&S Technology
 982F3C Sichuan Changhong Electric
 14C1FF ShenZhen QianHai Comlan communication
-000417 Elau AG
+000417 ELAU AG
 ECFAAA The IMS Company
 F00786 Shandong Bittel Electronics
 00D0F6 Nokia
@@ -13368,7 +13968,7 @@ E89309 Samsung Electronics
 001DAF Nortel Networks
 88A6C6 Sagemcom Broadband SAS
 94D469 Cisco Systems
-882BD7 Addnergie  Technologies
+882BD7 Addénergie Technologies
 0090CC Planex Communications
 2057AF Shenzhen Fh-net Optoelectronics
 54DC1D Yulong Computer Telecommunication Scientific (Shenzhen)
@@ -13381,11 +13981,11 @@ ACA213 Shenzhen Bilian electronic
 0022CF Planex Communications
 E417D8 8bitdo Technology HK Limited
 9CD332 PLC Technology
-38F8CA Owin
+38F8CA OWIN
 44334C Shenzhen Bilian electronic
 64899A LG Electronics (Mobile Communications)
 002105 Alcatel-Lucent IPD
-001BC5 Ieee Registration Authority
+001BC5 IEEE Registration Authority
 48DF37 Hewlett Packard Enterprise
 C0E42D Tp-link Technologies
 8CA6DF Tp-link Technologies
@@ -13401,16 +14001,16 @@ F8A9D0 LG Electronics (Mobile Communications)
 CCFA00 LG Electronics (Mobile Communications)
 74A722 LG Electronics (Mobile Communications)
 F01C13 LG Electronics (Mobile Communications)
-58FCDB Ieee Registration Authority
-B0C5CA Ieee Registration Authority
-7419F8 Ieee Registration Authority
+58FCDB IEEE Registration Authority
+B0C5CA IEEE Registration Authority
+7419F8 IEEE Registration Authority
 A816B2 LG Electronics (Mobile Communications)
 64BC0C LG Electronics (Mobile Communications)
-90C682 Ieee Registration Authority
+90C682 IEEE Registration Authority
 C01ADA Apple
-000031 Qpsx Communications
+000031 QPSX Communications
 000E1E QLogic
-0014D1 Trendnet
+0014D1 TRENDnet
 CC52AF Universal Global Scientific Industrial
 001C14 VMware
 005056 VMware
@@ -13439,12 +14039,12 @@ FC528D Technicolor CH USA
 506583 Texas Instruments
 B09122 Texas Instruments
 FC51A4 Arris Group
-9857D3 HON Hai-ccpbg  Precision Ind.co.
+9857D3 HON Hai-ccpbg Precision Ind.co.
 FCF528 Zyxel Communications
 00A0C5 Zyxel Communications
 A09E1A Polar Electro Oy
 1CD6BD Leedarson Lighting
-D0D94F Ieee Registration Authority
+D0D94F IEEE Registration Authority
 001E04 Hanson Research
 60C0BF ON Semiconductor
 AC0481 Jiangsu Huaxing Electronics
@@ -13470,7 +14070,7 @@ C4693E Turbulence Design
 B0CF4D MI-Zone Technology Ireland
 289AFA TCT mobile
 001A34 Konka Group
-0011FC Harting Electronics Gmbh
+0011FC Harting Electronics GmbH
 002389 Hangzhou H3C Technologies, Limited
 3CE5A6 Hangzhou H3C Technologies, Limited
 5CDD70 Hangzhou H3C Technologies, Limited
@@ -13480,7 +14080,7 @@ D8209F Cubro Acronet GesmbH
 8C7716 Longcheer Telecommunication Limited
 68FB7E Apple
 84A134 Apple
-A0D385 Auma Riester Gmbh & KG
+A0D385 AUMA Riester GmbH & KG
 1414E6 Ningbo Sanhe Digital
 002582 Maksat Technologies (P)
 0C5101 Apple
@@ -13496,7 +14096,7 @@ AC6FBB Tatung Technology
 0060B1 Input/Output
 547F54 Ingenico
 6C2483 Microsoft Mobile Oy
-6891D0 Ieee Registration Authority
+6891D0 IEEE Registration Authority
 E04F43 Universal Global Scientific Industrial
 38700C Arris Group
 000E2E Edimax Technology
@@ -13526,7 +14126,7 @@ D8D723 IDS
 00A0F4 GE
 AC0D1B LG Electronics (Mobile Communications)
 F0D1B8 Ledvance
-986D35 Ieee Registration Authority
+986D35 IEEE Registration Authority
 88795B Konka Group
 081F71 Tp-link Technologies
 5CCA1A Microsoft Mobile Oy
@@ -13546,7 +14146,7 @@ D8803C Anhui Huami Information Technology Company Limited
 00A0B8 NetApp
 00C88B Cisco Systems
 24C3F9 Securitas Direct AB
-2C21D7 Imax
+2C21D7 IMAX
 0009D2 Mai Logic
 006016 Clariion
 981FB1 Shenzhen Lemon Network Technology
@@ -13571,7 +14171,7 @@ E49A79 Apple
 F01B6C vivo Mobile Communication
 A0B9ED Skytap
 94C960 Zhongshan B&T technology.co.
-74C330 Shenzhen Fast Technologies
+74C330 Shenzhen FAST Technologies
 403F8C Tp-link Technologies
 DCB3B4 Honeywell Environmental & Combustion Controls (Tianjin)
 001D3B Nokia Danmark A/S
@@ -13741,11 +14341,11 @@ CC3D82 Intel Corporate
 BC305B Dell
 388602 Flexoptix GmbH
 4065A3 Sagemcom Broadband SAS
-D02212 Ieee Registration Authority
-100723 Ieee Registration Authority
-A44F29 Ieee Registration Authority
-74F8DB Ieee Registration Authority
-A43BFA Ieee Registration Authority
+D02212 IEEE Registration Authority
+100723 IEEE Registration Authority
+A44F29 IEEE Registration Authority
+74F8DB IEEE Registration Authority
+A43BFA IEEE Registration Authority
 B8CA3A Dell
 ECF4BB Dell
 D4BED9 Dell
@@ -13762,7 +14362,7 @@ C0830A 2Wire
 0054BD Swelaser AB
 001E4C Hon Hai Precision Ind.
 20BB76 COL Giovanni Paolo SpA
-3CDD89 Somo Holdings & TECH.
+3CDD89 SOMO Holdings & Tech.
 1801E3 Bittium Wireless
 149182 Belkin International
 18622C Sagemcom Broadband SAS
@@ -13800,7 +14400,7 @@ D83C69 Shenzhen Tinno Mobile Technology
 F4F5D8 Google
 8C579B Wistron Neweb
 0059AC KPN.
-40D855 Ieee Registration Authority
+40D855 IEEE Registration Authority
 34AB37 Apple
 2400BA Huawei Technologies
 24DF6A Huawei Technologies
@@ -13899,8 +14499,6 @@ B075D5 zte
 D0154A zte
 0026ED zte
 006057 Murata Manufacturing
-783E53 BSkyB
-0019FB BSkyB
 14B968 Huawei Technologies
 5CF96A Huawei Technologies
 083E8E Hon Hai Precision Ind.
@@ -13977,7 +14575,7 @@ DCA5F4 Cisco Systems
 BCF1F2 Cisco Systems
 C80084 Cisco Systems
 40A6E8 Cisco Systems
-3085A9 Asustek Computer
+3085A9 ASUSTek Computer
 B83861 Cisco Systems
 580A20 Cisco Systems
 2C3ECF Cisco Systems
@@ -13991,10 +14589,10 @@ A0ECF9 Cisco Systems
 BC671C Cisco Systems
 001947 Cisco Spvtg
 001839 Cisco-Linksys
-002215 Asustek Computer
-E0CB4E Asustek Computer
+002215 ASUSTek Computer
+E0CB4E ASUSTek Computer
 547C69 Cisco Systems
-001731 Asustek Computer
+001731 ASUSTek Computer
 DCCEC1 Cisco Systems
 9C57AD Cisco Systems
 60FEC5 Apple
@@ -14099,7 +14697,7 @@ D03E5C Huawei Technologies
 C49E41 G24 Power Limited
 B813E9 Trace Live Network
 80B709 Viptela
-F00D5C JinQianMao  Technology
+F00D5C JinQianMao Technology
 54BE53 zte
 280E8B Beijing Spirit Technology Development
 F44D30 Elitegroup Computer Systems
@@ -14107,7 +14705,6 @@ F44D30 Elitegroup Computer Systems
 38D40B Samsung Electronics
 E83A12 Samsung Electronics
 24DA9B Motorola Mobility, a Lenovo Company
-30E090 Linctronix,
 A4DCBE Huawei Technologies
 ECB870 Beijing Heweinet Technology
 94BBAE Husqvarna AB
@@ -14129,7 +14726,7 @@ E0319E Valve
 3C5CC3 Shenzhen First Blue Chip Technology
 C49FF3 Mciao Technologies
 788E33 Jiangsu Seuic Technology
-ECEED8 Ztlx Network Technology
+ECEED8 ZTLX Network Technology
 80EB77 Wistron
 483974 Proware Technologies
 30FFF6 HangZhou KuoHeng Technology
@@ -14182,14 +14779,14 @@ F41563 F5 Networks
 785F4C Argox Information
 34CC28 Nexpring,
 54E2C8 Dongguan Aoyuan Electronics Technology
-6C1E70 Guangzhou Ybds IT
+6C1E70 Guangzhou YBDS IT
 54B80A D-Link International
 D8ADDD Sonavation
 8833BE Ivenix
 E48D8C Routerboard.com
 706879 Saijo Denki International
-10AF78 Shenzhen Atue Technology
-CC19A8 PT Inovao e Sistemas SA
+10AF78 Shenzhen ATUE Technology
+CC19A8 PT Inovação e Sistemas SA
 B4B265 Daeho I&T
 E03560 Challenger Supply Holdings
 3CCB7C TCT mobile
@@ -14209,10 +14806,10 @@ CCA4AF Shenzhen Sowell Technology
 7C8274 Shenzhen Hikeen Technology
 94D417 GPI Korea
 244B81 Samsung Electronics
-704E66 Shenzhen Fast Technologies
+704E66 Shenzhen FAST Technologies
 D855A3 zte
 38D82F zte
-F07959 Asustek Computer
+F07959 ASUSTek Computer
 E08E3C Aztech Electronics Pte
 844BB7 Beijing Sankuai Online Technology
 68F0BC Shenzhen LiWiFi Technology
@@ -14257,7 +14854,7 @@ E89606 testo Instruments (Shenzhen)
 600417 Posbank
 207693 Lenovo (Beijing) Limited.
 084656 Veo-labs
-EC3C5A Shen Zhen Heng Sheng HUI Digital Technology
+EC3C5A SHEN ZHEN HENG Sheng HUI Digital Technology
 4488CB Camco Technologies NV
 6CBFB5 Noon Technology
 50294D Nanjing IOT Sensor Technology
@@ -14277,18 +14874,18 @@ F42853 Zioncom Electronics (Shenzhen)
 D4EC86 LinkedHope Intelligent Technologies
 1C9C26 Zoovel Technologies
 046785 scemtec Hard- und Software fuer Mess- und Steuerungstechnik GmbH
-D0FA1D Qihoo  360  Technology
-AC11D3 Suzhou Hotek  Video Technology
+D0FA1D Qihoo 360 Technology
+AC11D3 Suzhou Hotek Video Technology
 8432EA Anhui Wanzten P&T
 E01D38 Beijing HuaqinWorld Technology
 E47FB2 Fujitsu Limited
 FC6DC0 BME
 24D13F Mexus
-7824AF Asustek Computer
-FC9FE1 Conwin.tech.
+7824AF ASUSTek Computer
+FC9FE1 CONWIN.Tech.
 B89BE4 ABB Power Systems Power Generation
 A81B5D Foxtel Management
-505065 Takt
+505065 TAKT
 40C62A Shanghai Jing Ren Electronic Technology
 E8150E Nokia
 C44202 Samsung Electronics
@@ -14318,7 +14915,7 @@ F884F2 Samsung Electronics
 B0754D Nokia
 E0CBEE Samsung Electronics
 4C3909 HPL Electric & Power Private Limited
-907EBA Utek Technology (shenzhen)
+907EBA UTEK Technology (shenzhen)
 A002DC Amazon Technologies
 542AA2 Alpha Networks
 84948C Hitron Technologies.
@@ -14344,13 +14941,13 @@ D8492F Canon
 3C25D7 Nokia
 18FF2E Shenzhen Rui Ying Da Technology
 847207 I&C Technology
-CCA614 Aifa Technology
+CCA614 AIFA Technology
 90F1B0 Hangzhou Anheng Info&Tech
 4C8B30 Actiontec Electronics
 0805CD DongGuang EnMai Electronic ProductLtd.
 54D163 Max-tech
 48B5A7 Glory Horse Industries
-0C4F5A ASA-RT s.r.l.
+0C4F5A Asa-rt s.r.l.
 D4224E Alcatel Lucent
 9C86DA Phoenix Geophysics
 2C073C Devline Limited
@@ -14363,7 +14960,7 @@ ACB859 Uniband Electronic,
 6047D4 Forics Electronic Technology
 FCF8B7 Tronteq Electronic
 30F42F ESP
-704E01 Kwangwon Tech
+704E01 Kwangwon TECH
 746A8F VS Vision Systems GmbH
 54A31B Shenzhen Linkworld Technology
 CC398C Shiningtek
@@ -14379,7 +14976,6 @@ C4291D Klemsan Elektrik Elektronik San.ve Tic.as.
 2C957F zte
 3C0C48 Servergy
 10DEE4 automationNEXT GmbH
-F03A4B Bloombase
 404A18 Addrek Smart Solutions
 C0C569 Shanghai Lynuc CNC Technology
 C4C0AE Midori Electronic
@@ -14388,7 +14984,7 @@ ACC595 Graphite Systems
 D8150D Tp-link Technologies
 5850AB TLS
 7CCD11 MS-Magnet
-98FF6A Otec(shanghai)technology
+98FF6A OTEC(Shanghai)Technology
 BC1A67 YF Technology
 4CD7B6 Helmer Scientific
 8425A4 Tariox Limited
@@ -14412,7 +15008,7 @@ FC09D8 Acteon Group
 BC2D98 ThinGlobal
 1879A2 GMJ Electric Limited
 E0C86A Shenzhen Tw-scie
-BCEE7B Asustek Computer
+BCEE7B ASUSTek Computer
 3413A8 Mediplan Limited
 7C9763 Openmatics s.r.o.
 48A2B7 Kodofon JSC
@@ -14430,18 +15026,18 @@ FCE1D9 Stable Imaging Solutions
 50206B Emerson Climate Technologies Transportation Solutions
 7CBF88 Mobilicom
 60DB2A HNS
-B04545 Yacoub Automation Gmbh
+B04545 Yacoub Automation GmbH
 C8EE75 Pishion International
 CC3429 Tp-link Technologies
 64BABD SDJ Technologies
 24C848 mywerk Portal GmbH
 CCFB65 Nintendo
-A0A23C Gpms
+A0A23C GPMS
 68FCB3 Next Level Security Systems
 94C3E4 Atlas Copco IAS GmbH
 34885D Logitech Far East
 88576D XTA Electronics
-BC4100 Codaco Electronic S.r.o.
+BC4100 Codaco Electronic s.r.o.
 FCD817 Beijing Hesun TechnologiesLtd.
 682DDC Wuhan Changjiang Electro-Communication Equipment
 E8611F Dawning Information Industry
@@ -14451,12 +15047,12 @@ E8611F Dawning Information Industry
 9C443D Chengdu Xuguang Technology
 B424E7 Codetek Technology
 542F89 Euclid Laboratories
-909916 Elvees Neotek Ojsc
+909916 Elvees NeoTek OJSC
 00A2FF abatec group AG
 6024C1 Jiangsu Zhongxun Electronic Technology
 A0143D Parrot SA
 FC1BFF V-zug AG
-F42896 Specto Paineis Eletronicos Ltda
+F42896 Specto Paineis Eletronicos LTDA
 78CB33 DHC Software
 60A9B0 Merchandising Technologies
 5027C7 Technart
@@ -14468,14 +15064,14 @@ EC3E09 Performance Designed Products
 34A3BF Terewave.
 8C088B Remote Solution
 B43E3B Viableware
-0C5CD8 Doli Elektronik Gmbh
+0C5CD8 DOLI Elektronik GmbH
 3C15EA Tescom
 E80410 Private
 F4BD7C Chengdu jinshi communication
 DCC422 Systembase Limited
 C8F36B Yamato Scale
 98F8C1 IDT Technology Limited
-6CD1B0 Wing Sing Electronics Hong Kong Limited
+6CD1B0 WING SING Electronics HONG KONG Limited
 A4F522 Chofu Seisakusho
 845C93 Chabrier Services
 68E166 Private
@@ -14485,14 +15081,14 @@ BC2BD7 Revogi Innovation
 CC2A80 Micro-Biz intelligence solutions
 60FEF9 Thomas & Betts
 B8DC87 IAI
-7C6FF8 Shenzhen Acto Digital Video Technology
+7C6FF8 ShenZhen ACTO Digital Video Technology
 DCF755 Sitronik
 5C026A Applied Vision
 0C9301 PT. Prasimax Inovasi Teknologi
 746630 T:mi Ytti
 6CB350 Anhui comhigher tech
 3859F8 MindMade Sp. z o.o.
-4CDF3D Team Engineers Advance Technologies India PVT
+4CDF3D TEAM Engineers Advance Technologies India PVT
 E89218 Arcontia International AB
 0075E1 Ampt
 98CDB4 Virident Systems
@@ -14512,7 +15108,7 @@ B050BC Shenzhen Basicom Electronic
 841E26 Kernel-i
 B4346C Matsunichi Digital Technology (hong Kong) Limited
 0086A0 Private
-A05B21 Envinet Gmbh
+A05B21 Envinet GmbH
 50B8A2 ImTech Technologies,
 B04C05 Fresenius Medical Care Deutschland GmbH
 B0793C Revolv
@@ -14549,7 +15145,7 @@ D0EB03 Zhehua technology limited
 683EEC Ereca
 C42628 Airo Wireless
 30AABD Shanghai Reallytek Information Technology
-A4B818 Penta Gesellschaft Fr Elektronische Industriedatenverarbeitung mbH
+A4B818 Penta Gesellschaft für elektronische Industriedatenverarbeitung mbH
 C04DF7 Serelec
 0C8484 Zenovia Electronics
 005907 LenovoEMC Products USA
@@ -14581,7 +15177,7 @@ C80E95 OmniLync
 080EA8 Velex s.r.l.
 B8C46F Primmcon Industries
 D8B02E Guangzhou Zonerich Business Machine
-C4E032 Ieee 1904.1 Working Group
+C4E032 IEEE 1904.1 Working Group
 58EB14 Proteus Digital Health
 C458C2 Shenzhen Tatfook Technology
 D0CDE1 Scientech Electronics
@@ -14590,12 +15186,12 @@ E08177 GreenBytes
 9C9811 Guangzhou Sunrise Electronics Development
 B86091 Onnet Technologies and Innovations
 8C76C1 Goden Tech Limited
-8C078C Flow Data
+8C078C FLOW DATA
 F8DFA8 zte
 A895B0 Aker Subsea
 104D77 Innovative Computer Engineering
-C45DD8 Hdmi Forum
-C4EBE3 Rrcn SAS
+C45DD8 HDMI Forum
+C4EBE3 RRCN SAS
 94756E QinetiQ North America
 4C1A95 Novakon
 60BB0C Beijing HuaqinWorld Technology
@@ -14610,7 +15206,7 @@ C044E3 Shenzhen Sinkna Electronics
 18550F Cisco Spvtg
 187A93 Amiccom Electronics
 8887DD DarbeeVision
-30C82A WI-BIZ srl
+30C82A Wi-biz srl
 88A3CC Amatis Controls
 C0A0C7 Fairfield Industries
 DCA989 Macandc
@@ -14654,7 +15250,7 @@ C0AA68 Osasi Technos
 485A3F Wisol
 60BC4C EWM Hightec Welding GmbH
 1C11E1 Wartsila Finland Oy
-50465D Asustek Computer
+50465D ASUSTek Computer
 74BFA1 Hyunteck
 CC262D Verifi
 3C8AE5 Tensun Information Technology(Hangzhou)
@@ -14665,7 +15261,7 @@ F8AA8A Axview Technology (Shenzhen)
 7C0187 Curtis Instruments
 54F666 Berthold Technologies GmbH andKG
 34C803 Nokia
-F05F5A Getriebebau Nord Gmbh and KG
+F05F5A Getriebebau NORD GmbH and KG
 801DAA Avaya
 7C092B Bekey A/S
 842BBC Modelleisenbahn GmbH
@@ -14682,7 +15278,7 @@ B4009C CableWorld
 74273C ChangYang Technology (Nanjing)
 087CBE Quintic
 E804F3 Throughtek
-0868EA Eito Electronics
+0868EA EITO Electronics
 F82285 Cypress Technology
 C4AD21 Mediaedge
 E85BF0 Imaging Diagnostics
@@ -14695,7 +15291,7 @@ C438D3 Tagatec
 AC14D2 wi-daq
 9C4CAE Mesa Labs
 20C1AF i Wit Digital, Limited
-80AAA4 Usag
+80AAA4 USAG
 30AEF6 Radio Mobile Access
 085B0E Fortinet
 EC42F0 ADL Embedded Solutions
@@ -14710,7 +15306,7 @@ C0C946 Mitsuya Laboratories
 F4600D Panoptic Technology
 A82BD6 Shina System
 ACCF23 Hi-flying electronics technology
-609084 Dssd
+609084 DSSD
 FC1D59 I Smart Cities HK
 78C4AB Shenzhen Runsil Technology
 B0A86E Juniper Networks
@@ -14744,7 +15340,7 @@ FC2A54 Connected Data
 045C06 Zmodo Technology
 747B7A ETH
 48EA63 Zhejiang Uniview Technologies
-E88DF5 Znyx Networks
+E88DF5 ZNYX Networks
 90F72F Phillips Machine & Welding
 D05785 Pantech
 408B07 Actiontec Electronics
@@ -14758,19 +15354,19 @@ AC3D75 Hangzhou Zhiway Technologies
 A090DE Veedims
 642DB7 Seungil Electronics
 002A6A Cisco Systems
-F436E1 Abilis Systems Sarl
+F436E1 Abilis Systems SARL
 781C5A Sharp
 E80C75 Syncbak
 800A06 Comtec
 608C2B Hanson Technology
 940070 Nokia
 BC2C55 Bear Flag Design
-0C7523 Beijing Gehua Catv Network
+0C7523 Beijing Gehua CATV Network
 04F021 Compex Systems Pte
 2818FD Aditya Infotech
 D8B90E Triple Domain Vision
 342F6E Anywire
-CCEED9 Vahle Automation Gmbh
+CCEED9 Vahle Automation GmbH
 005CB1 Gospell Digital Technology
 B08E1A URadio Systems
 D8E952 Keopsys
@@ -14784,14 +15380,14 @@ F0007F Janz - Contadores de Energia
 506028 Xirrus
 0091FA Synapse Product Development
 A05AA4 Grand Products Nevada
-F0EEBB Vipar Gmbh
+F0EEBB Vipar GmbH
 6CE907 Nokia
 E4FA1D PAD Peripheral Advanced Design
 1C5C55 Prima Cinema
 34BA9A Asiatelco Technologies
 506441 Greenlee
 9C1FDD Accupix
-7CDD11 Chongqing MAS Sci&tech.co.
+7CDD11 Chongqing MAS SCI&TECH.Co.
 B8FD32 Zhejiang Roicx Microelectronics
 70EE50 Netatmo
 984A47 CHG Hospital Beds
@@ -14812,7 +15408,7 @@ B89AED OceanServer Technology
 C87D77 Shenzhen Kingtech Communication Equipment
 94AE61 Alcatel Lucent
 5CCEAD Cdyne
-AC54EC Ieee P1823 Standards Working Group
+AC54EC IEEE P1823 Standards Working Group
 709756 Happyelectronics
 B820E7 Guangzhou Horizontal Information & Network Integration
 00CD90 MAS Elektronik AG
@@ -14843,10 +15439,10 @@ D4F63F IEA S.r.l.
 2839E7 Preceno Technology Pte.Ltd.
 685E6B PowerRay
 20C8B3 Shenzhen Bul-tech
-F8E7B5 tech Tecnologia Ltda
+F8E7B5 µTech Tecnologia LTDA
 D4CEB8 Enatel
 807A7F ABB Genway Xiamen Electrical Equipment
-24DAB6 Sistemas de Gestin Energtica S.A. de C.V
+24DAB6 Sistemas de Gestión Energética de C.V
 B07D62 Dipl.-Ing. H. Horstmann GmbH
 B8F5E7 WayTools
 B81999 Nesys
@@ -14872,7 +15468,6 @@ C8A1BA Neul
 C43A9F Siconix
 686E23 Wi3
 DCF05D Letta Teknoloji
-5C16C7 Big Switch Networks
 848F69 Dell
 3C096D Powerhouse Dynamics
 900D66 Digimore Electronics
@@ -14891,14 +15486,14 @@ D43AE9 Dongguan ipt Industrial
 18F650 Multimedia Pacific Limited
 688470 eSSys
 48DCFB Nokia
-20B7C0 Omicron Electronics Gmbh
+20B7C0 Omicron electronics GmbH
 8058C5 NovaTec Kommunikationstechnik GmbH
 B8C716 Fiberhome Telecommunication Technologies
 D42C3D Sky Light Digital Limited
 A45A1C smart-electronic GmbH
 806459 Nimbus
-8C89A5 Micro-Star INT'L
-B4A5A9 Modi Gmbh
+8C89A5 Micro-Star Int'l
+B4A5A9 MODI GmbH
 C436DA Rusteletech
 0432F4 Partron
 1C184A ShenZhen RicherLink Technologies
@@ -14913,12 +15508,12 @@ B83A7B Worldplay (Canada)
 1407E0 Abrantix AG
 DCCF94 Beijing Rongcheng Hutong Technology
 A4DB2E Kingspan Environmental
-C8FE30 Bejing Dayo Mobile Communication Technology
+C8FE30 Bejing DAYO Mobile Communication Technology
 E4D71D Oraya Therapeutics
 24C9DE Genoray
 54055F Alcatel Lucent
 6C5D63 ShenZhen Rapoo Technology
-941673 Point Core Sarl
+941673 Point Core SARL
 5C56ED 3pleplay Electronics Private Limited
 78028F Adaptive Spectrum and Signal Alignment (assia)
 DC16A2 Medtronic Diabetes
@@ -14938,13 +15533,12 @@ D4945A Cosmo
 B42A39 Orbit Merret, spol. s r. o.
 70E843 Beijing C&W Optical Communication Technology
 2C7ECF Onzo
-103711 Simlink AS
 50E549 Giga-byte Technology
 B4B88D Thuh Company
-4C73A5 Kove
+4C73A5 KOVE
 70A41C Advanced Wireless Dynamics S.L.
 BCBBC9 Kellendonk Elektronik GmbH
-E42AD3 Magneti Marelli S.p.A. Powertrain
+E42AD3 Magneti Marelli Powertrain
 E83EB6 RIM
 BC35E5 Hydro Systems Company
 9C5D95 VTC Electronics
@@ -14969,21 +15563,21 @@ F8DAF4 Taishan Online Technology
 108CCF Cisco Systems
 D8E3AE Cirtec Medical Systems
 08B7EC Wireless Seismic
-18AF9F Digitronic Automationsanlagen Gmbh
+18AF9F Digitronic Automationsanlagen GmbH
 00B342 MacroSAN Technologies
 1CF5E7 Turtle Industry
 980EE4 Private
 447DA5 Vtion Information Technology (fujian)
 0CCDD3 Eastriver Technology
 E46C21 messMa GmbH
-00B033 OAO Izhevskiy radiozavod
+00B033 OAO "Izhevskiy radiozavod"
 081735 Cisco Systems
 C89C1D Cisco Systems
 E437D7 Henri Depaepes.
 E0A1D7 SFR
 9481A4 Azuray Technologies
 BCE09D Eoslink
-9C220E Tascan Systems Gmbh
+9C220E Tascan Systems GmbH
 7CDD90 Shenzhen Ogemray Technology
 0C3C65 Dome Imaging
 C8DF7C Nokia
@@ -14997,28 +15591,27 @@ FCAF6A Qulsar
 34BDF9 Shanghai WDK Industrial
 CCBE71 OptiLogix BV
 0C469D MS Sedco
-B09AE2 Stemmer Imaging Gmbh
+B09AE2 Stemmer Imaging GmbH
 14EE9D AirNav Systems
 78D004 Neousys Technology
 8895B9 Unified Packet Systems Crop
 D8FE8F IDFone
 888C19 Brady Asia Pacific
-448C52 Ktis
+448C52 KTIS
 006DFB Vutrix Technologies
 841888 Juniper Networks
 9067B5 Alcatel-Lucent
 E0F379 Vaddio
-78B6C1 Aobo Telecom
+78B6C1 AOBO Telecom
 08D29A Proformatique
 C89383 Embedded Automation
 78A051 iiNet Labs
 804F58 ThinkEco
-0475F5 Csst
+0475F5 CSST
 24BA30 Technical Consumer Products
 188ED5 TP Vision Belgium N.V. - innovation site Brugge
 E80C38 Daeyoung Information System
 E08A7E Exponent
-A8B0AE Leoni
 E42771 Smartlabs
 34DF2A Fujikon Industrial,Limited
 2CDD0C Discovergy GmbH
@@ -15032,9 +15625,8 @@ B4A4E3 Cisco Systems
 8C1F94 RF Surgical System
 4491DB Shanghai Huaqin Telecom Technology
 14D76E Conch Electronic
-AC83F0 ImmediaTV
 CC6B98 Minetec Wireless Technologies
-3C04BF Pravis Systemsltd.,
+3C04BF Pravis SystemsLtd.,
 94DD3F A+V Link Technologies
 F44227 S & S Research
 C8A729 SYStronics
@@ -15047,7 +15639,7 @@ BCFFAC Topcon
 7C55E7 YSI
 70B08C Shenou Communication Equipment
 C03B8F Minicom Digital Signage
-20FEDB M2M SolutionS.
+20FEDB M2M Solutions.
 0C8D98 TOP Eight IND
 40C7C9 Naviit
 7CBB6F Cosco Electronics
@@ -15058,20 +15650,20 @@ C8A1B6 Shenzhen Longway Technologies
 D0574C Cisco Systems
 F8DAE2 NDC Technologies
 705EAA Action Target
-34F968 Atek Products
+34F968 ATEK Products
 20B0F7 Enclustra GmbH
 543131 Raster Vision
 D0E347 Yoga
 F0ED1E Bilkon Bilgisayar Kontrollu Cih. Im.Ltd.
 C416FA Prysm
 506F9A Wi-Fi Alliance
-842914 Emporia Telecom Produktions- und Vertriebsgesmbh & KG
+842914 Emporia Telecom Produktions- und VertriebsgesmbH & KG
 BC7DD1 Radio Data Comms
 585076 Linear Equipamentos Eletronicos SA
 F0F9F7 IES GmbH & KG
 38580C Panaccess Systems GmbH
 4451DB Raytheon BBN Technologies
-DCFAD5 Strong Ges.m.b.h.
+DCFAD5 Strong Ges.m.b.H.
 6C8D65 Wireless Glue Networks
 9803A0 ABB n.v. Power Quality Products
 CC43E3 Trump
@@ -15092,7 +15684,7 @@ A85BB0 Shenzhen Dehoo Technology
 4C60D5 airPointe of New Hampshire
 888717 Canon
 6CDC6A Promethean Limited
-9055AE Ericsson, EAB/RWI/K
+9055AE Ericsson, Eab/rwi/k
 1010B6 McCain
 009363 Uni-Link Technology
 D4823E Argosy Technologies
@@ -15104,7 +15696,7 @@ BC6A16 tdvine
 003A9D NEC Platforms
 28CD4C Individual Computers GmbH
 8C53F7 A&D Engineering
-7C7673 Enmas Gmbh
+7C7673 Enmas GmbH
 6C6F18 Stereotaxis
 84C727 Gnodal
 087695 Auto Industrial
@@ -15126,7 +15718,7 @@ F02408 Talaris (Sweden) AB
 8081A5 Tongqing Communication Equipment (shenzhen)
 B482FE Askey Computer
 307C30 RIM
-BC4E3C Core Staff
+BC4E3C CORE Staff
 502A8B Telekom Research and Development Sdn Bhd
 EC43E6 Awcer
 7812B8 Orantek Limited
@@ -15138,7 +15730,7 @@ F02FD8 Bi2-Vision
 F47626 Viltechmeda UAB
 0C17F1 Telecsys
 003A9B Cisco Systems
-2C3427 Erco & Gener
+2C3427 ERCO & Gener
 80912A Lih Rong electronic Enterprise
 7C2F80 Gigaset Communications GmbH
 10B7F6 Plastoform Industries
@@ -15184,9 +15776,9 @@ E8DAAA VideoHome Technology
 7CCFCF Shanghai Seari Intelligent System
 68AAD2 Datecs,
 A4DE50 Total Walther GmbH
-1CF061 Scaps Gmbh
+1CF061 Scaps GmbH
 A893E6 Jiangxi Jinggangshan Cking Communication Technology
-C4AAA1 Summit Development, Spol.s r.o.
+C4AAA1 Summit Development, spol.s r.o.
 3032D4 Hanilstm
 E064BB DigiView S.r.l.
 DC3350 TechSAT GmbH
@@ -15231,7 +15823,7 @@ D8D67E GSK CNC Equipment
 00263C Bachmann Technology GmbH & KG
 00263D MIA
 002678 Logic Instrument SA
-002677 Deif A/S
+002677 DEIF A/S
 00268E Alta Solutions
 002688 Juniper Networks
 0025DA Secura Key
@@ -15252,19 +15844,19 @@ D8D67E GSK CNC Equipment
 0025CC Mobile Communications Korea Incorporated
 0025F9 GMK electronic design GmbH
 0025F7 Ansaldo STS USA
-00261B Laurel Bank Machines
-002614 Ktnf
+00261B Laurel BANK Machines
+002614 KTNF
 002603 Shenzhen Wistar Technology
 0025A6 Central Network Solution
 0025AA Beijing Soul Technology
 002588 Genie Industries
 002580 Equipson
 0025BD Italdata Ingegneria dell'Idea
-0025B7 Costar  electronics
+0025B7 Costar electronics
 00257D PointRed Telecom Private
 0025A2 Alta Definicion Linceo S.L.
 00256D Broadband Forum
-00256C Azimut Production Association JSC
+00256C "Azimut" Production Association JSC
 002563 Luxtera
 002593 DatNet Informatikai Kft.
 00258E The Weather Channel
@@ -15273,7 +15865,7 @@ D8D67E GSK CNC Equipment
 0025C8 S-Access GmbH
 0025C0 ZillionTV
 00251B Philips CareServant
-002518 Power Plus Communications AG
+002518 Power PLUS Communications AG
 002515 SFR
 00250D GZT Telkom-Telmor sp. z o.o.
 00250E gt german telematics gmbh
@@ -15300,7 +15892,7 @@ D8D67E GSK CNC Equipment
 002508 Maquet Cardiopulmonary AG
 0024FC QuoPin
 0024FB Private
-0024FA Hilger u. Kern Gmbh
+0024FA Hilger u. Kern GMBH
 0024D0 Shenzhen Sogood Industry
 0024CC Fascinations Toys and Gifts
 0024C7 Mobilarm
@@ -15311,7 +15903,7 @@ D8D67E GSK CNC Equipment
 0024A3 Sonim Technologies
 0024AA Dycor Technologies
 0024A9 Ag Leader Technology
-0024A6 Telestar Digital Gmbh
+0024A6 Telestar Digital GmbH
 00249B Action Star Enterprise
 002471 Fusion MultiSystems dba Fusion-io
 002474 Autronica Fire And Securirty
@@ -15345,12 +15937,12 @@ D8D67E GSK CNC Equipment
 0023B5 Ortana
 0023B9 Airbus Defence and Space Deutschland GmbH
 0023BD Digital Ally
-0023D5 Warema Electronic Gmbh
+0023D5 Warema electronic GmbH
 0023C9 Sichuan Tianyi Information Science & Technology Stock
-0023CE Kita Denshi
+0023CE KITA Denshi
 0023A9 Beijing Detianquan Electromechanical Equipment
 00239B Elster Solutions
-00237B Whdi
+00237B WHDI
 002324 G-pro Computer
 0023E0 INO Therapeutics
 002390 Algolware
@@ -15404,7 +15996,7 @@ D8D67E GSK CNC Equipment
 00228A Teratronik elektronische systeme gmbh
 00228E Tv-numeric
 002254 Bigelow Aerospace
-002257 3com Europe
+002257 3COM Europe
 002276 Triple EYE
 002274 FamilyPhone AB
 002236 Vector SP. Z O.O.
@@ -15414,7 +16006,7 @@ D8D67E GSK CNC Equipment
 00220B National Source Coding Center
 00220C Cisco Systems
 0021EA Bystronic Laser AG
-0021FD Lacroix TrafficU
+0021FD Lacroix Trafficu
 0021CD LiveTV
 0021D0 Global Display Solutions Spa
 002228 Breeze Innovations
@@ -15438,13 +16030,13 @@ D8D67E GSK CNC Equipment
 00217D Pyxis S.r.l.
 00216F SymCom
 0021A3 Micromint
-0021A5 Erlphase Power Technologies
+0021A5 ERLPhase Power Technologies
 00219D Adesys BV
 002195 GWD Media Limited
 002188 EMC
 00211A LInTech
 002116 Transcon Electronic Systems, spol. s r. o.
-002115 Phywe Systeme Gmbh & KG
+002115 Phywe Systeme GmbH & KG
 002141 Radlive
 002140 EN Technologies
 00213D Cermetek Microelectronics
@@ -15483,10 +16075,10 @@ D8D67E GSK CNC Equipment
 001FA6 Stilo srl
 001F97 Bertana srl
 001F8C CCS
-001F10 Toledo DO Brasil Industria DE Balancas  Ltda
+001F10 Toledo DO Brasil Industria DE Balancas LTDA
 001F0F Select Engineered Systems
 001F02 Pixelmetrix Pte
-001EFE Level S.r.o.
+001EFE Level s.r.o.
 001F1A Prominvest
 001F18 Hakusan.Mfg.Co
 001F13 S.& A.S.
@@ -15502,7 +16094,7 @@ D8D67E GSK CNC Equipment
 001F34 Lung Hwa Electronics
 001EEB Talk-A-Phone
 001E6A Beijing Bluexon Technology
-001E66 Resol Elektronische Regelungen Gmbh
+001E66 Resol Elektronische Regelungen GmbH
 001E63 Vibro-Meter SA
 001E7F CBM of America
 001E82 SanDisk
@@ -15519,7 +16111,7 @@ D8D67E GSK CNC Equipment
 001E6F Magna-Power Electronics
 001EA1 Brunata a/s
 001E53 Further Tech
-001E4E Dako Edv-ingenieur- und Systemhaus Gmbh
+001E4E DAKO EDV-Ingenieur- und Systemhaus GmbH
 001E49 Cisco Systems
 001E28 Lumexis
 001E24 Zhejiang Bell Technology
@@ -15540,12 +16132,12 @@ D8D67E GSK CNC Equipment
 001DB1 Crescendo Networks
 001DB4 Kumho ENG
 001DA4 Hangzhou System Technology
-001D9F Matt   R.p.traczynscy Sp.J.
-001D90 Emco Flow Systems
+001D9F MATT R.P.Traczynscy Sp.J.
+001D90 EMCO Flow Systems
 001D93 Modacom
 001D94 Climax Technology
 001D8E Alereon
-001DDB C-BEL
+001DDB C-bel
 001DE6 Cisco Systems
 001DE7 Marine Sonic Technology
 001D7B Ice Energy
@@ -15561,11 +16153,11 @@ D8D67E GSK CNC Equipment
 001D2D Pylone
 001D5D Control Dynamics
 001D59 Mitra Energy & Infrastructure
-001D2B Wuhan Pont Technology
+001D2B Wuhan Pont Technology 
 001D22 Foss Analytical A/S
 001D23 Sensus
-001D3E Saka Techno Science
-001D40 Intel  GE Care Innovations
+001D3E SAKA Techno Science
+001D40 Intel – GE Care Innovations
 001D57 Caetec Messtechnik
 001D51 Babcock & Wilcox Power Generation Group
 001D4C Alcatel-Lucent
@@ -15592,7 +16184,7 @@ D8D67E GSK CNC Equipment
 001C74 Syswan Technologies
 001C68 Anhui Sun Create Electronics
 001C66 Ucamp
-001C98 Lucky Technology (hk) Company Limited
+001C98 Lucky Technology (HK) Company Limited
 001C81 NextGen Venturi
 001C7A Perfectone Netware Company
 001C53 Synergy Lighting Controls
@@ -15600,7 +16192,7 @@ D8D67E GSK CNC Equipment
 001C92 Tervela
 001C8A Cirrascale
 001C38 Bio-Rad Laboratories
-001C30 Mode Lighting (UK )
+001C30 Mode Lighting (UK
 001C2E HPN Supply Chain
 001C2A Envisacor Technologies
 001C02 Pano Logic
@@ -15616,7 +16208,7 @@ D8D67E GSK CNC Equipment
 001BF0 Value Platforms Limited
 001C1B Hyperstone GmbH
 001C10 Cisco-Linksys
-001BD2 Ultra-x Asia Pacific
+001BD2 Ultra-x ASIA Pacific
 001B8D Electronic Computer Systems
 001B86 Bosch Access Systems GmbH
 001BC2 Integrated Control Technology Limitied
@@ -15628,7 +16220,7 @@ D8D67E GSK CNC Equipment
 001B56 Tehuti Networks
 001BC6 Strato Rechenzentrum AG
 001BC4 Ultratec
-001BA1 mic AB
+001BA1 Åmic AB
 001B96 General Sensing
 001AEA Radio Terminal Systems
 001ADD PePWave
@@ -15640,14 +16232,14 @@ D8D67E GSK CNC Equipment
 001B03 Action Technology (SZ)
 001AFB Joby
 001AFD Evolis
-001B1E Hart Communication Foundation
+001B1E HART Communication Foundation
 001B4C Signtech
 001AD5 KMC Chain Industrial
 001AD0 Albis Technologies AG
 001AD3 Vamp
 001AD8 AlsterAero GmbH
 001ADA Biz-2-Me
-001A6F MI.TEL s.r.l.
+001A6F Mi.tel s.r.l.
 001A71 Diostech
 001A69 Wuhan Yangtze Optical Technology
 001A67 Infinite QL Sdn Bhd
@@ -15658,7 +16250,7 @@ D8D67E GSK CNC Equipment
 001ACB Autocom Products
 001ACF C.T. Elettronica
 001AA3 Delorme
-001A9B Adec & Parter AG
+001A9B ADEC & Parter AG
 001A9D Skipper Wireless
 001A85 NV Michel Van de Wiele
 001A8E 3Way Networks
@@ -15675,7 +16267,7 @@ D8D67E GSK CNC Equipment
 001A64 IBM
 001A51 Alfred Mann Foundation
 001A55 ACA-Digital
-0019E6 Toyo Medic
+0019E6 TOYO Medic
 0019E2 Juniper Networks
 0019E8 Cisco Systems
 0019DF Thomson
@@ -15693,10 +16285,10 @@ D8D67E GSK CNC Equipment
 0019F4 Convergens Oy
 001996 TurboChef Technologies
 001997 Soft Device Sdn Bhd
-001998 Sato
+001998 SATO
 00199C Ctring
 001946 Cianet Industria e Comercio S/A
-001949 Tentel  Comtech
+001949 Tentel Comtech
 001944 Fossil Partners
 001971 Guangzhou Unicomp Technology
 001964 Doorking
@@ -15705,7 +16297,7 @@ D8D67E GSK CNC Equipment
 001967 Teldat Sp.J.
 001952 Acogito
 00198B Novera Optics Korea
-001961 Blaupunkt  Embedded Systems GmbH
+001961 Blaupunkt Embedded Systems GmbH
 001942 ON Software International Limited
 00193F RDI technology(Shenzhen)
 001941 Pitney Bowes
@@ -15725,7 +16317,7 @@ D8D67E GSK CNC Equipment
 00188A Infinova
 001886 El-tech
 001887 Metasystem SpA
-0018BE Ansa
+0018BE ANSA
 0018BA Cisco Systems
 0018B4 Dawon Media
 0018B6 S3C
@@ -15733,7 +16325,7 @@ D8D67E GSK CNC Equipment
 0018A0 Cierma Ascenseurs
 001893 Shenzhen Photon Broadband Technology
 0018B1 IBM
-00187B 4NSYS
+00187B 4nsys
 00187F Zodianet
 00187E RGB Spectrum
 00189D Navcast
@@ -15773,7 +16365,7 @@ D8D67E GSK CNC Equipment
 0017D6 Bluechips Microhouse
 001787 Brother, Brother & Sons ApS
 001789 Zenitron
-001760 Naito Densei Machida MFG.CO.
+001760 Naito Densei Machida Mfg.co.
 001761 Private
 001768 Zinwave
 001769 Cymphonix
@@ -15784,11 +16376,11 @@ D8D67E GSK CNC Equipment
 001734 ADC Telecommunications
 00172E FXC
 00172B Global Technologies
-001772 Astro Strobel Kommunikationssysteme Gmbh
+001772 Astro Strobel Kommunikationssysteme GmbH
 00173E LeucotronEquipamentos Ltda.
 001798 Azonic Technology
 001747 Trimble
-00177A Assa Abloy AB
+00177A ASSA Abloy AB
 0016F4 Eidicom
 0016E7 Dynamix Promotions Limited
 0016E5 Fordley Development Limited
@@ -15797,7 +16389,7 @@ D8D67E GSK CNC Equipment
 00171A Winegard Company
 0016C8 Cisco Systems
 0016C4 SiRF Technology
-0016F3 Cast Information
+0016F3 CAST Information
 0016F5 Dalian Golden Hualu Digital Technology
 0016F1 OmniSense
 0016DD Gigabeam
@@ -15805,8 +16397,8 @@ D8D67E GSK CNC Equipment
 001716 Qno Technology
 001726 m2c Electronic Technology
 001721 Fitre
-0016F9 Cetrta POT, D.o.o.
-00170A Inew Digital Company
+0016F9 Cetrta POT, d.o.o.
+00170A INEW Digital Company
 0016BD ATI Industrial Automation
 0016C0 Semtech
 0016C2 Avtec Systems
@@ -15825,7 +16417,6 @@ D8D67E GSK CNC Equipment
 001691 Moser-Baer AG
 001688 ServerEngines
 00168B Paralan
-001682 Pro Dex
 00160A Sweex Europe BV
 001602 Ceyon Technology
 001600 CelleBrite Mobile Synchronization
@@ -15866,7 +16457,7 @@ D8D67E GSK CNC Equipment
 00154C Saunders Electronics
 00154D Netronome Systems
 001549 Dixtal Biomedica Ind. Com. Ltda
-00153D Elim Product
+00153D ELIM Product
 001544 coM.s.a.t. AG
 001539 Technodrive srl
 001531 Kocom
@@ -15886,14 +16477,14 @@ D8D67E GSK CNC Equipment
 0014DD Covergence
 0014D4 K Technology
 0014CF Invisio Communications
-0014BE Wink communication technologyLTD
+0014BE Wink communication technologyltd
 001511 Data Center Systems
 00150E Openbrain Technologies
 00150D Hoana Medical
 00151C Leneco
 001519 StoreAge Networking Technologies
 001506 Neo Photonics
-001504 Game Plus
+001504 GAME PLUS
 001505 Actiontec Electronics
 0014FE Artech Electronics
 0014DE Sage Instruments
@@ -15916,7 +16507,7 @@ D8D67E GSK CNC Equipment
 001491 Daniels Electronics dbo Codan Rado Communications
 00146E H. Stoll GmbH & KG
 0014AA Ashly Audio
-001409 Magneti Marelli   S.E.
+001409 Magneti Marelli S.E.
 00140B First International Computer
 0013FD Nokia Danmark A/S
 001400 Minerva Korea
@@ -15926,8 +16517,8 @@ D8D67E GSK CNC Equipment
 001456 Edge Products
 001450 Heim Systems GmbH
 001452 Calculex
-001442 Atto
-001447 Boaz
+001442 ATTO
+001447 BOAZ
 00143E AirLink Communications
 00145D WJ Communications
 00143B Sensovation AG
@@ -15948,10 +16539,9 @@ D8D67E GSK CNC Equipment
 0013A8 Tanisys Technology
 0013DA Diskware
 0013D8 Princeton Instruments
-001399 Stac
+001399 STAC
 0013E9 VeriWave
-001395 congatec AG
-001356 Flir Radiation
+001356 FLIR Radiation
 00135A Project T&E Limited
 001361 Biospace
 001362 ShinHeung Precision
@@ -15973,15 +16563,15 @@ D8D67E GSK CNC Equipment
 001374 Atheros Communications
 001369 Honda Electron
 001342 Vision Research
-001340 AD.EL s.r.l.
+001340 Ad.el s.r.l.
 00130C HF System
 00130F Egemen Bilgisayar Muh San ve Tic STI
 001313 GuangZhou Post & Telecom Equipment
 0012CB CSS
 0012CE Advanced Cybernetics Group
 0012CA Mechatronic Brick Aps
-0012C7 Securay Technologiesco.
-0012CD Asem SpA
+0012C7 Securay TechnologiesCo.
+0012CD ASEM SpA
 0012E8 Fraunhofer IMS
 0012DD Shengqu Information Technology (Shanghai)
 00131D Scanvaegt International A/S
@@ -16004,7 +16594,7 @@ D8D67E GSK CNC Equipment
 0012BD Avantec Manufacturing Limited
 0012AB WiLife
 00129B E2S Electronic Engineering Solutions
-001298 Mico Electric(shenzhen) Limited
+001298 MICO Electric(shenzhen) Limited
 001272 Redux Communications
 00126A Optoelectronics
 0012C0 HotLava Systems
@@ -16017,17 +16607,17 @@ D8D67E GSK CNC Equipment
 001205 Terrasat Communications
 001238 SetaBox Technology
 00123C Second Rule
-00123E Erune Technology
+00123E Erune technology
 001254 Spectra Technologies Holdings Company
 00124F nVent
 001221 B.Braun Melsungen AG
-001212 Plus
+001212 PLUS
 001213 Metrohm AG
 001218 Aruze
 001249 Delta Elettronica
 00124D Inducon BV
 001266 Swisscom Hospitality Services SA
-00125E Caen
+00125E CAEN
 00125D CyberNet
 001223 Pixim
 00123A Posystech
@@ -16045,7 +16635,7 @@ D8D67E GSK CNC Equipment
 0011A5 Fortuna Electronic
 00113C Micronas GmbH
 001131 Unatech.
-001127 TASI
+001127 Tasi
 00112A Niko NV
 00112B NetModule AG
 00116F Netforyou
@@ -16058,7 +16648,7 @@ D8D67E GSK CNC Equipment
 001151 Mykotronx
 00114E 690885 Ontario
 00112D iPulse Systems
-00117B Bchi  Labortechnik AG
+00117B Büchi Labortechnik AG
 000FEE XTec, Incorporated
 000FE4 Pantech
 000FE7 Lutron Electronics
@@ -16075,7 +16665,7 @@ D8D67E GSK CNC Equipment
 001123 Appointech
 00110F netplat
 000FD6 Sarotech
-001115 Epin Technologies
+001115 EPIN Technologies
 000FC7 Dionica R&D
 000F64 D&R Electronica Weesp BV
 000F75 First Silicon Solutions
@@ -16083,7 +16673,7 @@ D8D67E GSK CNC Equipment
 000F7A BeiJing NuQX Technology
 000FAD FMN communications GmbH
 000FAB Kyushu Electronics Systems
-000FAC Ieee 802.11
+000FAC IEEE 802.11
 000F72 Sandburst
 000FB3 Actiontec Electronics
 000F9C Panduit
@@ -16142,14 +16732,14 @@ D8D67E GSK CNC Equipment
 000E67 Eltis Microelectronics
 000E65 TransCore
 000E43 G-Tek Electronics Sdn. Bhd.
-000E44 Digital 5
+000E44 Digital
 000E74 Solar Telecom. Tech
 000E7A GemWon Communications
 000E80 Thomson Technology
 000E85 Catalyst Enterprises
 000E32 Kontron Medical
 000E0B Netac Technology
-000E11 BDT Bro und Datentechnik GmbH &KG
+000E11 BDT Büro und Datentechnik GmbH &KG
 000DF5 Teletronics International
 000DF7 Space Dynamics Lab
 000DEB CompXs Limited
@@ -16158,15 +16748,14 @@ D8D67E GSK CNC Equipment
 000DE7 Snap-on OEM Group
 000DC6 DigiRose Technology
 000DC1 SafeWeb
-000DF0 Qcom Technology
+000DF0 QCOM Technology
 000DE5 Samsung Thales
 000DC0 Spagat AS
-000DDD Profilo Telra Elektronik Sanayi ve Ticaret. A.
-000DF8 Orga Kartensysteme Gmbh
+000DDD Profilo Telra Elektronik Sanayi ve Ticaret. A.Ş
+000DF8 ORGA Kartensysteme GmbH
 000E16 SouthWing S.L.
 000DA7 Private
 000DAD Dataprobe
-000DA9 T.e.a.m. S.L.
 000DAB Parker Hannifin GmbH Electromechanical Division Europe
 000DA8 Teletronics Technology
 000D79 Dynamic Solutions
@@ -16174,7 +16763,7 @@ D8D67E GSK CNC Equipment
 000DAF Plexus (UK)
 000DB1 Japan Network Service
 000D83 Sanmina-SCI Hungary
-000D7F Midas  Communication Technologies PTE ( Foreign Branch)
+000D7F Midas Communication Technologies PTE ( Foreign Branch)
 000D75 Kobian Pte - Taiwan Branch
 000D78 Engineering & Security
 000D9E Tokuden Ohizumi Seisakusyo
@@ -16183,7 +16772,7 @@ D8D67E GSK CNC Equipment
 000D9A Infotec
 000D6E K-Patents Oy
 000D6A Redwood Technologies
-000DBA Oc Document Technologies GmbH
+000DBA Océ Document Technologies GmbH
 000DBD Cisco Systems
 000DB5 Globalsat Technology
 000D97 ABB/Tropos
@@ -16205,17 +16794,17 @@ D8D67E GSK CNC Equipment
 000D33 Prediwave
 000D2F AIN Comm.Tech.Co.
 000D5D Raritan Computer
-000D63 Dent Instruments
+000D63 DENT Instruments
 000D66 Cisco Systems
-000CCD IEC - Tc57
+000CCD IEC - TC57
 000CCB Design Combus
-000CC9 Ilwoo Data & Technology
+000CC9 Ilwoo DATA & Technology
 000CE9 Bloomberg L.P.
 000CEA aphona Kommunikationssysteme
 000CDA FreeHand Systems
 000CF5 InfoExpress
 000CEE jp-embedded
-000CAF TRI Term
+000CAF TRI TERM
 000CB3 Round
 000CDD AOS technologies AG
 000CA5 Naman NZ
@@ -16224,7 +16813,7 @@ D8D67E GSK CNC Equipment
 000C7A DaTARIUS Technologies GmbH
 000C79 Extel Communications P/L
 000C75 Oriental integrated electronics.
-000C5D Chic Technology (china)
+000C5D CHIC Technology (china)
 000C4F UDTech Japan
 000C62 ABB AB, Cewe-Control
 000C4C Arcor AG&Co.
@@ -16262,7 +16851,7 @@ D8D67E GSK CNC Equipment
 000B60 Cisco Systems
 000B65 Sy.A.C. srl
 000B5F Cisco Systems
-000B61 Friedrich Ltze GmbH & KG
+000B61 Friedrich Lütze GmbH & KG
 000B59 ScriptPro
 000B5C Newtech
 000B7E Saginomiya Seisakusho
@@ -16272,7 +16861,7 @@ D8D67E GSK CNC Equipment
 000BA4 Shiron Satellite Communications (1996)
 000BD0 XiMeta Technology Americas
 000BC5 SMC Networks
-000BC6 ISAC
+000BC6 Isac
 000BC1 Bay Microsystems
 000B8B Kerajet
 000B89 Top Global Technology
@@ -16286,7 +16875,7 @@ D8D67E GSK CNC Equipment
 000B03 Taekwang Industrial
 000B01 Daiichi Electronics
 000B3E BittWare
-000B29 LS(LG) Industrial Systems
+000B29 Ls(lg) Industrial Systems
 000B39 Keisoku Giken
 000B33 Vivato Technologies
 000B05 Pacific Broadband Networks
@@ -16294,9 +16883,9 @@ D8D67E GSK CNC Equipment
 000B5B Rincon Research
 000AF6 Emerson Climate Technologies Retail Solutions
 000B11 Himeji ABC Trading
-000B41 Ing. Bro Dr. Beutlhauser
-000AEA Adam Elektronik ti
-000AE3 Yang MEI Technology
+000B41 Ing. Büro Dr. Beutlhauser
+000AEA ADAM Elektronik ŞTI
+000AE3 YANG MEI Technology
 000ADC RuggedCom
 000AB7 Cisco Systems
 000AAD Stargames
@@ -16336,10 +16925,10 @@ D8D67E GSK CNC Equipment
 0009E2 Sinbon Electronics
 0009DA Control Module
 0009D7 DC Security Products
-0009D8 Flt Communications AB
-000A14 Teco a.s.
+0009D8 Fält Communications AB
+000A14 TECO a.s.
 000A0B Sealevel Systems
-000A10 Fast Media Integrations AG
+000A10 FAST media integrations AG
 0009DB eSpace
 0009D5 Signal Communication
 0009D3 Western DataCom
@@ -16348,7 +16937,7 @@ D8D67E GSK CNC Equipment
 0009E6 Cyber Switching
 0009FB Philips Patient Monitoring
 00098F Cetacean Networks
-000987 Nishi Nippon Electric Wire & Cable
+000987 Nishi Nippon Electric WIRE & Cable
 000989 VividLogic
 000986 Metalink
 00098C Option Wireless Sweden
@@ -16372,15 +16961,15 @@ D8D67E GSK CNC Equipment
 0009A5 Hansung Eletronic Industries Development
 000962 Sonitor Technologies AS
 00095D Dialogue Technology
-00099A Elmo Company, Limited
+00099A ELMO Company, Limited
 00099C Naval Research Laboratory
 000984 MyCasa Network
 00092B iQstor Networks
-000926 Yoda Communications
+000926 YODA Communications
 000927 Toyokeiki
 000923 Heaman System
 00091D Proteam Computer
-0008EB Romwin
+0008EB ROMWin
 0008E8 Excel Master
 0008DC Wiznet
 0008DD Telena Communications
@@ -16475,7 +17064,7 @@ D8D67E GSK CNC Equipment
 000719 Mobiis
 00070D Cisco Systems
 00070E Cisco Systems
-00070B Novabase SGPS
+00070B Novabase Sgps
 000710 Adax
 0006E8 Optical Network Testing
 0006EE Shenyang Neu-era Information & Technology Stock
@@ -16494,7 +17083,7 @@ D8D67E GSK CNC Equipment
 0006CC JMI Electronics
 0006BF Accella Technologies
 000690 Euracom Communication GmbH
-0006E1 Techno Trade s.a
+0006E1 Techno Trade
 00062E Aristos Logic
 000624 Gentner Communications
 000625 The Linksys Group
@@ -16513,7 +17102,7 @@ D8D67E GSK CNC Equipment
 000623 MGE UPS Systems France
 00060B Artesyn Embedded Technologies
 00067E WinCom Systems
-000677 Sick AG
+000677 SICK AG
 000666 Roving Networks
 000667 Tripp Lite
 00064D Sencore
@@ -16529,7 +17118,7 @@ D8D67E GSK CNC Equipment
 0005E0 Empirix
 0005D8 Arescom
 0005E4 Red Lion Controls
-0005F2 Power R
+0005F2 Power
 0005F3 Webyn
 000601 Otanikeiki
 000605 Inncom International
@@ -16541,7 +17130,7 @@ D8D67E GSK CNC Equipment
 0005C4 Telect
 0005A3 QEI
 00059E Zinwell
-0005A5 Kott
+0005A5 KOTT
 0005B3 Asahi-Engineering
 00059D Daniel Computing Systems
 0005A4 Lucid Voice
@@ -16568,7 +17157,7 @@ D8D67E GSK CNC Equipment
 00057C RCO Security AB
 000583 ImageCom Limited
 00054B Eaton Automation AG
-0004C8 Liba Maschinenfabrik Gmbh
+0004C8 LIBA Maschinenfabrik GmbH
 0004CC Peek Traffic
 0004BF VersaLogic
 0004C3 Castor Informatique
@@ -16586,7 +17175,7 @@ D8D67E GSK CNC Equipment
 000506 Reddo Networks AB
 0004E2 SMC Networks
 0004CB Tdsoft Communication
-000526 Ipas Gmbh
+000526 IPAS GmbH
 000467 Wuhan Research Institute of MII
 00045A The Linksys Group
 000463 Bosch Security Systems
@@ -16627,7 +17216,7 @@ D8D67E GSK CNC Equipment
 000406 Fa. Metabox AG
 0003F8 SanCastle Technologies
 0003FA TiMetra Networks
-0003C6 Icue Systems
+0003C6 ICUE Systems
 0003BB Signal Communications Limited
 0003BE Netility
 0003DF Desana Systems
@@ -16636,7 +17225,7 @@ D8D67E GSK CNC Equipment
 0003FB Enegate
 0003F6 Allegro Networks
 000415 Rasteme Systems
-000398 Wisi
+000398 WISI
 000395 California Amplifier
 000392 Hyundai Teletek
 00038E Atoga Systems
@@ -16655,14 +17244,14 @@ D8D67E GSK CNC Equipment
 000345 Routrek Networks
 0002C8 Technocom Communications Technology (pte)
 0002B8 WHI Konsult AB
-0002A9 Racom, S.r.o.
+0002A9 Racom, s.r.o.
 0002BB Continuous Computing
 0002BC LVL 7 Systems
 00030F Digital China (Shanghai) Networks
 000311 Micro Technology
 00030D Uniwill Computer
 000309 Texcel Technology PLC
-000303 Jama Electronics
+000303 JAMA Electronics
 000305 MSC Vertriebs GmbH
 0002FE Viditec
 00019F ReadyNet
@@ -16670,17 +17259,16 @@ D8D67E GSK CNC Equipment
 0002F4 Pctel
 0002E9 CS Systemes De Securite - C3S
 0002E5 Timeware
-0002E0 Etas Gmbh
+0002E0 ETAS GmbH
 0002CE FoxJet
 0002C3 Arelnet
 000316 Nobell Communications
 000329 F3
 000321 Reco Research
-0002F5 Vive Synergies
+0002F5 VIVE Synergies
 0002D5 ACR
 0002AB CTC Union Technologies
 0002A4 AddPac Technology
-0002A3 ABB Switzerland, Power Systems
 0002A0 Flatstack
 0002B2 Cablevision
 0002B7 Watanabe Electric Industry
@@ -16696,7 +17284,7 @@ D8D67E GSK CNC Equipment
 000294 Tokyo Sokushin
 000296 Lectron
 00028E Rapid 5 Networks
-00024F IPM Datacom S.R.L.
+00024F IPM Datacom S.r.l.
 000271 Zhone Technologies
 00028A Ambit Microsystems
 0001FA Horoscas
@@ -16704,7 +17292,7 @@ D8D67E GSK CNC Equipment
 000285 Riverstone Networks
 000279 Control Applications
 000251 Soma Networks
-0001F5 Erim
+0001F5 ERIM
 0001FF Data Direct Networks
 0001FC Keyence
 0001FD Digital Voice Systems
@@ -16726,14 +17314,14 @@ D8D67E GSK CNC Equipment
 00023C Creative Technology
 00306C Hitex Holding GmbH
 00308B Brix Networks
-000177 Edsl
+000177 EDSL
 00014D Shin Kin Enterprises
 0001DA Wincomm
 0001D2 inXtron
 0001C6 Quarry Technologies
 00016E Conklin
 000174 CyberOptics
-00015E Best Technology
+00015E BEST Technology
 000161 Meta Machine Technology
 0001A1 Mag-Tek
 000186 Uwe Disch
@@ -16770,22 +17358,22 @@ D8D67E GSK CNC Equipment
 00011E Precidia Technologies
 000155 Promise Technology
 003094 Cisco Systems
-00308A Nicotra Sistemi S.P.A
+00308A Nicotra Sistemi
 003072 Intellibyte
 003040 Cisco Systems
 003032 MagicRam
 0030EA TeraForce Technology
 00309B Smartware
-003045 Village Networks, (VNI)
+003045 Village Networks, (vni)
 0030E5 Amper Datos
 003006 Superpower Computer
 003038 XCP
-003079 CQOS
+003079 Cqos
 00300C Congruency
 00304C Appian Communications
 0030E8 Ensim
 0030C9 LuxN
-003028 Fase Saldatura srl
+003028 FASE Saldatura srl
 003069 Impacct Technology
 0030C3 Flueckiger Elektronik AG
 00305A Telgen
@@ -16795,7 +17383,7 @@ D8D67E GSK CNC Equipment
 003077 Onprem Networks
 003047 Nissei Electric
 0030D4 AAE Systems
-00D0D7 B2C2
+00D0D7 B2c2
 00D073 ACN Advanced Communications
 00D057 Ultrak
 0030AB Delta Networks
@@ -16808,7 +17396,7 @@ D8D67E GSK CNC Equipment
 0030D0 Tellabs
 003014 Divio
 003081 Altos C&C
-00D0F0 Convision Technology Gmbh
+00D0F0 Convision Technology GMBH
 00D010 Convergent Networks
 00D04B LA CIE Group
 00D00E Pluris
@@ -16830,8 +17418,8 @@ D8D67E GSK CNC Equipment
 00D004 Pentacom
 00D005 ZHS Zeitmanagementsysteme
 00D0D3 Cisco Systems
-00D026 Hirschmann Austria Gmbh
-00D0DA Taicom Data Systems
+00D026 Hirschmann Austria GMBH
+00D0DA Taicom DATA Systems
 00D03C Vieo
 00D0B4 Katsujima
 00D086 Foveon
@@ -16842,11 +17430,11 @@ D8D67E GSK CNC Equipment
 00D0DC Modular Mining Systems
 00D01E Pingtel
 00D0CA Intrinsyc Software International
-00D065 Toko Electric
+00D065 TOKO Electric
 00D09A Filanet
 00D0AE Oresis Communications
 00D0F2 Monterey Networks
-00D014 ROOT
+00D014 Root
 00D023 Infortrend Technology
 00D0A2 Integrated Device
 00D034 Ormec Systems
@@ -16855,14 +17443,14 @@ D8D67E GSK CNC Equipment
 00D01D Furuno Electric
 00504C Galil Motion Control
 005076 IBM
-0050D4 Joohong Information &
+0050D4 Joohong Information
 0050A6 Optronics
 0050A9 Moldat Wireless Technolgies
 00509B Switchcore AB
 00507E Newer Technology
 0050CE LG International
 0050F7 Venture Manufacturing (singapore)
-005019 Spring Tide Networks
+005019 Spring TIDE Networks
 0050FD Visioncomm
 0050BF Metalligence Technology
 005036 Netcam
@@ -16871,7 +17459,7 @@ D8D67E GSK CNC Equipment
 005047 Private
 00D06C Sharewave
 0050A7 Cisco Systems
-005055 Doms A/S
+005055 DOMS A/S
 005072 Corvis
 00D0EE Dictaphone
 00501B ABL Canada
@@ -16880,14 +17468,14 @@ D8D67E GSK CNC Equipment
 00903D Biopac Systems
 0090D7 NetBoost
 005083 Gilbarco
-0050DC TAS Telefonbau A. Schwabe Gmbh & KG
-005008 Tiva Microcomputer (tmc)
+0050DC TAS Telefonbau A. Schwabe GMBH & KG
+005008 TIVA Microcomputer (tmc)
 005052 Tiara Networks
 005027 Genicom
 00505A Network Alchemy
 005039 Mariner Networks
 005064 CAE Electronics
-0050B8 Inova Computers Gmbh & KG
+0050B8 Inova Computers GMBH & KG
 00505B Kawasaki LSI U.s.a.
 0050CC Seagate Cloud Systems
 005016 Molex Canada
@@ -16900,7 +17488,7 @@ D8D67E GSK CNC Equipment
 0090EF Integrix
 0090C5 Internet Magic
 00908C Etrend Electronics
-009048 Zeal
+009048 ZEAL
 0090B9 Beran Instruments
 0090C4 Javelin Systems
 0090A5 Spectra Logic
@@ -16913,23 +17501,23 @@ D8D67E GSK CNC Equipment
 00900B Lanner Electronics
 0090CE avateramedical Mechatronics GmbH
 009007 Domex Technology
-00902D Data Electronics (aust.)
+00902D DATA Electronics (aust.)
 0090D4 BindView Development
 009029 Crypto AG
 0090DF Mitsubishi Chemical America
 0090C0 K.J. LAW Engineers
 00901F Adtec Productions
 009024 Pipelinks
-00903A Nihon Media Tool
+00903A Nihon Media TOOL
 0090B2 Avici Systems
 0090B6 Fibex Systems
 009063 Coherent Communications Systems
-009062 ICP Vortex Computersysteme Gmbh
-0010D3 Grips Electronic Gmbh
-0010FB Zida Technologies Limited
+009062 ICP Vortex Computersysteme GmbH
+0010D3 Grips Electronic GMBH
+0010FB ZIDA Technologies Limited
 001053 Computer Technology
 0010ED Sundance Technology
-00106C Ednt Gmbh
+00106C EDNT GmbH
 0010E9 Raidtec
 001003 Imatron
 001071 Advanet
@@ -16937,7 +17525,7 @@ D8D67E GSK CNC Equipment
 009095 Universal Avionics
 009041 Applied Digital Access
 00905A Dearborn Group
-009011 Wavtrace
+009011 WAVTrace
 009065 Finisar
 009023 Zilog
 0090F6 Escalate Networks
@@ -16950,12 +17538,12 @@ D8D67E GSK CNC Equipment
 0090C3 Topic Semiconductor
 0010C8 Communications Electronics Security Group
 0010F3 Nexcom International
-001086 Atto Technology
-0010DF Rise Computer
+001086 ATTO Technology
+0010DF RISE Computer
 001072 GVN Technologies
 0010DA Kollmorgen
 0010E4 NSI
-00107E Bachmann Electronic Gmbh
+00107E Bachmann Electronic GmbH
 0010A0 Innovex Technologies
 001016 T.sqware
 001090 Cimetrics
@@ -16974,15 +17562,15 @@ D8D67E GSK CNC Equipment
 0010CD Interface Concept
 001061 Hostlink
 001099 InnoMedia
-0010E1 S.I. TECH
-0010BB Data & Information Technology
+0010E1 S.I. Tech
+0010BB DATA & Information Technology
 001020 Hand Held Products
-00103A Diamond Network Tech
+00103A Diamond Network TECH
 001004 THE Brantley Coile Company
 0010EF Dbtel Incorporated
 001088 American Networks
 001022 SatCom Media
-001076 Eurem Gmbh
+001076 Eurem GmbH
 00103F Tollgrade Communications
 001049 ShoreTel
 00105E Spirent plc, Service Assurance Broadband
@@ -16998,18 +17586,18 @@ D8D67E GSK CNC Equipment
 00100F Industrial CPU Systems
 0010BC Aastra Telecom
 00E0BF Torrent Networking Technologies
-00E0E3 Sk-elektronik Gmbh
+00E0E3 Sk-elektronik GMBH
 00E0C6 Link2it,
 00E0E5 Cinco Networks
 00E061 EdgePoint Networks
-00E053 Cellport LABS
-00E0D3 Datentechnik Gmbh
+00E053 Cellport Labs
+00E0D3 Datentechnik GmbH
 00E043 VitalCom
 00E0B3 EtherWAN Systems
 00E0ED Silicom
 00E0B8 Gateway 2000
 00E07C Mettler-toledo
-00E026 Redlake Masd
+00E026 Redlake MASD
 00E020 Tecnomen OY
 00E00D Radiant Systems
 00E0DC Nexware
@@ -17022,9 +17610,9 @@ D8D67E GSK CNC Equipment
 00E01A Comtec Systems.
 00E078 Berkeley Networks
 00E087 LeCroy - Networking Productions Division
-00E041 Cspi
+00E041 CSPI
 00E0E2 Innova
-00E081 Tyan Computer
+00E081 TYAN Computer
 00E057 HAN Microtelecom.
 00E0BC Symon Communications
 00E082 Anerma
@@ -17033,10 +17621,10 @@ D8D67E GSK CNC Equipment
 00E031 Hagiwara Electric
 00E00B Rooftop Communications
 00E0B2 Telmax Communications
-00E02F Mcns Holdings
-00E07E Walt Disney Imagineering
+00E02F MCNS Holdings
+00E07E WALT Disney Imagineering
 00E099 Samson AG
-0060AE Trio Information Systems AB
+0060AE TRIO Information Systems AB
 006053 Toyoda Machine Works
 006056 Network Tools
 00600C Eurotech
@@ -17044,7 +17632,7 @@ D8D67E GSK CNC Equipment
 00605F Nippon Unisoft
 006091 First Pacific Networks
 00601D Lucent Technologies
-00607B Fore Systems
+00607B FORE Systems
 00E06C Ultra Electronics Command & Control Systems
 00E04A ZX Technologies
 0060C9 ControlNet
@@ -17058,9 +17646,9 @@ D8D67E GSK CNC Equipment
 0060EF Flytech Technology
 006085 Storage Concepts
 006011 Crystal Semiconductor
-0060F5 Icon WEST
+0060F5 ICON West
 006062 Telesync
-0060E9 Atop Technologies
+0060E9 ATOP Technologies
 006043 iDirect
 006028 Macrovision
 0060F0 Johnson & Johnson Medical
@@ -17068,14 +17656,14 @@ D8D67E GSK CNC Equipment
 006096 T.S. Microtech
 00603A Quick Controls
 000288 Global Village Communication
-006034 Robert Bosch Gmbh
+006034 Robert Bosch GmbH
 006050 Internix
 0060FA Educational Technology Resources
 0060DA Red Lion Controls
 0060E4 Compuserve
 00608F Tekram Technology
 0060C4 Soliton Systems K.K.
-00A03C Eg&g Nuclear Instruments
+00A03C EG&G Nuclear Instruments
 00A0C4 Cristie Electronics
 00A063 JRL Systems
 00A02C interWAVE Communications
@@ -17090,7 +17678,7 @@ D8D67E GSK CNC Equipment
 00A071 Video Lottery Technologies
 006000 Xycom
 006045 Pathlight Technologies
-00A05D CS Computer Systeme Gmbh
+00A05D CS Computer Systeme GmbH
 00A061 Puritan Bennett
 0060A6 Particle Measuring Systems
 00602A Symicron Computer Communications
@@ -17104,7 +17692,7 @@ D8D67E GSK CNC Equipment
 00A031 Hazeltine, MS 1-17
 00A041 Inficon
 00A0A7 Vorax
-00A07E Avid Technology
+00A07E AVID Technology
 00A06F Color Sentinel Systems
 00A0C7 Tadiran Telecommunications
 00A01A Binar Elektronik AB
@@ -17117,9 +17705,9 @@ D8D67E GSK CNC Equipment
 00A01F Tricord Systems
 00A06C Shindengen Electric MFG.
 00A0DB Fisher & Paykel Production
-00A081 Alcatel Data Networks
+00A081 Alcatel DATA Networks
 00A0B1 First Virtual
-002010 Jeol System Technology
+002010 JEOL System Technology
 00209F Mercury Computer Systems
 00A073 Com21
 00A03A Kubotek
@@ -17130,19 +17718,19 @@ D8D67E GSK CNC Equipment
 00A046 Scitex
 00A0D4 Radiolan
 00A092 H. Bollmann Manufacturers
-00200D Carl Zeiss
+00200D CARL Zeiss
 00202D Taiyo
 002091 J125, National Security Agency
-0020BD Niobrara R & D
+0020BD Niobrara R &
 002054 Sycamore Networks
 0020A7 Pairgain Technologies
 002055 Altech
 00200A Source-comm
-0020CF Test & Measurement Systems
+0020CF TEST & Measurement Systems
 0020B4 Terma Elektronik AS
-0020E4 Hsing Tech Enterprise
+0020E4 Hsing TECH Enterprise
 00206C Evergreen Technology
-00205E Castle ROCK
+00205E Castle Rock
 002012 Camtronics Medical Systems
 002075 Motorola Communication Israel
 0020A5 API Engineering
@@ -17161,23 +17749,23 @@ D8D67E GSK CNC Equipment
 002039 Scinets
 002072 Worklink Innovations
 0020EC Techware Systems
-00206E XACT
+00206E Xact
 0020F1 Altos India Limited
-002041 Data NET
+002041 DATA NET
 002076 Reudo
 0020E8 Datatrek
 0020C5 Eagle Technology
-002009 Packard Bell Elec.
-002027 Ming Fortune Industry
+002009 Packard BELL Elec.
+002027 MING Fortune Industry
 00208A Sonix Communications
-0020D2 RAD Data Communications
+0020D2 RAD DATA Communications
 002002 Seritech Enterprise
 00204B Autocomputer
 0020EA Efficient Networks
 00206A Osaka Computer
-0020DB Xnet Technology
+0020DB XNET Technology
 0020BB ZAX
-0020A8 Sast Technology
+0020A8 SAST Technology
 002045 ION Networks
 002049 Comtron
 002050 Korea Computer
@@ -17187,27 +17775,27 @@ D8D67E GSK CNC Equipment
 002021 Algorithms Software PVT.
 00C0F9 Artesyn Embedded Technologies
 00C075 Xante
-001C7C Perq Systems
+001C7C PERQ Systems
 00C039 Teridian Semiconductor
 00C0A9 Barron Mccann
 00C04B Creative Microsystems
-00C0B9 Funk Software
+00C0B9 FUNK Software
 00C015 NEW Media
 00C083 Trace Mountain Products
 00C094 VMX
-00C019 Leap Technology
+00C019 LEAP Technology
 00C0CF Imatran Voima OY
-00C07D Risc Developments
+00C07D RISC Developments
 00C043 Stratacom
 00C0B5 Corporate Network Systems
-00C0ED US Army Electronic
+00C0ED US ARMY Electronic
 00C032 I-cubed Limited
-00C0A5 Dickens Data Systems
-00C0EF Abit
+00C0A5 Dickens DATA Systems
+00C0EF ABIT
 00C061 Solectek
 00C0AD Marben Communication Systems
 00C07F Nupon Computing
-00C057 Myco Electronics
+00C057 MYCO Electronics
 00C056 Somelec
 00C027 Cipher Systems
 00C05C Elonex PLC
@@ -17218,11 +17806,11 @@ D8D67E GSK CNC Equipment
 00C0BB Forval Creative
 00C0E0 DSC Communication
 00C05B Networks Northwest
-00C008 Seco SRL
+00C008 SECO SRL
 00C0B7 American Power Conversion
 00C0D3 Olympus Image Systems
 00C0E8 Plexcom
-00C0DA Nice Systems
+00C0DA NICE Systems
 00C0D1 Comtree Technology
 00C038 Raster Image Processing System
 00409B HAL Computer Systems
@@ -17234,19 +17822,19 @@ D8D67E GSK CNC Equipment
 0040E1 Marner International
 0040FE Symplex Communications
 0040E5 Sybus
-0040A5 Clinicomp INTL.
+0040A5 Clinicomp Intl.
 004005 ANI Communications
 0040D9 American Megatrends
 00404C Hypertec
 00C030 Integrated Engineering B. V.
 00C0A6 Exicom Australia
 00C0CB Control Technology
-00C0EB SEH Computertechnik Gmbh
+00C0EB SEH Computertechnik GMBH
 0040DB Advanced Technical Solutions
 00C092 Mennen Medical
 00C052 Burr-brown
 00400E Memotec
-00C03D Wiesemann & Theis Gmbh
+00C03D Wiesemann & Theis GMBH
 0040C8 Milan Technology
 0040BA Alliant Computer Systems
 004038 Talent Electric Incorporated
@@ -17254,7 +17842,7 @@ D8D67E GSK CNC Equipment
 004088 Mobius Technologies
 004032 Digital Communications
 0040C2 Applied Computing Devices
-0040D4 Gage Talker
+0040D4 GAGE Talker
 0040CE Net-source
 004062 E-systems,/garland DIV.
 004034 Bustek
@@ -17262,37 +17850,37 @@ D8D67E GSK CNC Equipment
 00400F Datacom Technologies
 004006 Sampo Technology
 0080AA Maxpeed
-00C050 Toyo Denki Seizo K.K.
+00C050 TOYO Denki Seizo K.K.
 0040C6 Fibernet Research
-004047 Wind River Systems
+004047 WIND River Systems
 004050 Ironics, Incorporated
 008092 Silex Technology
 008093 Xyron
-00805A Tulip Computers Internat'l B.V
+00805A Tulip Computers Internat'l
 004041 Fujikura
-00804E Apex Computer Company
+00804E APEX Computer Company
 008055 Fermilab
-00802A Test Systems & Simulations
+00802A TEST Systems & Simulations
 008035 Technology Works
 00807E Southern Pacific
 0080EF Rational
 0080F0 Panasonic Communications
 00801D Integrated Inference Machines
-008075 Parsytec Gmbh
+008075 Parsytec GMBH
 008051 Fibermux
 0080C6 National Datacomm
 0080C0 Penril Datacomm
-00802E Castle Rock Computing
+00802E Castle ROCK Computing
 0080F2 Raycom Systems
 0080BD THE Furukawa Electric
 008025 Telit Wireless Solutions GmbH
-0080EA Adva Optical Networking
+0080EA ADVA Optical Networking
 00001E Telsist Industria Electronica
 000050 Radisys
 008004 Antlow Communications
 0080D0 Computer Peripherals
 008024 Kalpana
-008040 John Fluke Manufacturing
+008040 JOHN Fluke Manufacturing
 008021 Alcatel Canada
 0080E8 Cumulus Corporatiion
 008069 Computone Systems
@@ -17306,21 +17894,21 @@ D8D67E GSK CNC Equipment
 000066 Talaris Systems
 000049 Apricot Computers
 0000FA Microsage Computer Systems
-0000D4 Pure Data
+0000D4 PURE DATA
 000019 Applied Dynamics International
 000015 Datapoint
-00001C Bell Technologies
+00001C BELL Technologies
 000034 Network Resources
 000022 Visual Technology
 0000B5 Datability Software SYS.
 00002F Timeplex
 0000B8 Seikosha
-0000E6 Aptor Produits DE Comm Indust
+0000E6 Aptor Produits DE COMM Indust
 000084 Supernet
 00009A RC Computer A/S
 000027 Japan Radio Company
 0000E8 Accton Technology
-00004B ICL Data OY
+00004B ICL DATA OY
 0000E0 Quadram
 0000AB Logic Modeling
 0080AC Imlogix, Division OF Genesys
@@ -17329,7 +17917,7 @@ D8D67E GSK CNC Equipment
 000078 Labtam Limited
 00005A SysKonnect GmbH
 00005B Eltec Elektronik AG
-000071 Adra Systems
+000071 ADRA Systems
 000073 Siecor
 0000B9 Mcdonnell Douglas Computer SYS
 0000BF Symmetric Computer Systems
@@ -17338,14 +17926,14 @@ D8D67E GSK CNC Equipment
 0000C8 Altos Computer Systems
 0000D5 Micrognosis International
 00003A Chyron
-000059 Hellige Gmbh
+000059 Hellige GMBH
 000069 Concord Communications
 0000E7 Star Gate Technologies
 00004D DCI
 000023 ABB Industrial Systems AB
 0000BE THE NTI Group
 0000D9 Nippon Telegraph & Telephone
-000080 Cray Communications A/S
+000080 CRAY Communications A/S
 08002A Mosaic Technologies
 080089 Kinetics
 080086 Konica Minolta Holdings
@@ -17363,14 +17951,14 @@ AA0000 Digital Equipment
 AA0001 Digital Equipment
 AA0002 Digital Equipment
 000007 Xerox
-00801F Krupp Atlas Electronik Gmbh
+00801F Krupp Atlas Electronik GMBH
 080006 Siemens AG
 04E0C4 Triumph-adler AG
 020701 Racal-datacom
 080013 Exxon
 00DD08 Ungermann-bass
 000005 Xerox
-021C7C Perq Systems
+021C7C PERQ Systems
 080065 Genrad
 84A9EA Career Technologies USA
 000009 Xerox
@@ -17379,10 +17967,10 @@ AA0002 Digital Equipment
 08004B Planning Research
 02AA3C Olivetti Telecomm SPA (olteco)
 080059 A/S Mycron
-080008 Bolt Beranek AND Newman
+080008 BOLT Beranek AND Newman
 F47488 New H3C Technologies
-FCC233 Asustek Computer
-401175 Ieee Registration Authority
+FCC233 ASUSTek Computer
+401175 IEEE Registration Authority
 8031F0 Samsung Electronics
 583526 Deeplet Technology
 34B5A3 CIG Shanghai
@@ -17397,7 +17985,7 @@ F0264C Sigrist-Photometer AG
 D80B9A Samsung Electronics
 AC8D34 Huawei Technologies
 645299 The Chamberlain Group
-F875A4 Lcfc(hefei) Electronics Technology
+F875A4 LCFC(HeFei) Electronics Technology
 00D2B1 TPV Display Technology (Xiamen)
 C0E434 AzureWave Technology
 6C710D Cisco Systems
@@ -17415,7 +18003,7 @@ B4BC7C Texas Instruments
 E0AAB0 Suntaili Enterprise,
 683943 ittim
 10C65E Adapt-IP
-7CA7B0 Shenzhen Bilian Electronicltd
+7CA7B0 Shenzhen Bilian Electronic，ltd
 20311C vivo Mobile Communication
 104F58 Aruba, a Hewlett Packard Enterprise Company
 B4E842 Hong Kong Bouffalo Lab Limited
@@ -17425,9 +18013,9 @@ F0A7B2 Futaba
 14A32F Huawei Device
 04D3B5 Huawei Device
 00BB1C Huawei Device
-80AC7C SichuanAI-LinkTechnologyCo.
+80AC7C Sichuan AI-Link Technology
 DC4BFE Shenzhen Belon Technology
-506255 Ieee Registration Authority
+506255 IEEE Registration Authority
 58D50A Murata Manufacturing
 88A303 Samsung Electronics
 FCDE90 Samsung Electronics
@@ -17449,7 +18037,7 @@ F0A35A Apple
 6C310E Cisco Systems
 2877F1 Apple
 A8E77D Texas Instruments
-DC543D Itel Mobile Limited
+DC543D ITEL Mobile Limited
 0C8447 Fiberhome Telecommunication Technologies
 9C6B72 Realme Chongqing MobileTelecommunications
 50C6AD Fiberhome Telecommunication Technologies
@@ -17460,7 +18048,7 @@ ECA940 Arris Group
 FC8596 Axonne
 5CB4E2 Inspur Software Group
 3C510E Cisco Systems
-D8AED0 Shanghai Engineering Science & Technology,ltd Cgnpc
+D8AED0 Shanghai Engineering Science & Technology,LTD Cgnpc
 E0859A Shenzhen Rf-link Technology
 0C42A1 Mellanox Technologies
 B47AF1 Hewlett Packard Enterprise
@@ -17469,10 +18057,10 @@ F4D9C6 Unionman Technology
 34F150 Hui Zhou Gaoshengda Technology
 CC5289 Shenzhen Optfocus Technology.
 CC5D78 JTD Consulting
-BCF9F2 Teko
+BCF9F2 TEKO
 000EA4 Quantum
 005084 Quantum
-809F9B SichuanAI-LinkTechnologyCo.
+809F9B Sichuan AI-Link Technology
 A82BCD Huawei Technologies
 48DC2D Huawei Technologies
 ACEB51 Universal Electronics
@@ -17490,7 +18078,7 @@ A824B8 Nokia
 E8910F Fiberhome Telecommunication Technologies
 D005E4 Huawei Device
 30AAE4 Huawei Device
-14AB56 Wuxi Funide Digital
+14AB56 WUXI Funide Digital
 E8D8D1 HP
 28CDC4 Chongqing Fugui Electronics
 000CDF JAI Manufacturing
@@ -17507,7 +18095,7 @@ AC9085 Apple
 6C55E8 Technicolor CH USA
 342FBD Nintendo
 A02D13 AirTies Wireless Networks
-8468C8 Totolink Technology Intl Limited
+8468C8 Totolink Technology Int‘l Limited
 9C28F7 Xiaomi Communications
 10521C Espressif
 6C42AB Subscriber Networks
@@ -17519,13 +18107,13 @@ C0D682 Arista Networks
 CC2D1B SFR
 80E540 Arris Group
 000DB4 Stormshield
-2CF05D Micro-star Intl
+2CF05D Micro-Star INTL
 943BB0 New H3C Technologies
 9043E2 Cornami
 803049 Liteon Technology
-E84943 Yuge Information Technology
+E84943 YUGE Information technology
 501408 AiNET
-289AF7 Adva Optical Networking
+289AF7 ADVA Optical Networking
 B0B194 zte
 10C3AB Huawei Technologies
 2811EC Huawei Technologies
@@ -17540,13 +18128,13 @@ B4157E Celona
 645E2C IRay Technology
 00E0EC Celestica
 703811 Siemens Mobility Limited
-646266 Ieee Registration Authority
+646266 IEEE Registration Authority
 487AF6 NCS Electrical SDN BHD
 486E70 Zhejiang Tmall Technology
 601D9D Sichuan AI-Link Technology
 D85F77 Telink Semiconductor (Shanghai)
 2C97ED Sony Imaging Products & Solutions
-20826A Guangdong Oppo Mobile Telecommunications
+20826A Guangdong OPPO Mobile Telecommunications
 B89047 Apple
 909C4A Apple
 908C43 Apple
@@ -17617,8 +18205,8 @@ E0D462 Huawei Device
 C4F57C Brocade Communications Systems
 0012F2 Brocade Communications Systems
 6C2F8A Samsung Electronics
-F0B022 Toho Electronics
-987ECA Inventus Power Eletronica do Brasil Ltda
+F0B022 TOHO Electronics
+987ECA Inventus Power Eletronica do Brasil LTDA
 2C9FFB Wistron Neweb
 50382F ASE Group Chung-Li
 0C14D2 China Mobile Group Device
@@ -17626,11 +18214,10 @@ D4F829 Sagemcom Broadband SAS
 E06234 Texas Instruments
 708CBB Mimodisplaykorea
 B848AA EM Microelectronic
-D834EE Stem Audio
 F8572E Core Brands
 001C91 Gefen
-244BFE Asustek Computer
-7CDDE9 Atom Tech
+244BFE ASUSTek Computer
+7CDDE9 ATOM tech
 F86BD9 Cisco Systems
 C014FE Cisco Systems
 7CAD4F Cisco Systems
@@ -17647,7 +18234,7 @@ D477B2 Netix Global
 605661 Ixecloud Tech
 0C599C Juniper Networks
 44F4E7 Cohesity
-706979 Ieee Registration Authority
+706979 IEEE Registration Authority
 FC609B New H3C Technologies
 E8A1F8 zte
 98A942 Guangzhou Tozed Kangwei Intelligent Technology
@@ -17714,9 +18301,8 @@ BC03A7 MFP Michelin
 2C6F51 Herospeed Digital Technology Limited
 04A2F3 Fiberhome Telecommunication Technologies
 CCDB93 Cisco Systems
-18D61C Shenzhen Tinno Mobile Technology
 5448E6 Beijing Xiaomi Mobile Software
-60D4E9 Guangdong Oppo Mobile Telecommunications
+60D4E9 Guangdong OPPO Mobile Telecommunications
 30C50F Huawei Technologies
 2868D2 Huawei Technologies
 90A935 JWEntertainment
@@ -17738,7 +18324,7 @@ D88C79 Google
 0008F6 Sumitomo Electric Industries
 00005F Sumitomo Electric Industries
 18ECE7 Buffalo.inc
-F469D5 Ieee Registration Authority
+F469D5 IEEE Registration Authority
 083AF2 Espressif
 743A20 New H3C Technologies
 30C9AB Cloud Network Technology Singapore PTE.
@@ -17754,10 +18340,10 @@ D4AFF7 Arista Networks
 60077C Jala Group
 609866 Texas Instruments
 047E23 China Mobile IOT Company Limited
-14CCB3 AO GK Nateks
+14CCB3 AO "GK Nateks"
 DCCD2F Seiko Epson
-9454CE Guangdong Oppo Mobile Telecommunications
-388ABE Guangdong Oppo Mobile Telecommunications
+9454CE Guangdong OPPO Mobile Telecommunications
+388ABE Guangdong OPPO Mobile Telecommunications
 689320 New H3C Technologies
 5484DC zte
 38549B zte
@@ -17766,7 +18352,7 @@ DCCD2F Seiko Epson
 04C1D8 Huawei Device
 C8BC9C Huawei Device
 B0FEE5 Huawei Device
-C81739 Itel Mobile Limited
+C81739 ITEL Mobile Limited
 58D061 Huawei Technologies
 34EFB6 Edgecore Networks
 E874C7 Sentinhealth
@@ -17775,7 +18361,7 @@ E4842B Hangzhou Softel Optic
 B8D309 Cox Communications
 94026B Optictimes
 D46A91 SnapAV
-80EE25 Shenzhen Skyworth  Digital  Technology
+80EE25 Shenzhen Skyworth Digital Technology
 4487DB Tymphany Acoustic Technology (Huizhou)
 D021F9 Ubiquiti Networks
 D03D52 Ava Security Limited
@@ -17784,15 +18370,15 @@ F490EA Deciso
 DC5285 Apple
 E88152 Apple
 908158 Apple
-B4ADA3 GuangzhouShiyuanElectronicTechnologyCompanyLimited
+B4ADA3 Guangzhou Shiyuan Electronic Technology Company Limited
 642315 Huawei Device
 A4C74B Huawei Device
 D0D23C Apple
 78E3DE Apple
-18FDCB Ieee Registration Authority
+18FDCB IEEE Registration Authority
 D4482D Shenzhen Deejoy Lighting Technology
 D8F8AF Daontec
-408C4C Shenzhen MiaoMing  Intelligent Technology
+408C4C Shenzhen MiaoMing Intelligent Technology
 6CADAD Chongqing Fugui Electronics
 CCE0DA Baidu Online Network Technology (Beijing)
 141B30 Shenzhen Yipingfang Network Technology
@@ -17814,7 +18400,6 @@ FC698C Andreas Stihl AG & KG
 E4C32A Tp-link Technologies
 909A4A Tp-link Technologies
 BC9789 Huawei Device
-3CE038 Plumeria Networks
 AC122F Fantasia Trading
 FC45C3 Texas Instruments
 AC6AA3 Shenzhen Kertong Technology
@@ -17832,18 +18417,17 @@ C8B6D3 Huawei Technologies
 FC8D3D Leapfive Tech.
 002386 IMI Hydronic Engineering international SA
 A06974 Honor Device
-C033DA Shenzhen Jrun Technologies
-607072 Shenzhen Hongde Smart Link Technology
+C033DA Shenzhen JRUN Technologies
+607072 Shenzhen Hongde Smart LINK Technology
 DCB7FC Alps Electric (Ireland)
 ACFAA5 digitron
-78C95E Midmark Rtls
+78C95E Midmark RTLS
 20CD6E Realme Chongqing Mobile Telecommunications
-BC69CB Panasonic Life Solutions Networks
 089356 Huawei Technologies
 000789 Allradio
 6C146E Huawei Technologies
 44E968 Huawei Technologies
-DC4A9E Ieee Registration Authority
+DC4A9E IEEE Registration Authority
 E0C377 Samsung Electronics
 4CFBF4 Optimal Audio
 846082 Private
@@ -17864,11 +18448,11 @@ C469F0 Huawei Technologies
 C09435 Arris Group
 18B6CC We
 F85E42 Technicolor CH USA
-30A023 Rock Path S.R.L
+30A023 ROCK PATH S.r.l
 E848B8 TP-Link Limited
 78CB2C Join Digital
 309E1D Ohsung
-687912 Ieee Registration Authority
+687912 IEEE Registration Authority
 EC6488 Honor Device
 74D6CB New H3C Technologies
 0C3AFA New H3C Technologies
@@ -17878,9 +18462,9 @@ EC6488 Honor Device
 F8B1DD Apple
 F8665A Apple
 A8817E Apple
-8C476E Ieee Registration Authority
+8C476E IEEE Registration Authority
 48701E Texas Instruments
-E8C320 Austco Marketing & Service (USA)
+E8C320 Austco Marketing & Service (usa)
 AC3328 Huawei Device
 002306 Alpsalpine
 002433 Alpsalpine
@@ -17902,12 +18486,12 @@ E4D3AA Fujitsu Connected Technologies Limited
 C8A40D Cooler Master Technology
 38420B Sonos
 C83A6B Roku
-A453EE Ieee Registration Authority
+A453EE IEEE Registration Authority
 8C4962 Roku
 E02E3F Huawei Device
 C4BF60 Tecno Mobile Limited
 D040EF Murata Manufacturing
-8C8CAA Lcfc(hefei) Electronics Technology
+8C8CAA LCFC(HeFei) Electronics Technology
 90CCDF Intel Corporate
 085BD6 Intel Corporate
 B40EDE Intel Corporate
@@ -17928,7 +18512,7 @@ BC9D42 Shenzhen Rf-link Technology
 4C7525 Espressif
 7404F0 Mobiwire Mobiles (NingBo)
 240B88 Taicang T&W Electronics
-0C938F Guangdong Oppo Mobile Telecommunications
+0C938F Guangdong OPPO Mobile Telecommunications
 78F9B4 Nokia Solutions and Networks GmbH & KG
 60A8FE Nokia Solutions and Networks GmbH & KG
 D8EFCD Nokia Solutions and Networks GmbH & KG
@@ -17961,7 +18545,7 @@ C41411 Apple
 CCC95D Apple
 38B5D3 SecuWorks
 34318F Apple
-446FD8 Ieee Registration Authority
+446FD8 IEEE Registration Authority
 C89402 Chongqing Fugui Electronics
 7CB94C Bouffalo Lab (Nanjing)
 DC15C8 AVM Audiovisuelles Marketing und Computersysteme GmbH
@@ -17972,9 +18556,9 @@ C833E5 Huawei Technologies
 B844AE TCT mobile
 E4F75B Arris Group
 F8790A Arris Group
-0CCF89 Shenzhen Bilian Electronicltd
+0CCF89 Shenzhen Bilian Electronic，ltd
 0C8C69 Shenzhen elink smart
-D8BBC1 Micro-star Intl
+D8BBC1 Micro-Star INTL
 AC5AFC Intel Corporate
 1C937C Arris Group
 58FC20 Altice Labs
@@ -18002,7 +18586,7 @@ B0227A HP
 344AC3 HuNan ZiKun Information Technology
 682D83 Shenzhen Dinghe Communication Company
 A84397 Innogrit
-D8CD2C Wuxi Neihua Network Technology
+D8CD2C WUXI Neihua Network Technology
 58D391 Quectel Wireless Solutions
 08474C Nokia
 90C119 Nokia
@@ -18010,7 +18594,6 @@ D8CD2C Wuxi Neihua Network Technology
 E405F8 Bytedance
 F845C4 Shenzhen Netforward Micro-Electronic
 781053 China Mobile Group Device
-9C4F5F TAP Sound System
 00080C VDA Group
 D097FE Realme Chongqing Mobile Telecommunications
 843A5B Inventec(Chongqing)
@@ -18019,7 +18602,7 @@ D097FE Realme Chongqing Mobile Telecommunications
 F83E95 Huawei Technologies
 481258 Huawei Technologies
 D8EB46 Google
-2C17E0 Systemes ET Technologies Identification (stid)
+2C17E0 Systemes ET Technologies Identification (STid)
 CC3296 Huawei Device
 98CDAC Espressif
 808AF7 Nanoleaf
@@ -18049,7 +18632,7 @@ C09296 zte
 4C7766 Shenzhen Mercury Communication Technologies
 78E36D Espressif
 145AFC Liteon Technology
-1CA0EF Ieee Registration Authority
+1CA0EF IEEE Registration Authority
 001885 Motorola Solutions
 D8E72B Netscout Systems
 18BFB3 Samsung Electronics,, Memory Division
@@ -18067,7 +18650,7 @@ D07D33 Huawei Device
 C0E1BE Huawei Technologies
 D035E5 EM Microelectronic
 9096F3 Buffalo.inc
-540E58 Guangdong Oppo Mobile Telecommunications
+540E58 Guangdong OPPO Mobile Telecommunications
 5C648E Zyxel Communications
 30E396 Huawei Device
 C4A151 Sichuan Tianyi Comheart Telecom
@@ -18090,9 +18673,9 @@ B0A7B9 TP-Link Limited
 60E6F0 Wistron Neweb
 201F3B Google
 B825B5 Trakm8
-20D276 Itel Mobile Limited
+20D276 ITEL Mobile Limited
 08A842 Huawei Device
-C8F5D6 Ieee Registration Authority
+C8F5D6 IEEE Registration Authority
 405899 Logitech Far East
 8C4DEA Cerio
 04B9E3 Samsung Electronics
@@ -18103,33 +18686,32 @@ C45E5C Huawei Technologies
 E85C0A Cisco Systems
 2C6DC1 Intel Corporate
 70B950 Texas Instruments
-D09FD9 Ieee Registration Authority
+D09FD9 IEEE Registration Authority
 54C250 Iskratel d.o.o.
 00FAB6 Kontakt Micro-Location Sp z o.o.
 D01769 Murata Manufacturing
 A0B086 Hirschmann Automation and Control GmbH
-30B346 Cjsc Norsi-trans
+30B346 CJSC Norsi-trans
 20C19B Intel Corporate
 A8556A 3S System Technology
-000B3A Pesa
+000B3A PESA
 5CE42A Intel Corporate
-1874E2 Ieee Registration Authority
-F0C814 Shenzhen Bilian Electronicltd
+1874E2 IEEE Registration Authority
+F0C814 Shenzhen Bilian Electronic，ltd
 CC3ADF Neptune Technology Group
-68EC8A Private
 3C62F0 Sercomm
 983B67 DWnet Technologies(Suzhou)
 58355D Huawei Device
 AC7E01 Huawei Device
-6C9392 Beko Technologies Gmbh
+6C9392 BEKO Technologies GmbH
 FC8A3D zte
 F8F082 Nagtech
-8C1F64 Ieee Registration Authority
+8C1F64 IEEE Registration Authority
 085A11 D-Link International
 50325F Silicon Laboratories
 F47B09 Intel Corporate
-E87829 Ieee Registration Authority
-EC9468 Meta System SPA
+E87829 IEEE Registration Authority
+EC9468 META System SPA
 1C4190 Universal Electronics
 64C403 Quectel Wireless Solutions
 A0E453 Sony
@@ -18157,13 +18739,13 @@ D05162 Sony
 3039A9 Hongshan Information Science and Technology (HangZhou)
 1C573E Altice Labs
 D0167C eero
-A85B36 Ieee Registration Authority
+A85B36 IEEE Registration Authority
 4C77CB Intel Corporate
 9C6BF0 Shenzhen Yipingfang Network Technology
 44953B RLTech India Private Limited
 84144D Intel Corporate
 20B868 Motorola Mobility, a Lenovo Company
-289C6E Shanghai High-Flying Electronics  Technology
+289C6E Shanghai High-Flying Electronics Technology
 84F703 Espressif
 2C1165 Silicon Laboratories
 B41CAB ICR
@@ -18190,8 +18772,8 @@ DCB72E Xiaomi Communications
 703E97 Iton Technology
 104738 Nokia Shanghai Bell
 6C11B3 Wu Qi Technologies
-A0941A Guangdong Oppo Mobile Telecommunications
-1C2CE0 Shanghai  Mountain View Silicon
+A0941A Guangdong OPPO Mobile Telecommunications
+1C2CE0 Shanghai Mountain View Silicon
 000CEC Orolia USA
 08FA28 Huawei Technologies
 F4B19C AltoBeam (China)
@@ -18210,10 +18792,10 @@ EC937D Technicolor CH USA
 18FC26 Qorvo International Pte.
 589835 Technicolor Delivery Technologies Belgium NV
 906A94 hangzhou huacheng network technology
-100C29 Shenzhen Norco Lntelligent Technology
-283613 Ieee Registration Authority
+100C29 Shenzhen Norco lntelligent Technology
+283613 IEEE Registration Authority
 78524A Optonic GmbH
-00CE30 Express Luck Industrial
+00CE30 Express LUCK Industrial
 C46E33 Zhong Ge Smart Technology
 5C8382 Nokia
 7432C2 Kyolis
@@ -18234,27 +18816,27 @@ EC7C2C Huawei Technologies
 105A17 Tuya Smart
 B8374A Apple
 8C3DB1 Beijing H-IoT Technology
-546706 Guangdong Oppo Mobile Telecommunications
-1055E4 Shenzhen Skyworth  Digital  Technology
+546706 Guangdong OPPO Mobile Telecommunications
+1055E4 Shenzhen Skyworth Digital Technology
 C0F535 Ampak Technology
 C4E532 Arcadyan
 F8B54D Intel Corporate
 6401FB Landis+Gyr GmbH
-207BD2 Asix Electronics
+207BD2 ASIX Electronics
 182DF7 JY Company
 EC2C11 CWD Innovation Limited
 F03575 Hui Zhou Gaoshengda Technology
 908175 Samsung Electronics
 307467 Samsung Electronics
 F0CD31 Samsung Electronics
-38A8CD Ieee Registration Authority
+38A8CD IEEE Registration Authority
 E444E5 Extreme Networks
 545284 Huawei Device
 646140 Huawei Device
 C4170E Huawei Device
 687724 Tp-link Technologies
 2067E0 Shenzhen iComm Semiconductor
-7C8334 Ieee Registration Authority
+7C8334 IEEE Registration Authority
 D0C35A Jabil Circuit de Chihuahua
 84B630 Sichuan Tianyi Comheart Telecom
 58C7AC New H3C Technologies
@@ -18264,22 +18846,351 @@ D86C5A Humax
 4C3FA7 uGrid Network
 B898AD Motorola Mobility, a Lenovo Company
 94FF3C Fortinet
-7052D8 Itel Mobile Limited
+7052D8 ITEL Mobile Limited
 08FA79 vivo Mobile Communication
-1CAE3E Ieee Registration Authority
+1CAE3E IEEE Registration Authority
 001D5B Tecvan Informatica Ltda
 9C2BA6 Ruijie Networks
 941457 Shenzhen Sundray Technologies Company Limited
 64B94E Dell Technologies
 EC2BEB Amazon Technologies
 5447E8 Syrotech Networks.
+3C5576 Cloud Network Technology Singapore PTE.
+0CCAFB TPVision Europe
 BC5729 Shenzhen KKM
-0CCAFB TPVision Europe B.V
 E48210 Huawei Technologies
 F8F7B9 Huawei Technologies
+185345 Nokia
+38A9EA Private
+0816D5 Goertek
+1C568E Zioncom Electronics (Shenzhen)
+E01F2B Nokia Solutions and Networks GmbH & KG
+A08222 Qingdao Haier Technology
+28563A Fiberhome Telecommunication Technologies
+04C461 Murata Manufacturing
+AC8226 Qingdao Haier Technology
+4448FF Qingdao Haier Technology
+A8C266 Humax
+F84E17 Sony
+540F57 Silicon Laboratories
+C8CB9E Intel Corporate
+70A741 Ubiquiti Networks
+D4D7CF Realme Chongqing Mobile Telecommunications
+F4E4D7 Fujian Star-net Communication
+E84727 Quectel Wireless Solutions
+D4E2CB Technicolor CH USA
+28C538 Apple
+0499B9 Apple
+F84D89 Apple
+78028B Apple
+BCDB09 Cisco Meraki
+0434F6 Motorola (Wuhan) Mobility Technologies Communication
+14019C Ubyon
+F89522 Huawei Technologies
+F8B132 Huawei Technologies
+546925 PS Inodic
+E8B5D0 Dell
+E8CBED Chipsea Technologies(Shenzhen)
+7813E0 Fujian Star-net Communication
+4861EE Samsung Electronics
+A84B4D Samsung Electronics
+6007C4 Guangdong OPPO Mobile Telecommunications
+086F48 Shenzhen iComm Semiconductor
+F4F309 Samsung Electronics
+7857B0 Gertec Brasil LTDA
+C4F122 Nexar
+64BE63 Stordis GmbH
+0CC6FD Xiaomi Communications
+50DAD6 Xiaomi Communications
+18B96E Dongguan Liesheng Electronic
+546990 Huawei Technologies
+D80A60 Huawei Technologies
+3C869A Huawei Technologies
+2C2768 Huawei Technologies
+D07880 Fiberhome Telecommunication Technologies
+14CB65 Microsoft
+3408E1 Texas Instruments
+5058B0 Hunan Greatwall Computer System
+E06CF6 Essencore limited
+78C62B Fujian Star-net Communication
+D46624 Cisco Systems
+9C9019 Beyless
+3CE038 Omnifi
+001682 OMS Motion
+D4F98D Espressif
+04CE09 Shenzhen Skyworth Digital Technology
+1C869A Samsung Electronics
+D8FBD6 Amazon Technologies
+9C47F9 LJU Automatisierungstechnik GmbH
+70A8D3 Intel Corporate
+2C3358 Intel Corporate
+086AE5 Amazon Technologies
+A81710 Bouffalo Lab (Nanjing)
+206296 Shenzhen Malio Technology
+A08069 Intel Corporate
+A06720 China Dragon Technology Limited
+94C9B7 IEEE Registration Authority
+605699 Private
+E8EECC Fantasia Trading
+5C16C7 Arista Networks
+4CE0DB Xiaomi Communications
+7C33F9 Huawei Technologies
+541651 Ruijie Networks
+7087A7 Murata Manufacturing
+AC0425 ball-b GmbH KG
+04BD97 Cisco Systems
+F03A4B Bloombase
+0002A3 Hitachi Energy Switzerland
+38F7F1 Huawei Device
+4076A9 Huawei Device
+F438C1 Huawei Device
+28EA2D Apple
+209BE6 Guangzhou Shiyuan Electronic Technology Company Limited
+B8E60C Apple
+48352B Apple
+4CE6C0 Apple
+3888A4 Apple
+44DA30 Apple
+84160C Broadcom Limited
+74E6B8 LG Electronics
+28D0F5 Ruijie Networks
+941865 Netgear
+C89BD7 Realme Chongqing Mobile Telecommunications
+28B133 Shineman(shenzhen) Tech. Cor.
+D004B0 Samsung Electronics
+98B08B Samsung Electronics
+A8587C Shoogee GmbH & KG
+9C2595 Samsung Electronics
+90F260 Shenzhen Honesty Electronics
+1889CF Tecno Mobile Limited
+985F4F Tongfang Computer
+34F86E Parker Hannifin
+0CAEBD Edifier International
+6CD869 Guangzhou Sat Infrared
+381EC7 Chipsea Technologies(Shenzhen)
+089204 Dell
+40679B Shenzhen Skyworth Digital Technology
+F0A654 Cloud Network Technology Singapore PTE.
+3CCFB4 Telink Semiconductor (Shanghai)
+043CE8 Shenzhen SuperElectron Technology
+A8E621 Amazon Technologies
+E831CD Espressif
+88D039 Tonly Technology
+E8F375 Nokia
+103711 Norbit ITS
+C0886D Securosys SA
+24813B Cisco Systems
+C409B7 Juniper Networks
+0CB8E8 Renesas Electronics (Penang) Sdn. Bhd.
+EC5C84 Murata Manufacturing
+BC9B5E Hangzhou Hikvision Digital Technology
+487412 OnePlus Technology (Shenzhen)
+B0F208 AVM Audiovisuelles Marketing und Computersysteme GmbH
+F0B2B9 Intel Corporate
+A069D9 New H3C Technologies
+20FE00 Amazon Technologies
+F421AE Shanghai Xiaodu Technology Limited
+F412FA Espressif
+DC99FE Armatura
+9CF155 Nokia
+E47305 Shenzhen INVT Electric
+B01B4B Invisible Fun Studio Limited
+604F5B Huawei Device
+14DCE2 Thales AVS France
+78FBD8 Apple
+A4C337 Apple
+B0F1D8 Apple
+D0880C Apple
+1C57DC Apple
+747446 Google
+7820A5 Nintendo
+2078CD Apple
+30D53E Apple
+5023A2 Apple
+98698A Apple
+5046AE Mercury
+B099D7 Samsung Electronics
+90EB48 Shanghai XinMiaoLink Technology
+B4B742 Amazon Technologies
+78A03F Amazon Technologies
+50C1F0 NXP Semiconductor (Tianjin)
+F4848D Tp-link Technologies
+581122 ASUSTek Computer
+60BEB4 S-Bluetech, limited
+90DF7D Realme Chongqing Mobile Telecommunications
+A854A2 Heimgard Technologies AS
+742A8A shenzhen worldelite electronics
+BC1D89 Motorola Mobility, a Lenovo Company
+B87EE5 Intelbras
+94ABFE Nokia
+74694A Sichuan Tianyi Comheart Telecom
+78152D Union CHIP Technology Limited
+98A92D New H3C Technologies
+00A554 Intel Corporate
+0C8629 IEEE Registration Authority
+50DCD0 Observint Technologies
+E0036B Samsung Electronics
+1869D4 Samsung Electronics
+D4F0EA Beijing Xiaomi Mobile Software
+5876AC Sernet (suzhou) Technologies
+80691A Belkin International
+643172 Zhejiang Hising Technology
+D0FCD0 Humax
+20FADB Huahao Kunpeng Technology (chengDu)
+0C8B95 Espressif
+685E1C Texas Instruments
+38AB41 Texas Instruments
+CC4792 ASIX Electronics
+E046EE Netgear
+DCBE49 ITEL Mobile Limited
+9C9561 Hui Zhou Gaoshengda Technology
+9C4F5F Google
+A02942 Intel Corporate
+1071B3 Zyxel Communications
+F0D415 Intel Corporate
+D4D853 Intel Corporate
+0463D0 Huawei Device
+14448F Edgecore Networks
+3425BE Amazon Technologies
+C0EDE5 Guangdong OPPO Mobile Telecommunications
+10A562 Iton Technology
+D4A3EB Shenzhen iComm Semiconductor
+9CBFCD Huawei Technologies
+B89FCC Huawei Technologies
+9CE041 Nokia
+783486 Nokia
+8C763F Arris Group
+281293 Honor Device
+C0A938 Huawei Technologies
+5C24E2 Suzhou Denbom Electronic S&T
+64989E Trinnov Audio
+BCC746 Hon Hai Precision Ind.co.
+30E8E4 Qorvo International Pte.
+000DA9 Ingeteam
+30E090 Genevisio
+FCB97E GE Appliances
+88034C Weifang Goertek Electronics
+48DC9D Grandprint(Beijing) Technology
+64FD96 Sagemcom Broadband SAS
+C8EBEC Shenzhen Youhua Technology
+047C16 Micro-Star INTL
+94C5A6 ITEL Mobile Limited
+7CECB1 Apple
+5CE91E Apple
+E0D738 WireStar Networks
+404244 Cisco Systems
+04B6BE CIG Shanghai
+A8B0AE BizLink Special Cables Germany GmbH
+F0B661 eero
+E06A05 Shenzhen Youhua Technology
+4857D2 Broadcom Limited
+9C2183 Broadcom Limited
+241FBD Extreme Networks
+D834EE Shure Incorporated
+0425F0 Nokia
+1CBCEC silex technology
+403B7B Huawei Device
+0830CE Fiberhome Telecommunication Technologies
+90CD1F Quectel Wireless Solutions
+90235B Amazon Technologies
+14130B Garmin International
+489BE0 Realme Chongqing Mobile Telecommunications
+5CFA25 Sagemcom Broadband SAS
+B0A2E7 Shenzhen Tinno Mobile Technology
+A04C5B Shenzhen Tinno Mobile Technology
+BC4101 Shenzhen Tinno Mobile Technology
+18D61C Shenzhen Tinno Mobile Technology
+749779 Cloud Network Technology Singapore PTE.
+34CF6C Hangzhou Taili wireless communication equipment
+F8CDC8 Sichuan Tianyi Comheart Telecom
+B0285B Juhua Technology
+C82496 Jiangsu Yinhe Electronics
+E0F678 Fiberhome Telecommunication Technologies
+402230 Shenzhen SuperElectron Technology
+145BB9 ConMet
+28F7D6 Fiberhome Telecommunication Technologies
+B8B409 Samsung Electronics
+2418C0 E. Wehrle GmbH
+AC83F0 Cobalt Digital
+AC15A2 TP-Link Limited
+ACDF9F Arcadyan
+B859C8 70mai
+A8E207 GOIP Global Services Pvt.
+74E798 Juniper Networks
+D4E22F Roku
+001395 congatec GmbH
+2877B1 Tri plus grupa d.o.o.
+C43CB0 Shenzhen Bilian Electronic，ltd
+3C0B4F Yandex Services AG
+4C312D Sichuan AI-Link Technology
+405EF6 Samsung Electronics
+945244 Samsung Electronics
+9C2E7A Samsung Electronics
+7C6305 Amazon Technologies
+044F7A China Mobile Group Device
+C04E30 Espressif
+AC606F Nokia Shanghai Bell
+D87E6F Cascination AG
+5431D4 TGW Mechanics GmbH
+9401AC Wuhan Qianyang Iotian Technology
+0019FB SKY UK Limited
+783E53 SKY UK Limited
+24A7DC SKY UK Limited
+E016B1 Advanced Design Technology
+E4B555 Huawei Device
+C06911 Arista Networks
+2C93FB Sercomm France Sarl
+38A6CE SKY UK Limited
+68EC8A IKEA of Sweden AB
+4802AF Telit Communication
+FCC737 Shaanxi Gangsion Electronic Technology
+94286F zte
+400EF3 zte
+1C46D1 SKY UK Limited
+003F10 Shenzhen GainStrong Technology
+8822B2 Chipsea Technologies (Shenzhen)
+687A64 Intel Corporate
+BC0358 Intel Corporate
+88B863 Hisense Visual Technology
+BC69CB Panasonic Electric Works Networks
+58C57E Fiberhome Telecommunication Technologies
+743AF4 Intel Corporate
+582B0A Texas Instruments
+B4466B Realtimeid AS
+C4EB39 Sagemcom Broadband SAS
+0052C8 Made Studio Design
+F0C1CE GoodWe Technologies
+0C9192 Intel Corporate
+48AD9A Intel Corporate
+6865B7 Zhishang Chuanglian Technology
+089DF4 Intel Corporate
+DC4628 Intel Corporate
+906AEB Microsoft
+E46A35 Realme Chongqing Mobile Telecommunications
+2004F3 Honor Device
+589A3E Amazon Technologies
+E838A0 Vizio
+ECC07A Laird Connectivity
+68B9C2 Earda Technologies
+C81EC2 ITEL Mobile Limited
+38E7C0 Hui Zhou Gaoshengda Technology
+D8E844 zte
+6883CB Apple
+FC1263 Askey Computer
+58305B Shanghai Junqian Sensing Technology
+C071AA ShenZhen OnMicro Electronics
+9C0591 Mellanox Technologies
+709C45 Huawei Technologies
+0009DF Vestel Elektronik San ve Tic. A.S.
+A03131 Procenne Digital Security
+FC0736 Huawei Device
+94A07D Huawei Device
+5C0758 Ufispace
+84F44C International Integrated Systems.
+DCE650 Extreme Networks
 F8D027 Seiko Epson
-5C666C Guangdong Oppo Mobile Telecommunications
-4C4BF9 Ieee Registration Authority
+5C666C Guangdong OPPO Mobile Telecommunications
+4C4BF9 IEEE Registration Authority
 1CEA0B Edgecore Networks
 44EFBF China Dragon Technology Limited
 B81F5E Apption Labs Limited
@@ -18295,8 +19206,8 @@ ECFA5C Beijing Xiaomi Electronics
 F8B46A Hewlett Packard
 BCB0E7 Huawei Technologies
 5434EF Huawei Technologies
-88D5A8 Itel Mobile Limited
-208593 Ieee Registration Authority
+88D5A8 ITEL Mobile Limited
+208593 IEEE Registration Authority
 ACE342 Huawei Technologies
 9017C8 Huawei Technologies
 E4922A DBG Holdings Limited
@@ -18305,7 +19216,7 @@ E4922A DBG Holdings Limited
 54E7D5 Sun Cupid Technology (HK)
 189088 eero
 4C56DF Targus US
-241510 Ieee Registration Authority
+241510 IEEE Registration Authority
 6C4D51 Shenzhen Ceres Technology
 889D98 Allied-telesisK.K.
 DCF8B9 zte
@@ -18320,12 +19231,11 @@ C82B96 Espressif
 D015A6 Aruba, a Hewlett Packard Enterprise Company
 000163 Cisco Systems
 205F3D Cambridge Communication Systems
-04819B BSkyB
 E00084 Huawei Technologies
 2CA89C Creatz
 4CDC0D Coral Telecom Limited
 004E01 Dell
-C4E1A1 Guangdong Oppo Mobile Telecommunications
+C4E1A1 Guangdong OPPO Mobile Telecommunications
 ACC358 Continental Automotive Czech Republic s.r.o.
 3CECEF Super Micro Computer
 1855E3 Apple
@@ -18353,7 +19263,7 @@ B0B5E8 Ruroc
 541589 MCS Logic
 845733 Microsoft
 002423 AzureWave Technologies (Shanghai)
-8C593C Ieee Registration Authority
+8C593C IEEE Registration Authority
 6029D5 Davolink
 509744 Integrated Device Technology (Malaysia) Sdn. Bhd.
 58F39C Cisco Systems
@@ -18365,7 +19275,7 @@ F41D6B Huawei Technologies
 7CEC9B Fuzhou Teraway Information Technology
 CC9070 Cisco Systems
 2841C6 Huawei Technologies
-380118 Ulvac
+380118 ULVAC
 14ADCA China Mobile Iot Limited company
 809133 AzureWave Technology
 B4F58E Huawei Technologies
@@ -18384,9 +19294,9 @@ BC98DF Motorola Mobility, a Lenovo Company
 B0A6F5 Xaptum
 ACF5E6 Cisco Systems
 DCB082 Nokia
-F8C397 Nzxt
-70DDA8 Guangdong Oppo Mobile Telecommunications
-4C6F9C Guangdong Oppo Mobile Telecommunications
+F8C397 NZXT
+70DDA8 Guangdong OPPO Mobile Telecommunications
+4C6F9C Guangdong OPPO Mobile Telecommunications
 782C29 New H3C Technologies
 BC9FE4 Aruba, a Hewlett Packard Enterprise Company
 702E80 Diehl Connectivity Solutions
@@ -18401,7 +19311,7 @@ B0AAD2 Sichuan tianyi kanghe communications
 109397 Arris Group
 5075F1 Arris Group
 C46516 Hewlett Packard
-E41E0A Ieee Registration Authority
+E41E0A IEEE Registration Authority
 CCA12B TCL King Electrical Appliances (Huizhou)
 AC00D0 zte
 E8C417 Fiberhome Telecommunication Technologies
@@ -18411,19 +19321,19 @@ E8C417 Fiberhome Telecommunication Technologies
 84B866 Beijing XiaoLu technology
 18BC5A Zhejiang Tmall Technology
 C4C138 OWLink Technology
-AC37C9 Raid Incorporated
+AC37C9 RAID Incorporated
 205869 Ruckus Wireless
 CC37AB Edgecore Networks
 1422DB eero
-C86314 Ieee Registration Authority
+C86314 IEEE Registration Authority
 243154 Huawei Technologies
 2C58E8 Huawei Technologies
-70CD91 Teracom Telematica S.A
+70CD91 Teracom Telematica
 2C1875 Skyworth Digital Technology(Shenzhen)
 D06EDE Sagemcom Broadband SAS
 18399C Skorpios Technologies
 94C2BD Tecnobit
-4883B4 Guangdong Oppo Mobile Telecommunications
+4883B4 Guangdong OPPO Mobile Telecommunications
 84B8B8 Motorola (Wuhan) Mobility Technologies Communication
 D041C9 Fiberhome Telecommunication Technologies
 E8018D Fiberhome Telecommunication Technologies
@@ -18446,7 +19356,7 @@ B0BB8B Wavetel Technology Limited
 A483E7 Apple
 F4AFE7 Apple
 AC88FD Apple
-503E7C LeiShen Intelligent  SystemLtd
+503E7C LeiShen Intelligent SystemLtd
 24586E zte
 B4A305 Xiamen Yaxon Network
 803E48 Shenzhen Gongjin Electronics
@@ -18465,7 +19375,7 @@ C010B1 HMD Global Oy
 90895F Weifang Goertek Electronics
 48D845 Shenzhen Mainuoke Electronics
 0CE041 iDruide
-B88FB4 Jabil Circuit Italia S.R.L
+B88FB4 Jabil Circuit Italia S.r.l
 0052C2 peiker acustic GmbH
 8C53D2 China Mobile Group Device
 D45383 Murata Manufacturing
@@ -18498,7 +19408,7 @@ C8F6C8 Fiberhome Telecommunication Technologies
 1C3B8F Selve GmbH & KG
 E4E749 Hewlett Packard
 ECC57F Suzhou Pairlink Network Technology
-38C2BA Cctv Neotech
+38C2BA CCTV Neotech
 A0F9B7 Ademco Smart Homes Technology(Tianjin)Co.
 A83CCB Rossma
 886FD4 Dell
@@ -18570,10 +19480,10 @@ E43C80 University of Oklahoma
 706D15 Cisco Systems
 A4A1E4 Innotube
 94EAEA Tellescom Industria E Comercio EM Telecomunicacao
-1CFD08 Ieee Registration Authority
+1CFD08 IEEE Registration Authority
 B8599F Mellanox Technologies
 301389 Siemens AG, Automations & Drives,
-98D3E7 Netafim L
+98D3E7 Netafim
 F063F9 Huawei Technologies
 7CC385 Huawei Technologies
 900EB3 Shenzhen Amediatech Technology
@@ -18588,7 +19498,7 @@ C8D9D2 Hewlett Packard
 809621 Lenovo
 78055F Shenzhen WYC Technology
 00EABD Cisco Systems
-48872D Shen Zhen DA XIA Long QUE Technology
+48872D SHEN ZHEN DA XIA LONG QUE Technology
 E81A58 Technologic Systems
 C0BFA7 Juniper Networks
 F05494 Honeywell Connected Building
@@ -18598,7 +19508,7 @@ C474F8 Hot Pepper
 142233 Fiberhome Telecommunication Technologies
 743400 MTG
 DC3757 Integrated Device Technology (Malaysia) Sdn. Bhd.
-005099 3com Europe
+005099 3COM Europe
 04BC87 Shenzhen JustLink Technology
 54C33E Ciena
 EC79F2 Startel
@@ -18619,31 +19529,30 @@ A89A93 Sagemcom Broadband SAS
 0415D9 Viwone
 ECB313 Shenzhen Gongjin Electronics
 B08BCF Cisco Systems
-00608C 3com
-00A024 3com
-0020AF 3com
-00104B 3com
+00608C 3COM
+00A024 3COM
+0020AF 3COM
+00104B 3COM
 A85AF3 Shanghai Siflower Communication Technology
 70FD46 Samsung Electronics
 8C83E1 Samsung Electronics
 889F6F Samsung Electronics
 5C63C9 Intellithings
 0C96E6 Cloud Network Technology (Samoa) Limited
-3C8994 BSkyB
 E00EE1 We
 000C43 Ralink Technology
 8C9246 Oerlikon Textile Gmbh&Co.KG
 000E94 Maas International BV
-4898CA SichuanAI-LinkTechnologyCo.
+4898CA Sichuan AI-Link Technology
 247E51 zte
 E8B541 zte
-0C9D92 Asustek Computer
-988ED4 Itel Mobile Limited
+0C9D92 ASUSTek Computer
+988ED4 ITEL Mobile Limited
 E8A788 Xiamen Leelen Technology
 582D34 Qingping Electronics (Suzhou)
 20DE88 IC Realtime
 F4068D devolo AG
-001A31 Scan Coin AB
+001A31 SCAN COIN AB
 001B84 Scan Engineering Telecom
 482CA0 Xiaomi Communications
 3412F9 Huawei Technologies
@@ -18658,7 +19567,7 @@ A09351 Cisco Systems
 98039B Mellanox Technologies
 208984 Compal Information (kunshan)
 B4CEFE James Czekaj
-F8CC6E Depo Electronics
+F8CC6E DEPO Electronics
 F8369B Texas Instruments
 88AE1D Compal Information (kunshan)
 B888E3 Compal Information (kunshan)
@@ -18721,7 +19630,7 @@ C0D2F3 Hui Zhou Gaoshengda Technology
 B88303 Hewlett Packard Enterprise
 203DBD LG Innotek
 A45385 Weifang Goertek Electronics
-00402F Xlnt Designs
+00402F XLNT Designs
 04ECBB Fiberhome Telecommunication Technologies
 64A2F9 OnePlus Technology (Shenzhen)
 A87D12 Huawei Technologies
@@ -18732,7 +19641,7 @@ BC9911 Zyxel Communications
 E48F65 Yelatma Instrument Making Enterprise
 0000A8 Stratus Technologies
 0004FC Stratus Technologies
-3C24F0 Ieee Registration Authority
+3C24F0 IEEE Registration Authority
 00BB3A Amazon Technologies
 0CB34F Shenzhen Xiaoqi Intelligent Technology
 3CF4F9 Moda-InnoChips
@@ -18740,13 +19649,12 @@ E48F65 Yelatma Instrument Making Enterprise
 C08135 Ningbo Forfan technology
 840D8E Espressif
 002082 Oneac
-B4C0F5 Shenzhen Tinno Mobile Technology
-406231 Gifa
+406231 GIFA
 FCB7F0 Idaho National Laboratory
 2C28B7 Hangzhou Ruiying technology
 106530 Dell
 046B1B Sysdine
-B0A37E Qing DAO Haier Telecom
+B0A37E QING DAO Haier Telecom
 3CEAF9 Jubixcoltd
 58DB15 Tecno Mobile Limited
 5050CE Hangzhou Dianyixia Communication Technology
@@ -18775,7 +19683,7 @@ A056F3 Apple
 549963 Apple
 90DD5D Apple
 DC2919 AltoBeam (Xiamen) Technology
-885FE8 Ieee Registration Authority
+885FE8 IEEE Registration Authority
 002FD9 Fiberhome Telecommunication Technologies
 B4CD27 Huawei Technologies
 C819F7 Samsung Electronics
@@ -18795,7 +19703,7 @@ BC6A2F Henge Docks
 184C08 Rockwell Automation
 DC0265 Meditech Kft
 14A72B currentoptronics Pvt.Ltd
-A4DA22 Ieee Registration Authority
+A4DA22 IEEE Registration Authority
 3C1710 Sagemcom Broadband SAS
 DC729B Huawei Technologies
 909497 Huawei Technologies
@@ -18818,16 +19726,16 @@ D4E6B7 Samsung Electronics
 E8DEFB Mesotic SAS
 C400AD Advantech Technology (china)
 94FE9D Shenzhen Gongjin Electronics
-6CB6CA Divus Gmbh
+6CB6CA Divus GmbH
 04D13A Xiaomi Communications
 4CC206 Somfy
 040973 Hewlett Packard Enterprise
 3499D7 Universal Flow Monitors
-0C8BD3 Itel Mobile Limited
+0C8BD3 ITEL Mobile Limited
 C0A8F0 Adamson Systems Engineering
-9C431E Ieee Registration Authority
+9C431E IEEE Registration Authority
 0024AF Dish Technologies
-282C02 Ieee Registration Authority
+282C02 IEEE Registration Authority
 FCA183 Amazon Technologies
 6C2ACB Paxton Access
 583BD9 Fiberhome Telecommunication Technologies
@@ -18835,14 +19743,13 @@ DCA266 Hon Hai Precision Ind.
 C48466 Apple
 347C25 Apple
 CC2DB7 Apple
-A0BDCD BSkyB
 BC91B5 Infinix mobility limited
 282FC2 Automotive Data Solutions
 980074 Raisecom Technology
 18C19D Integrated Device Technology (Malaysia) Sdn. Bhd.
 0C9838 Xiaomi Communications
 74EACB New H3C Technologies
-D41A3F Guangdong Oppo Mobile Telecommunications
+D41A3F Guangdong OPPO Mobile Telecommunications
 D8B122 Juniper Networks
 B4C799 Extreme Networks
 646E6C Radio Datacom
@@ -18851,7 +19758,7 @@ E88E60 NSD
 0024BA Texas Instruments
 60512C TCT mobile
 64DB81 Syszone
-44AD19 Xingfei h.klimited
+44AD19 Xingfei （h.k）limited
 38ADBE New H3C Technologies
 5CAD76 Shenzhen TCL New Technology
 5C865C Samsung Electronics
@@ -18871,7 +19778,7 @@ C8458F Wyler AG
 7846C4 Daehap Hyper-tech
 5CE28C Zyxel Communications
 E4BD4B zte
-38D7CA 7hugs Labs
+38D7CA 7hugs LABS
 000144 Dell EMC
 08001B Dell EMC
 7C010A Texas Instruments
@@ -18927,14 +19834,14 @@ C421C8 Kyocera
 80739F Kyocera
 705812 Panasonic AVC Networks Company
 04209A Panasonic AVC Networks Company
-34008A Ieee Registration Authority
+34008A IEEE Registration Authority
 A41115 Robert Bosch Engineering and Business Solutions pvt.
 40D63C Equitech Industrial(DongGuan)Co.
 F4F3AA JBL GmbH & KG
 9050CA Hitron Technologies.
 409922 AzureWave Technology
 C06D1A Tianjin Henxinhuifeng Technology
-107B44 Asustek Computer
+107B44 ASUSTek Computer
 84253F silex technology
 0008C9 TechniSat Digital GmbH Daun
 D8B12A Panasonic Mobile Communications
@@ -18948,7 +19855,7 @@ E86819 Huawei Technologies
 5C0979 Huawei Technologies
 E4FB5D Huawei Technologies
 0001CC Japan Total Design Communication
-0030C8 GAD LINE
+0030C8 GAD Line
 0016E0 3Com
 D8DECE Isung
 703EAC Apple
@@ -18958,10 +19865,10 @@ AC512C Infinix mobility limited
 309935 zte
 0C72D9 zte
 1062D0 Technicolor CH USA
-50642B Xiaomi Electronics,co.
+50642B Xiaomi Electronics,CO.
 28401A C8 MediSensors
 30C01B Shenzhen Jingxun Software Telecommunication Technology
-8886C2 Stabilo International Gmbh
+8886C2 Stabilo International GmbH
 08A8A1 Cyclotronics Power Concepts
 F4B520 Biostar Microtech international
 CC2F71 Intel Corporate
@@ -18991,10 +19898,10 @@ B8F8BE Bluecom
 00D01F Senetas
 6447E0 Feitian Technologies
 B44F96 Zhejiang Xinzailing Technology
-4C65A8 Ieee Registration Authority
+4C65A8 IEEE Registration Authority
 B0DFC1 Tenda Technology,Ltd.Dongguan branch
 9C6F52 zte
-E86D65 Audio Mobil Elektronik Gmbh
+E86D65 Audio Mobil Elektronik GmbH
 706E6D Cisco Systems
 604762 Beijing Sensoro Technology
 BC1C81 Sichuan iLink Technology
@@ -19011,9 +19918,9 @@ D822F4 Avnet Silica
 001CFA Alarm.com
 60313B Sunnovo International Limited
 6CB227 Sony Video & Sound Products
-986F60 Guangdong Oppo Mobile Telecommunications
+986F60 Guangdong OPPO Mobile Telecommunications
 000CAB Commend International GmbH
-745427 Shenzhen Fast Technologies
+745427 Shenzhen FAST Technologies
 60720B BLU Products
 308976 Dalian Lamba Technology
 2C2617 Oculus VR
@@ -19079,22 +19986,22 @@ F80377 Apple
 F49634 Intel Corporate
 107D1A Dell
 70AF24 TP Vision Belgium NV
-A41163 Ieee Registration Authority
+A41163 IEEE Registration Authority
 C4D197 Ventia Utility Services
 2C86D2 Cisco Systems
-7CE97C Itel Mobile Limited
+7CE97C ITEL Mobile Limited
 8058F8 Motorola Mobility, a Lenovo Company
 DCA4CA Apple
 8C8FE9 Apple
 70AF25 Nishiyama Industry
 E8D11B Askey Computer
-9800C1 Guangzhou Creator Technology,ltd.(china)
-54E1AD Lcfc(hefei) Electronics Technology
-98D3D2 Mekra Lang Gmbh & KG
+9800C1 GuangZhou Creator Technology,Ltd.(CHINA)
+54E1AD LCFC(HeFei) Electronics Technology
+98D3D2 Mekra Lang GmbH & KG
 0C5F35 Niagara Video
 F8A34F zte
 001912 Welcat
-8C78D7 Shenzhen Fast Technologies
+8C78D7 Shenzhen FAST Technologies
 B8EAAA ICG Networks
 B8F883 Tp-link Technologies
 DCFE18 Tp-link Technologies
@@ -19147,9 +20054,9 @@ AC1826 Seiko Epson
 A4EE57 Seiko Epson
 9CAED3 Seiko Epson
 707C69 Avaya
-500B91 Ieee Registration Authority
+500B91 IEEE Registration Authority
 F8461C Sony Interactive Entertainment
-704D7B Asustek Computer
+704D7B ASUSTek Computer
 64A68F Zhongshan Readboy Electronics
 38BC01 Huawei Technologies
 341E6B Huawei Technologies
@@ -19167,7 +20074,7 @@ B05216 Hon Hai Precision Ind.
 A0E4CB Zyxel Communications
 284ED7 OutSmart Power Systems
 14A78B Zhejiang Dahua Technology
-A0B8F8 Amgen U.S.A.
+A0B8F8 Amgen U.s.a.
 884477 Huawei Technologies
 149D09 Huawei Technologies
 686975 Angler Labs
@@ -19186,7 +20093,7 @@ E47DBD Samsung Electronics
 407183 Juniper Networks
 C81B5C BCTech
 5CE30E Arris Group
-1CC0E1 Ieee Registration Authority
+1CC0E1 IEEE Registration Authority
 001A39 Merten GmbH&CoKG
 FCECDA Ubiquiti Networks
 00B0E1 Cisco Systems
@@ -19211,7 +20118,7 @@ A01081 Samsung Electronics
 4CF95D Huawei Technologies
 8421F1 Huawei Technologies
 00F22C Shanghai B-star Technology
-0005EE Vanderbilt International (SWE) AB
+0005EE Vanderbilt International (swe) AB
 F07960 Apple
 A0D795 Apple
 0090E7 Horsch Elektronik AG
@@ -19222,7 +20129,6 @@ F8633F Intel Corporate
 F0D5BF Intel Corporate
 6474F6 Shooter Detection Systems
 981333 zte
-2047ED BSkyB
 748A69 Korea Image Technology
 BC4760 Samsung Electronics
 04180F Samsung Electronics
@@ -19230,10 +20136,10 @@ BC4760 Samsung Electronics
 002566 Samsung Electronics
 D0DB32 Nokia
 E80036 Befs
-C09F05 Guangdong Oppo Mobile Telecommunications
+C09F05 Guangdong OPPO Mobile Telecommunications
 5C4979 AVM Audiovisuelles Marketing und Computersysteme GmbH
 C0F945 Toshiba Toko Meter Systems
-70F8E7 Ieee Registration Authority
+70F8E7 IEEE Registration Authority
 D42C44 Cisco Systems
 843DC6 Cisco Systems
 002485 ConteXtream
@@ -19292,7 +20198,7 @@ C8DE51 IntegraOptics
 68C44D Motorola Mobility, a Lenovo Company
 400D10 Arris Group
 943DC9 Asahi Net
-440444 Guangdong Oppo Mobile Telecommunications
+440444 Guangdong OPPO Mobile Telecommunications
 00177E Meshcom Technologies
 A00460 Netgear
 9884E3 Texas Instruments
@@ -19304,7 +20210,7 @@ C4F5A5 Kumalift
 304487 Hefei Radio Communication Technology
 2C9D1E Huawei Technologies
 0081C4 Cisco Systems
-58E876 Ieee Registration Authority
+58E876 IEEE Registration Authority
 D03742 Yulong Computer Telecommunication Scientific (Shenzhen)
 001765 Nortel Networks
 0015E8 Nortel Networks
@@ -19349,7 +20255,7 @@ BCF5AC LG Electronics (Mobile Communications)
 A84E3F Hitron Technologies.
 0C4885 LG Electronics (Mobile Communications)
 0022A9 LG Electronics (Mobile Communications)
-2C6A6F Ieee Registration Authority
+2C6A6F IEEE Registration Authority
 08D833 Shenzhen RF Technology
 A46032 MRV Communications (Networks)
 40667A mediola - connected living AG
@@ -19360,13 +20266,13 @@ A46032 MRV Communications (Networks)
 9C2A83 Samsung Electronics
 C80210 LG Innotek
 A039F7 LG Electronics (Mobile Communications)
-1CCAE3 Ieee Registration Authority
-E4956E Ieee Registration Authority
-B437D1 Ieee Registration Authority
-0055DA Ieee Registration Authority
-78C2C0 Ieee Registration Authority
+1CCAE3 IEEE Registration Authority
+E4956E IEEE Registration Authority
+B437D1 IEEE Registration Authority
+0055DA IEEE Registration Authority
+78C2C0 IEEE Registration Authority
 000EE8 Zioncom Electronics (Shenzhen)
-00C095 Znyx Networks
+00C095 ZNYX Networks
 002025 Control Technology
 001A6B Universal Global Scientific Industrial
 001641 Universal Global Scientific Industrial
@@ -19385,7 +20291,7 @@ B86B23 Toshiba
 0008F1 Voltaire
 00199D Vizio
 00E08B QLogic
-D8EB97 Trendnet
+D8EB97 TRENDnet
 001C7E Toshiba
 002517 Venntis
 00600F Westell Technologies
@@ -19401,13 +20307,13 @@ D8EB97 Trendnet
 446EE5 Huawei Technologies
 88F7C7 Technicolor CH USA
 683E34 Meizu Technology
-C8778B Mercury Systems  Trusted Mission Solutions
+C8778B Mercury Systems – Trusted Mission Solutions
 00044B Nvidia
 AC9B0A Sony
 104FA8 Sony
 000B6B Wistron Neweb
 AC040B Peloton Interactive
-48FCB6 Lava International(h.k) Limited
+48FCB6 LAVA International(h.k) Limited
 B0E235 Xiaomi Communications
 40C729 Sagemcom Broadband SAS
 14C913 LG Electronics
@@ -19416,7 +20322,6 @@ FC2325 EosTek (Shenzhen)
 FC3D93 Longcheer Telecommunication Limited
 D8E0B8 Bulat
 603197 Zyxel Communications
-C0C976 Shenzhen Tinno Mobile Technology
 588BF3 Zyxel Communications
 5067F0 Zyxel Communications
 001349 Zyxel Communications
@@ -19440,12 +20345,12 @@ B0D7CC Tridonic GmbH & KG
 381DD9 Fn-link Technology Limited
 1CB9C4 Ruckus Wireless
 8C59C3 ADB Italia
-B824F0 Soyo Technology Development
+B824F0 SOYO Technology Development
 D85B2A Samsung Electronics
 FCA89A Sunitec Enterprise
 1C7B23 Qingdao Hisense Communications
-000BDE Teldix Gmbh
-CCD31E Ieee Registration Authority
+000BDE Teldix GmbH
+CCD31E IEEE Registration Authority
 34B354 Huawei Technologies
 1C6E76 Quarion Technology
 90C1C6 Apple
@@ -19459,10 +20364,10 @@ F40F24 Apple
 0062EC Cisco Systems
 CC167E Cisco Systems
 C46AB7 Xiaomi Communications
-000AED Harting Electronics Gmbh
+000AED Harting Electronics GmbH
 240A11 TCT mobile
 D8E56D TCT mobile
-540593 Woori Elec
+540593 Woori ELEC
 C02FF1 Volta Networks
 E8A7F2 sTraffic
 001F20 Logitech Europe SA
@@ -19476,15 +20381,15 @@ F8DA0C Hon Hai Precision Ind.
 1C1B0D Giga-byte Technology
 48E9F1 Apple
 903809 Ericsson AB
-00A006 Image Data Processing System Group
+00A006 Image DATA Processing System Group
 C83F26 Microsoft
-3497F6 Asustek Computer
+3497F6 ASUSTek Computer
 50680A Huawei Technologies
 002238 Logiplus
 000C49 Dangaard Telecom Denmark A/S
 0008B9 Kaonmedia
 60B387 Synergics Technologies GmbH
-A4D8CA Hong Kong Water World Technology Limited
+A4D8CA HONG KONG Water World Technology Limited
 8019FE JianLing Technology
 60B4F7 Plume Design
 487ADA Hangzhou H3C Technologies, Limited
@@ -19504,14 +20409,14 @@ A08CFD Hewlett Packard
 4883C7 Sagemcom Broadband SAS
 40163B Samsung Electronics
 44650D Amazon Technologies
-D4F207 Diaodiao(beijing)technology
+D4F207 DIAODIAO(Beijing)Technology
 D4AD2D Fiberhome Telecommunication Technologies
 F08CFB Fiberhome Telecommunication Technologies
 48555F Fiberhome Telecommunication Technologies
 FC3F7C Huawei Technologies
 384C4F Huawei Technologies
 0CBF3F Shenzhen Lencotion Technology
-50FF99 Ieee Registration Authority
+50FF99 IEEE Registration Authority
 84E323 Green Wave Telecommunication SDN BHD
 705A9E Technicolor CH USA
 04A316 Texas Instruments
@@ -19521,7 +20426,7 @@ FC084A Fujitsu Limited
 BC9889 Fiberhome Telecommunication Technologies
 24615A China Mobile Group Device
 405EE1 Shenzhen H&T Intelligent Control
-002578 JSC Concern Sozvezdie
+002578 JSC "Concern "Sozvezdie"
 30B49E Tp-link Technologies
 C83870 Samsung Electronics
 1C553A QianGua
@@ -19531,7 +20436,7 @@ C83870 Samsung Electronics
 98E7F5 Huawei Technologies
 085BDA CliniCare
 1CC035 Planex Communications
-34543C Takaoka Toko
+34543C Takaoka TOKO
 1866DA Dell
 583277 Reliance Communications
 248A07 Mellanox Technologies
@@ -19553,7 +20458,7 @@ C4E510 Mechatro
 00351A Cisco Systems
 00AF1F Cisco Systems
 803896 Sharp
-0060EC Hermary Opto Electronics
+0060EC Hermary OPTO Electronics
 C0CCF8 Apple
 9C4FDA Apple
 8489AD Apple
@@ -19683,7 +20588,7 @@ CC1FC4 InVue
 28B2BD Intel Corporate
 002243 AzureWave Technology
 00006E Artisoft
-448723 Hoya Service
+448723 HOYA Service
 D86C02 Huaqin Telecom Technology
 60BEB5 Motorola Mobility, a Lenovo Company
 F8F1B6 Motorola Mobility, a Lenovo Company
@@ -19757,7 +20662,7 @@ F8E71E Ruckus Wireless
 08863B Belkin International
 247C4C Herman Miller
 E46F13 D-Link International
-2C56DC Asustek Computer
+2C56DC ASUSTek Computer
 003146 Juniper Networks
 00604C Sagemcom Broadband SAS
 001F95 Sagemcom Broadband SAS
@@ -19790,14 +20695,12 @@ F4FC32 Texas Instruments
 90D7EB Texas Instruments
 0017E8 Texas Instruments
 001783 Texas Instruments
-00F871 DGS Denmark A/S
 2435CC Zhongshan Scinan Internet of Things
 2C3033 Netgear
 CC46D6 Cisco Systems
 0041D2 Cisco Systems
 2CAB00 Huawei Technologies
 A8CA7B Huawei Technologies
-BC4434 Shenzhen Tinno Mobile Technology
 04BF6D Zyxel Communications
 F88FCA Google
 3898D8 Meritech
@@ -19812,7 +20715,7 @@ BC5436 Apple
 6C8DC1 Apple
 84ACFB Crouzet Automatismes
 7CBB8A Nintendo
-FCFFAA Ieee Registration Authority
+FCFFAA IEEE Registration Authority
 0CD746 Apple
 60A37D Apple
 88A25E Juniper Networks
@@ -19969,15 +20872,15 @@ E4D3F1 Cisco Systems
 8478AC Cisco Systems
 0090A6 Cisco Systems
 009086 Cisco Systems
-00248C Asustek Computer
-002354 Asustek Computer
-1C872C Asustek Computer
+00248C ASUSTek Computer
+002354 ASUSTek Computer
+1C872C ASUSTek Computer
 60182E ShenZhen Protruly Electronic
 C4143C Cisco Systems
 3C08F6 Cisco Systems
-001E8C Asustek Computer
-0013D4 Asustek Computer
-20CF30 Asustek Computer
+001E8C ASUSTek Computer
+0013D4 ASUSTek Computer
+20CF30 ASUSTek Computer
 BC1665 Cisco Systems
 F872EA Cisco Systems
 D0C789 Cisco Systems
@@ -20088,9 +20991,9 @@ C869CD Apple
 A4B805 Apple
 90C99B Tesorion Nederland
 5CADCF Apple
-080A4E Planet Bingo  3rd Rock Gaming
+080A4E Planet Bingo® — 3rd Rock Gaming®
 B49D0B BQ
-3C8CF8 Trendnet
+3C8CF8 TRENDnet
 E81363 Comstock RD
 741865 Shanghai DareGlobal Technologies
 BC6C21 Apple
@@ -20108,7 +21011,7 @@ F40E22 Samsung Electronics
 A4A6A9 Private
 8C10D4 Sagemcom Broadband SAS
 F898B9 Huawei Technologies
-5CB559 Cnex Labs
+5CB559 CNEX Labs
 B83A9D Alarm.com
 6858C5 ZF TRW Automotive
 C01173 Samsung Electronics
@@ -20134,8 +21037,7 @@ E855B4 SAI Technology
 340CED Moduel AB
 2827BF Samsung Electronics
 94D859 TCT mobile
-2CFCE4 Ctek Sweden AB
-C0EE40 Laird Technologies
+2CFCE4 CTEK Sweden AB
 F4B8A7 zte
 300C23 zte
 C0B713 Beijing Xiaoyuer Technology
@@ -20155,15 +21057,15 @@ F4E9D4 QLogic
 74852A Pegatron
 9CB6D0 Rivet Networks
 40B89A Hon Hai Precision Ind.
-1CB72C Asustek Computer
+1CB72C ASUSTek Computer
 4CEEB0 SHC Netzwerktechnik GmbH
 800184 HTC
 44C69B Wuhan Feng Tian Information Network
 FCE33C Huawei Technologies
 C02567 Nexxt Solutions
-A8827F Cibn Oriental Network(beijing)
+A8827F CIBN Oriental Network(Beijing)
 D048F3 Dattus
-B8C3BF Henan Chengshi NetWork TechnologyLtd
+B8C3BF Henan Chengshi NetWork Technology，Ltd
 44962B Aidon Oy
 E076D0 Ampak Technology
 B008BF Vital Connect
@@ -20172,7 +21074,7 @@ E807BF Shenzhen Boomtech Industry
 84F129 Metrascale
 B89ACD Elite Optoelectronic(asia)co.
 D468BA Shenzhen Sundray Technologies Company Limited
-086266 Asustek Computer
+086266 ASUSTek Computer
 9C3066 RWE Effizienz GmbH
 18BDAD L-tech
 60E6BC Sino-Telecom Technology
@@ -20181,7 +21083,7 @@ D06A1F BSE
 700136 Fatek Automation
 FCA22A PT. Callysta Multi Engineering
 A45602 fenglian Technology
-94E2FD Boge Kompressoren Otto Boge Gmbh & KG
+94E2FD Boge Kompressoren OTTO Boge GmbH & KG
 F01E34 Orico Technologies
 DCE026 Patrol Tag
 B40566 SP Best
@@ -20192,7 +21094,7 @@ A89008 Beijing Yuecheng Technology
 8CBFA6 Samsung Electronics
 C8A823 Samsung Electronics
 B0C559 Samsung Electronics
-F42C56 Senor Tech
+F42C56 Senor TECH
 FCDC4A G-Wearables
 1C14B3 Airwire Technologies
 A48CDB Lenovo
@@ -20227,7 +21129,6 @@ BC52B4 Nokia
 00F3DB WOO Sports
 78312B zte
 C81B6B Innova Security
-3438AF Inlab Software GmbH
 B4A828 Shenzhen Concox Information Technology
 00A2F5 Guangzhou Yuanyun Network Technology
 1008B1 Hon Hai Precision Ind.
@@ -20241,7 +21142,7 @@ E42354 Shenzhen Fuzhi Software Technology
 9470D2 Winfirm Technology
 A44AD3 ST Electronics(Shanghai)
 7CB177 Satelco AG
-CC3080 Vaio
+CC3080 VAIO
 587BE9 AirPro Technology India Pvt.
 8C18D9 Shenzhen RF Technology
 C4BD6A SKF GmbH
@@ -20260,9 +21161,9 @@ AC3870 Lenovo Mobile Communication Technology
 4CBC42 Shenzhen Hangsheng Electronics
 70F196 Actiontec Electronics
 188219 Alibaba Cloud Computing
-28A5EE Shenzhen Sdgi Catv
+28A5EE Shenzhen SDGI CATV
 ECB907 CloudGenix
-F42833 Mmpc
+F42833 MMPC
 0C8C8F Kamo Technology Limited
 A4A4D3 Bluebank Communication TechnologyLtd
 A8329A Digicom Futuristic Technologies
@@ -20286,29 +21187,29 @@ BC4E5D ZhongMiao Technology
 84850A Hella Sonnen- und Wetterschutztechnik GmbH
 08CD9B samtec automotive electronics & software GmbH
 28E6E9 SIS Sat Internet Services GmbH
-F4FD2B Zoyi Company
+F4FD2B ZOYI Company
 F4F646 Dediprog Technology
 300D2A Zhejiang Wellcom Technology
-045C8E Gosund Group
+045C8E gosund Group
 7CC4EF Devialet
 D85DFB Private
 DCF110 Nokia
 608F5C Samsung Electronics
 DC38E1 Juniper Networks
-908C63 GZ Weedong Networks Technology
+908C63 GZ Weedong Networks Technology 
 E8EF89 Opmex Tech.
 109266 Samsung Electronics
-EC2E4E Hitachi-lg Data Storage
+EC2E4E Hitachi-lg DATA Storage
 3481C4 AVM GmbH
 983713 PT.Navicom Indonesia
 A47E39 zte
-CCB691 Necmagnuscommunications
-40167E Asustek Computer
+CCB691 NECMagnusCommunications
+40167E ASUSTek Computer
 F84A73 Eumtech
 142BD6 Guangdong Appscomm
 FCC2DE Murata Manufacturing
 98349D Krauss Maffei Technologies GmbH
-880FB6 Jabil Circuits India Pvt,-ehtp Unit
+880FB6 Jabil Circuits India Pvt,-EHTP unit
 B46698 Zealabs srl
 687CC8 Measurement Systems S. de R.L.
 74F85D Berkeley Nucleonics
@@ -20336,7 +21237,7 @@ E0D31A Eques Technology, Limited
 68D247 Portalis LC
 50B695 Micropoint Biotechnologies
 B4430D Broadlink
-A06518 Vnpt Technology
+A06518 VNPT Technology
 7C8D91 Shanghai Hongzhuo Information Technology
 748F1B MasterImage 3D
 083F76 Intellian Technologies
@@ -20357,9 +21258,9 @@ C0F991 GME Standard Communications P/L
 D87CDD Sanix Incorporated
 707C18 Adata Technology
 14F28E ShenYang ZhongKe-Allwin TechnologyLTD
-BC14EF Iton Technology Limited
+BC14EF ITON Technology Limited
 080371 KRG Corporate
-200E95 IEC  TC9 Wg43
+200E95 IEC – TC9 WG43
 C8F68D S.e.technologies Limited
 3CD4D6 WirelessWERX
 0C1262 zte
@@ -20385,9 +21286,8 @@ C098E5 University of Michigan
 708D09 Nokia
 98FB12 Grand Electronics (HK)
 3C1040 daesung network
-443C9C Pintsch Tiefenbach GmbH
 28FC51 The Electric Controller and Manufacturing
-407496 Afun Technology
+407496 aFUN Technology
 701D7F Comtech Technology
 705986 OOO TTV
 844F03 Ablelink Electronics
@@ -20395,7 +21295,7 @@ C098E5 University of Michigan
 6064A1 RADiflow
 58B961 Solem Electronique
 0C473D Hitron Technologies.
-8CCDA2 ACTP
+8CCDA2 Actp
 84262B Nokia
 986CF5 zte
 447BC4 DualShine Technology(SZ)Co.
@@ -20411,7 +21311,7 @@ F89550 Proton Products Chengdu
 187ED5 shenzhen kaism technology
 841B38 Shenzhen Excelsecu Data Technology
 4CCBF5 zte
-44700B Iffu
+44700B IFFU
 54A54B NSC Communications Siberia
 BC2B6B Beijing Haier IC Design
 98D331 Shenzhen Bolutek Technology
@@ -20438,7 +21338,7 @@ F47A4E Woojeon&Handan
 04848A 7inova Technology Limited
 EC2257 JiangSu NanJing University Electronic Information Technology
 F037A1 Huike Electronics (shenzhen)
-704CED TMRG
+704CED Tmrg
 F08EDB VeloCloud Networks
 C0A39E EarthCam
 109AB9 Tosibox Oy
@@ -20449,7 +21349,7 @@ DCAE04 Celoxica
 8005DF Montage Technology Group Limited
 681D64 Sunwave Communications
 907A0A Gebr. Bode GmbH & KG
-A0C6EC Shenzhen Anyk Technology
+A0C6EC ShenZhen ANYK Technology
 78E8B6 zte
 1078CE Hanvit SI
 D8DA52 Apator
@@ -20470,7 +21370,7 @@ E8481F Advanced Automotive Antennas
 04DF69 Car Connectivity Consortium
 78DAB3 GBO Technology
 700FEC Poindus Systems
-F02405 Opus High Technology
+F02405 OPUS High Technology
 D41090 iNFORM Systems AG
 78D5B5 Navielektro KY
 E47D5A Beijing Hanbang Technology
@@ -20480,10 +21380,10 @@ E4F7A1 Datafox GmbH
 D862DB Eno
 C47DFE A.N. Solutions GmbH
 CCBD35 Steinel GmbH
-6CECA1 Shenzhen Clou Electronics
+6CECA1 Shenzhen CLOU Electronics
 B03850 Nanjing Cas-zdc IOT System
 748E08 Bestek
-78F5E5 Bega Gantenbrink-leuchten KG
+78F5E5 BEGA Gantenbrink-Leuchten KG
 8C3C07 Skiva Technologies
 38A86B Orga BV
 F07765 Sourcefire
@@ -20503,14 +21403,14 @@ A08A87 HuiZhou KaiYue Electronic
 C0C3B6 Automatic Systems
 A0EB76 AirCUVE
 FC4499 Swarco LEA d.o.o.
-DC647C C.R.S. iiMotion GmbH
+DC647C C.r.s. iiMotion GmbH
 148692 Tp-link Technologies
 A8154D Tp-link Technologies
 5CF370 CC&C Technologies
-A4E0E6 Filizola S.A. Pesagem E Automacao
+A4E0E6 Filizola Pesagem E Automacao
 381766 Promzakaz
 18E8DD Moduletek
-D073D5 Lifi Labs Management
+D073D5 LIFI LABS Management
 149448 BLU Castle
 48F925 Maestronic
 386793 Asia Optical
@@ -20535,7 +21435,7 @@ ACA430 Peerless AV
 A4D856 Gimbal
 785517 SankyuElectronics
 B47F5E Foresight Manufacture (S) Pte
-A0FE91 Avat Automation Gmbh
+A0FE91 AVAT Automation GmbH
 74ECF1 Acumen
 5809E5 Kivic
 504F94 Loxone Electronics GmbH
@@ -20553,13 +21453,13 @@ E85AA7 LLC Emzior
 9C9C1D Starkey Labs
 D0D6CC Wintop
 58D071 BW Broadcast
-1C52D6 Flat Display Technology
+1C52D6 FLAT Display Technology
 D0DFB2 Genie Networks Limited
 386645 Oosic Technology
 B85AF7 Ouya
 34F62D Sharp
 4C8FA5 Jastec
-84ED33 Bbmc
+84ED33 BBMC
 E82E24 Out of the Fog Research
 80FA5B Clevo
 C0B339 Comigo
@@ -20579,13 +21479,13 @@ ACE87E Bytemark Computer Consulting
 C0A0E2 Eden Innovations
 080FFA KSP
 E8ABFA Shenzhen Reecam Tech.Ltd.
-DCB058 Brkert Werke GmbH
+DCB058 Bürkert Werke GmbH
 6C5A34 Shenzhen Haitianxiong Electronic
 9038DF Changzhou Tiannengbo System
 185253 Pixord
 683B1E Countwise
 ACA22C Baycity Technologies
-303294 W-IE-NE-R Plein & Baus GmbH
+303294 W-ie-ne-r Plein & Baus GmbH
 7C822D Nortec
 10FBF0 KangSheng
 6C9AC9 Valentine Research
@@ -20602,7 +21502,7 @@ F46DE2 zte
 F0ACA4 HBC-radiomatic
 60748D Atmaca Elektronik
 B8B7D7 2GIG Technologies
-808287 Atcom Technologyltd.
+808287 Atcom TechnologyLtd.
 28A186 enblink
 503955 Cisco Spvtg
 78D129 Vicos
@@ -20626,13 +21526,13 @@ CCC104 Applied Technical Systems
 D806D1 Honeywell Fire System (Shanghai)
 647657 Innovative Security Designs
 907025 Garea Microsys
-10D1DC Instar Deutschland Gmbh
+10D1DC Instar Deutschland GmbH
 34996F VPI Engineering
 944A09 BitWise Controls
 BC28D6 Rowley Associates Limited
 10BD18 Cisco Systems
 5869F9 Fusion Transactive
-D41E35 Toho Electronics
+D41E35 TOHO Electronics
 4C72B9 Pegatron
 2CEDEB Alpheus Digital Company Limited
 0CD996 Cisco Systems
@@ -20651,7 +21551,7 @@ F8A03D Dinstar Technologies
 BC811F Ingate Systems
 D867D9 Cisco Systems
 A4E731 Nokia
-98A7B0 Mcst ZAO
+98A7B0 MCST ZAO
 4C068A Basler Electric Company
 E856D6 NCTech
 C08170 Effigis GeoSolutions
@@ -20671,7 +21571,7 @@ A0F450 HTC
 A0F419 Nokia
 1C973D Pricom Design
 BC0200 Stewart Audio
-489153 Weinmann Gerte fr Medizin GmbH + KG
+489153 Weinmann Geräte für Medizin GmbH + KG
 AC9403 Envision Peripherals
 68D925 ProSys Development Services
 848D84 Rajant
@@ -20683,13 +21583,13 @@ AC9403 Envision Peripherals
 18D66A Inmarsat
 1C7C45 Vitek Industrial Video Products
 3C3888 ConnectQuest
-48D7FF Blankom Antennentechnik Gmbh
+48D7FF Blankom Antennentechnik GmbH
 C47130 Fon Technology S.L.
 D8337F Office FA.com
 0036F8 Conti Temic microelectronic GmbH
 A4F7D0 LAN Accessories
 C85645 Intermas France
-44348F MXT Industrial Ltda
+44348F MXT Industrial LTDA
 D4EC0C Harley-Davidson Motor Company
 28E608 Tokheim
 74FF7D Wren Sound Systems
@@ -20715,10 +21615,10 @@ AC3D05 Instorescreen Aisa
 286094 Capelec
 A45630 Cisco Systems
 C43C3C Cybelec SA
-B826D4 Furukawa Industrial S.A. Produtos Eltricos
+B826D4 Furukawa Industrial Produtos Elétricos
 B87447 Convergence Technologies
 7463DF VTS GmbH
-BC125E Beijing  WisVideo
+BC125E Beijing WisVideo
 14E4EC mLogic
 3828EA Fujian Netcom Technology
 D01AA7 UniPrint
@@ -20732,7 +21632,7 @@ E05DA6 Detlef Fink Elektronik & Softwareentwicklung
 00D632 GE Energy
 0C9E91 Sankosha
 383F10 DBL Technology
-ACD364 ABB SPA, ABB Sace DIV.
+ACD364 ABB SPA, ABB SACE DIV.
 2CEE26 Petroleum Geo-Services
 C8F9F9 Cisco Systems
 A4EF52 Telewave
@@ -20752,7 +21652,7 @@ B4D8A9 BetterBots
 9CB008 Ubiquitous Computing Technology
 A8776F Zonoff
 648788 Juniper Networks
-00FA3B Cloos Electronic Gmbh
+00FA3B Cloos Electronic GMBH
 541DFB Freestyle Energy
 60B606 Phorus
 9092B4 Diehl BGT Defence GmbH & KG
@@ -20765,8 +21665,8 @@ B8975A Biostar Microtech Int'l
 10C2BA UTT
 90D74F Bookeen
 64C5AA South African Broadcasting
-98AAD7 Blue Wave Networking
-9C53CD Engicam S.r.l.
+98AAD7 BLUE WAVE Networking
+9C53CD Engicam s.r.l.
 608645 Avery Weigh-Tronix
 FC8FC4 Intelligent Technology
 10FC54 Shany Electronic
@@ -20779,7 +21679,7 @@ F8F7D3 International Communications
 28D1AF Nokia
 24C0B3 RSF
 FC455F Jiangxi Shanshui Optoelectronic Technology
-F04A2B Pyramid Computer Gmbh
+F04A2B Pyramid Computer GmbH
 302DE8 JDA, (JDA Systems)
 48A6D2 GJsun Optical Science and Tech
 500B32 Foxda Technology Industrial(ShenZhen)Co.
@@ -20789,26 +21689,25 @@ E039D7 Plexxi
 D4E33F Nokia
 68CD0F U Tek Company Limited
 603FC5 COX
-A4E391 Deny Fontaine
+A4E391 DENY Fontaine
 AC6FD9 Valueplus
 DC1EA3 Accensus
 A40130 ABIsystems
 90A783 JSW Pacific
 F8462D Syntec Incorporation
 78A5DD Shenzhen Smarteye Digital Electronics
-ECE744 Omntec mfg.
 28AF0A Sirius XM Radio
 5CD4AB Zektor
 08FC52 OpenXS BV
 4C32D9 M Rutty Holdings
 08A12B ShenZhen EZL Technology
-A00CA1 Sktb Skit
+A00CA1 SKTB SKiT
 64E84F Serialway Communication Technology
 2C9EFC Canon
 182B05 8D Technologies
-240BB1 Kostal Industrie Elektrik Gmbh
+240BB1 Kostal Industrie Elektrik GmbH
 20EEC6 Elefirst Science & Tech
-E01E07 Anite Telecoms  US.
+E01E07 Anite Telecoms US.
 7C6B33 Tenyu Tech
 147DC5 Murata Manufacturing
 00B9F6 Shenzhen Super Rich Electronics
@@ -20824,9 +21723,9 @@ F44450 BND
 0462D7 Alstom Hydro France
 D4507A Ceiva Logic
 64D989 Cisco Systems
-645DD7 Shenzhen Lifesense Medical Electronics,
+645DD7 Shenzhen Lifesense Medical Electronics
 EC4670 Meinberg Funkuhren GmbH & KG
-D05A0F I-bt Digital
+D05A0F I-BT Digital
 EC9681 2276427 Ontario
 5C076F Thought Creator
 3C0FC1 KBC Networks
@@ -20845,10 +21744,10 @@ F4B164 Lightning Telecommunications Technology
 70B035 Shenzhen Zowee Technology
 8821E3 Nebusens
 90B97D Johnson Outdoors Marine Electronics d/b/a Minnkota
-7CF429 Nuuo
-CCB55A Fraunhofer Itwm
-AC8ACD Roger D.wensker, G.wensker sp.j.
-984246 SOL Industry PTE.
+7CF429 NUUO
+CCB55A Fraunhofer ITWM
+AC8ACD Roger D.Wensker, G.Wensker sp.j.
+984246 SOL Industry Pte.
 3429EA MCD Electronics SP. Z O.O.
 8C82A8 Insigma Technology
 60190C Rramac
@@ -20859,11 +21758,11 @@ F80332 Khomp
 90B8D0 Joyent
 AC4723 Genelec
 E8BA70 Cisco Systems
-D4A425 Smax Technology
+D4A425 SMAX Technology
 281471 Lantis
 24470E PentronicAB
 D09B05 Emtronix
-8C11CB Abus Security-center Gmbh & KG
+8C11CB ABUS Security-Center GmbH & KG
 FC8329 Trei technics
 14EB33 BSMediasoft
 F4B549 Xiamen Yeastar Information Technology
@@ -20893,7 +21792,7 @@ B03829 Siliconware Precision Industries
 7C6C39 Pixsys SRL
 18B3BA Netlogic AB
 8C5FDF Beijing Railway Signal Factory
-D47B75 Harting Electronics Gmbh
+D47B75 Harting Electronics GmbH
 D8DF0D beroNet GmbH
 ACF97E Elesys
 204005 feno GmbH
@@ -20913,8 +21812,7 @@ D8C99D EA Display Limited
 34684A Teraworks
 CCFC6D RIZ Transmitters
 E03E7D data-complex GmbH
-0CC6AC Dags
-042605 GFR Gesellschaft fr Regelungstechnik und Energieeinsparung mbH
+0CC6AC DAGS
 24F0FF GHT
 9CC0D2 Conductix-Wampfler GmbH
 CCF67A Ayecka Communication Systems
@@ -20932,7 +21830,7 @@ A036FA Ettus Research
 EC836C RM Tech
 303955 Shenzhen Jinhengjia Electronic
 FC5B24 Weibel Scientific A/S
-78593E Rafi Gmbh &KG
+78593E RAFI GmbH &KG
 509772 Westinghouse Digital
 503DE5 Cisco Systems
 540496 Gigawave
@@ -20961,7 +21859,7 @@ DC9C52 Sapphire Technology Limited.
 649B24 V Technology
 846EB1 Park Assist
 6C504D Cisco Systems
-B8D06F Guangzhou Hkust FOK Ying Tung Research Institute
+B8D06F Guangzhou Hkust FOK YING TUNG Research Institute
 EC14F6 BioControl AS
 E8995A PiiGAB, Processinformation i Goteborg AB
 401D59 Biometric Associates
@@ -20978,7 +21876,7 @@ ACAB8D Lyngso Marine A/S
 6083B2 GkWare e.K.
 80D019 Embed
 68EBC5 Angstrem Telecom
-A0B5DA Hongkong Thtf
+A0B5DA HongKong THTF
 8886A0 Simton Technologies
 A45055 Busware.de
 A89B10 inMotion
@@ -20994,7 +21892,7 @@ D0BB80 SHL Telemedicine International
 1CDF0F Cisco Systems
 68BDAB Cisco Systems
 9CADEF Obihai Technology
-C88B47 Nolangroup S.P.A con Socio Unico
+C88B47 Nolangroup con Socio Unico
 C4CD45 Beijing Boomsense Technology
 8CE7B3 Sonardyne International
 088DC8 Ryowa Electronics
@@ -21006,7 +21904,7 @@ D81C14 Compacta International
 008C10 Black Box
 90903C Trison Technology
 E061B2 Hangzhou Zenointel Technology
-9411DA ITF Frschl GmbH
+9411DA ITF Fröschl GmbH
 8039E5 Patlite
 DC7B94 Cisco Systems
 5CCA32 Theben AG
@@ -21022,11 +21920,11 @@ B0B8D5 Nanjing Nengrui Auto Equipment
 EC542E Shanghai XiMei Electronic Technology
 FCD4F6 Messana Air.Ray Conditioning s.r.l.
 D466A8 Riedo Networks
-F0E5C3 Drgerwerk AG & KG aA
+F0E5C3 Drägerwerk AG & KG aA
 D82986 Best Wish Technology
 446132 ecobee
 F41F0B Yamabishi
-A082C7 P.T.I
+A082C7 P.t.i
 043604 Gyeyoung I&T
 A4B2A7 Adaxys Solutions AG
 D0D0FD Cisco Systems
@@ -21035,7 +21933,7 @@ E05B70 Innovid,
 E87AF3 S5 Tech S.r.l.
 CC5C75 Weightech Com. Imp. Exp. Equip. Pesagem Ltda
 1C6F65 Giga-byte Technology
-90E0F0 Ieee 1722a Working Group
+90E0F0 IEEE 1722a Working Group
 40520D Pico Technology
 807D1B Neosystem
 18B209 Torrey Pines Logic
@@ -21051,26 +21949,26 @@ A4AE9A Maestro Wireless Solutions
 C848F5 Medison Xray
 78A714 Amphenol
 F893F3 Volans
-7866AE Ztec Instruments
+7866AE ZTEC Instruments
 4C022E CMR Korea
 34AAEE Mikrovisatos Servisas UAB
 44D63D Talari Networks
 78A2A0 Nintendo
 48FCB8 Woodstream
 D4000D Phoenix Broadband Technologies
-AC5135 MPI Tech
+AC5135 MPI TECH
 74B9EB JinQianMao Technology
 D45297 nSTREAMS Technologies
 1880CE Barberry Solutions
 24B6B8 Friem SPA
-A4561B Mcot
-80C63F Remec Broadband Wireless
+A4561B MCOT
+80C63F Remec Broadband Wireless 
 40D40E Biodata
 0C826A Wuhan Huagong Genuine Optics Technology
 E0271A TTC Next-generation Home Network System WG
 0097FF Heimann Sensor GmbH
 E4AB46 UAB Selteka
-945B7E Trilobit LTDA.
+945B7E Trilobit Ltda.
 04E548 Cohda Wireless
 7071BC Pegatron
 7884EE Indra Espacio
@@ -21087,11 +21985,11 @@ C8EF2E Beijing Gefei Tech.
 B09134 Taleo
 A4C2AB Hangzhou Lead-it Information & Technology
 48AA5D Store Electronic Systems
-042F56 Atocs (shenzhen)
+042F56 Atocs (Shenzhen)
 E85E53 Infratec Datentechnik GmbH
 88BA7F Qfiednet
 64DB18 OpenPattern
-90A2DA Gheo SA
+90A2DA GHEO SA
 9889ED Anadem Information
 D81BFE Twinlinx
 FC4463 Universal Audio
@@ -21103,7 +22001,7 @@ EC8EAD DLX
 D8AE90 Itibia Technologies
 B8653B Bolymin
 38E8DF b gmbh medien + datenbanken
-1C129D Ieee PES Psrc/sub
+1C129D IEEE PES Psrc/sub
 E0CA4D Shenzhen Unistar Communication
 0CC9C6 Samwin Hong Kong Limited
 1062C9 Adatis GmbH & KG
@@ -21126,7 +22024,7 @@ A438FC Plastic Logic
 18FC9F Changhe Electronics
 94592D EKE Building Technology Systems
 CC69B0 Global Traffic Technologies
-A0593A V.D.S. Video Display Systems srl
+A0593A V.d.s. Video Display Systems srl
 CCEA1C Dconworks
 7C08D9 Shanghai B-Star Technology
 2059A0 Paragon Technologies
@@ -21135,7 +22033,7 @@ A0BFA5 Coresys
 B05B1F Thermo Fisher Scientific
 24D2CC SmartDrive Systems
 0CEF7C AnaCom
-ECE9F8 Guang Zhou TRI-SUN Electronics Technology
+ECE9F8 Guang Zhou Tri-sun Electronics Technology
 34CE94 Parsec (Pty)
 34EF8B NTT Communications
 687F74 Cisco-Linksys
@@ -21153,10 +22051,10 @@ DCE71C AUG Elektronik GmbH
 A870A5 UniComm
 F8472D X2gen Digital
 08184C A. S. Thomas
-10880F Daruma Telecomunicaes e Informtica
+10880F Daruma Telecomunicações e Informática
 FC6198 NEC Personal Products
 74D850 Evrisko Systems
-54B620 Suhdol E&Cltd.
+54B620 Suhdol E&CLtd.
 78C40E H&D Wireless
 2C0623 Win Leader
 0C2755 Valuable Techologies Limited
@@ -21171,7 +22069,7 @@ E41F13 IBM
 7C1EB3 2N Telekomunikace a.s.
 4456B7 Spawn Labs
 44C9A2 Greenwald Industries
-906DC8 DLG Automao Industrial Ltda
+906DC8 DLG Automação Industrial Ltda
 584CEE Digital One Technologies, Limited
 002721 Shenzhen Baoan Fenda Industrial
 A07332 Cashmaster International Limited
@@ -21196,7 +22094,7 @@ A07332 Cashmaster International Limited
 0026D3 Zeno Information System
 0026D1 S Squared Innovations
 0026CB Cisco Systems
-002701 Incostartec Gmbh
+002701 INCOstartec GmbH
 0026FB AirDio Wireless
 00271A Geenovo Technology
 002714 Grainmustards,
@@ -21212,27 +22110,27 @@ A07332 Cashmaster International Limited
 002647 WFE Technology
 002640 Baustem Broadband Technologies
 002653 DaySequerra
-00267B GSI Helmholtzzentrum fr Schwerionenforschung GmbH
+00267B GSI Helmholtzzentrum für Schwerionenforschung GmbH
 002687 corega K.K
 00268D CellTel
-002628 companytec automao e controle ltda.
-00261F SAE Magnetics (H.K.)
+002628 companytec automação e controle ltda.
+00261F SAE Magnetics (h.k.)
 00261E Qingbang Elec(sz)
 002619 FRC
 0025EA Iphion BV
 0025F0 Suga Electronics Limited
 0025E8 Idaho Technology
-0025E4 Omni-wifi
-0025FC Enda Endustriyel Elektronik STI.
+0025E4 OMNI-WiFi
+0025FC ENDA Endustriyel Elektronik STI.
 0025FA J&M Analytik AG
 002633 MIR - Medical International Research
-0025D7 Cedo
+0025D7 CEDO
 0025D8 Korea Maintenance
 0025D2 InpegVision
-002630 AcorelS
+002630 Acorels
 00262A Proxense
 0025FE Pilot Electronics
-00257B STJ  Electronics  PVT
+00257B STJ Electronics PVT
 00257C Huachentel Technology Development
 002575 FiberPlex Technologies
 002570 Eastern Communications Company Limited
@@ -21259,7 +22157,7 @@ A07332 Cashmaster International Limited
 002527 Bitrode
 002525 Ctera Networks
 002551 SE-Elektronic GmbH
-00253A CEVA
+00253A Ceva
 0024A2 Hong Kong Middleware Technology Limited
 0024B9 Wuhan Higheasy Electronic Technology DevelopmentLtd
 0024BD Hainzl Industriesysteme GmbH
@@ -21269,18 +22167,18 @@ A07332 Cashmaster International Limited
 0024E2 Hasegawa Electric
 0024E0 DS Tech
 0024F3 Nintendo
-002501 JSC Supertel
+002501 JSC "Supertel"
 0024C8 Broadband Solutions Group
 0024C5 Meridian Audio Limited
 002496 Ginzinger electronic systems
 002499 Aquila Technologies
 00248A Kaga Electronics
-002435 Wide
+002435 WIDE
 002431 Uni-v
 002432 Neostar Technology
 002443 Nortel Networks
 002441 Wanzl Metallwarenfabrik GmbH
-00243B Cssi (S) Pte
+00243B CSSI (S) Pte
 002451 Cisco Systems
 00244A Voyant International
 002447 Kaztek Systems
@@ -21289,10 +22187,10 @@ A07332 Cashmaster International Limited
 00245D Terberg besturingstechniek
 002450 Cisco Systems
 002458 PA Bastion CC
-002473 3com Europe
+002473 3COM Europe
 00246B Covia
-0023F5 Wilo SE
-0023FF Beijing Httc Technology
+0023F5 WILO SE
+0023FF Beijing HTTC Technology
 0023F6 Softwell Technology
 0023F3 Glocom
 0023F0 Shanghai Jinghan Weighing Apparatus
@@ -21303,7 +22201,7 @@ A07332 Cashmaster International Limited
 00241D Giga-byte Technology
 00241A Red Beetle
 002414 Cisco Systems
-00240C Delec Gmbh
+00240C Delec GmbH
 0023F9 Double-Take Software
 0023E9 F5 Networks
 0023EA Cisco Systems
@@ -21311,12 +22209,12 @@ A07332 Cashmaster International Limited
 0023B6 Securite Communications / Honeywell
 0023B8 Sichuan Jiuzhou Electronic Technology
 0023BA Chroma
-0023BC EQ-SYS GmbH
+0023BC Eq-sys GmbH
 0023B1 Longcheer Technology (Singapore) Pte
 002396 Andes Technology
 002394 Samjeon
 002377 Isotek Electronics
-002371 Soam Systel
+002371 SOAM Systel
 0023A1 Trend Electronics
 0023A6 E-Mon
 0023A8 Marshall Electronics
@@ -21332,7 +22230,7 @@ A07332 Cashmaster International Limited
 00234B Inyuan Technology
 002349 Helmholtz Centre Berlin for Material and Energy
 002346 Vestac
-002307 Future Innovation Tech
+002307 Future Innovation TECH
 002305 Cisco Systems
 0022FF Nivis
 002344 Objective Interface Systems
@@ -21345,7 +22243,7 @@ A07332 Cashmaster International Limited
 00230E Gorba AG
 002362 Goldline Controls
 00235E Cisco Systems
-002322 Kiss Teknical Solutions
+002322 KISS Teknical Solutions
 0022B6 Superflow Technologies Group
 0022B5 Novita
 0022B2 4RF Communications
@@ -21354,19 +22252,19 @@ A07332 Cashmaster International Limited
 0022AE Mattel
 0022D5 Eaton Electrical Group Data Center Solutions - Pulizzi
 0022D1 Albrecht Jung GmbH & KG
-0022D2 All Earth Comrcio de Eletrnicos LTDA.
-0022C2 Proview Eletrnica do Brasil Ltda
+0022D2 All Earth Comércio de Eletrônicos Ltda.
+0022C2 Proview Eletrônica do Brasil LTDA
 0022BD Cisco Systems
-0022BA Huth Elektronik Systeme Gmbh
+0022BA HUTH Elektronik Systeme GmbH
 0022BB beyerdynamic GmbH & KG
 0022A3 California Eastern Laboratories
 002302 Cobalt Digital
 0022F5 Advanced Realtime Tracking GmbH
 0022CA Anviz Biometric Tech.
-0022C7 Segger Microcontroller Gmbh & KG
+0022C7 Segger Microcontroller GmbH & KG
 0022C1 Active Storage
-00228F Cnrs
-002297 Xmos Semiconductor
+00228F CNRS
+002297 XMOS Semiconductor
 002292 Cinetal
 0022E5 Fisher-Rosemount Systems
 0022E4 Apass Technology
@@ -21387,7 +22285,7 @@ A07332 Cashmaster International Limited
 002239 Indiana Life Sciences Incorporated
 002235 Strukton Systems bv
 002279 Nippon Conlux
-002271 Jger Computergesteuerte Metechnik GmbH.
+002271 Jäger Computergesteuerte Meßtechnik GmbH.
 002247 DAC Engineering
 00221F eSang Technologies
 0021E6 Starlight Video Limited
@@ -21412,7 +22310,7 @@ A07332 Cashmaster International Limited
 0021EC Solutronic GmbH
 002205 WeLink Solutions
 002209 Omron Healthcare
-00218C Topcontrol Gmbh
+00218C TopControl GMBH
 00218A Electronic Design and Manufacturing Company
 00218B Wescon Technology
 002184 Powersoft SRL
@@ -21430,7 +22328,7 @@ A07332 Cashmaster International Limited
 0021AF Radio Frequency Systems
 002154 D-tacq Solutions
 002169 Prologix
-00214B Shenzhen Hamp Science & Technology
+00214B Shenzhen HAMP Science & Technology
 002145 Semptian Technologies
 001FFE HPN Supply Chain
 001FFF Respironics
@@ -21443,22 +22341,22 @@ A07332 Cashmaster International Limited
 00213F A-Team Technology
 00211B Cisco Systems
 00212D Scimolex
-001FD5 Microrisc S.r.o.
+001FD5 Microrisc s.r.o.
 001FB1 Cybertech
 001FB2 Sontheim Industrie Elektronik GmbH
 001FEE ubisys technologies GmbH
 001FEF Shinsei Industries
-001FEC Synapse lectronique
+001FEC Synapse Électronique
 001FCA Cisco Systems
 001FC3 SmartSynch
 001FE0 EdgeVelocity
 001FD8 A-trust Computer
 001FD7 Telerad SA
-001FD3 Riva Networks
+001FD3 RIVA Networks
 001FC1 Hanlong Technology
 001FBB Xenatech
 001FE8 Kurusugawa Electronics Industry
-001FAB I.S High Tech.inc
+001FAB I.S HIGH Tech.inc
 001FAC Goodmill Systems
 001F36 Bellwin Information,
 001F3D Qbit GmbH
@@ -21469,7 +22367,7 @@ A07332 Cashmaster International Limited
 001F7F Phabrix Limited
 001F76 AirLogic Systems
 001F73 Teraview Technology
-001F62 JSC Stilsoft
+001F62 JSC "Stilsoft"
 001F67 Hitachi
 001F56 Digital Forecast
 001F52 UVT Unternehmensberatung fur Verkehr und Technik GmbH
@@ -21480,13 +22378,13 @@ A07332 Cashmaster International Limited
 001F39 Construcciones y Auxiliar de Ferrocarriles
 001F7C Witelcom AS
 001F7A WiWide
-001F77 Heol Design
+001F77 HEOL Design
 001F94 Lascar Electronics
 001F8E Metris USA
 001F61 Talent Communication Networks
-001ECE Bisa Technologies (hong Kong) Limited
+001ECE BISA Technologies (Hong Kong) Limited
 001EC8 Rapid Mobile (Pty)
-001ECC Cdvi
+001ECC CDVI
 001EC5 Middle Atlantic Products
 001F03 NUM AG
 001EFF Mueller-Elektronik GmbH & KG
@@ -21525,7 +22423,7 @@ A07332 Cashmaster International Limited
 001E69 Thomson
 001E92 Jeulin
 001E91 Kimin Electronic
-001E89 Crfs Limited
+001E89 CRFS Limited
 001E86 MEL
 001E88 Andor System Support
 001E0C Sherwood Information Partners
@@ -21533,7 +22431,7 @@ A07332 Cashmaster International Limited
 001E01 Renesas Technology Sales
 001DFF Network Critical Solutions
 001E00 Shantou Institute of Ultrasonic Instruments
-001E54 Toyo Electric
+001E54 TOYO Electric
 001E3C Lyngbox Media AB
 001E4D Welkin Sciences
 001E4B City Theatrical
@@ -21546,7 +22444,7 @@ A07332 Cashmaster International Limited
 001E26 Digifriends
 001E23 Electronic Educational Devices
 001DF3 SBS Science & Technology
-001DEE Nextvision Sistemas Digitais DE Televiso LTDA.
+001DEE Nextvision Sistemas Digitais DE Televisão Ltda.
 001DEA Commtest Instruments
 001DDD DAT H.K. Limited
 001DE4 Visioneered Image Systems
@@ -21570,7 +22468,7 @@ A07332 Cashmaster International Limited
 001D15 Shenzhen Dolphin Electronic
 001D16 SFR
 001D11 Analogue & Micro
-001D12 Rohm
+001D12 ROHM
 001D47 Covote GmbH & KG
 001D41 Hardy Instruments
 001D3D Avidyne
@@ -21601,12 +22499,12 @@ A07332 Cashmaster International Limited
 001CA1 Akamai Technologies
 001C99 Shunra Software
 001CF9 Cisco Systems
-001CF1 SUPoX Technology
+001CF1 SUPoX Technology 
 001CCE By Techdesign
 001CF3 EVS Broadcast Equipment
 001CF4 Media Technology Systems
 001CE6 Innes
-001CB9 Kwang Sung Electronics
+001CB9 Kwang SUNG Electronics
 001D03 Design Solutions
 001CA3 Terra
 001C90 Empacket
@@ -21615,12 +22513,12 @@ A07332 Cashmaster International Limited
 001C88 Transystem
 001C86 Cranite Systems
 001C4F Macab AB
-001C4E Tasa International Limited
+001C4E TASA International Limited
 001C4B Gener8
-001C9B Feig Electronic Gmbh
+001C9B FEIG Electronic GmbH
 001C95 Opticomm
 001C97 Enzytek Technology,
-001C70 Novacomm Ltda
+001C70 Novacomm LTDA
 001C6E Newbury Networks
 001C6B Covax
 001C69 Packet Vision
@@ -21641,16 +22539,16 @@ A07332 Cashmaster International Limited
 001BD0 Identec Solutions
 001BCD Daviscomms (S) PTE
 001BCA Beijing Run Technology Company
-001BCC Kingtek Cctv Alliance
+001BCC Kingtek CCTV Alliance
 001BF4 Kenwin Industrial(hk)
 001BF9 Intellitect Water
 001BFA G.i.N. mbH
-001BF3 Transradio Sendersysteme Berlin AG
+001BF3 Transradio SenderSysteme Berlin AG
 001C21 Nucsafe
 001C1E emtrion GmbH
 001BDE Renkus-Heinz
-001BDB Valeo Vecs
-001BD8 Flir Systems
+001BDB Valeo VECS
+001BD8 FLIR Systems
 001BD4 Cisco Systems
 001C2D FlexRadio Systems
 001C2C Synapse
@@ -21661,7 +22559,7 @@ A07332 Cashmaster International Limited
 001B73 DTL Broadcast
 001B71 Telular
 001B97 Violin Technologies
-001BA8 Ubi&mobi
+001BA8 UBI&MOBI
 001B81 Dataq Instruments
 001B7D CXR Anderson Jacobson
 001B79 Faiveley Transport
@@ -21683,14 +22581,14 @@ A07332 Cashmaster International Limited
 001B46 Blueone Technology
 001B40 Network Automation mxc AB
 001B42 Wise & Blue
-001B35 Chongqing Jinou Science & Technology Development
+001B35 ChongQing Jinou Science & Technology Development
 001B36 Tsubata Engineering,Ltd. (Head Office)
 001B39 Proxicast
 001B3B Yi-Qing
 001B20 TPine Technology
-001B22 Palit Microsystems ( H.K.)
+001B22 Palit Microsystems ( H.k.)
 001B1C Coherent
-001B19 Ieee I&M Society TC9
+001B19 IEEE I&M Society TC9
 001B64 IsaacLandKorea
 001B26 RON-Telecom ZAO
 001B13 Icron Technologies
@@ -21698,7 +22596,7 @@ A07332 Cashmaster International Limited
 001AA9 Fujian Star-net Communication
 001AA8 Mamiya Digital Imaging
 001A99 Smarty (HZ) Information Electronics
-001AA6 Telefunken Radio Communication Systems GmbH &CO.KG
+001AA6 Telefunken Radio Communication Systems GmbH &co.kg
 001A96 Ecler
 001A91 FusionDynamic
 001A8C Sophos
@@ -21711,7 +22609,7 @@ A07332 Cashmaster International Limited
 001A3A Dongahelecomm
 001A3B Doah Elecom
 001A3C Technowave
-001A40 A-four Tech
+001A40 A-four TECH
 001A30 Cisco Systems
 001A7B Teleco
 001A36 Aipermon GmbH & KG
@@ -21724,7 +22622,7 @@ A07332 Cashmaster International Limited
 001A63 Elster Solutions
 001A59 Ircona
 001A46 Digital Multimedia Technology
-001A25 Delta Dore
+001A25 Delta DORE
 0019FE Shenzhen Seecomm Technology
 0019FD Nintendo
 001A0D HandHeld entertainment
@@ -21733,22 +22631,21 @@ A07332 Cashmaster International Limited
 0019D9 Zeutschel GmbH
 001A01 Smiths Medical
 0019CA Broadata Communications
-0019D3 Trak Microwave
+0019D3 TRAK Microwave
 0019C3 Qualitrol
 0019BE Altai Technologies Limited
 0019B4 Intellio
 0019BA Paradox Security Systems
-0019A1 LG Information & COMM.
+0019A1 LG Information & Comm.
 0019A8 WiQuest Communications
 0019ED Axesstel
-0019F6 Acconet (PTE)
+0019F6 Acconet (pte)
 001A15 gemalto e-Payment
 001968 Digital Video Networks(Shanghai)
 00197F Plantronics
 00197A MAZeT GmbH
 001978 Datum Systems
 001989 Sonitrol
-00198E Oticon A/S
 001980 Gridpoint Systems
 001983 CCT R&D Limited
 00194C Fujian Stelcom information & Technology
@@ -21761,7 +22658,7 @@ A07332 Cashmaster International Limited
 001950 Harman Multimedia
 0018EE Videology Imaging Solutions
 0018EB Blue Zen Enterprises Private Limited
-001924 Lbnl  Engineering
+001924 LBNL Engineering
 00191A Irlink
 001916 PayTec AG
 00190E Atech Technology
@@ -21783,7 +22680,7 @@ A07332 Cashmaster International Limited
 00188F Montgomery Technology
 001884 Fon Technology S.L.
 001880 Maxim Integrated Products
-0018D0 AtRoad,  A Trimble Company
+0018D0 AtRoad, A Trimble Company
 0018D2 High-Gain Antennas
 0018D3 Teamcast
 0018C6 OPW Fuel Management Systems
@@ -21838,7 +22735,7 @@ A07332 Cashmaster International Limited
 001795 Cisco Systems
 001759 Cisco Systems
 001754 Arkino HiTOP Limited
-001752 DAGS
+001752 Dags
 001756 Vinci Labs Oy
 001777 Obsidian Research
 00176A Avago Technologies
@@ -21856,7 +22753,7 @@ A07332 Cashmaster International Limited
 00170F Cisco Systems
 001704 Shinco Electronics Group
 001707 InGrid
-001712 Isco International
+001712 ISCO International
 0016D8 Senea AB
 0016D6 TDA Tech
 0016D5 Synccom
@@ -21888,17 +22785,17 @@ A07332 Cashmaster International Limited
 00BAC0 Biometric Access Company
 001685 Elisa Oyj
 001680 Bally Gaming + Systems
-001696 QDI Technology (H.K.) Limited
+001696 QDI Technology (h.k.) Limited
 0016BE Infranet
 0016AB Dansensor A/S
-001653 Lego System A/S IE Electronics Division
+001653 LEGO System A/S IE Electronics Division
 001652 Hoatech Technologies
 001650 Kratos EPD
 0015FA Cisco Systems
 0015FC Littelfuse Startco
 0015F7 Wintecronics
 001630 Vativ Technologies
-00162F Geutebrck GmbH
+00162F Geutebrück GmbH
 00162B Togami Electric Mfg.co.
 001642 Pangolin
 001637 Citel SpA
@@ -21929,9 +22826,9 @@ A07332 Cashmaster International Limited
 001523 Meteor Communications
 001524 Numatics
 00151B Isilon Systems
-001573 NewSoft  Technology
+001573 NewSoft Technology
 001575 Nevis Networks
-00156C Sane System
+00156C SANE System
 00156A DG2L Technologies Pvt.
 001529 N3
 00152D TenX Networks
@@ -21959,7 +22856,7 @@ A07332 Cashmaster International Limited
 0014ED Airak
 0014CE NF
 0014D0 BTI Systems
-001503 Proficomms S.r.o.
+001503 PROFIcomms s.r.o.
 001509 Plus Technology
 0014F0 Business Security OL AB
 0014F2 Cisco Systems
@@ -21993,7 +22890,7 @@ A07332 Cashmaster International Limited
 00143C Rheinmetall Canada
 00141A Deicy
 00141C Cisco Systems
-00140C GKB Cctv
+00140C GKB CCTV
 0013FE Grandtec Electronic
 001435 CityCom
 001448 Inventec Multimedia & Telecom
@@ -22005,27 +22902,26 @@ A07332 Cashmaster International Limited
 0013BF Media System Planning
 0013BB Smartvue
 0013B5 Wavesat
-0013AF Numa Technology
+0013AF NUMA Technology
 0013B0 Jablotron
 00139A K-ubique ID
 00139E Ciara Technologies
-00139D MaxLinear Hispania S.L.U.
+00139D MaxLinear Hispania S.l.u.
 0013D5 RuggedCom
 0013D6 TII Network Technologies
 0013DB Shoei Electric
 0013CD MTI
 0013D3 Micro-star International
-0013CA Pico Digital
 0013E6 Technolution
 0013DF Ryvor
 00138D Kinghold
-0013ED Psia
+0013ED PSIA
 0013B1 Intelligent Control Systems (Asia) Pte
 00133C Quintron Systems
 00133D Micro Memory Curtiss Wright
 00133F Eppendorf Instrumente GmbH
 001341 Shandong New Beiyang Information Technology
-001330 Euro Protection Surveillance
+001330 EURO Protection Surveillance
 001325 Cortina Systems
 001331 CellPoint Connect
 001335 VS Industry Berhad
@@ -22039,7 +22935,7 @@ A07332 Cashmaster International Limited
 001375 American Security Products
 001358 Realm Systems
 0012C1 Check Point Software Technologies
-0012BB Telecommunications Industry Association TR-41 Committee
+0012BB Telecommunications Industry Association Tr-41 Committee
 0012B6 Santa Barbara Infrared
 0012B9 Fusion Digital Technology
 0012ED AVG Advanced Technologies
@@ -22053,7 +22949,7 @@ A07332 Cashmaster International Limited
 001306 Always On Wireless
 0012FD Optimus IC
 001305 Epicom
-0012E4 Ziehl Industrie-electronik Gmbh + KG
+0012E4 Ziehl industrie-electronik GmbH + KG
 001297 O2Micro
 00129D First International Computer do Brasil
 00129C Yulinet
@@ -22081,10 +22977,10 @@ A07332 Cashmaster International Limited
 001239 S Net Systems
 00122F Sanei Electric
 001230 Picaso Infocommunication
-001246 T.O.M Technology.
-001256 LG Information & COMM.
+001246 T.o.m Technology.
+001256 LG Information & Comm.
 001214 Koenig & Bauer AG
-00120F Ieee 802.3
+00120F IEEE 802.3
 00121D Netfabric
 00120C CE-Infosys Pte
 0011B3 Yoshimiya
@@ -22116,7 +23012,7 @@ A07332 Cashmaster International Limited
 001148 Prolon Control Systems
 001140 Nanometrics
 001144 Assurance Technology
-001163 System SPA DEPT. Electronics
+001163 System SPA Dept. Electronics
 00118F Eutech Instruments PTE.
 00118D Hanchang System
 00115F ITX Security
@@ -22133,7 +23029,7 @@ A07332 Cashmaster International Limited
 000FFF Control4
 000FFC Merit Li-Lin Ent.
 001113 Fraunhofer Fokus
-001112 Honeywell Cmss
+001112 Honeywell CMSS
 000FE0 NComputing
 000FE3 Damm Cellular Systems A/S
 001128 Streamit
@@ -22153,7 +23049,7 @@ A07332 Cashmaster International Limited
 000FBF DGT Sp. z o.o.
 000F92 Microhard Systems
 000FCB 3Com
-000FD5 Schwechat - Rise
+000FD5 Schwechat - RISE
 000F67 West Instruments
 000F6E BBox
 000F6F FTA Communication Technologies
@@ -22175,7 +23071,7 @@ A07332 Cashmaster International Limited
 000F71 Sanmei Electronics
 000F6B GateWare Communications GmbH
 000ED5 Copan Systems
-000ECA Wtss
+000ECA WTSS
 000ECC Tableau
 000ECB VineSys Technology
 000ED2 Filtronic plc
@@ -22191,11 +23087,10 @@ A07332 Cashmaster International Limited
 000EFB Macey Enterprises
 000F09 Private
 000EDC Tellion
-000ECD Skov A/S
+000ECD SKOV A/S
 000EDB XiNCOM
-000EDD Shure Incorporated
 000EC2 Lowrance Electronics
-000EA3 Cncr-it,ltd,hangzhou P.r.china
+000EA3 Cncr-it,LTD,HangZhou P.r.china
 000EA2 McAfee
 000E9B Ambit Microsystems
 000E78 Amtelco
@@ -22210,11 +23105,11 @@ A07332 Cashmaster International Limited
 000E3C Transact Technologies
 000E63 Lemke Diagnostics GmbH
 000E5B ParkerVision - Direct2Data
-000E60 360SUN Digital Broadband
+000E60 360sun Digital Broadband
 000E54 AlphaCell Wireless
 000E4E Waveplus Technology
 000E4A Changchun Huayu Webpad
-000E93 Milnio 3 Sistemas Electrnicos
+000E93 Milénio 3 Sistemas Electrónicos
 000E8D Systems in Progress Holding GmbH
 000E76 Gemsoc Innovision
 000E7D Electronics Line 3000
@@ -22239,7 +23134,7 @@ A07332 Cashmaster International Limited
 000E22 Private
 000E1C Hach Company
 000E02 Advantech AMT
-000DC9 Thales Elektronik Systeme Gmbh
+000DC9 Thales Elektronik Systeme GmbH
 000D81 Pepperl+Fuchs GmbH
 000D7A DiGATTO Asia Pacific Pte
 000D77 FalconStor Software
@@ -22253,7 +23148,7 @@ A07332 Cashmaster International Limited
 000DBC Cisco Systems
 000D9F RF Micro Devices
 000DA5 Fabric7 Systems
-000DC5 EchoStar Global B.V.
+000DC5 EchoStar Global
 000D99 Orbital Sciences; Launch Systems Group
 000D6C M-Audio
 000D70 Datamax
@@ -22294,7 +23189,7 @@ A07332 Cashmaster International Limited
 000D0E Inqnet Systems
 000D11 Dentsply - Gendex
 000CC8 Xytronix Research & Design
-000CCA Hgst a Western Digital Company
+000CCA HGST a Western Digital Company
 000CD0 Symetrix
 000CD9 Itcare
 000CD5 Passave
@@ -22323,19 +23218,18 @@ A07332 Cashmaster International Limited
 000C01 Abatron AG
 000C39 Sentinel Wireless
 000C33 Compucase Enterprise
-000C36 Sharp Takaya Electronics Industry
 000BF6 Nitgen
 000BFD Cisco Systems
 000BFA Exemys SRL
 000BF4 Private
-000BFB D-NET International
+000BFB D-net International
 000C1D Mettler & Fuchs AG
 000C1E Global Cache
 000C1A Quest Technical Solutions
 000C24 Anator
 000C19 Telio Communications GmbH
 000C13 MediaQ
-000C06 Nixvue Systems  Pte
+000C06 Nixvue Systems Pte
 000C2D FullWave Technology
 000C26 Weintek Labs.
 000C2B Elias Technology
@@ -22358,13 +23252,12 @@ A07332 Cashmaster International Limited
 000BCB Fagor Automation , S. Coop
 000BC8 AirFlow Networks
 000BCE Free2move AB
-000BCF Agfa NDT
+000BCF AGFA NDT
 000BC3 Multiplex
 000BBE Cisco Systems
 000BE0 SercoNet
 000BBD Connexionz Limited
-000B40 Cambridge Industries Group (CIG)
-000B44 Concord IDea
+000B40 Cambridge Industries Group (cig)
 000B42 commax
 000B47 Advanced Energy
 000B81 Kaparel
@@ -22387,20 +23280,20 @@ A07332 Cashmaster International Limited
 000B1D LayerZero Power Systems
 000B19 Vernier Networks
 000B16 Communication Machinery
-000B12 Nuri Telecom
+000B12 NURI Telecom
 000AC5 Color Kinetics
 000ABD Rupprecht & Patashnick
-000ACB Xpak MSA Group
+000ACB XPAK MSA Group
 000AD5 Brainchild Electronic
 000AD6 BeamReach Networks
 000AFE NovaPal
 000AFD Kentec Electronics
 000AEF Otrum ASA
 000AE5 ScottCare
-000AB0 Loytec Electronics Gmbh
+000AB0 Loytec electronics GmbH
 000AB5 Digital Electronic Network
 000AD2 Jepico
-000A98 M+F Gwinner GmbH &
+000A98 M+F Gwinner GmbH
 000A9B TB Group
 000A6C Walchem
 000A5F almedio
@@ -22413,7 +23306,7 @@ A07332 Cashmaster International Limited
 000A5B Power-One as
 000A55 Markem
 000A73 Scientific Atlanta
-000A69 Sunny Bell Technology
+000A69 Sunny bell Technology
 000A84 Rainsun Enterprise
 000A7E The Advantage Group
 000A4C Molecular Devices
@@ -22436,7 +23329,7 @@ A07332 Cashmaster International Limited
 0009E8 Cisco Systems
 0009ED CipherOptics
 000A40 Crown Audio -- Harmanm International
-000A26 Ceia
+000A26 CEIA
 000A1D Optical Communications Products
 000A16 Lassen Research
 000A18 Vichel
@@ -22446,7 +23339,7 @@ A07332 Cashmaster International Limited
 0009A2 Interface
 0009A1 Telewise Communications
 00097D SecWell Networks Oy
-000976 Datasoft Isdn Systems Gmbh
+000976 Datasoft ISDN Systems GmbH
 0009C6 Visionics
 0009D1 Seranoa Networks
 0009CE SpaceBridge Semiconductor
@@ -22482,7 +23375,7 @@ A07332 Cashmaster International Limited
 0008FA KEB Automation KG
 000959 Sitecsoft
 000957 Supercaller
-0008D2 Zoom Networks
+0008D2 ZOOM Networks
 0008C5 Liontech
 0008AA Karam
 0008AB EnerLinx.com
@@ -22491,7 +23384,7 @@ A07332 Cashmaster International Limited
 0008EA Motion Control Engineering
 0008ED ST&T Instrument
 000888 Oullim Information Technology
-000885 EMS Dr. Thomas Wnsche
+000885 EMS Dr. Thomas Wünsche
 000872 Sorenson Communications
 00089A Alcatel Microelectronics
 0008A1 CNet Technology
@@ -22506,7 +23399,7 @@ A07332 Cashmaster International Limited
 00087D Cisco Systems
 000875 Acorp Electronics
 000816 Bluelon ApS
-000811 Voix
+000811 VOIX
 000806 Raonet Systems
 00086F Resources Computer Network
 000867 Uptime Devices
@@ -22552,7 +23445,7 @@ A07332 Cashmaster International Limited
 000747 Mecalc
 000779 Sungil Telecom
 00077E Elrest GmbH
-000778 Gerstel Gmbh & KG
+000778 Gerstel GmbH & KG
 00076D Flexlight Networks
 000730 Hutchison Optel Telecom Technology
 000722 The Nielsen Company
@@ -22575,17 +23468,17 @@ A07332 Cashmaster International Limited
 000700 Zettamedia Korea
 0006C5 Innovi Technologies Limited
 0006C6 lesswire AG
-0006B7 Telem Gmbh
+0006B7 Telem GmbH
 0006EF Maxxan Systems
 0006E9 Intime
-0006EA Elzet80 Mikrocomputer Gmbh&co. KG
+0006EA Elzet80 Mikrocomputer GmbH&Co. KG
 000708 Bitrage
 000712 JAL Information Technology
 000713 IP One
 000707 Interalia
 0006F2 Platys Communications
 0006FA IP Square
-000703 Csee Transport
+000703 CSEE Transport
 000706 Sanritz
 0006D1 Tahoe Networks
 0006D4 Interactive Objects
@@ -22627,14 +23520,14 @@ A06A00 Verilink
 000632 Mesco Engineering GmbH
 000634 GTE Airfone
 00060C Melco Industries
-00060E Igys Systems
+00060E IGYS Systems
 000614 Prism Holdings
 000608 At-Sky SAS
 0005C3 Pacific Instruments
 0005B9 Airvana
 0005BC Resource Data Management
 0005BE Kongsberg Seatex AS
-0005BD Roax BV
+0005BD ROAX BV
 0005C1 A-Kyung Motion
 0005B4 Aceex
 000598 Cronos S.r.l.
@@ -22655,7 +23548,7 @@ A06A00 Verilink
 000576 NSM Technology
 00056A Heuft Systemtechnik GmbH
 000568 Piltofish Networks AB
-0005B6 Insys Microelectronics Gmbh
+0005B6 Insys Microelectronics GmbH
 000555 Japan Cash Machine
 000552 Xycotec Computer GmbH
 00054A Ario Data Networks
@@ -22696,15 +23589,14 @@ A06A00 Verilink
 000485 PicoLight
 0004DA Relax Technology
 0004C5 ASE Technologies
-000436 Elansat Technologies
+000436 ELANsat Technologies
 000432 Voyetra Turtle Beach
-000435 InfiNet
 000437 Powin Information Technology
 00040C Kanno Works
 000408 Sanko Electronics
 000407 Topcon Positioning Systems
 000409 Cratos Networks
-000455 Antara.net
+000455 ANTARA.net
 000457 Universal Access Technology
 00044D Cisco Systems
 000454 Quadriga UK
@@ -22739,18 +23631,18 @@ A06A00 Verilink
 00035D Bosung Hi-Net
 000379 Proscend Communications
 00036F Telsey SPA
-000372 Ulan
+000372 ULAN
 00033A Silicon Wave
 000332 Cisco Systems
 00030E Core Communications
 000312 TRsystems GmbH
 000341 Axon Digital Design
 008037 Ericsson Group
-00033D Ilshin Lab
+00033D ILSHin Lab
 000366 ASM Pacific Technology
 000362 Vodtel Communications
 00034D Chiaro Networks
-000322 Idis
+000322 IDIS
 00031D Taiwan Commate Computer
 000326 Iwasaki Information Systems
 000290 Woorigisool
@@ -22794,18 +23686,18 @@ A06A00 Verilink
 00020C Metro-Optix
 000216 Cisco Systems
 000214 Dtvro
-00020F Aatr
+00020F AATR
 0001C3 Acromag
 0001C2 ARK Research
 0001EA Cirilium
 0001E0 Fast Systems
 0001AC Sitara Networks
-0001ED Seta
+0001ED SETA
 0001F6 Association of Musical Electronics Industry
 0001CB EVR
 0001D6 manroland AG
-0001AD Coach Master International  d.b.a. CMI Worldwide
-000188 Lxco Technologies ag
+0001AD Coach Master International d.b.a. CMI Worldwide
+000188 LXCO Technologies ag
 00019B Kyoto Microcomputer
 00017F Experience Music Project
 00015A Digital Video Broadcasting
@@ -22818,10 +23710,10 @@ A06A00 Verilink
 000187 I2SE GmbH
 000180 AOpen
 000197 Cisco Systems
-00019A Leunig Gmbh
+00019A Leunig GmbH
 000159 S1
 000171 Allied Data Technologies
-0030AC Systeme Lauer GmbH &
+0030AC Systeme Lauer GmbH
 0030FB AZS Technology AG
 0030AE Times N System
 003003 Phasys
@@ -22836,41 +23728,41 @@ A06A00 Verilink
 00011F RC Networks
 00B080 Mannesmann Ipulsys
 00B01E Rantic Labs
-00B0F0 Caly Networks
+00B0F0 CALY Networks
 00B09A Morrow Technologies
 00302E Hoft & Wessel AG
 0030ED Expert Magnetics
-00300F IMT - Information Management T
-003082 Taihan Electric Wire
+00300F IMT - Information Management
+003082 Taihan Electric WIRE
 0030A9 Netiverse
 0030FE DSA GmbH
 0030C4 Canon Imaging Systems
 00304D ESI
 081443 Unibrain
 00B009 Grass Valley, A Belden Brand
-00B0AC Siae-microelettronica
+00B0AC SIAE-Microelettronica
 003023 Cogent Computer Systems
-003090 Cyra Technologies
+003090 CYRA Technologies
 0030A7 Schweitzer Engineering
-00307C Adid SA
+00307C ADID SA
 003055 Renesas Technology America
 00302F GE Aviation System
 00300E Klotz Digital AG
 0030D5 DResearch GmbH
 003018 Jetway Information
 00309F Amber Networks
-0030A8 Ol'e Communications
+0030A8 OL'E Communications
 0030D1 Inova
 0030BB CacheFlow
 0030AF Honeywell GmbH
-0030AA Axus Microsystems
+0030AA AXUS Microsystems
 003089 Spectrapoint Wireless
 00309A Astro Terra
-003087 Vega Grieshaber KG
+003087 VEGA Grieshaber KG
 003062 IP Video Networks
 00302D Quantum Bridge Communications
-0030CB Omni Flow Computers
-00306B Cmos Systems
+0030CB OMNI FLOW Computers
+00306B CMOS Systems
 0030AD Shanghai Communication
 0030CF TWO Technologies
 0030B2 L-3 Sonoma EO
@@ -22880,12 +23772,12 @@ A06A00 Verilink
 00D048 Ecton
 00D0A5 American Arium
 00305D Digitra Systems
-003036 RMP Elektroniksysteme Gmbh
+003036 RMP Elektroniksysteme GMBH
 00D0CF Moreton BAY
 00D07F Strategy & Technology, Limited
 0030E6 Draeger Medical Systems
 0030BD Belkin Components
-003007 OPTI
+003007 Opti
 00D0C2 Balthazar Technology AB
 00D022 Incredible Technologies
 00D071 Echelon
@@ -22900,20 +23792,19 @@ A06A00 Verilink
 00D082 Iowave
 00D081 RTD Embedded Technologies
 00D002 Ditech
-00D085 Otis Elevator Company
+00D085 OTIS Elevator Company
 00D011 Prism Video
 00D0DF Kuzumi Electronics
 00D09B Spectel
 00D067 Campio Communications
 00D058 Cisco Systems
-00D032 Yano Electric
-00D0F1 Sega Enterprises
+00D032 YANO Electric
+00D0F1 SEGA Enterprises
 00D03A Zoneworx
 00D001 VST Technologies
 00503E Cisco Systems
 005020 Mediastar
 00D075 Alaris Medical Systems
-00D04C Eurotel Telecom
 00D0E1 Avionitek Israel
 00D008 Mactell
 00D0D9 Dedicated Microcomputers
@@ -22921,7 +23812,7 @@ A06A00 Verilink
 00D09C Kapadia Communications
 00D0F3 Solari DI Udine SPA
 00D039 Utilicom
-00D0A0 Mips Denmark
+00D0A0 MIPS Denmark
 00D00A Lanaccess Telecom
 00D01C SBS Technologies,
 00D0D5 Grundig AG
@@ -22932,10 +23823,10 @@ A06A00 Verilink
 00D062 Digigram
 00D08D Phoenix Group
 00D03D Galileo Technology
-0050C6 Loop Telecommunication International
+0050C6 LOOP Telecommunication International
 00509F Horizon Computer
 0050A5 Capitol Business Systems
-005000 Nexo Communications
+005000 NEXO Communications
 005090 Dctri
 00503B Mediafire
 005046 Menicx International
@@ -22943,38 +23834,37 @@ A06A00 Verilink
 0050B0 Technology Atlanta
 0050DD Serra Soldadura
 005063 OY Comsel System AB
-00508D Abit Computer
+00508D ABIT Computer
 0050A0 Delta Computer Systems
 005066 AtecoM GmbH advanced telecomunication modules
 005059 iBAHN
-0050D9 Engetron-engenharia Eletronica IND. e COM. Ltda
+0050D9 Engetron-engenharia Eletronica IND. e COM. LTDA
 005001 Yamashita Systems
 005067 Aerocomm
-0050B6 Good WAY IND.
+0050B6 GOOD WAY IND.
 00504B Barconet N.V.
 0050EA XEL Communications
 0050C8 Addonics Technologies
 0050C4 IMD
 005089 Safety Management Systems
-0050F4 Sigmatek Gmbh & KG
+0050F4 Sigmatek GMBH & KG
 005021 EIS International
 00505E Digitek Micrologic
-0050E8 Nomadix
 0050AE FDK
 0050E7 Paradise Innovations (asia)
 0050FB VSK Electronics
-009073 Gaio Technology
+009073 GAIO Technology
 00907B E-tech
 009081 Aloha Networks
 00901C mps Software Gmbh
 005086 Telkom SA
 00501A IQinVision
 00508F Asita Technologies Int'l
-005015 Bright Star Engineering
+005015 Bright STAR Engineering
 005057 Broadband Access Systems
 005088 Amano
 005031 Aeroflex Laboratories
-0090DB Next Level Communications
+0090DB NEXT Level Communications
 009056 Telestream
 009068 DVT
 00905E Rauland-borg
@@ -22994,15 +23884,15 @@ A06A00 Verilink
 00902E Namco Limited
 009037 Acucomm
 009078 MER Telemanagement Solutions
-0090B8 Rohde & Schwarz Gmbh & KG
+0090B8 Rohde & Schwarz GMBH & KG
 00901A Unisphere Solutions
 0090B5 Nikon
 009005 Protech Systems
 009059 Telecom Device K.K.
 0090CA Accord Video Telecommunications
-0090E9 Janz Computer AG
+0090E9 JANZ Computer AG
 0090EB Sentry Telecom Systems
-0090FE Elecom,  (laneed DIV.)
+0090FE Elecom, (laneed Div.)
 0090BB Tainet Communication System
 009090 I-bus
 0090D5 Euphonix
@@ -23010,7 +23900,7 @@ A06A00 Verilink
 00908F Audio Codes
 00909E Critical IO
 001092 Netcore
-00101C OHM Technologies INTL
+00101C OHM Technologies Intl
 001046 Alcorn Mcbride
 001028 Computer Technica
 0010B7 Coyote Technologies
@@ -23023,9 +23913,7 @@ A06A00 Verilink
 000400 Lexmark International
 0010C5 Protocol Technologies
 00101A PictureTel
-001047 Echo Eletric
-00903F Aztec Radiomedia
-001043 A2
+001047 ECHO Eletric
 0010A5 Oxford Instruments
 0010D7 Argosy Research
 00102C Lasat Networks A/S
@@ -23038,13 +23926,13 @@ A06A00 Verilink
 00102E Network Systems & Technologies PVT.
 0010B0 Meridian Technology
 001021 Encanto Networks
-001064 DNPG
-001074 Aten International
+001064 Dnpg
+001074 ATEN International
 00109E Aware
 001005 UEC Commercial
 0010B8 Ishigaki Computer System
-00108B Laseranimation Sollinger Gmbh
-0010C7 Data Transmission Network
+00108B Laseranimation Sollinger GMBH
+0010C7 DATA Transmission Network
 001070 Caradon Trend
 0010BA Martinho-davis Systems
 0010B4 Atmosphere Networks
@@ -23052,9 +23940,9 @@ A06A00 Verilink
 001067 Ericsson
 00E07D Netronix
 00E028 Aptix
-00E08C Neoparadigm LABS
-00E0A1 Hima Paul Hildebrandt Gmbh KG
-00E088 Ltx-credence
+00E08C Neoparadigm Labs
+00E0A1 HIMA PAUL Hildebrandt GmbH KG
+00E088 LTX-Credence
 00E05D Unitec
 00E05E Japan Aviation Electronics Industry
 00E09D Sarnoff
@@ -23066,8 +23954,8 @@ A06A00 Verilink
 00E03D Focon Electronic Systems A/S
 00E046 Bently Nevada
 00E07B BAY Networks
-00E01D Webtv Networks
-00E0CD Saab Sensis
+00E01D WebTV Networks
+00E0CD SAAB Sensis
 00E08D Pressure Systems
 00E019 ING. Giordano Elettronica
 00E047 InFocus
@@ -23076,12 +23964,12 @@ A06A00 Verilink
 00E0FF Security Dynamics Technologies
 00E0AB Dimat
 00E030 Melita International
-00E033 E.E.P.D. GmbH
+00E033 E.e.p.d. GmbH
 00E0A2 Microslate
 00E079 A.t.n.r.
 00E075 Verilink
 006039 SanCom Technology
-006049 Vina Technologies
+006049 VINA Technologies
 00608D Unipulse
 00E02E SPC Electronics
 00E09A Positron
@@ -23089,15 +23977,15 @@ A06A00 Verilink
 006099 SBE
 0060B3 Z-com
 006002 Screen Subtitling Systems
-006089 Xata
+006089 XATA
 006021 DSC
 0060B8 Corelis
 00E0AA Electrosonic
-00E010 Hess Sb-automatenbau Gmbh
+00E010 HESS Sb-automatenbau GmbH
 00E0D2 Versanet Communications
 0060CE Acclaim Communications
 006036 AIT Austrian Institute of Technology GmbH
-00608E HE Electronics, Technologie & Systemtechnik Gmbh
+00608E HE Electronics, Technologie & Systemtechnik GmbH
 00601A Keithley Instruments
 00606A Mitsubishi Wireless Communications.
 0060AD MegaChips
@@ -23112,9 +24000,9 @@ A06A00 Verilink
 0060BA Sahara Networks
 006098 HT Communications
 0060DE Kayser-Threde GmbH
-0060D0 Snmp Research Incorporated
+0060D0 SNMP Research Incorporated
 006015 Net2net
-00609D PMI Food Equipment Group
+00609D PMI FOOD Equipment Group
 0060A2 Nihon Unisys Limited
 006084 Digital Video
 00602D Alerton Technologies
@@ -23140,7 +24028,7 @@ A06A00 Verilink
 00A0ED Brooks Automation
 0060CA Harmonic Systems Incorporated
 006024 Gradient Technologies
-0060AF Pacific Micro DATA
+0060AF Pacific Micro Data
 006038 Nortel Networks
 00604F Tattile SRL
 00A0D0 TEN X Technology
@@ -23149,7 +24037,7 @@ A06A00 Verilink
 00A08C MultiMedia LANs
 00A058 Glory
 00A077 Fujitsu Nexion
-00A0A0 Compact DATA
+00A0A0 Compact Data
 00A038 Email Electronics
 00A065 Symantec
 00A0A3 Reliable Power Meters
@@ -23159,8 +24047,8 @@ A06A00 Verilink
 00A07F Gsm-syntel
 00A029 Coulter
 00A087 Microsemi
-00A043 American Technology LABS
-00A042 Spur Products
+00A043 American Technology Labs
+00A042 SPUR Products
 00A0C1 Ortivus Medical AB
 00A04F Ameritec
 00A0CF Sotas
@@ -23174,24 +24062,24 @@ A06A00 Verilink
 00A0E5 NHC Communications
 00A036 Applied Network Technology
 00A0D2 Allied Telesis International
-00A09B Qpsx Communications
+00A09B QPSX Communications
 00A000 Centillion Networks
 00A08A Brooktrout Technology
-00A07B Dawn Computer Incorporation
+00A07B DAWN Computer Incorporation
 00A05C Inventory Conversion
 00200F Ebrains
 00A0D3 Instem Computer Systems
 00A0B4 Texas Microsystems
-00A060 Acer Peripherals
+00A060 ACER Peripherals
 00A083 Asimmphony Turkey
 00A0AA Spacelabs Medical
 00A03B Toshin Electric
 00A0F3 Staubli
 0020DF Kyosan Electric MFG.
-0020C7 Akai Professional M.I.
+0020C7 AKAI Professional M.I.
 00A004 Netpower
 002029 Teleprocessing Products
-002069 Isdn Systems
+002069 ISDN Systems
 00208B Lapis Technologies
 00202B Advanced Telecommunications Modules
 00206B Konica Minolta Holdings
@@ -23201,16 +24089,16 @@ A06A00 Verilink
 0020F9 Paralink Networks
 002092 Chess Engineering
 002043 Neuron Company Limited
-002071 IBR Gmbh
-00207C Autec Gmbh
-002057 Titze Datentechnik Gmbh
-0020E5 Apex DATA
+002071 IBR GMBH
+00207C Autec GMBH
+002057 Titze Datentechnik GmbH
+0020E5 APEX Data
 002087 Memotec
 0020BC Long Reach Networks
 00C0C0 Shore Microsystems
 00C00C Relia Technolgies
 00C073 Xedia
-00C0D4 Axon Networks
+00C0D4 AXON Networks
 00C0CD Comelta
 0020ED Giga-byte Technology
 002085 Eaton
@@ -23222,14 +24110,14 @@ A06A00 Verilink
 002017 Orbotech
 002093 Landings Technology
 002063 Wipro Infotech
-002016 Showa Electric Wire & Cable
-00204D Inovis Gmbh
-00205F Gammadata Computer Gmbh
-00201F Best Power Technology
+002016 Showa Electric WIRE & Cable
+00204D Inovis GMBH
+00205F Gammadata Computer GMBH
+00201F BEST Power Technology
 0020B6 Agile Networks
 0020D1 Microcomputer Systems (M) SDN.
 0020CE Logical Design Group
-002014 Global View
+002014 Global VIEW
 0020C2 Texas Memory Systems
 00C0F3 Network Communications
 002056 Neoproducts
@@ -23240,10 +24128,10 @@ A06A00 Verilink
 00205D Nanomatic OY
 00C005 Livingston Enterprises
 00C077 Daewoo Telecom
-00C0C8 Micro Byte
+00C0C8 Micro BYTE
 00C069 Axxcelera Broadband Wireless
 00C067 United Barcode Industries
-00C0A3 Dual Enterprises
+00C0A3 DUAL Enterprises
 00C018 Lanart
 009D8E Cardiac Recorders
 00BB01 Octothorpe
@@ -23251,23 +24139,22 @@ A06A00 Verilink
 00C090 Praim S.r.l.
 00C0DE Zcomm
 00C013 Netrix
-00C06B OSI Plus
+00C06B OSI PLUS
 00C04C Department OF Foreign Affairs
 00C07C Hightech Information
-00C0B8 Fraser's Hill
+00C0B8 Fraser's HILL
 00C062 Impulse Technology
 00C0EC Dauphin Technology
-00C086 THE Lynk
+00C086 THE LYNK
 00C058 Dataexpert
 00C0D0 Ratoc System
 00C0BF Technology Concepts
 00C0BA Netvantage
 00C05E Vari-lite
-00C0D5 Werbeagentur Jrgen Siebert
-00C063 Morning Star Technologies
+00C0D5 Werbeagentur Jürgen Siebert
+00C063 Morning STAR Technologies
 00C021 Netexpress
 00C0DB IPC (pte)
-00C09B Reliance Comm/tec
 00C0E3 Ositech Communications
 00C0FE Aptec Computer Systems
 00C016 Electronic Theatre Controls
@@ -23276,39 +24163,38 @@ A06A00 Verilink
 00C089 Telindus Distribution
 00C0B0 GCC Technologies
 00C00A Micro Craft
-00C074 Toyoda Automatic Loom
+00C074 Toyoda Automatic LOOM
 00404E Fluent
-00408D THE Goodyear Tire & Rubber
+00408D THE Goodyear TIRE & Rubber
 00401B Printer Systems
 0040A3 Microunity Systems Engineering
 0040B3 ParTech
 00401D Invisible Software
-00C0CA ALFA
-00C06C Svec Computer
+00C0CA Alfa
+00C06C SVEC Computer
 0040FF Telebit
 00401F Colorgraph
 0040AF Digital Products
 0040F7 Polaroid
 004037 Sea-ilan
-00C026 Lans Technology
+00C026 LANS Technology
 00407E Evergreen Systems
 0040F9 Combinet
-00C0A7 Seel
+00C0A7 SEEL
 00C04A Group 2000 AG
 004054 Connection Machines Services
 004004 ICM
-004058 Kronos
 004018 Adobe Systems
-00404A West Australian Department
+00404A WEST Australian Department
 00403C Forks
-004042 N.a.t. Gmbh
+004042 N.a.t. GMBH
 0040F2 Janich & Klass Computertechnik
 0040A2 Kingstar Technology
-0040DC Tritec Electronic Gmbh
+0040DC Tritec Electronic GMBH
 004060 Comendec
 004056 MCM Japan
 004030 GK Computer
-004040 Ring Access
+004040 RING Access
 008057 Adsoft
 0080BB Hughes LAN Systems
 00403D Teradata
@@ -23319,15 +24205,15 @@ A06A00 Verilink
 004046 UDC Research Limited
 00C0D7 Taiwan Trading Center DBA
 0040DA Telspec
-0040C7 Ruby Tech
-004052 Star Technologies
+0040C7 RUBY TECH
+004052 STAR Technologies
 00402E Precision Software
 00402B Trigem Computer
-00401A Fuji Electric
+00401A FUJI Electric
 00405F AFE Computers
 004080 Athenix
 004051 Garbee and Garbee
-00407A Societe D'exploitation DU Cnit
+00407A Societe D'exploitation DU CNIT
 004031 Kokusai Electric
 0040D3 Kimpsion International
 0040EE Optimem
@@ -23340,7 +24226,7 @@ A06A00 Verilink
 008053 Intellicom
 008026 Network Products
 0080B0 Advanced Information
-0080FA RWT Gmbh
+0080FA RWT GMBH
 0080FD Exsceed Corpration
 0080FE Azure Technologies
 00803C TVS Electronics
@@ -23349,19 +24235,19 @@ A06A00 Verilink
 004049 Roche Diagnostics International
 004029 Compex
 00409E Concurrent Technologies
-0080AD Cnet Technology
+0080AD CNET Technology
 00800E Atlantix
 0080AB Dukane Network Integration
-0080F1 Opus Systems
+0080F1 OPUS Systems
 008029 Eagle Technology
 008072 Microplex Systems
 004001 Zero One Technology
-004071 ATM Computer Gmbh
+004071 ATM Computer GMBH
 008011 Digital Systems Int'l.
 008034 SMT Goupil
 0080E4 Northwest Digital Systems
 0080EC Supercomputing Solutions
-00802C THE Sage Group PLC
+00802C THE SAGE Group PLC
 0080D6 Nuvotech
 00800A Japan Computer
 00804B Eagle Technologiesltd.
@@ -23392,21 +24278,21 @@ A06A00 Verilink
 000039 Toshiba
 00003C Auspex Systems
 00007E Clustrix
-0000CB Compu-shack Electronic Gmbh
+0000CB Compu-shack Electronic GMBH
 000013 Camex
-000095 Sony Tektronix
+000095 SONY Tektronix
 000057 Scitex
-0000D6 Punch Line Holding
+0000D6 Punch LINE Holding
 00009E Marli
 000042 Metier Management Systems
 00007D Oracle
 000096 Marconi Electronics
-00005E Icann, Iana Department
-000038 CSS Labs
+00005E Icann, IANA Department
+000038 CSS LABS
 000044 Castelle
 0000CE Megadata
 00007B Research Machines
-00000F NEXT
+00000F Next
 0000BB Tri-data
 00001A Advanced Micro Devices
 00007F Linotype-hell AG
@@ -23424,17 +24310,17 @@ A06A00 Verilink
 080040 Ferranti Computer SYS. Limited
 08003A Orcatech
 08003D Cadnetix Corporations
-080038 Bulls.
+080038 BULLs.
 080073 Tecmar
-080072 Xerox Univ Grant Program
-08006A At&t
+080072 Xerox UNIV Grant Program
+08006A AT&T
 08007A Indata
 080079 THE Droid Works
 08004D Corvus Systems
 08002F Prime Computer
 08002C Britton LEE
 080062 General Dynamics
-08005C Four Phase Systems
+08005C FOUR Phase Systems
 08005A IBM
 080052 Insystec
 08001E Apollo Computer
@@ -23455,15 +24341,15 @@ A06A00 Verilink
 080002 Bridge Communications
 08001A Tiara/ 10net
 08008B Pyramid Technology
-080012 Bell Atlantic Integrated SYST.
-14A1BF Assa Abloy Korea, Unilock
+080012 BELL Atlantic Integrated Syst.
+14A1BF ASSA Abloy Korea, Unilock
 9483C4 GL Technologies (Hong Kong) Limited
-080030 Royal Melbourne Inst OF Tech
+080030 Royal Melbourne INST OF TECH
 00000B Matrix
 00009B Information International
 9C93B0 Megatronix (Beijing) Technology
 64AEF1 Qingdao Hisense Electronics
-080016 Barrister Info SYS
+080016 Barrister INFO SYS
 44CB8B LG Innotek
 B4055D Inspur Electronic Information Industry
 984827 Tp-link Technologies
@@ -23474,12 +24360,12 @@ D8A315 vivo Mobile Communication
 80647A Ola Sense
 70F82B DWnet Technologies(Suzhou)
 142475 4DReplay
-10DCB6 Ieee Registration Authority
+10DCB6 IEEE Registration Authority
 F89E28 Cisco Meraki
 F8C4F3 Shanghai Infinity Wireless Technologies
 D4772B Nanjing Ztlink Network Technology
 64F9C0 Analog Devices
-18D0C5 Guangdong Oppo Mobile Telecommunications
+18D0C5 Guangdong OPPO Mobile Telecommunications
 34ED1B Cisco Systems
 BCA511 Netgear
 000A7B Cornelius Consult
@@ -23491,21 +24377,21 @@ C02E26 Private
 34D262 SZ DJI Technology
 0812A5 Amazon Technologies
 807FF8 Juniper Networks
-440377 Ieee Registration Authority
+440377 IEEE Registration Authority
 002487 Transact Campus
 B4E9A3 port industrial automation GmbH
 38E8EE Nanjing Youkuo Electric Technology
 90B8E0 Shenzhen Yanray Technology
-9CF531 Guangdong Oppo Mobile Telecommunications
+9CF531 Guangdong OPPO Mobile Telecommunications
 80E455 New H3C Technologies
 2C4CC6 Murata Manufacturing
 7C210D Cisco Systems
 4CBC72 Primex Wireless
 6802B8 Compal Broadband Networks
 3463D4 Bionix Supplychain Technologies SLU
-08F7E9 Hrcp Research and Development Partnership
+08F7E9 HRCP Research and Development Partnership
 8CBA25 Unionman Technology
-D49E3B GuangzhouShiyuanElectronicTechnologyCompanyLimited
+D49E3B Guangzhou Shiyuan Electronic Technology Company Limited
 DCDCE2 Samsung Electronics
 A0AC69 Samsung Electronics
 1089FB Samsung Electronics
@@ -23520,7 +24406,7 @@ C0B5CD Huawei Device
 58EAFC ELL-IoT
 9013DA Athom
 14115D Skyworth Digital Technology(Shenzhen)
-E4F327 Atol
+E4F327 ATOL
 6819AC Guangzhou Xianyou Intelligent Technogoly
 E82E0C Netint Technologies
 1892A4 Ciena
@@ -23535,10 +24421,10 @@ A897CD Arris Group
 A4307A Samsung Electronics
 FC8E5B China Mobile Iot Limited company
 142A14 ShenZhen Selenview Digital Technology
-D87E76 Itel Mobile Limited
+D87E76 ITEL Mobile Limited
 384B5B Ztron Technology Limited
 B86142 Beijing Tricolor Technology
-200A0D Ieee Registration Authority
+200A0D IEEE Registration Authority
 E47C65 Sunstar Communication Technology
 9C54DA SkyBell Technologies
 4C494F zte
@@ -23550,7 +24436,7 @@ DC8983 Samsung Electronics
 5CCB99 Samsung Electronics
 D46075 Baidu Online Network Technology (Beijing)
 78C5F8 Huawei Device
-D45D64 Asustek Computer
+D45D64 ASUSTek Computer
 90B144 Samsung Electronics
 48DD0C eero
 940C98 Apple
@@ -23574,7 +24460,7 @@ CCD42E Arcadyan
 C853E1 Beijing Bytedance Network Technology
 14169D Cisco Systems
 48A2E6 Resideo
-90E2FC Ieee Registration Authority
+90E2FC IEEE Registration Authority
 F008D1 Espressif
 5894B2 BrainCo
 B09575 Tp-link Technologies
@@ -23582,7 +24468,7 @@ B4B055 Huawei Technologies
 048C16 Huawei Technologies
 98DD5B Takumi Japan
 3C5CF1 eero
-14AE85 Ieee Registration Authority
+14AE85 IEEE Registration Authority
 90749D IRay Technology
 8C3B32 Microfan
 D0D3E0 Aruba, a Hewlett Packard Enterprise Company
@@ -23590,8 +24476,8 @@ D0D3E0 Aruba, a Hewlett Packard Enterprise Company
 B0CCFE Huawei Device
 540DF9 Huawei Device
 006619 Huawei Device
-FC3964 Itel Mobile Limited
-14472D Guangdong Oppo Mobile Telecommunications
+FC3964 ITEL Mobile Limited
+14472D Guangdong OPPO Mobile Telecommunications
 E490FD Apple
 84AB1A Apple
 206D31 Firewalla
@@ -23614,7 +24500,7 @@ B4F18C Huawei Device
 B8CEF6 Mellanox Technologies
 B802A4 Aeonsemi
 E48326 Huawei Technologies
-9405BB Ieee Registration Authority
+9405BB IEEE Registration Authority
 8C5FAD Fiberhome Telecommunication Technologies
 ACC25D Fiberhome Telecommunication Technologies
 8C0C87 Nokia
@@ -23623,7 +24509,7 @@ CC418E MSA Innovation
 CCA7C1 Google
 388479 Cisco Meraki
 7C9EBD Espressif
-1C0219 Guangdong Oppo Mobile Telecommunications
+1C0219 Guangdong OPPO Mobile Telecommunications
 C8D778 BSH Hausgeraete GmbH
 9C611D Panasonic of North America
 C095DA NXP India Private Limited
@@ -23655,7 +24541,7 @@ F45420 Tellescom Industria E Comercio EM Telecomunicacao
 0C817D EEP Elektro-Elektronik Pranjic GmbH
 04F5F4 Proxim Wireless
 C8BCE5 Sense Things Japan
-E8B470 Ieee Registration Authority
+E8B470 IEEE Registration Authority
 001BED Brocade Communications Systems
 000CDB Brocade Communications Systems
 000480 Brocade Communications Systems
@@ -23680,7 +24566,7 @@ EC63ED Hyundai Autoever
 D46761 XonTel Technology
 E44122 OnePlus Technology (Shenzhen)
 9C19C2 Dongguan Liesheng Electronic
-BC26A1 Factory Five
+BC26A1 Factory FIVE
 74CBF3 Lava international limited
 F0D14F Linear
 001168 HomeLogic
@@ -23688,7 +24574,7 @@ F0D14F Linear
 FCBC0E Zhejiang Cainiao Supply Chain Management
 2CD066 Xiaomi Communications
 B05CDA HP
-DCBD7A GuangzhouShiyuanElectronicTechnologyCompanyLimited
+DCBD7A Guangzhou Shiyuan Electronic Technology Company Limited
 9016BA Huawei Technologies
 60AAEF Huawei Device
 D0F3F5 Huawei Device
@@ -23696,7 +24582,7 @@ D44649 Huawei Technologies
 9400B0 Huawei Technologies
 2479EF Greenpacket Berhad, Taiwan
 AC2334 Infinix mobility limited
-002B67 Lcfc(hefei) Electronics Technology
+002B67 LCFC(HeFei) Electronics Technology
 F8BC0E eero
 50E039 Zyxel Communications
 B85776 lignex1
@@ -23770,18 +24656,17 @@ C086B3 Shenzhen Voxtech
 44ADB1 Sagemcom Broadband SAS
 1C98C1 Cloud Network Technology Singapore PTE.
 A09B17 Taicang T&W Electronics
-4401BB Shenzhen Bilian Electronicltd
+4401BB Shenzhen Bilian Electronic，ltd
 A0D83D Fiberhome Telecommunication Technologies
 58F2FC Huawei Device
 643AEA Cisco Systems
-507043 BSkyB
-D01411 Ieee Registration Authority
+D01411 IEEE Registration Authority
 3C53D7 Cedes AG
 E8136E Huawei Technologies
 4CAE13 Huawei Technologies
 4C2EFE Shenzhen Comnect Technology
 DCD444 Huawei Device
-E0B260 Teno Network Technologies Company Limited
+E0B260 TENO Network Technologies Company Limited
 A446B4 Huawei Device
 0CC844 Cambridge Mobile Telematics
 E8DA20 Nintendo
@@ -23806,7 +24691,7 @@ A83759 Huawei Device
 68545A Intel Corporate
 3CE3E7 China Mobile Group Device
 CC47BD Rhombus Systems
-4C93A6 Ieee Registration Authority
+4C93A6 IEEE Registration Authority
 001E31 infomark
 50F7ED Huawei Device
 4CB99B Weifang Goertek Electronics
@@ -23833,7 +24718,7 @@ CCB0A8 Huawei Device
 502873 Huawei Device
 8C47BE Dell
 142C78 GooWi Wireless Technology, Limited
-98FC84 Ieee Registration Authority
+98FC84 IEEE Registration Authority
 20F44F Nokia
 0476B0 Cisco Systems
 40F078 Cisco Systems
@@ -23842,7 +24727,7 @@ CCB0A8 Huawei Device
 9C6937 Qorvo International Pte.
 F82E3F Huawei Technologies
 90A5AF Huawei Technologies
-3C7C3F Asustek Computer
+3C7C3F ASUSTek Computer
 34916F UserGate
 0C8B7D Vizio
 EC4D3E Beijing Xiaomi Mobile Software
@@ -23858,11 +24743,9 @@ EC3EB3 Zyxel Communications
 FC449F zte
 204EF6 AzureWave Technology
 443583 Apple
-38CA73 Shenzhen MiaoMing  Intelligent Technology
+38CA73 Shenzhen MiaoMing Intelligent Technology
 6C0DC4 Beijing Xiaomi Electronics
-C440F6 Guangdong Oppo Mobile Telecommunications
-A47D9F Shenzhen iComm Semiconductor
-84EA97 Shenzhen iComm Semiconductor
+C440F6 Guangdong OPPO Mobile Telecommunications
 0055B1 Shanghai Baud Data Communication
 74901F Ragile Networks
 C0252F Shenzhen Mercury Communication Technologies
@@ -23883,7 +24766,6 @@ D47EE4 China Mobile IOT Company Limited
 1CA852 Sensaio PTE
 787DF3 Sterlite Technologies Limited
 C094AD zte
-D021AC Yo Labs
 342B70 Arris
 1C90BE Ericsson AB
 00163B Communications & Power Industries
@@ -23902,13 +24784,13 @@ A07751 ASMedia Technology
 30BE3B Mitsubishi Electric
 0CB789 Honor Device
 7891E9 Raisecom Technology
-8C3401 Guangdong Oppo Mobile Telecommunications
+8C3401 Guangdong OPPO Mobile Telecommunications
 60DB98 Calix
 6872C3 Samsung Electronics
 70B13D Samsung Electronics
 FC7FF1 Aruba, a Hewlett Packard Enterprise Company
 3CA37E Huawei Technologies
-F8E43B Asix Electronics
+F8E43B ASIX Electronics
 48EF61 Huawei Device
 78F09B Huawei Device
 00E93A AzureWave Technology
@@ -23923,7 +24805,7 @@ A49733 Askey Computer
 C4E90A D-Link International
 F0B4D2 D-Link International
 E01CFC D-Link International
-F02F74 Asustek Computer
+F02F74 ASUSTek Computer
 006E02 Xovis AG
 ACF85C Chengdu Higon Integrated Circuit Design
 181171 Guangzhou Doctorpai Education & Technology
@@ -23936,7 +24818,6 @@ F465A6 Apple
 FCD436 Motorola Mobility, a Lenovo Company
 0CEC8D Motorola Mobility, a Lenovo Company
 184F5D JRC Mobility
-08CBE5 R3 - Reliable Realtime Radio Communications GmbH
 F023AE Ampak Technology
 E07726 Huawei Device
 94A67E Netgear
@@ -23954,7 +24835,6 @@ D8109F Huawei Technologies
 ACAE19 Roku
 34FEC5 Shenzhen Sunwoda intelligent hardware
 A8F766 ITE Tech
-14B2E5 Shenzhen iComm Semiconductor
 00213E TomTom International BV
 683E26 Intel Corporate
 8C554A Intel Corporate
@@ -24002,7 +24882,7 @@ D05AFD Realme Chongqing Mobile Telecommunications
 F0F564 Samsung Electronics
 00DCB2 Extreme Networks
 6C13D5 Cisco Systems
-0008B0 Huber+suhner Bktel Gmbh
+0008B0 Huber+suhner BKtel GmbH
 84DB9E Pink Nectarine Health AB
 1869D8 Tuya Smart
 68ABBC Beijing Xiaomi Mobile Software
@@ -24011,7 +24891,7 @@ F0F564 Samsung Electronics
 B06088 Intel Corporate
 0C7329 Sercomm
 5CC336 ittim
-FC041C Guangdong Oppo Mobile Telecommunications
+FC041C Guangdong OPPO Mobile Telecommunications
 F4D488 Apple
 682F67 Apple
 003DE1 Huawei Device
@@ -24035,11 +24915,11 @@ B48A5F Juniper Networks
 00E0DF DZS GmbH
 E0E8BB Unicom Vsens Telecommunications
 E4C90B Radwin
-982782 Ieee Registration Authority
+982782 IEEE Registration Authority
 38A067 Nokia Solutions and Networks GmbH & KG
 7C1B93 Huawei Device
 DC2D3C Huawei Device
-041119 Ieee Registration Authority
+041119 IEEE Registration Authority
 E455A8 Cisco Meraki
 0881B2 Logitech (China) Technology
 C4F174 eero
@@ -24047,10 +24927,9 @@ C4F174 eero
 E00CE5 Huawei Technologies
 2841EC Huawei Technologies
 7C004D Huawei Technologies
-04D320 Itel Mobile Limited
+04D320 ITEL Mobile Limited
 1C9957 Intel Corporate
-F46B8C Hon Hai Precision Ind.
-FC3497 Asustek Computer
+FC3497 ASUSTek Computer
 847AB6 AltoBeam (China)
 78A6A0 Hangzhou Ezviz Software
 4851CF Intelbras
@@ -24067,7 +24946,7 @@ A4CEDA Arcadyan
 8C4361 Hailo Digital Hub GmbH & KG
 54725E Unionman Technology
 98C3D2 Ningbo Sanxing Medical Electric
-245DFC Ieee Registration Authority
+245DFC IEEE Registration Authority
 487E48 Earda Technologies
 E0E37C Huawei Device
 2418C6 Hunan Fn-link Technology Limited
@@ -24091,7 +24970,7 @@ F8D478 Flextronics Tech.(Ind) Pvt
 90A822 Amazon Technologies
 74AD98 Cisco Systems
 848C8D Apple
-0C5CB5 Ieee Registration Authority
+0C5CB5 IEEE Registration Authority
 E84F25 Murata Manufacturing
 0425E0 Taicang T&W Electronics
 3085EB Fiberhome Telecommunication Technologies
@@ -24113,7 +24992,7 @@ F889D2 Cloud Network Technology Singapore PTE.
 1027F5 TP-Link Limited
 B04F13 Dell
 C04B13 WonderSound Technology
-9C7F81 Shenzhen Fast Technologies
+9C7F81 Shenzhen FAST Technologies
 C4BCD7 New Ryatek
 C0AEFD Shenzhen Hc-wlan Technology
 206A94 Hitron Technologies.
@@ -24126,7 +25005,7 @@ DC87CB Beijing Perfectek Technologies
 5CB00A Huawei Technologies
 00C06A Zahner-Elektrik Ingeborg Zahner-Schiller GmbH & KG.
 201E88 Intel Corporate
-20CE2A Ieee Registration Authority
+20CE2A IEEE Registration Authority
 5813D3 Gemtek Technology
 00E5E4 Sichuan Tianyi Comheart Telecom
 1469A2 Sichuan Tianyi Comheart Telecom
@@ -24136,7 +25015,7 @@ DC87CB Beijing Perfectek Technologies
 68262A Sichuan Tianyi Comheart Telecom
 B8224F Sichuan Tianyi Comheart Telecom
 908674 Sichuan Tianyi Comheart Telecom
-88C9B3 Ieee Registration Authority
+88C9B3 IEEE Registration Authority
 C8BD69 Samsung Electronics
 643AB1 Sichuan Tianyi Comheart Telecom
 44BA46 Sichuan Tianyi Comheart Telecom
@@ -24167,7 +25046,7 @@ C0F9B0 Huawei Technologies
 609BB4 Huawei Technologies
 C0238D Samsung Electronics
 2811A8 Intel Corporate
-C0FBF9 Ieee Registration Authority
+C0FBF9 IEEE Registration Authority
 4CD577 Chongqing Fugui Electronics
 EC08E5 Motorola Mobility, a Lenovo Company
 80CC9C Netgear
@@ -24176,7 +25055,7 @@ EC08E5 Motorola Mobility, a Lenovo Company
 CC1531 Intel Corporate
 280FEB LG Innotek
 74E20C Amazon Technologies
-105403 Intarso Gmbh
+105403 Intarso GmbH
 000C04 Tecnova
 844709 Shenzhen IP3 Century Intelligent Technology
 0091EB Renesas Electronics (Penang) Sdn. Bhd.
@@ -24189,9 +25068,9 @@ DCF56E Wellysis
 60FCF1 Private
 E84FA7 Huawei Device
 C0D063 EM Microelectronic
-7C10C9 Asustek Computer
+7C10C9 ASUSTek Computer
 00C06F Komatsu
-A8671E Ratp
+A8671E RATP
 8CE9B4 Zhejiang Dahua Technology
 08855B Kontron Europe GmbH
 E4B503 Realme Chongqing Mobile Telecommunications
@@ -24220,14 +25099,14 @@ D88C73 zte
 D8DE3A Apple
 E87865 Apple
 A04ECF Apple
-50D065 Esylux Gmbh
+50D065 Esylux GmbH
 0887C7 Apple
 8C1D96 Intel Corporate
 60DD8E Intel Corporate
 90593C Az-technology SDN BHD
 1CC10C Intel Corporate
 F4A475 Intel Corporate
-38FF13 Joint Stock Company Research Instinite Masshtab
+38FF13 Joint Stock Company "Research Instinite "Masshtab"
 D0DBB7 Casa Systems
 2864EF Shenzhen Fsan Intelligent Technology
 C89E43 Netgear
@@ -24239,8 +25118,7 @@ BC091B Intel Corporate
 00BFAF Hui Zhou Gaoshengda Technology
 0064AF Dish Technologies
 04ECD8 Intel Corporate
-F02A2B Ieee Registration Authority
-0025DF Private
+F02A2B IEEE Registration Authority
 D0497C OnePlus Technology (Shenzhen)
 B4ECFF Wuhan IPG Technologies
 F057A6 Intel Corporate
@@ -24262,7 +25140,6 @@ F0B13F Huawei Device
 5CD06E Xiaomi Communications
 90F157 Garmin International
 FC5C45 Ruckus Wireless
-E0CB56 Shenzhen iComm Semiconductor
 4C0220 Xiaomi Communications
 40E1E4 Nokia Solutions and Networks GmbH & KG
 E446B0 Fujitsu Client Computing Limited
@@ -24270,13 +25147,12 @@ E446B0 Fujitsu Client Computing Limited
 E075AA Beijing Jingling Information System Technology
 54CE82 zte
 F4CE48 Extreme Networks
-584849 Ieee Registration Authority
+584849 IEEE Registration Authority
 708976 Tuya Smart
-0899E8 Kemas Gmbh
+0899E8 Kemas GmbH
 18F87F Wha Yu Industrial
 444F8E WiZ
-04B86A BSkyB
-1C880C Shenzhen Skyworth  Digital  Technology
+1C880C Shenzhen Skyworth Digital Technology
 EC354D Wingtech Mobile Communications
 80615F Beijing Sinead Technology
 44AE44 Huawei Device
@@ -24305,18 +25181,17 @@ B859CE Earda Technologies
 8C7AAA Apple
 9C36F8 Hyundai Kefico
 E0B72E ShenZhen Qualmesh Technology
-80C3BA Sennheiser electronic GmbH & KG
-04421A Asustek Computer
+04421A ASUSTek Computer
 2CE032 TCL King Electrical Appliances(Huizhou)Co.
 A0D2B1 Amazon Technologies
 806D71 Amazon Technologies
 081605 Vodafone Italia
 207C14 Qotom
 1C53F9 Google
-2CB0FD Shenzhen MiaoMing  Intelligent Technology
+2CB0FD Shenzhen MiaoMing Intelligent Technology
 C4FBC8 Shenzhen Candour
 E80115 Coocaa Network Technology
-8CEA12 Shenzhen MiaoMing  Intelligent Technology
+8CEA12 Shenzhen MiaoMing Intelligent Technology
 88AC9E Shenzhen Youhua Technology
 C8BD4D Samsung Electronics
 2C15BF Samsung Electronics
@@ -24340,10 +25215,9 @@ DCA782 Huawei Technologies
 045170 Zhongshan K-mate General Electronics
 384554 Harman/Becker Automotive Systems GmbH
 88D82E Intel Corporate
-180EAC Shenzhen Fast Technologies
-4CEAAE Guangdong Oppo Mobile Telecommunications
+180EAC Shenzhen FAST Technologies
+4CEAAE Guangdong OPPO Mobile Telecommunications
 50547B Nanjing Qinheng Microelectronics
-D0A0D6 TV Rheinland (China)
 144920 Huawei Technologies
 D41AD1 Zyxel Communications
 B845F4 New H3C Technologies
@@ -24365,12 +25239,376 @@ E070EA HP
 405F7D TCT mobile
 4C034F Intel Corporate
 04D921 Occuspace
-986EE8 Ieee Registration Authority
+986EE8 IEEE Registration Authority
 D4ADFC Private
-34A5B4 Navtech PTE
-E89F6D Espressif
 1C73E2 Huawei Technologies
 8C83E8 Huawei Technologies
+6457E5 Beijing Royaltech
+FC9BD4 EdgeQ
+145790 Qingdao Haier Technology
+F829C0 Availink
+24B72A China Dragon Technology Limited
+34A5B4 Navtech PTE
+E89F6D Espressif
+9877CB Vorteks ED
+3498B5 Netgear
+389461 Renesas Electronics (Penang) Sdn. Bhd.
+485519 Espressif
+F8FCE1 Amazon Technologies
+703217 Intel Corporate
+1859F5 Cisco Systems
+14C9CF Sigmastar Technology
+6444D5 Private
+DC6294 Guangzhou Lango Electronics Technology
+5C46B0 SIMCom Wireless Solutions Limited
+3C219C Intel Corporate
+EC4269 HMD Global Oy
+281D21 IN ONE Smart Technology(h,k,)limited
+74E336 Fujian Star-net Communication
+B0739C Amazon Technologies
+C4345B Huawei Technologies
+84BA20 Silicon Laboratories
+003C84 Silicon Laboratories
+C02C5C Apple
+D45763 Apple
+049F15 Private
+483E5E Sernet (suzhou) Technologies
+50EBF6 ASUSTek Computer
+C448FA Taicang T&W Electronics
+A89892 Guangdong OPPO Mobile Telecommunications
+E0720A Shenzhen SuperElectron Technology
+60FF12 Samsung Electronics
+24C613 Samsung Electronics
+94E129 Samsung Electronics
+D0A0D6 ChengDu TD Tech
+24D904 Sichuan Changhong Network Technologies
+902759 Nanjing Jiahao Technology
+0013CA ATX
+2804C6 Wanan Hongsheng ElectronicLtd
+D47954 Huawei Device
+C44F96 Alps Alpine
+685811 Fiberhome Telecommunication Technologies
+C839AC Huawei Device
+145594 Huawei Device
+08C06C Huawei Device
+FC0296 Xiaomi Communications
+60E85B Texas Instruments
+EC2A72 Dell
+B4BA02 Agatel
+14EBB6 TP-Link Limited
+54AF97 TP-Link Limited
+54CF8D Huawei Technologies
+F863D9 Arris Group
+A405D6 Arris Group
+DCA633 Arris Group
+1845B3 IEEE Registration Authority
+ECE744 Omntec mfg.
+2C4DDE Tecno Mobile Limited
+303F7B Shenzhen Youhua Technology
+D48457 GD Midea Air-Conditioning Equipment
+D8CFBF Motorola Mobility, a Lenovo Company
+D48866 Huawei Technologies
+00C09B Tellabs Enterprise
+68BE49 Nebula Matrix
+940D2D Universal Electronics
+94F827 Shanghai Imilab TechnologyLtd
+F0B040 Hunan Fn-link Technology Limited
+482F6B Aruba, a Hewlett Packard Enterprise Company
+4C06B7 ProDVX Europe
+7486E2 Dell
+A88C3E Microsoft
+F814FE Unionman Technology
+34CE69 Nokia Solutions and Networks GmbH & KG
+70B8F6 Espressif
+149E5D JSC "IB Reform"
+F82551 Seiko Epson
+E484D3 Xiaomi Communications
+04106B Xiaomi Communications
+04CCBC Huawei Technologies
+1CE504 Huawei Technologies
+2C0BAB Huawei Technologies
+E0A25A Shanghai Mo xiang Network Technology
+147EA1 Britania Eletrônicos
+E81656 Hangzhou BroadLink Technology
+94D2BC Huawei Technologies
+7453A8 ACL Airshop BV
+68C8EB Rockwell Automation
+348511 Shenzhen Skyworth Digital Technology
+201F54 Raisecom Technology
+7C97E1 Huawei Device
+C83E9E Huawei Device
+60DD70 Apple
+98A5F9 Apple
+E0D045 Intel Corporate
+000C36 S-Takaya Electronics Industry
+ECA907 Apple
+2887BA TP-Link Limited
+3460F9 TP-Link Limited
+6425EC guangdong kesheng zhixun technology
+684AE9 Samsung Electronics
+0050E8 Nomadix
+54ACFC LIZN ApS
+F4B898 Texas Instruments
+B0D278 Texas Instruments
+A439B3 Beijing Xiaomi Mobile Software
+6CFFCE Sagemcom Broadband SAS
+C899B2 Arcadyan
+B03893 Onda TLC GmbH
+1C9D72 Technicolor CH USA
+0CB815 Espressif
+800CF9 Amazon Technologies
+A09208 Tuya Smart
+C8727E Nokia
+00F871 Demant A/S
+60A6C5 Huawei Technologies
+208C86 Huawei Technologies
+F0A951 Huawei Technologies
+64D69A Intel Corporate
+185E0B zte
+D0BB61 zte
+AC7352 Guangdong OPPO Mobile Telecommunications
+588FCF Hangzhou Ezviz Software
+942A6F Ubiquiti Networks
+F4E2C6 Ubiquiti Networks
+A84FB1 Cisco Systems
+50C275 GN Audio A/S
+94B555 Espressif
+74F2FA Xiaomi Communications
+3CE9F7 Intel Corporate
+F4CE23 Intel Corporate
+5C843C Sony Interactive Entertainment
+E8AEC5 Arista Networks
+4017F6 TKH Security
+004058 UKG
+2C301A Technicolor CH USA for Telus
+E8C7CF Wistron Neweb
+C049EF Espressif
+ECE7A7 Intel Corporate
+E42B79 Nokia
+C814B4 Sichuan Tianyi Comheart Telecom
+00198E Demant A/S
+000B44 Concord Idea
+60FB00 Shenzhen Bilian Electronic，ltd
+CC5C61 Huawei Device
+1CF42B Huawei Device
+6C51BF Huawei Device
+D09200 FiRa Consortium
+E893F3 Graphiant
+280244 Apple
+E85F02 Apple
+E0F62D Juniper Networks
+BCDF58 Google
+7CC180 Apple
+00D04C Eseye Design
+BC606B Shanghai Baud Data Communication
+DCFE23 Murata Manufacturing
+347379 xFusion Digital Technologies, Limited
+04E69E Zhongguancun Xinhaizeyou Technology
+7C8AC0 EVBox BV
+AC80AE Fiberhome Telecommunication Technologies
+D83DCC shenzhen UDD Technologies,co.
+0417B6 Smart Innovation
+00BE43 Dell
+B4E265 Shenzhen SDMC Technology
+CC60C8 Microsoft
+00EBD8 Mercusys Technologies
+6C8D77 Cisco Systems
+7411B2 Cisco Systems
+B417A8 Facebook Technologies
+EC7C5C Juniper Networks
+1054D2 IEEE Registration Authority
+001043 A2
+C4DF39 Realme Chongqing Mobile Telecommunications
+809733 Shenzhen Elebao Technology
+F46D2F Tp-link Technologies
+00A265 M2Motive Technology
+D8365F Intelbras
+7404F1 Intel Corporate
+000435 InfiNet
+5478C9 Ampak Technology
+FC101A Palo Alto Networks
+6CAEE3 Nokia
+0CAC8A Sagemcom Broadband SAS
+10634B Shenzhen Mercury Communication Technologies
+E84DEC Xerox
+C8B82F eero
+B43AE2 Huawei Technologies
+F0C8B5 Huawei Technologies
+B85DC3 Huawei Technologies
+B4A7C6 Servercom (india) Private Limited
+D0A46F China Dragon Technology Limited
+1C76F2 Samsung Electronics
+80C3BA Sennheiser Consumer Audio GmbH
+4035E6 Samsung Electronics
+2C60CD NR Electric
+286B35 Intel Corporate
+3043D7 IEEE Registration Authority
+A41EE1 Taicang T&W Electronics
+E8FB1C AzureWave Technology
+C0EE40 Laird Connectivity
+A47D9F Shenzhen iComm Semiconductor
+30045C Shenzhen SuperElectron Technology
+3C4645 Shanghai Infinity Wireless Technologies
+A4F933 Intel Corporate
+10F60A Intel Corporate
+70D823 Intel Corporate
+888FA4 Huawei Device
+5068AC Huawei Device
+9079CF zte
+8C1E80 Cisco Systems
+50392F Ingram Micro Services
+FC8417 Honor Device
+2CA79E Huawei Technologies
+0C7FB2 Arris Group
+C4DEE2 Espressif
+68B6B3 Espressif
+FCA05A Oray.com
+84EA97 Shenzhen iComm Semiconductor
+14B2E5 Shenzhen iComm Semiconductor
+E0CB56 Shenzhen iComm Semiconductor
+90486C Ring
+3C82C0 Technicolor CH USA
+102407 Huawei Technologies
+74D9EB Petabit Scale
+D021AC Yohana
+7CE152 THE Goodyear TIRE & Rubber Company
+28CDC1 Raspberry Pi Trading
+00903F WorldCast Systems
+ACB566 Renesas Electronics (Penang) Sdn. Bhd.
+381F26 IEEE Registration Authority
+EC2125 Toshiba
+00E5F1 Buffalo.inc
+34EE2A ConMet
+50E636 AVM Audiovisuelles Marketing und Computersysteme GmbH
+684E05 Hunan Fn-link Technology Limited
+7820BD Polysense (Beijing) Technologies
+F04DD4 Sagemcom Broadband SAS
+AC2929 Infinix mobility limited
+5C1BF4 Apple
+A851AB Apple
+3CCE0D Shenzhen juduoping Technology
+0499BB Apple
+60E9AA Cloud Network Technology Singapore PTE.
+240F5E Shenzhen z-router Technology
+E83A4B China Mobile Group Device
+78669D Hui Zhou Gaoshengda Technology
+48468D Zepcam
+000EDD Shure Incorporated
+6C976D Motorola Mobility, a Lenovo Company
+6411A4 Motorola Mobility, a Lenovo Company
+904992 YSTen Technology
+18FD74 Routerboard.com
+40D95A Ampak Technology
+4CD0DD Huawei Technologies
+E4902A Huawei Technologies
+905E44 Huawei Technologies
+F0877F Magnetar Technology Shenzhen
+74D4DD Quanta Computer
+C8D6B7 Solidigm Technology
+10F068 Ruckus Wireless
+443C9C Pintsch GmbH
+2064DE Sunitec Enterprise
+A40F98 Guangdong OPPO Mobile Telecommunications
+D880DC Huawei Device
+E8B3EF Fiberhome Telecommunication Technologies
+B49F4D Fiberhome Telecommunication Technologies
+F46C68 Wistron Neweb
+8493B2 zte
+74B725 Huawei Device
+408EDF Huawei Device
+BC4434 Shenzhen Tinno Mobile Technology
+70662A Sony Interactive Entertainment
+605B30 Dell
+34AC11 China Mobile Group Device
+4432C2 GOAL
+18B185 Qiao Information Technology (Zhengzhou)
+A0B765 Espressif
+CCDBA7 Espressif
+C86C20 Sichuan Tianyi Comheart Telecom
+C0C976 Shenzhen Tinno Mobile Technology
+B4C0F5 Shenzhen Tinno Mobile Technology
+E8F791 Xiaomi Communications
+0C975F Aruba, a Hewlett Packard Enterprise Company
+DC71DD AX Technologies
+54A9C8 Home Control Singapore Pte
+3C69D1 ADC Automotive Distance Control System GmbH
+04BAD6 D-Link
+303F5D PT HAN SUNG Electoronics Indonesia
+307F10 Guangdong OPPO Mobile Telecommunications
+A490CE vivo Mobile Communication
+F8B8B4 Shenzhen Skyworth Digital Technology
+B0FBDD Shenzhen SuperElectron Technology
+E09C8D Seakeeper
+343A20 Aruba, a Hewlett Packard Enterprise Company
+7C0C92 Suzhou Mobydata Smart System
+18E91D Huawei Technologies
+48706F Huawei Technologies
+F46ADD Liteon Technology
+98D742 Samsung Electronics
+C82AF1 TCT mobile
+3CE90E Espressif
+A842E3 Espressif
+042605 Bosch Building Automation GmbH
+A0BDCD SKY UK Limited
+3C8994 SKY UK Limited
+04819B SKY UK Limited
+507043 SKY UK Limited
+04B86A SKY UK Limited
+3C457A SKY UK Limited
+3CFEAC Cisco Systems
+04A741 Cisco Systems
+A0889D Huawei Device
+D49B74 Kinetic Technologies
+2047ED SKY UK Limited
+40F8DF Canon
+F46B8C Hon Hai Precision Industry
+74375F Sercomm Philippines
+F43BD8 Intel Corporate
+7C67AB Roku
+0C7FED IEEE Registration Authority
+E08614 Novatel Wireless Solutions
+A8DE68 Beijing Wide Technology
+3C4E56 Shenzhen Chuangwei-rgb Electronics
+C84BD6 Dell
+6C302A Texas Instruments
+7446B3 Texas Instruments
+08B61F Espressif
+944E5B Ubee Interactive, Limited
+B4BA9D SKY UK Limited
+50F261 Photon Sail Technologies
+80DAC2 Technicolor CH USA
+00410E Cloud Network Technology Singapore PTE.
+FC6179 IEEE Registration Authority
+4C7274 Shenzhenshi Xinzhongxin TechnologyLtd
+98A2C0 Cisco Systems
+EC74D7 Grandstream Networks
+306371 Shenzhenshi Xinzhongxin TechnologyLtd
+8812AC Hunan Fn-link Technology Limited
+28011C zte
+5C3E1B Apple
+7C2ACA Apple
+288EEC Apple
+A08CF2 Yinuolink
+40475E eero
+20E6DF eero
+F4931C Universal Electronics
+C8848C Ruckus Wireless
+B07839 GD Midea Air-Conditioning Equipment
+749E75 Aruba, a Hewlett Packard Enterprise Company
+E05A1B Espressif
+488AE8 vivo Mobile Communication
+CCBA6F Huawei Technologies
+785C5E Huawei Technologies
+98818A Huawei Device
+A8AA7C Huawei Device
+B4C2F7 Huawei Device
+1C3283 Comtti Intelligent Technology(Shenzhen)
+F41C71 Shenzhen Sanmu Communication Technology
+70110E zte
+0025DF Taser International
+08CBE5 R3 Solutions GmbH
+E886CF Nokia
+3438AF Inlab Networks GmbH
 7C8AE1 Compal Information (kunshan)
 54E4A9 BHR Tech GmbH
 208058 Ciena
@@ -24385,8 +25623,8 @@ A8C252 Huawei Device
 A04147 Huawei Device
 1CAECB Huawei Technologies
 4CF19E Groupe Atlantic
-2036D7 Shanghai Reacheng  Communication Technology
-68070A TPVision Europe B.V
+2036D7 Shanghai Reacheng Communication Technology
+68070A TPVision Europe
 4CEBBD Chongqing Fugui Electronics
 7CC926 Wuhan GreeNet Information Service
 5C75AF Fitbit
@@ -24411,7 +25649,7 @@ AC7713 Honeywell Safety Products (Shanghai)
 18A4A9 Vanu
 80E82C Hewlett Packard
 D4ADBD Cisco Systems
-2440AE Niic Technology
+2440AE NIIC Technology
 F40E01 Apple
 1495CE Apple
 50DE06 Apple
@@ -24426,9 +25664,9 @@ FC1D43 Apple
 C0CBF1 Mobiwire Mobiles (NingBo)
 FC7D6C Hyesung Techwin
 E47E9A zte
-2C16BD Ieee Registration Authority
+2C16BD IEEE Registration Authority
 30A889 Decimator Design
-B4A2EB Ieee Registration Authority
+B4A2EB IEEE Registration Authority
 1CD5E2 Shenzhen Youhua Technology
 0024E9 Samsung Electronics
 683B78 Cisco Systems
@@ -24463,7 +25701,7 @@ B8C385 Huawei Technologies
 ACDB48 Arris Group
 C80D32 Holoplot GmbH
 D05794 Sagemcom Broadband SAS
-04D9F5 Asustek Computer
+04D9F5 ASUSTek Computer
 B891C9 Handreamnet
 C8A776 Huawei Technologies
 A400E2 Huawei Technologies
@@ -24482,9 +25720,9 @@ C4F7D5 Cisco Systems
 88EF16 Arris Group
 8CA96F D&M Holdings
 7CD661 Xiaomi Communications
-B0FD0B Ieee Registration Authority
+B0FD0B IEEE Registration Authority
 98B8BA LG Electronics (Mobile Communications)
-0CE99A Atls Altec
+0CE99A ATLS Altec
 4C11AE Espressif
 8C89FA Zhejiang Hechuan Technology
 4CBC48 Cisco Systems
@@ -24501,13 +25739,12 @@ A8E544 Huawei Technologies
 88E64B Juniper Networks
 D8D090 Dell
 50C4DD Buffalo.inc
-0084ED Private
 E002A5 ABB Robotics
 F42E7F Aruba, a Hewlett Packard Enterprise Company
 B4CC04 Piranti
 B8D526 Zyxel Communications
-F0B968 Itel Mobile Limited
-04E56E Thub
+F0B968 ITEL Mobile Limited
+04E56E THUB
 1C7F2C Huawei Technologies
 88BCC1 Huawei Technologies
 1CBFCE Shenzhen Century Xinyang Technology
@@ -24538,7 +25775,7 @@ B85D0A Apple
 147BAC Nokia
 906D05 BXB Electronics
 D4BBC8 vivo Mobile Communication
-489507 Guangdong Oppo Mobile Telecommunications
+489507 Guangdong OPPO Mobile Telecommunications
 24BF74 Private
 CCDC55 Dragonchip Limited
 28FFB2 Toshiba
@@ -24546,12 +25783,12 @@ CCDC55 Dragonchip Limited
 F4B5AA zte
 E8ACAD zte
 0836C9 Netgear
-745BC5 Ieee Registration Authority
+745BC5 IEEE Registration Authority
 9440C9 Hewlett Packard Enterprise
 A041A7 NL Ministry of Defense
 E446DA Xiaomi Communications
 1C12B0 Amazon Technologies
-4CBC98 Ieee Registration Authority
+4CBC98 IEEE Registration Authority
 2CF432 Espressif
 647366 Shenzhen Siera Technology
 041EFA Bissell Homecare
@@ -24560,10 +25797,10 @@ D411A3 Samsung Electronics
 04BA8D Samsung Electronics
 744D28 Routerboard.com
 00A085 Private
-E05A9F Ieee Registration Authority
+E05A9F IEEE Registration Authority
 8C5AF8 Beijing Xiaomi Electronics
 D45800 Fiberhome Telecommunication Technologies
-90842B Lego System A/S
+90842B LEGO System A/S
 00267E Parrot SA
 2C557C Shenzhen Youhua Technology
 F4BCDA Shenzhen Jingxun Software Telecommunication Technology
@@ -24596,10 +25833,10 @@ A41791 Shenzhen Decnta Technology
 109C70 Prusa Research s.r.o.
 E84C56 Intercept Services Limited
 A41908 Fiberhome Telecommunication Technologies
-80D336 Cern
+80D336 CERN
 64255E Observint Technologies
 90940A Analog Devices
-40B076 Asustek Computer
+40B076 ASUSTek Computer
 D43D39 Dialog Semiconductor
 0014A5 Gemtek Technology
 C0B5D7 Chongqing Fugui Electronics
@@ -24611,13 +25848,13 @@ B8BC5B Samsung Electronics
 108EBA Molekule
 4C218C Panasonic India Private limited
 2C4E7D Chunghua Intelligent Network Equipment
-A4F465 Itel Mobile Limited
-4C917A Ieee Registration Authority
+A4F465 ITEL Mobile Limited
+4C917A IEEE Registration Authority
 743A65 NEC
 00255C NEC
 684F64 Dell
 CC70ED Cisco Systems
-907E30 Lars
+907E30 LARS
 84EB3E Vivint Smart Home
 00A0D5 Sierra Wireless
 18BB26 Fn-link Technology Limited
@@ -24626,11 +25863,10 @@ ECF0FE zte
 94A40C Diehl Metering GmbH
 70B317 Cisco Systems
 B00247 Ampak Technology
-BCE796 Wireless Cctv
+BCE796 Wireless CCTV
 948FCF Arris Group
 A8F5DD Arris Group
-44D3AD Shenzhen Tinno Mobile Technology
-9C8275 YichipMicroelectronics (Hangzhou)
+9C8275 Yichip Microelectronics (Hangzhou)
 5CCBCA Fujian Star-net Communication
 28E98E Mitsubishi Electric
 34F8E7 Cisco Systems
@@ -24646,7 +25882,7 @@ D49E05 zte
 C09AD0 Apple
 94B01F Apple
 98CC4D Shenzhen mantunsci
-B8C74A Guangdong Oppo Mobile Telecommunications
+B8C74A Guangdong OPPO Mobile Telecommunications
 D8CE3A Xiaomi Communications
 102C6B Ampak Technology
 7485C4 New H3C Technologies
@@ -24674,7 +25910,7 @@ A89042 Beijing Wanwei Intelligent Technology
 BC7596 Beijing Broadwit Technology
 1C34DA Mellanox Technologies
 2CA02F Veroguard Systems
-6C5C3D Ieee Registration Authority
+6C5C3D IEEE Registration Authority
 782327 Samsung Electronics
 DCF756 Samsung Electronics
 68A47D Sun Cupid Technology (HK)
@@ -24701,13 +25937,13 @@ CCD4A1 MitraStar Technology
 10DFFC Siemens AG
 847F3D Integrated Device Technology (Malaysia) Sdn. Bhd.
 C4FDE6 Drtech
-CC988B Sony Visual Products
+CC988B SONY Visual Products
 30E3D6 Spotify USA
 9CA525 Shandong USR IOT Technology Limited
 E0456D China Mobile Group Device
 283926 CyberTAN Technology
 8CFCA0 Shenzhen Smart Device Technology
-1C427D Guangdong Oppo Mobile Telecommunications
+1C427D Guangdong OPPO Mobile Telecommunications
 806933 Huawei Technologies
 BC26C7 Cisco Systems
 BC5EA1 PsiKick
@@ -24716,7 +25952,7 @@ BC5EA1 PsiKick
 608C4A Apple
 74B587 Apple
 FCB6D8 Apple
-3C6A2C Ieee Registration Authority
+3C6A2C IEEE Registration Authority
 241B7A Apple
 8CFE57 Apple
 C0A600 Apple
@@ -24725,7 +25961,7 @@ E0C286 Aisai Communication Technology
 7405A5 Tp-link Technologies
 286DCD Beijing Winner Microelectronics
 541031 Smarto
-44A466 Groupe Ldlc
+44A466 Groupe LDLC
 D80D17 Tp-link Technologies
 18C2BF Buffalo.inc
 E81CBA Fortinet
@@ -24738,10 +25974,10 @@ E4DB6D Beijing Xiaomi Electronics
 00A0D1 Inventec
 0018CC Axiohm SAS
 001827 NEC Unified Solutions Nederland
-009004 3com Europe
-00068C 3com
-02608C 3com
-00D0D8 3com
+009004 3COM Europe
+00068C 3COM
+02608C 3COM
+00D0D8 3COM
 18937F Ampak Technology
 A43523 Guangdong Donyan Network Technologies
 B4A94F Mercury
@@ -24766,7 +26002,7 @@ DC9088 Huawei Technologies
 80A796 Neurotek
 CC2119 Samsung Electronics
 302303 Belkin International
-9CF6DD Ieee Registration Authority
+9CF6DD IEEE Registration Authority
 001E80 Icotera A/S
 48881E EthoSwitch
 3C71BF Espressif
@@ -24777,9 +26013,9 @@ CC2119 Samsung Electronics
 502FA8 Cisco Systems
 902BD2 Huawei Technologies
 08D59D Sagemcom Broadband SAS
-C08359 Ieee Registration Authority
-EC83D5 Gird Systems
-14942F Usys
+C08359 IEEE Registration Authority
+EC83D5 GIRD Systems
+14942F USYS
 FCB10D Shenzhen Tian Kun Technology
 20F77C vivo Mobile Communication
 001EEC Compal Information (kunshan)
@@ -24788,12 +26024,12 @@ F0761C Compal Information (kunshan)
 00451D Cisco Systems
 A0D635 WBS Technology
 34800D Cavium
-B44BD6 Ieee Registration Authority
+B44BD6 IEEE Registration Authority
 D8912A Zyxel Communications
-3C427E Ieee Registration Authority
+3C427E IEEE Registration Authority
 000BA3 Siemens AG
 000C8A Bose
-243A82 Irts
+243A82 IRTS
 880907 MKT Systemtechnik GmbH & KG
 58A48E PixArt Imaging
 30D659 Merging Technologies SA
@@ -24810,18 +26046,18 @@ AC751D Huawei Technologies
 641C67 Digibras Industria DO Brasils/a
 60058A Hitachi Metals
 BC22FB RF Industries
-0080B6 Mercury Systems  Trusted Mission Solutions
+0080B6 Mercury Systems – Trusted Mission Solutions
 08512E Orion Diagnostica Oy
 98A404 Ericsson AB
 00CC3F Universal Electronics
 74B91E Nanjing Bestway Automation System
-A019B2 Ieee Registration Authority
+A019B2 IEEE Registration Authority
 8C15C7 Huawei Technologies
 60FA9D Huawei Technologies
 DC9914 Huawei Technologies
 4C3FD3 Texas Instruments
 B05365 China Mobile IOT Company Limited
-308841 SichuanAI-LinkTechnologyCo.
+308841 Sichuan AI-Link Technology
 44EFCF Ugene Solution
 304596 Huawei Technologies
 C0F4E6 Huawei Technologies
@@ -24831,7 +26067,7 @@ D868C3 Samsung Electronics
 C493D9 Samsung Electronics
 A82BB9 Samsung Electronics
 ACFD93 Weifang Goertek Electronics
-00B8C2 Heights Telecom T
+00B8C2 Heights Telecom
 F4BF80 Huawei Technologies
 000E8F Sercomm
 A0E617 Matis
@@ -24842,7 +26078,7 @@ FC90FA Independent Technologies
 D0B214 PoeWit
 C42456 Palo Alto Networks
 B4B686 Hewlett Packard
-4CEDFB Asustek Computer
+4CEDFB ASUSTek Computer
 7C2EBD Google
 6CAF15 Webasto SE
 E4E130 TCT mobile
@@ -24856,7 +26092,7 @@ E0191D Huawei Technologies
 3C15FB Huawei Technologies
 CC934A Sierra Wireless
 00CFC0 China Mobile Group Device
-DC330D Qing DAO Haier Telecom
+DC330D QING DAO Haier Telecom
 688975 nuoxc
 40F04E Integrated Device Technology (Malaysia) Sdn. Bhd.
 0021F2 Easy3call Technology Limited
@@ -24876,7 +26112,7 @@ AC35EE Fn-link Technology Limited
 881196 Huawei Technologies
 E40EEE Huawei Technologies
 28D997 Yuduan Mobile
-301F9A Ieee Registration Authority
+301F9A IEEE Registration Authority
 0C2C54 Huawei Technologies
 D4C19E Ruckus Wireless
 70695A Cisco Systems
@@ -24886,10 +26122,10 @@ D07714 Motorola Mobility, a Lenovo Company
 B481BF Meta-Networks
 946AB0 Arcadyan
 4818FA Nocsys
-587A6A Guangdong Oppo Mobile Telecommunications
-A038F8 Oura Health Oy
+587A6A Guangdong OPPO Mobile Telecommunications
+A038F8 OURA Health Oy
 687924 ELS-GmbH & KG
-28FD80 Ieee Registration Authority
+28FD80 IEEE Registration Authority
 0CAE7D Texas Instruments
 304511 Texas Instruments
 E81AAC Orfeo Soundworks
@@ -24910,7 +26146,7 @@ F4844C Texas Instruments
 B4F2E8 Arris Group
 3C574F China Mobile Group Device
 D49CF4 Palo Alto Networks
-8C1645 Lcfc(hefei) Electronics Technology
+8C1645 LCFC(HeFei) Electronics Technology
 689861 Beacon
 609813 Shanghai Visking Digital Technology
 506B4B Mellanox Technologies
@@ -24931,7 +26167,6 @@ D4A33D Apple
 F0766F Apple
 4098AD Apple
 6C4D73 Apple
-1CA0B8 Hon Hai Precision Ind.
 D88466 Extreme Networks
 000496 Extreme Networks
 00E02B Extreme Networks
@@ -24947,15 +26182,15 @@ B0672F Bowers & Wilkins
 D86375 Xiaomi Communications
 D89C67 Hon Hai Precision Ind.
 64209F Tilgin AB
-A43E51 Anov France
-702605 Sony Visual Products
+A43E51 ANOV France
+702605 SONY Visual Products
 0090F1 Seagate Cloud Systems
 845A81 ffly4u
 CC81DA Phicomm (Shanghai)
 00806C Secure Systems & Services
 007263 Netcore Technology
 1C27DD Datang Gohighsec(zhejiang)Information Technology
-B8C8EB Itel Mobile Limited
+B8C8EB ITEL Mobile Limited
 80C5F2 AzureWave Technology
 64F88A China Mobile IOT Company Limited
 68DB54 Phicomm (Shanghai)
@@ -24964,7 +26199,7 @@ B45253 Seagate Technology
 001D38 Seagate Technology
 005013 Seagate Cloud Systems
 C8DF84 Texas Instruments
-240D6C Smnd
+240D6C SMND
 48555C Wu Qi Technologies
 18F0E4 Xiaomi Communications
 588A5A Dell
@@ -24976,15 +26211,15 @@ D8E004 Vodia Networks
 2CFDAB Motorola (Wuhan) Mobility Technologies Communication
 30B4B8 LG Electronics
 380E4D Cisco Systems
-3873EA Ieee Registration Authority
+3873EA IEEE Registration Authority
 4C5262 Fujitsu Technology Solutions GmbH
-803BF6 Look Easy International Limited
+803BF6 LOOK EASY International Limited
 30EB1F Skylab M&C Technology
 549A4C Guangdong Homecare Technology
 EC1D8B Cisco Systems
 EC7097 Arris Group
 5819F8 Arris Group
-D07FC4 Ou Wei TechnologyLtd. of Shenzhen City
+D07FC4 Ou Wei Technology，Ltd. of Shenzhen City
 1479F3 China Mobile Group Device
 0CCEF6 Guizhou Fortuneship Technology
 1806FF Acer Computer(Shanghai) Limited.
@@ -24998,7 +26233,6 @@ A4B52E Integrated Device Technology (Malaysia) Sdn. Bhd.
 64CBA3 Pointmobile
 ECFABC Espressif
 08BA22 Swaive
-28C13C Hon Hai Precision Ind.
 B0ECE1 Private
 60E78A Unisem
 282986 APC by Schneider Electric
@@ -25015,7 +26249,7 @@ B8C111 Apple
 1046B4 FormericaOE
 9CE33F Apple
 386B1C Shenzhen Mercury Communication Technologies
-DC5583 Guangdong Oppo Mobile Telecommunications
+DC5583 Guangdong OPPO Mobile Telecommunications
 001248 Dell EMC
 006048 Dell EMC
 7CC95A Dell EMC
@@ -25033,7 +26267,7 @@ E8361D Sense Labs
 887598 Samsung Electronics
 C0174D Samsung Electronics
 20F19E Arris Group
-C89F42 Vdii Innovation AB
+C89F42 VDII Innovation AB
 7091F3 Universal Electronics
 080069 Silicon Graphics
 002291 Cisco Systems
@@ -25049,8 +26283,7 @@ BC825D Mitsumi Electric
 D0666D Shenzhen Bus-Lan Technology
 08152F Samsung Electronics, Artik
 F4F5DB Xiaomi Communications
-F4E204 Traqueur
-CC2237 Ieee Registration Authority
+CC2237 IEEE Registration Authority
 38D620 Limidea Concept Pte.
 74F91A Onface
 A434F1 Texas Instruments
@@ -25060,10 +26293,10 @@ BC3D85 Huawei Technologies
 38378B Huawei Technologies
 745C4B GN Audio A/S
 00149D Sound ID
-A8E824 Inim Electronics S.r.l.
+A8E824 INIM Electronics S.r.l.
 104963 Harting K.K.
-8CD48E Itel Mobile Limited
-642B8A ALL Best Industrial
+8CD48E ITEL Mobile Limited
+642B8A ALL BEST Industrial
 B8EE0E Sagemcom Broadband SAS
 ECD09F Xiaomi Communications
 78E103 Amazon Technologies
@@ -25071,7 +26304,7 @@ ECD09F Xiaomi Communications
 E4EC10 Nokia
 002692 Mitsubishi Electric
 8CC121 Panasonic AVC Networks Company
-EC0441 Shenzhen Tigo Semiconductor
+EC0441 ShenZhen TIGO Semiconductor
 ACBE75 Ufine Technologies
 00C08F Panasonic Electric Works
 B0350B Mobiwire Mobiles (ningbo)
@@ -25092,9 +26325,9 @@ C0A53E Apple
 547595 Tp-link Technologies
 C47154 Tp-link Technologies
 586163 Quantum Networks (SG) Pte.
-EC3DFD Shenzhen Bilian Electronicltd
-94D029 Guangdong Oppo Mobile Telecommunications
-308454 Guangdong Oppo Mobile Telecommunications
+EC3DFD Shenzhen Bilian Electronic，ltd
+94D029 Guangdong OPPO Mobile Telecommunications
+308454 Guangdong OPPO Mobile Telecommunications
 5C0339 Huawei Technologies
 F82819 Liteon Technology
 0015E5 Cheertek
@@ -25112,12 +26345,12 @@ D86C63 Google
 00227F Ruckus Wireless
 74911A Ruckus Wireless
 00C05D L&N Technologies
-58C583 Itel Mobile Limited
+58C583 ITEL Mobile Limited
 18204C Kummler+Matter AG
 18D225 Fiberhome Telecommunication Technologies
 18B430 Nest Labs
 30B164 Power Electronics International
-F88A3C Ieee Registration Authority
+F88A3C IEEE Registration Authority
 A40450 nFore Technology
 FC5A1D Hitron Technologies.
 94147A vivo Mobile Communication
@@ -25132,7 +26365,7 @@ B01F29 Helvetia
 14612F Avaya
 00309D Nimble Microsystems
 8C210A Tp-link Technologies
-4C189A Guangdong Oppo Mobile Telecommunications
+4C189A Guangdong OPPO Mobile Telecommunications
 CC4B73 Ampak Technology
 0015DC KT&C
 00187D Armorlink .Ltd
@@ -25141,7 +26374,7 @@ F430B9 Hewlett Packard
 C8DB26 Logitech
 A40E2B Facebook
 AC4E2E Shenzhen JingHanDa ElectronicsLtd
-4C910C Lanix Internacional, S.A. de C.V.
+4C910C Lanix Internacional, de C.V.
 A47886 Avaya
 0403D6 Nintendo
 5C1A6F Cambridge Industries(Group)
@@ -25166,35 +26399,35 @@ E0D55E Giga-byte Technology
 A040A0 Netgear
 000D2B Racal Instruments
 48A74E zte
-BC8AE8 Qing DAO Haier Telecom
+BC8AE8 QING DAO Haier Telecom
 F4DE0C Espod
 3C5282 Hewlett Packard
-08ED02 Ieee Registration Authority
+08ED02 IEEE Registration Authority
 E8FDE8 CeLa Link
 28C63F Intel Corporate
 88CC45 Skyworth Digital Technology(Shenzhen)
 600837 ivvi Scientific(Nanchang)Co.Ltd
 EC363F Markov
 5804CB Tianjin Huisun Technology
-60D7E3 Ieee Registration Authority
+60D7E3 IEEE Registration Authority
 1893D7 Texas Instruments
 A8B86E LG Electronics (Mobile Communications)
 CC90E8 Shenzhen Youhua Technology
 7C4F7D Sawwave
 9CAC6D Universal Electronics
-08EA40 Shenzhen Bilian Electronicltd
+08EA40 Shenzhen Bilian Electronic，ltd
 00D095 Alcatel-Lucent Enterprise
 0020DA Alcatel-Lucent Enterprise
 6C5976 Shanghai Tricheer Technology
 7C7B8B Control Concepts
 84A9C4 Huawei Technologies
 A0086F Huawei Technologies
-34CE00 Xiaomi Electronics,co.
+34CE00 Xiaomi Electronics,CO.
 D06F82 Huawei Technologies
 A0F479 Huawei Technologies
 844765 Huawei Technologies
 C4FF1F Huawei Technologies
-B83765 Guangdong Oppo Mobile Telecommunications
+B83765 Guangdong OPPO Mobile Telecommunications
 345BBB GD Midea Air-Conditioning Equipment
 C40BCB Xiaomi Communications
 84AFEC Buffalo.inc
@@ -25205,13 +26438,13 @@ A8A198 TCT mobile
 E0C0D1 CK Telecom (Shenzhen) Limited
 ACB57D Liteon Technology
 D4619D Apple
-D0498B Zoom Server
+D0498B ZOOM Server
 0827CE Nagano Keiki
 C0D3C0 Samsung Electronics
 948BC1 Samsung Electronics
 14568E Samsung Electronics
 14BD61 Apple
-503A7D AlphaTech PLC Intl
+503A7D AlphaTech PLC Int’l
 F4C4D6 Shenzhen Xinfa Electronic
 6837E9 Amazon Technologies
 2CA17D Arris Group
@@ -25228,7 +26461,7 @@ F8AB05 Sagemcom Broadband SAS
 E47DEB Shanghai Notion Information Technology
 C4B9CD Cisco Systems
 D461FE Hangzhou H3C Technologies, Limited
-2C4D54 Asustek Computer
+2C4D54 ASUSTek Computer
 349672 Tp-link Technologies
 64B473 Xiaomi Communications
 7451BA Xiaomi Communications
@@ -25236,20 +26469,20 @@ D461FE Hangzhou H3C Technologies, Limited
 7802F8 Xiaomi Communications
 00238A Ciena
 001081 DPS
-40F385 Ieee Registration Authority
+40F385 IEEE Registration Authority
 887873 Intel Corporate
 F87588 Huawei Technologies
 F44C7F Huawei Technologies
 28A24B Juniper Networks
+080027 PCS Systemtechnik GmbH
 F8A5C5 Cisco Systems
 7C5A1C Sophos
 B0F1EC Ampak Technology
 542B57 Night Owl SP
 501E2D StreamUnlimited Engineering GmbH
 E45D51 SFR
-EC01EE Guangdong Oppo Mobile Telecommunications
+EC01EE Guangdong OPPO Mobile Telecommunications
 6049C1 Avaya
-702084 Hon Hai Precision Ind.
 9C6650 Glodio Technolies,Ltd Tianjin Branch
 A0A33B Huawei Technologies
 7C67A2 Intel Corporate
@@ -25262,7 +26495,7 @@ F06E32 Microtel Innovation S.r.l.
 54C415 Hangzhou Hikvision Digital Technology
 3CF862 Intel Corporate
 2816AD Intel Corporate
-0060D3 At&t
+0060D3 AT&T
 848DC7 Cisco Spvtg
 001992 Adtran
 045D4B Sony
@@ -25286,7 +26519,7 @@ A408F5 Sagemcom Broadband SAS
 00B091 Transmeta
 ACC662 MitraStar Technology
 886B44 Sunnovo International Limited
-A4580F Ieee Registration Authority
+A4580F IEEE Registration Authority
 C8F733 Intel Corporate
 E0A700 Verkada
 58404E Apple
@@ -25311,9 +26544,9 @@ C09C04 Shaanxi GuoLian Digital TV Technology
 ACD657 Shaanxi GuoLian Digital TV Technology
 007686 Cisco Systems
 8C2FA6 Solid Optics
-8C192D Ieee Registration Authority
+8C192D IEEE Registration Authority
 00ACE0 Arris Group
-007532 Inid BV
+007532 INID BV
 6473E2 Arbiter Systems
 88C626 Logitech
 D0608C zte
@@ -25450,7 +26683,6 @@ B43A28 Samsung Electronics
 E4121D Samsung Electronics
 44D6E1 Snuza International
 FC9114 Technicolor CH USA
-486DBB Vestel Elektronik San ve Tic. A..
 002A10 Cisco Systems
 00A289 Cisco Systems
 44E9DD Sagemcom Broadband SAS
@@ -25468,7 +26700,7 @@ EC1F72 Samsung Electro-mechanics(thailand)
 84BE52 Huawei Technologies
 849FB5 Huawei Technologies
 A4CAA0 Huawei Technologies
-84E0F4 Ieee Registration Authority
+84E0F4 IEEE Registration Authority
 D83062 Apple
 D0E54D Arris Group
 A0C562 Arris Group
@@ -25487,7 +26719,7 @@ E4BEED Netcore Technology
 BC8AA3 NHN Entertainment
 A8BD27 Hewlett Packard Enterprise
 345760 MitraStar Technology
-C0D391 Ieee Registration Authority
+C0D391 IEEE Registration Authority
 D49B5C Chongqing Miedu Technology
 E8EB11 Texas Instruments
 44BFE3 Shenzhen Longtech Electronics
@@ -25517,7 +26749,7 @@ C81FBE Huawei Technologies
 D84FB8 LG Electronics
 000AEB Tp-link Technologies
 2C3731 Shenzhen Yifang Digital Technology
-60EE5C Shenzhen Fast Technologies
+60EE5C Shenzhen FAST Technologies
 6488FF Sichuan Changhong Electric
 002162 Nortel Networks
 02E6D3 Nixdorf Computer
@@ -25550,16 +26782,15 @@ C041F6 LG Electronics
 14E7C8 Integrated Device Technology (Malaysia) Sdn. Bhd.
 ECCD6D Allied Telesis
 18339D Cisco Systems
-146102 Alpine Electronics
 54276C Jiangsu Houge Technology
 9CA3A9 Guangzhou Juan Optical and Electronical Tech Joint Stock
 7CC709 Shenzhen Rf-link Technology
-A03E6B Ieee Registration Authority
-9802D8 Ieee Registration Authority
-64FB81 Ieee Registration Authority
+A03E6B IEEE Registration Authority
+9802D8 IEEE Registration Authority
+64FB81 IEEE Registration Authority
 0821EF Samsung Electronics
 34145F Samsung Electronics
-2C265F Ieee Registration Authority
+2C265F IEEE Registration Authority
 D0052A Arcadyan
 E4509A HW Communications
 702900 Shenzhen ChipTrip Technology
@@ -25570,7 +26801,7 @@ ECAAA0 Pegatron
 0007BA UTStarcom
 90A210 United Telecoms
 6C0B84 Universal Global Scientific Industrial
-001597 Aeta Audio Systems
+001597 AETA Audio Systems
 002397 Westell Technologies
 60E3AC LG Electronics (Mobile Communications)
 90F052 Meizu Technology
@@ -25622,7 +26853,7 @@ CCCC81 Huawei Technologies
 B456B9 Teraspek Technologies
 9CDD1F Intelligent Steward
 3C6816 VXi
-E811CA Shandong Kaer Electric.co.
+E811CA Shandong KAER Electric.co.
 70288B Samsung Electronics
 348A7B Samsung Electronics
 D0577B Intel Corporate
@@ -25636,7 +26867,7 @@ C4A366 zte
 444450 OttoQ
 50F5DA Amazon Technologies
 101212 Vivo International
-C85B76 Lcfc(hefei) Electronics Technology
+C85B76 LCFC(HeFei) Electronics Technology
 78FFCA Tecno Mobile Limited
 046565 Testop
 A8BB50 WiZ IoT Company Limited
@@ -25648,7 +26879,7 @@ A8BB50 WiZ IoT Company Limited
 F03EBF Gogoro Taiwan Limited
 3C92DC Octopod Technology
 1000FD LaonPeople
-C47C8D Ieee Registration Authority
+C47C8D IEEE Registration Authority
 745C9F TCT mobile
 8C99E6 TCT mobile
 449F7F DataCore Software
@@ -25685,9 +26916,9 @@ F4CC55 Juniper Networks
 341FE4 Arris Group
 0024F4 Kaminario
 001A29 Johnson Outdoors Marine Electronics d/b/a Minnkota
-0090AE Italtel S.p.a/rf-up-i
+0090AE Italtel/RF-UP-I
 00177D IDT Technology Limited
-00A045 Phoenix Contact Electronics Gmbh
+00A045 Phoenix Contact Electronics GmbH
 002378 GN Netcom A/S
 50C971 GN Netcom A/S
 F0407B Fiberhome Telecommunication Technologies
@@ -25695,7 +26926,7 @@ F0407B Fiberhome Telecommunication Technologies
 C825E1 Lemobile Information Technology (Beijing)
 945089 SimonsVoss Technologies GmbH
 042AE2 Cisco Systems
-E0B6F5 Ieee Registration Authority
+E0B6F5 IEEE Registration Authority
 0090FA Emulex
 00E0D5 Emulex
 001035 Elitegroup Computer Systems
@@ -25734,11 +26965,11 @@ D467E7 Fiberhome Telecommunication Technologies
 E42F26 Fiberhome Telecommunication Technologies
 04C1B9 Fiberhome Telecommunication Technologies
 C4BED4 Avaya
-D017C2 Asustek Computer
+D017C2 ASUSTek Computer
 349971 Quanta Storage
 9C52F8 Huawei Technologies
 EC13DB Juniper Networks
-5CF286 Ieee Registration Authority
+5CF286 IEEE Registration Authority
 E8FD72 Shanghai Linguo Technology
 98BB1E BYD Precision Manufacture Company
 AC5F3E Samsung Electro-mechanics(thailand)
@@ -25754,8 +26985,8 @@ A88195 Samsung Electronics
 00CCFC Cisco Systems
 0019C5 Sony Interactive Entertainment
 001315 Sony Interactive Entertainment
-1C234F Edmi  Europe
-A444D1 Wingtech Group (HongKongLimited
+1C234F EDMI Europe
+A444D1 Wingtech Group (HongKong）Limited
 006CFD Sichuan Changhong Electric
 545AA6 Espressif
 FC1A11 vivo Mobile Communication
@@ -25764,14 +26995,14 @@ A0C589 Intel Corporate
 001E1E Honeywell Life Safety
 002340 MiXTelematics
 B48B19 Apple
-38FDFE Ieee Registration Authority
-2C09CB Cobs AB
+38FDFE IEEE Registration Authority
+2C09CB COBS AB
 BCEC5D Apple
 28A02B Apple
 A84481 Nokia
 8844F6 Nokia
 F44D17 Goldcard High-tech
-38B8EB Ieee Registration Authority
+38B8EB IEEE Registration Authority
 9897D1 MitraStar Technology
 B83241 Wuhan Tianyu Information Industry
 0060DC NEC Magnus Communications
@@ -25800,9 +27031,9 @@ CC6DA0 Roku
 3C8970 Neosfar
 001742 Fujitsu Limited
 001999 Fujitsu Technology Solutions GmbH
-005A39 Shenzhen Fast Technologies
+005A39 Shenzhen FAST Technologies
 A089E4 Skyworth Digital Technology(Shenzhen)
-78CA83 Ieee Registration Authority
+78CA83 IEEE Registration Authority
 0C1167 Cisco Systems
 74EAE8 Arris Group
 F88E85 Comtrend
@@ -25820,10 +27051,10 @@ FC2F40 Calxeda
 BC620E Huawei Technologies
 74A528 Huawei Technologies
 5CF6DC Samsung Electronics
-0026E4 Canal +
-000117 Canal +
+0026E4 Canal
+000117 Canal
 E01D3B Cambridge Industries(Group)
-70C76F Inno S
+70C76F INNO
 38192F Nokia
 B8C68E Samsung Electronics
 04FE31 Samsung Electronics
@@ -25977,21 +27208,21 @@ E8BE81 Sagemcom Broadband SAS
 F4EB38 Sagemcom Broadband SAS
 001BBF Sagemcom Broadband SAS
 002569 Sagemcom Broadband SAS
-141FBA Ieee Registration Authority
-807B85 Ieee Registration Authority
-CC1BE0 Ieee Registration Authority
-F40E11 Ieee Registration Authority
+141FBA IEEE Registration Authority
+807B85 IEEE Registration Authority
+CC1BE0 IEEE Registration Authority
+F40E11 IEEE Registration Authority
 10F681 vivo Mobile Communication
 00217C 2Wire
 001FB3 2Wire
 002275 Belkin International
 0057D2 Cisco Systems
 3C6716 Lily Robotics
-00D0BD Lattice Semiconductor (LPA)
+00D0BD Lattice Semiconductor (lpa)
 001F3A Hon Hai Precision Ind.
 C8A030 Texas Instruments
 78C5E5 Texas Instruments
-0CFD37 Suse Linux Gmbh
+0CFD37 SUSE Linux GmbH
 2C228B CTR SRL
 0C6F9C Shaw Communications
 0017E4 Texas Instruments
@@ -26026,7 +27257,6 @@ B8A386 D-Link International
 ACCF85 Huawei Technologies
 3871DE Apple
 7081EB Apple
-00738D Shenzhen Tinno Mobile Technology
 34BA75 Everest Networks
 7C18CD E-tron
 00E0FC Huawei Technologies
@@ -26112,8 +27342,8 @@ CC78AB Texas Instruments
 1C7839 Shenzhen Tencent Computer System
 FCD733 Tp-link Technologies
 5C899A Tp-link Technologies
-A81B5A Guangdong Oppo Mobile Telecommunications
-2C5BB8 Guangdong Oppo Mobile Telecommunications
+A81B5A Guangdong OPPO Mobile Telecommunications
+2C5BB8 Guangdong OPPO Mobile Telecommunications
 08EB74 Humax
 E005C5 Tp-link Technologies
 388345 Tp-link Technologies
@@ -26133,7 +27363,6 @@ C40528 Huawei Technologies
 80717A Huawei Technologies
 0021E8 Murata Manufacturing
 000E6D Murata Manufacturing
-902106 BSkyB
 D02788 Hon Hai Precision Ind.
 904CE5 Hon Hai Precision Ind.
 001FE2 Hon Hai Precision Ind.
@@ -26207,8 +27436,8 @@ CCD539 Cisco Systems
 006070 Cisco Systems
 500604 Cisco Systems
 00E01E Cisco Systems
-00112F Asustek Computer
-001BFC Asustek Computer
+00112F ASUSTek Computer
+001BFC ASUSTek Computer
 A0554F Cisco Systems
 204C9E Cisco Systems
 84B802 Cisco Systems
@@ -26227,9 +27456,9 @@ F8C288 Cisco Systems
 001EE5 Cisco-Linksys
 484487 Cisco Spvtg
 38C85C Cisco Spvtg
-485B39 Asustek Computer
-BCAEC5 Asustek Computer
-10BF48 Asustek Computer
+485B39 ASUSTek Computer
+BCAEC5 ASUSTek Computer
+10BF48 ASUSTek Computer
 5067AE Cisco Systems
 F09E63 Cisco Systems
 6C9989 Cisco Systems
@@ -26308,10 +27537,10 @@ DC3714 Apple
 28F076 Apple
 141357 ATP Electronics
 B8B2EB Googol Technology (HK) Limited
-FCCF43 Huizhou City Huiyang District Meisiqi Industry Development
+FCCF43 Huizhou CITY Huiyang District Meisiqi Industry Development
 D848EE Hangzhou Xueji Technology
 B4EF04 Daihan Scientific
-A4DEC9 QLove Mobile Intelligence Information Technology (W.H.)
+A4DEC9 QLove Mobile Intelligence Information Technology (w.h.)
 CCE0C3 Exten Technologies
 646A74 Auth-servers
 4C8ECC Silkan SA
@@ -26343,12 +27572,12 @@ DC3CF6 Atomic Rules
 E80734 Champion Optical Network Engineering
 A43831 RF elements s.r.o.
 380546 Foctek Photonics
-D48304 Shenzhen Fast Technologies
+D48304 Shenzhen FAST Technologies
 DC2B2A Apple
 9C8DD3 Leonton Technologies
 E41A2C ZPE Systems
 E8BDD1 Huawei Technologies
-F41535 Spon Communication Technology
+F41535 SPON Communication Technology
 380AAB Formlabs
 382DE8 Samsung Electronics
 C08997 Samsung Electronics
@@ -26359,12 +27588,12 @@ D445E8 Jiangxi Hongpai Technology
 342606 CarePredict
 38B725 Wistron Infocomm (Zhongshan)
 ACEC80 Arris Group
-507B9D Lcfc(hefei) Electronics Technology
+507B9D LCFC(HeFei) Electronics Technology
 6C7220 D-Link International
 30A243 Shenzhen Prifox Innovation Technology
 380195 Samsung Electronics
 246E96 Dell
-44975A Shenzhen Fast Technologies
+44975A Shenzhen FAST Technologies
 5045F7 Liuhe Intelligence Technology
 AC676F Electrocompaniet A.S.
 640DE6 Petra Systems
@@ -26378,12 +27607,12 @@ E01AEA Allied Telesis
 F4C613 Alcatel-Lucent Shanghai Bell
 445F8C Intercel Group Limited
 B88981 Chengdu InnoThings Technology
-F02624 Wafa Technologies
+F02624 WAFA Technologies
 F8F464 Rawe Electonic GmbH
 5C5188 Motorola Mobility, a Lenovo Company
 EC0133 Trinus Systems
 2CC548 IAdea
-14DDA9 Asustek Computer
+14DDA9 ASUSTek Computer
 184F32 Hon Hai Precision Ind.
 DCA3AC RBcloudtech
 0CE725 Microsoft
@@ -26403,10 +27632,10 @@ D00492 Fiberhome Telecommunication Technologies
 1816C9 Samsung Electronics
 00FC8D Hitron Technologies.
 84DF19 Chuango Security Technology
-DC15DB Ge Ruili Intelligent Technology ( Beijing )
+DC15DB Ge Ruili Intelligent Technology ( Beijing
 E0DB10 Samsung Electronics
 546172 Zodiac Aerospace SAS
-EC60E0 Avi-on Labs
+EC60E0 Avi-on LABS
 B46D35 Dalian Seasky Automation;Ltd
 3CA31A Oilfind International
 30F335 Huawei Technologies
@@ -26458,19 +27687,19 @@ EC74BA Hirschmann Automation and Control GmbH
 FC3288 Celot Wireless
 D87495 zte
 5C3B35 Gehirn
-E4FED9 Edmi Europe
-5CF7C3 Syntech (hk) Technology Limited
+E4FED9 EDMI Europe
+5CF7C3 Syntech (HK) Technology Limited
 9CE230 Julong
 5C41E7 Wiatec International
 344CA4 amazipoint technology
-A8F038 Shen Zhen SHI JIN HUA TAI Electronics
+A8F038 SHEN ZHEN SHI JIN HUA TAI Electronics
 ACC73F Vitsmo
 74E277 Vizmonet Pte
 14893E Vixtel Technologies Limted
 BC54F9 Drogoo Technology
 78FC14 Family Zone Cyber Safety
 3809A4 Firefly Integrations
-BCE767 Quanzhou  TDX Electronics
+BCE767 Quanzhou TDX Electronics
 FCAFAC Socionext
 BC4DFB Hitron Technologies.
 2C337A Hon Hai Precision Ind.
@@ -26478,8 +27707,8 @@ BC4DFB Hitron Technologies.
 08EFAB Sayme Wireless Sensor Network
 7076FF Kerlink
 1436C6 Lenovo Mobile Communication Technology
-68F728 Lcfc(hefei) Electronics Technology
-382C4A Asustek Computer
+68F728 LCFC(HeFei) Electronics Technology
+382C4A ASUSTek Computer
 307350 Inpeco SA
 DCEC06 Heimi Network Technology
 CCBDD3 Ultimaker
@@ -26488,7 +27717,7 @@ CCBDD3 Ultimaker
 8463D6 Microsoft
 EC13B2 Netonix
 104E07 Shanghai Genvision Industries
-049B9C Eadingcore  Intelligent Technology
+049B9C Eadingcore Intelligent Technology
 842690 Beijing Thought Science
 801967 Shanghai Reallytek Information Technology
 2CF7F1 Seeed Technology
@@ -26501,22 +27730,21 @@ D84A87 OI Electric
 F03D29 Actility
 88708C Lenovo Mobile Communication Technology
 5014B5 Richfit Information Technology
-CC3F1D Intesis Software SL
 DCDA4F Getck Technology
 101218 Korins
 3428F0 ATN International Limited
 CC10A3 Beijing Nan Bao Technology
 5CAAFD Sonos
 14EDE4 Kaiam
-D01242 Bios
+D01242 BIOS
 603696 The Sapling Company
 54FFCF Mopria Alliance
 F4F26D Tp-link Technologies
 404EEB Higher Way Electronic
 C456FE Lava International
-ACB74F Metel S.r.o.
+ACB74F Metel s.r.o.
 C0EEFB OnePlus Tech (Shenzhen)
-304225 Burg-wchter KG
+304225 Burg-wächter KG
 FCDBB3 Murata Manufacturing
 CCF538 3isysnetworks
 B8BD79 TrendPoint Systems
@@ -26549,7 +27777,7 @@ C03D46 Shanghai Sango Network Technology
 30F7D7 Thread Technology
 18227E Samsung Electronics
 30C7AE Samsung Electronics
-FCD5D9 Shenzhen Sdmc Technology
+FCD5D9 Shenzhen SDMC Technology
 74DA38 Edimax Technology
 E4F4C6 Netgear
 CCA0E5 DZG Metering GmbH
@@ -26564,12 +27792,12 @@ ACA919 TrekStor GmbH
 B025AA Private
 D4B43E Messcomp Datentechnik GmbH
 94C014 Sorter Sp. j. Konrad Grzeszczyk MichaA, Ziomek
-9CFBF1 Mesomatic Gmbh &KG
-1027BE Tvip
+9CFBF1 Mesomatic GmbH &KG
+1027BE TVIP
 2087AC AES motomation
 709383 Intelligent Optical Network High Tech
 80D433 LzLabs GmbH
-B0DA00 Cera Electronique
+B0DA00 CERA Electronique
 1CAB01 Innovolt
 D8B6D6 Blu Tether Limited
 6C2C06 OOO NPP Systemotechnika-NN
@@ -26582,7 +27810,7 @@ B0869E Chloride S.r.L
 D057A1 Werma Signaltechnik GmbH & KG
 B4B542 Hubbell Power Systems
 54CDEE ShenZhen Apexis Electronic
-88E8F8 Yong TAI Electronic (dongguan)
+88E8F8 YONG TAI Electronic (dongguan)
 909864 Impex-Sat GmbH&amp;Co KG
 DCE578 Experimental Factory of Scientific Engineering and Special Design Department
 D86595 Toy's Myth
@@ -26592,7 +27820,7 @@ C4C919 Energy Imports
 38F098 Vapor Stone Rail Systems
 64E892 Morio Denki
 D8DD5F Balmuda
-D86194 Objetivos y Sevicios de Valor Anadido
+D86194 Objetivos y Sevicios de Valor Añadido
 E8FC60 Elcom Innovations Private Limited
 589CFC FreeBSD Foundation
 702C1F Wisol
@@ -26601,15 +27829,15 @@ F85C45 IC Nexus
 ACE069 Isaac Instruments
 30B5C2 Tp-link Technologies
 E07F53 Techboard SRL
-48FEEA Homa
+48FEEA HOMA
 E8EA6A StarTech.com
 04DB8A Suntech International
 90DFB7 s.m.s smart microwave sensors GmbH
 085700 Tp-link Technologies
 FC27A2 Trans Electric
 FCBBA1 Shenzhen Minicreate Technology
-F08A28 Jiangsu Hengsion Electronic S and T
-28BB59 Rnet Technologies
+F08A28 Jiangsu Hengsion Electronic S and
+28BB59 RNET Technologies
 242642 Sharp
 34DE34 zte
 FC1607 Taian Technology(Wuxi)
@@ -26625,7 +27853,6 @@ D0BD01 DS International
 8CDE99 Comlab
 4CE1BB Zhuhai HiFocus Technology
 24A87D Panasonic Automotive Systems Asia Pacific(Thailand)Co.
-EC71DB Shenzhen Baichuan Digital Technology
 A409CB Alfred Kaercher GmbH &amp; KG
 8C569D Imaging Solutions Group
 40B6B1 Sungsam
@@ -26650,7 +27877,7 @@ D46867 Neoventus Design Group
 F81CE5 Telefonbau Behnke GmbH
 889166 Viewcooper
 103378 Flectron
-14EDA5 Wachter GmbH Sicherheitssysteme
+14EDA5 Wächter GmbH Sicherheitssysteme
 50C006 Carmanah Signs
 04CB1D Traka plc
 A4E9A3 Honest Technology
@@ -26694,9 +27921,9 @@ AC5036 Pi-Coral
 0C9B13 Shanghai Magic Mobile TelecommunicationLtd.
 94BF1E eflow / Smart Device Planning and Development Division
 E8516E Tsmart
-AC220B Asustek Computer
+AC220B ASUSTek Computer
 B887A8 Step Ahead Innovations
-E0A198 Noja Power Switchgear
+E0A198 NOJA Power Switchgear
 88354C Transics
 3C6104 Juniper Networks
 CC4AE1 fourtec -Fourier Technologies
@@ -26716,12 +27943,12 @@ CCE8AC Soyea Technology
 B847C6 SanJet Technology
 B8CD93 Penetek
 28DB81 Shanghai Guao Electronic Technology
-3806B4 A.D.C. GmbH
-B8241A Sweda Informatica Ltda
+3806B4 A.d.c. GmbH
+B8241A Sweda Informatica LTDA
 A0B100 ShenZhen Cando Electronics
 201D03 Elatec GmbH
 E067B3 Shenzhen C-Data Technology
-1C4AF7 Amon
+1C4AF7 AMON
 E4776B Aartesys AG
 30F31D zte
 A0EC80 zte
@@ -26734,12 +27961,12 @@ E880D8 Gntek Electronics
 F835DD Gemtek Technology
 D8B04C Jinan USR IOT Technology
 CC04B4 Select Comfort
-5C15E1 Aidc Technology (S) PTE
+5C15E1 AIDC Technology (S) PTE
 E8519D Yeonhab Precision
 DC5726 Power-One
 F8DADF EcoTech
 30AE7B Deqing Dusun Electron
-68EC62 Yodo Technology
+68EC62 YODO Technology
 188857 Beijing Jinhong Xi-Dian Information Technology
 B8C855 Shanghai Gbcom Communication Technology
 78303B Stephen Technologies,Limited
@@ -26752,12 +27979,12 @@ DCD52A Sunny Heart Limited
 D866C6 Shenzhen Daystar Technology
 D00EA4 Porsche Cars North America
 784B08 f.robotics acquisitions
-84E4D9 Shenzhen Need Technology
-40BC73 Cronoplast  S.L.
+84E4D9 Shenzhen NEED technology
+40BC73 Cronoplast S.L.
 4007C0 Railtec Systems GmbH
-A4D3B5 Glitel Stropkov, S.r.o.
-D43A65 Igrs Engineering Lab
-F499AC Weber Schraubautomaten Gmbh
+A4D3B5 Glitel Stropkov, s.r.o.
+D43A65 IGRS Engineering Lab
+F499AC Weber Schraubautomaten GmbH
 D05099 ASRock Incorporation
 A49EDB AutoCrib
 1C76CA Terasic Technologies
@@ -26775,7 +28002,7 @@ F8FEA8 Technico Japan
 102831 Morion
 EC2C49 University of Tokyo
 D82916 Ascent Communication Technology
-2CF203 Emko Elektronik SAN VE TIC AS
+2CF203 EMKO Elektronik SAN VE TIC AS
 B4FE8C Centro Sicurezza Italia SpA
 40E730 DEY Storage Systems
 68B094 Inesa Electron
@@ -26786,19 +28013,19 @@ CC0DEC Cisco Spvtg
 50ABBF Hoseo Telecom
 0C722C Tp-link Technologies
 9CE635 Nintendo
-60A44C Asustek Computer
+60A44C ASUSTek Computer
 185AE8 Zenotech.Co.
 C47DCC Zebra Technologies
 E0AEED Loenk
 E492E7 Gridlink Tech.
-CC047C G-WAY Microwave
+CC047C G-way Microwave
 64535D Frauscher Sensortechnik
 3C6FF7 EnTek Systems
 2C7B5A Milper
 D4BF2D SE Controls Asia Pacific
 E0D9A2 Hippih aps
 FC0647 Cortland Research
-6CD146 Framos Gmbh
+6CD146 Framos GmbH
 54E032 Juniper Networks
 5461EA Zaplox AB
 D08B7E Passif Semiconductor
@@ -26810,7 +28037,7 @@ CC3A61 Samsung Electro Mechanics
 F8D7BF REV Ritter GmbH
 48BE2D Symanitron
 F02329 Showa Denki
-F073AE Peak-system Technik
+F073AE PEAK-System Technik
 48B8DE Homewins Technology
 10EA59 Cisco Spvtg
 0C191F Inform Electronik
@@ -26826,7 +28053,7 @@ B49842 zte
 645A04 Chicony Electronics
 AC1702 Fibar Group sp. z o.o.
 984CD3 Mantis Deposition
-08606E Asustek Computer
+08606E ASUSTek Computer
 3C57D5 FiveCo
 F84897 Hitachi
 F80BD0 Datang Telecom communication terminal (Tianjin)
@@ -26905,13 +28132,13 @@ C0A364 3D Systems Massachusetts
 1C5FFF Beijing Ereneben Information Technology,Ltd Shenzhen Branch
 6045BD Microsoft
 241064 Shenzhen Ecsino Tecnical
-7CEBEA Asct
+7CEBEA ASCT
 9C0DAC Tymphany HK Limited
 70B599 Embedded Technologies s.r.o.
 EC4C4D ZAO NPK RoTeK
 A4D18F Shenzhen Skyee Optical Fiber Communication Technology
 58343B Glovast Technology
-889676 TTC Marconi S.r.o.
+889676 TTC Marconi s.r.o.
 5C1737 I-View Now
 AC0A61 Labor S.r.L.
 1C43EC Japan Circuit
@@ -26923,15 +28150,15 @@ AC0A61 Labor S.r.L.
 20014F Linea Research
 EC0ED6 Itech Instruments SAS
 240917 Devlin Electronics Limited
-9C54CA Zhengzhou Vcom Science and Technology
+9C54CA Zhengzhou VCOM Science and Technology
 B43564 Fujian Tian Cheng Electron Science & Technical Development
 00BF15 Genetec
 38EE9D Anedo
-78BEBD Stulz Gmbh
+78BEBD Stulz GmbH
 D4DF57 Alpinion Medical Systems
 5048EB Beijing Haihejinsheng Network Technology
 B40E96 Heran
-508C77 Dirmeier Schanktechnik Gmbh &Co KG
+508C77 Dirmeier Schanktechnik GmbH &Co KG
 40704A Power Idea Technology Limited
 545EBD NL Technologies
 F47F35 Cisco Systems
@@ -26953,7 +28180,7 @@ A007B6 Advanced Technical Support
 B827EB Raspberry Pi Foundation
 84AF1F Beat System Service
 B058C4 Broadcast Microwave Services
-745798 Trumpf Laser Gmbh + KG
+745798 Trumpf Laser GmbH + KG
 2817CE Omnisense
 3CCE73 Cisco Systems
 B0BD6D Echostreams Innovative Solutions
@@ -26970,7 +28197,7 @@ E425E9 Color-Chip
 E840F2 Pegatron
 50053D CyWee Group
 F88C1C Kaishun Electronic Technology, Beijing
-1C0B52 Epicom S.A
+1C0B52 Epicom
 747E2D Beijing Thomson Citic Digital Technology
 885C47 Alcatel Lucent
 3CC1F6 Melange Systems Pvt.
@@ -26993,7 +28220,7 @@ F0F755 Cisco Systems
 1CB243 TDC A/S
 38BF33 NEC Casio Mobile Communications
 B467E9 Qingdao GoerTek Technology
-186751 Komeg Industrielle Messtechnik Gmbh
+186751 Komeg Industrielle Messtechnik GmbH
 645EBE Yahoo! Japan
 CCC50A Shenzhen Dajiahao Technology
 1CB17F NEC Platforms
@@ -27006,13 +28233,13 @@ D8BF4C Victory Concept Electronics Limited
 8C0CA3 Amper
 94DF58 IJ Electron
 48D54C Jeda Networks
-8CDE52 Issc Technologies
+8CDE52 ISSC Technologies
 082522 Advansee
 4C2F9D ICM Controls
 E467BA Danish Interpretation Systems A/S
 BCB852 Cybera
 C49300 8Devices
-6CA682 Edam Information & Communications
+6CA682 EDAM information & communications
 28D576 Premier Wireless
 70D6B6 Metrum Technologies
 C0A0DE Multi Touch Oy
@@ -27021,17 +28248,17 @@ C0A0DE Multi Touch Oy
 50FC30 Treehouse Labs
 B89674 AllDSP GmbH & KG
 48E1AF Vity
-1CBBA8 Ojsc Ufimskiy Zavod Promsvyaz
+1CBBA8 OJSC "Ufimskiy Zavod "Promsvyaz"
 006BA0 Shenzhen Universal Intellisys PTE
 A898C6 Shinbo
 B4211D Beijing GuangXin Technology
-903CAE Yunnan Ksec Digital Technology
+903CAE Yunnan KSEC Digital Technology
 70704C Purple Communications
 D89760 C2 Development
 F47ACC SolidFire
 905682 Lenbrook Industries Limited
 F0DA7C RLH Industries
-AC319D Shenzhen TG-NET Botone Technology
+AC319D Shenzhen Tg-net Botone Technology
 20107A Gemtek Technology
 78DDD6 c-scape
 C09132 Patriot Memory
@@ -27049,12 +28276,12 @@ A887ED ARC Wireless
 D4D249 Power Ethernet
 80427C Adolf Tedsen GmbH & KG
 E0DADC JVC Kenwood
-E843B6 Qnap Systems
+E843B6 QNAP Systems
 B89BC9 SMC Networks
 409FC7 Baekchun I&C
 00FC58 WebSilicon
 983571 Sub10 Systems
-5404A6 Asustek Computer
+5404A6 ASUSTek Computer
 186D99 Adanis
 A0E201 AVTrace(China)
 F0DEB9 ShangHai Y&Y Electronics
@@ -27063,7 +28290,7 @@ F0DEB9 ShangHai Y&Y Electronics
 98C845 PacketAccess
 989080 Linkpower Network System
 F83376 Good Mind Innovation
-50F61A Kunshan Jade Technologies
+50F61A Kunshan JADE Technologies
 542018 Tely Labs
 581FEF Tuttnaer
 58BDA3 Nintendo
@@ -27071,10 +28298,10 @@ F8F25A G-Lab GmbH
 307ECB SFR
 68F125 Data Controls
 BC764E Rackspace US
-CCC8D7 Cias Elettronica srl
-84D32A Ieee 1905.1
+CCC8D7 CIAS Elettronica srl
+84D32A IEEE 1905.1
 4C0289 LEX Computech
-C0E54E Aries Embedded Gmbh
+C0E54E Aries Embedded GmbH
 F8C001 Juniper Networks
 187C81 Valeo Vision Systems
 ACCC8E Axis Communications AB
@@ -27099,9 +28326,9 @@ CC60BB Empower RF Systems
 7CDD20 Ioxos Technologies
 ECF236 Neomontana Electronics
 0418B6 Private
-E4A5EF Tron Link Electronics
+E4A5EF TRON LINK Electronics
 3071B2 Hangzhou Prevail Optoelectronic Equipment
-DCCE41 FE Global Hong Kong Limited
+DCCE41 FE Global HONG KONG Limited
 FC6C31 LXinstruments GmbH
 705CAD Konami Gaming
 3C6F45 Fiberpro
@@ -27109,7 +28336,7 @@ FC6C31 LXinstruments GmbH
 30E4DB Cisco Systems
 88E0F3 Juniper Networks
 80971B Altenergy Power System
-587675 Beijing Echo Technologies
+587675 Beijing ECHO Technologies
 0C51F7 Chauvin Arnoux
 0CFC83 Airoha Technology,
 007F28 Actiontec Electronics
@@ -27117,7 +28344,7 @@ FC6C31 LXinstruments GmbH
 B09BD4 GNH Software India Private Limited
 F08BFE Costel.
 3C26D5 Sotera Wireless
-E84E06 Edup International (hk)
+E84E06 EDUP International (HK)
 00077D Cisco Systems
 CCD9E9 SCR Engineers
 34A709 Trevil srl
@@ -27130,7 +28357,7 @@ B45CA4 Thing-talk Wireless Communication Technologies Limited
 D0AFB6 Linktop Technology
 98EC65 Cosesy ApS
 ACC935 Ness
-008D4E Cjsc NII STT
+008D4E CJSC NII STT
 98F8DB Marini Impianti Industriali s.r.l.
 E41289 topsystem Systemhaus GmbH
 58E808 Autonics
@@ -27172,7 +28399,7 @@ B8F4D0 Herrmann Ultraschalltechnik GmbH & Kg
 C45600 Galleon Embedded Computing
 BC3E13 Accordance Systems
 A81B18 XTS
-D0A311 Neuberger Gebudeautomation GmbH
+D0A311 Neuberger Gebäudeautomation GmbH
 041D10 Dream Ware
 801440 Sunlit System Technology
 180B52 Nanotron Technologies GmbH
@@ -27207,7 +28434,7 @@ A424B3 FlatFrog Laboratories AB
 340804 D-Link
 F05D89 Dycon Limited
 AC80D6 Hexatronic AB
-9CF938 Areva NP Gmbh
+9CF938 Areva NP GmbH
 8CDB25 ESG Solutions
 FC3598 Favite
 90D92C Hug-witschi AG
@@ -27244,30 +28471,30 @@ F0C88C LeddarTech
 643409 BITwave Pte
 40C245 Shenzhen Hexicom Technology
 CC55AD RIM
-E8757F Firs Technologies(shenzhen)
+E8757F FIRS Technologies(Shenzhen)
 F0F7B3 Phorm
 00D38D Hotel Technology Next Generation
-C83EA7 Kunbus Gmbh
-60893C Thermo Fisher Scientific P.O.A.
+C83EA7 Kunbus GmbH
+60893C Thermo Fisher Scientific P.o.a.
 D86BF7 Nintendo
 74CD0C Smith Myers Communications
 CCCE40 Janteq
 B8EE79 YWire Technologies
-74D675 Wyma Tecnologia
+74D675 WYMA Tecnologia
 B40EDC LG-Ericsson
 E0EE1B Panasonic Automotive Systems Company of America
-74BE08 Atek Products
+74BE08 ATEK Products
 6063FD Transcend Communication Beijing
 D8B6C1 NetworkAccountant
 74A4A7 QRS Music Technologies
 700258 01db-metravib
 F455E0 Niceway CNC Technology,Ltd.Hunan Province
-20FDF1 3com Europe
+20FDF1 3COM Europe
 8497B8 Memjet
 A0DDE5 Sharp
 206AFF Atlas Elektronik UK Limited
 AC34CB Shanhai Gbcom Communication Technology
-9088A2 Ionics Technology ME Ltda
+9088A2 Ionics Technology ME LTDA
 40CD3A Z3 Technology
 482CEA Motorola Business Light Radios
 00336C SynapSense
@@ -27294,10 +28521,10 @@ FC7CE7 FCI USA
 78818F Server Racks Australia
 284846 GridCentric
 30694B RIM
-6C626D Micro-Star INT'L
+6C626D Micro-Star Int'l
 28068D ITL
 C00D7E Additech
-84C7A9 C3po
+84C7A9 C3PO
 D87157 Lenovo Mobile Communication Technology
 609AA4 GVI Security
 641084 Hexium Technical Development
@@ -27311,9 +28538,9 @@ F09CBB RaonThink
 38C7BA CS Services
 EC5C69 Mitsubishi Heavy Industries Mechatronics Systems
 6C92BF Inspur Electronic Information Industry
-44A8C2 Sewoo Tech
+44A8C2 Sewoo TECH
 80EE73 Shuttle
-FCE23F Clay Paky SPA
+FCE23F CLAY PAKY SPA
 58570D Danfoss Solar Inverters
 C4823F Fujian Newland Auto-ID Tech.
 E85B5B LG Electronics
@@ -27329,7 +28556,7 @@ A479E4 Klinfo
 D0F0DB Ericsson
 7C1476 Damall Technologies SAS
 8C541D LGE
-00A2DA Inat Gmbh
+00A2DA INAT GmbH
 003CC5 Wonwoo Engineering
 F077D0 Xcellen
 4CC602 Radios
@@ -27340,15 +28567,15 @@ D828C9 General Electric Consumer and Industrial
 44C233 Guangzhou Comet Technology DevelopmentLtd
 30EFD1 Alstom Strongwish (Shenzhen)
 7C2CF3 Secure Electrans
-081651 Shenzhen SEA Star Technology
+081651 Shenzhen SEA STAR Technology
 A863DF Displaire
 183BD2 BYD Precision Manufacture Company
 E43593 Hangzhou GoTo technologyLtd
-2C3A28 Fagor Electrnica
+2C3A28 Fagor Electrónica
 B45861 CRemote
 B0973A E-Fuel
 204E6B Axxana(israel)
-80F593 Irco Sistemas de Telecomunicacin
+80F593 IRCO Sistemas de Telecomunicación
 E497F0 Shanghai VLC Technologies
 B40832 TC Communications
 ECDE3D Lamprey Networks
@@ -27375,17 +28602,17 @@ E0E751 Nintendo
 003AAF BlueBit
 64168D Cisco Systems
 003A9C Cisco Systems
-7C6C8F AMS Neve
+7C6C8F AMS NEVE
 9CB206 Procentec
 88ED1C Cudo Communication
 9CCD82 Cheng UEI Precision Industry
 F06281 ProCurve Networking by HP
-C09C92 Coby
+C09C92 COBY
 C038F9 Nokia Danmark A/S
 F46349 Diffon
 74F07D BnCOM
 F852DF VNL Europe AB
-A8CB95 East Best
+A8CB95 EAST BEST
 F45FF7 DQ Technology
 7C3BD5 Imago Group
 5CE223 Delphin Technology AG
@@ -27410,7 +28637,7 @@ EC6C9F Chengdu Volans Technology
 002702 SolarEdge Technologies
 002704 Accelerated Concepts
 0026FA BandRich
-0026F9 S.E.M. srl
+0026F9 S.e.m. srl
 0026FD Interactive Intelligence
 0026F7 Nivetti Systems Pvt.
 0026F6 Military Communication Institute
@@ -27431,11 +28658,11 @@ EC6C9F Chengdu Volans Technology
 002690 I DO IT
 00268F MTA SpA
 002679 Euphonic Technologies
-0026AC Shanghai Luster Teraband Photonic
+0026AC Shanghai Luster Teraband photonic
 0026A6 Trixell
-00269C Itus Japan
+00269C ITUS Japan
 002694 Senscient
-002676 Commidt AS
+002676 COMMidt AS
 00261D COP Security System
 002617 OEM Worldwide
 002613 Engel Axil S.L.
@@ -27444,14 +28671,14 @@ EC6C9F Chengdu Volans Technology
 00260F Linn Products
 00260C Dataram
 00262B Wongs Electronics
-002620 Isgus Gmbh
+002620 Isgus GmbH
 002601 Cutera
 002635 Bluetechnix GmbH
-002657 OOO NPP Ekra
+002657 OOO NPP EKRA
 002652 Cisco Systems
 002666 EFM Networks
 0025F5 DVS Korea,
-0025EB Reutech Radar Systems (PTY)
+0025EB Reutech Radar Systems (pty)
 0025EE Avtex
 0025AE Microsoft
 0025AF Comfile Technology
@@ -27467,8 +28694,8 @@ EC6C9F Chengdu Volans Technology
 0025A4 EuroDesign embedded technologies GmbH
 0025C1 Nawoo Korea
 0025F6 netTALK.com
-00257A Camco Produktions- und Vertriebs-gmbh Fr  Beschallungs- und Beleuchtungsanlagen
-002576 Neli Technologies
+00257A Camco Produktions- und Vertriebs-GmbH für Beschallungs- und Beleuchtungsanlagen
+002576 NELI Technologies
 002574 Kunimi Media Device
 002559 Syphan Technologies
 002554 Pixel8 Networks
@@ -27476,7 +28703,7 @@ EC6C9F Chengdu Volans Technology
 002533 Wittenstein AG
 002530 Aetas Systems
 00252C Entourage Systems
-00258C Esus Elektronik SAN. VE DIS. TIC. STI.
+00258C ESUS Elektronik SAN. VE DIS. TIC. STI.
 00255A Tantalus Systems
 002587 Vitality
 002573 ST Electronics (Info-Security) Pte
@@ -27499,7 +28726,7 @@ EC6C9F Chengdu Volans Technology
 0024F5 NDS Surgical Imaging
 002467 AOC International (Europe) GmbH
 00246D Weinzierl Engineering GmbH
-002470 Aurotech Ultrasound AS.
+002470 Aurotech ultrasound AS.
 00246A Solid Year
 002492 Motorola, Broadband Solutions Group
 00248B Hybus
@@ -27507,7 +28734,7 @@ EC6C9F Chengdu Volans Technology
 002480 Meteocontrol GmbH
 00247A FU YI Cheng Technology
 002476 TAP.tv
-0024B4 Escatronic Gmbh
+0024B4 Escatronic GmbH
 0024B1 Coulomb Technologies
 00249C Bimeng Comunication System
 002498 Cisco Systems
@@ -27545,7 +28772,7 @@ EC6C9F Chengdu Volans Technology
 0023C3 LogMeIn
 0023B0 Comxion Technology
 0023E1 Cavena Image Products AB
-00237E Elster Gmbh
+00237E Elster GMBH
 00237C Neotion
 00237A RIM
 00236D ResMed
@@ -27553,13 +28780,13 @@ EC6C9F Chengdu Volans Technology
 002361 Unigen
 00232C Senticare
 00232B IRD A/S
-002336 Metel S.r.o.
+002336 Metel s.r.o.
 002338 OJ-Electronics A/S
 00233B C-Matic Systems
 00232A eonas IT-Beratung und -Entwicklung GmbH
 002327 Shouyo Electronics
 002328 Alcon Telecommunications
-002372 More Star Industrial Group Limited
+002372 MORE STAR Industrial Group Limited
 00234C KTC AB
 002343 TEM AG
 00235F Silicon Micro Sensors GmbH
@@ -27576,11 +28803,11 @@ EC6C9F Chengdu Volans Technology
 00230D Nortel Networks
 002303 Lite-on IT
 0022ED TSI Power
-0022E1 Zort Labs
+0022E1 ZORT Labs
 0022E0 Atlantic Software Technologies S.r.L.
 0022DF Tamuz Monitors
 00231A ITF
-0022BC Jdsu France SAS
+0022BC JDSU France SAS
 0022AA Nintendo
 0022C9 Lenord, Bauer & GmbH
 00228C Photon Europe GmbH
@@ -27590,20 +28817,20 @@ EC6C9F Chengdu Volans Technology
 00224A Raylase AG
 00224B Airtech Technologies
 002256 Cisco Systems
-002252 Zoll Lifecor
+002252 ZOLL Lifecor
 00224D Mitac International
 00229F Sensys Traffic AB
 002299 SeaMicro
-00226D Shenzhen Giec Electronics
+00226D Shenzhen GIEC Electronics
 00226E Gowell Electronic Limited
 00225D Digicable Network India Pvt.
 00227B Apogee Labs
-00227D YE Data
+00227D YE DATA
 0022A8 Ouman Oy
 002223 TimeKeeping Systems
 00221A Audio Precision
 002218 Akamai Technologies
-00223C Ratio Entwicklungen Gmbh
+00223C Ratio Entwicklungen GmbH
 0021E7 Informatics Services
 0021DC Tecnoalarm S.r.l.
 0021F1 Tutus Data AB
@@ -27612,7 +28839,7 @@ EC6C9F Chengdu Volans Technology
 002222 Schaffner Deutschland GmbH
 0021F8 Enseo
 0021F3 Si14 SpA
-002231 SMT&C
+002231 Smt&c
 002213 PCI
 002201 Aksys Networks
 00217B Bastec AB
@@ -27632,20 +28859,20 @@ EC6C9F Chengdu Volans Technology
 0021C4 Consilium AB
 002189 AppTech
 002122 Chip-pro
-002125 KUK JE Tong Shin
+002125 KUK JE TONG SHIN
 002126 Shenzhen Torch Equipment
 002113 Padtec S/A
 002112 Wiscom System
-00210E Orpak Systems L.T.D.
+00210E Orpak Systems L.t.d.
 002161 Yournet
-00215F Ihse Gmbh
+00215F IHSE GmbH
 002135 Alcatel-lucent
 002138 Cepheid
 002147 Nintendo
-002149 China Daheng Group
+002149 China Daheng Group 
 002156 Cisco Systems
 002151 Millinet
-00216C Odva
+00216C ODVA
 00211C Cisco Systems
 002118 Athena Tech
 001FBD Kyocera Wireless
@@ -27656,7 +28883,7 @@ EC6C9F Chengdu Volans Technology
 001FC8 Up-Today Industrial
 001FC5 Nintendo
 001FC0 Control Express Finland Oy
-001FBC Evga
+001FBC EVGA
 001FF9 Advanced Knowledge Associates
 001FED Tecan Systems
 001FE5 In-Circuit GmbH
@@ -27680,7 +28907,7 @@ EC6C9F Chengdu Volans Technology
 001F9E Cisco Systems
 001EE6 Shenzhen Advanced Video Info-Tech
 001EF7 Cisco Systems
-001F0B Federal State Unitary Enterprise Industrial UnionElectropribor
+001F0B Federal State Unitary Enterprise Industrial Union"Electropribor"
 001F0C Intelligent Digital Services GmbH
 001F08 Risco
 001F43 Entes Elektronik
@@ -27704,18 +28931,18 @@ EC6C9F Chengdu Volans Technology
 001ED6 Alentec & Orion AB
 001EC6 Obvius Holdings
 001EC4 Celio
-001EC1 3com Europe
+001EC1 3COM Europe
 001EB6 TAG Heuer SA
 001EAC Armadeus Systems
 001E77 Air2App
-001E7B R.I.CO. S.r.l.
+001E7B R.i.co. S.r.l.
 001E6E Shenzhen First Mile Communications
 001E6D IT R&D Center
 001E34 CryptoMetrics
-001E2D Stim
+001E2D STIM
 001E41 Microwave Communication & Component
-001DFC Ksic
-001E55 Cowon Systems
+001DFC KSIC
+001E55 Cowon SYSTEMS
 001E56 Bally Wulff Entertainment GmbH
 001E3F TrellisWare Technologies
 001E57 Alcoma, spol. s r.o.
@@ -27726,14 +28953,14 @@ EC6C9F Chengdu Volans Technology
 001DF1 Intego Systems
 001DED Grid Net
 001DC3 Rikor TV
-001DC1 Audinate L
+001DC1 Audinate
 001DB2 Hokkaido Electric Engineering
-001DAD Sinotech Engineering Consultants,  Geotechnical Enginee
+001DAD Sinotech Engineering Consultants, Geotechnical Enginee
 001DAB SwissQual License AG
 001D9C Rockwell Automation
 001DA0 Heng Yu Electronic Manufacturing Company Limited
 001DD8 Microsoft
-001DC8 Navionics Research, dba Scadametrics
+001DC8 Navionics Research, dba SCADAmetrics
 001DCC Ayon Cyber Security
 001D92 Micro-star Int'l
 001D8A TechTrex
@@ -27746,13 +28973,13 @@ EC6C9F Chengdu Volans Technology
 001D1D Inter-M
 001D0E Agapha Technology
 001D0A Davis Instruments
-001D67 Amec
+001D67 AMEC
 001D7C ABE Elettronica
 001D6D Confidant International
 001D75 Radioscape PLC
 001D53 S&O Electronics (Malaysia) Sdn. Bhd.
 001D54 Sunnic Technology & Merchandise
-001D5F Overspeed Sarl
+001D5F OverSpeed SARL
 001D58 CQ
 001D87 VigTech Labs Sdn Bhd
 001D2F QuantumVision
@@ -27787,7 +29014,7 @@ EC6C9F Chengdu Volans Technology
 001C8B MJ Innovations
 001C6D Kyohritsu Electronic Industry
 001C96 Linkwise Technology Pte
-001C29 Core Digital Electronics
+001C29 CORE Digital Electronics
 001C24 Formosa Wireless Systems
 001C20 CLB Benelux
 001C1C Center Communication Systems GmbH
@@ -27798,11 +29025,11 @@ EC6C9F Chengdu Volans Technology
 001BD6 Kelvin Hughes
 001BCF Dataupia
 001BCB Pempek Systems
-001BF5 Tellink Sistemas de Telecomunicacin S.L.
+001BF5 Tellink Sistemas de Telecomunicación S.L.
 001BE6 VR AG
 001BE2 AhnLab
-001BE0 Telenot Electronic Gmbh
-001C34 Huey Chiao International
+001BE0 Telenot Electronic GmbH
+001C34 HUEY Chiao International
 001C36 iNEWiT NV
 001C15 iPhotonix
 001C07 Cwlinux Limited
@@ -27810,7 +29037,7 @@ EC6C9F Chengdu Volans Technology
 001B9F Calyptech
 001B9A Apollo Fire Detectors
 001BBD FMC Kongsberg Subsea AS
-001BBE Icop Digital
+001BBE ICOP Digital
 001BB3 Condalo GmbH
 001BB7 Alta Heights Technology
 001B99 KS System GmbH
@@ -27818,7 +29045,7 @@ EC6C9F Chengdu Volans Technology
 001B8C JMicron Technology
 001B91 Efkon AG
 001B82 Taiwan Semiconductor
-001B89 Emza Visual Sense
+001B89 EMZA Visual Sense
 001B8B NEC Platforms
 001BAC Curtiss Wright Controls Embedded Computing
 001B6A Powerwave Technologies Sweden AB
@@ -27833,7 +29060,7 @@ EC6C9F Chengdu Volans Technology
 001B53 Cisco Systems
 001B49 Roberts Radio limited
 001B0E InoTec GmbH Organisationssysteme
-001B04 Affinity International S.p.a
+001B04 Affinity International
 001B06 Ateliers R. Laumonier
 001B31 Neural Image.
 001B29 Avantis.Co.
@@ -27880,13 +29107,13 @@ EC6C9F Chengdu Volans Technology
 0019F3 Cetis
 0019EF Shenzhen Linnking Electronics
 0019F7 Onset Computer
-0019EE Carlo Gavazzi Controls Spa-controls Division
+0019EE Carlo Gavazzi Controls SPA-Controls Division
 0019BF Citiway technology
 0019B6 Euro Emme s.r.l.
 0019EB Pyronix
 0019E7 Cisco Systems
 0019E9 S-Information Technolgy,
-0019DA Welltrans O&E Technology
+0019DA Welltrans O&E Technology 
 001A14 Xin Hua Control Engineering
 001A10 Lucent Trans Electronics
 001A0C Swe-Dish Satellite Systems AB
@@ -27894,7 +29121,7 @@ EC6C9F Chengdu Volans Technology
 0019D0 Cathexis
 0019D6 LS Cable and System
 0019D7 Fortunetek
-001A02 Secure Care Products
+001A02 Secure CARE Products
 0019F8 Embedded Systems Design
 001A07 Arecont Vision
 001A08 Simoco
@@ -27914,7 +29141,7 @@ EC6C9F Chengdu Volans Technology
 00199A Edo-evi
 001994 Jorjin Technologies
 00197C Riedel Communications GmbH
-0019A0 Nihon Data Systens
+0019A0 Nihon DATA Systens
 001991 avinfo
 00198C iXSea
 001962 Commerciant
@@ -27922,7 +29149,7 @@ EC6C9F Chengdu Volans Technology
 0018DD Silicondust Engineering
 0018DF The Morey
 0018E1 Verkerk Service Systemen
-0018DA Wrth Elektronik eiSos GmbH & KG
+0018DA Würth Elektronik eiSos GmbH & KG
 0018D5 Reigncom
 0018E7 Cameo Communications
 0018E4 Yiguang
@@ -27933,11 +29160,11 @@ EC6C9F Chengdu Volans Technology
 001928 Siemens AG, Transportation Systems
 001915 Tecom
 00191B Sputnik Engineering AG
-001909 Devi - Danfoss A/S
+001909 DEVI - Danfoss A/S
 001933 Strix Systems
 001904 WB Electronics Sp. z o.o.
 001934 Trendon Touch Technology
-00190D Ieee 1394c
+00190D IEEE 1394c
 001881 Buyang Electronics Industrial
 001876 WowWee
 00187A Wiremold
@@ -27948,7 +29175,7 @@ EC6C9F Chengdu Volans Technology
 0018A7 Yoggie Security Systems
 0018A2 XIP Technology AB
 00189C Weldex
-00189A Hana Micron
+00189A HANA Micron
 001864 Eaton
 001866 Leutron Vision
 001860 SIM Technology Group Shanghai Simcom,
@@ -27982,7 +29209,7 @@ EC6C9F Chengdu Volans Technology
 0017C5 SonicWALL
 0017BE Tratec Telecom
 0017C0 PureTech Systems
-0017BA Sedo
+0017BA SEDO
 0017D4 Monsoon Multimedia
 001780 Applied Biosystems
 0017A5 Ralink Technology
@@ -28005,8 +29232,8 @@ EC6C9F Chengdu Volans Technology
 001722 Hanazeder Electronic GmbH
 00173D Neology
 001740 Bluberi Gaming Technologies
-001732 Science-technical Center Rissa
-00176D Core
+001732 Science-Technical Center "rissa"
+00176D CORE
 001773 Laketune Technologies
 00173A Cloudastructure
 00172F NeuLion Incorporated
@@ -28023,7 +29250,7 @@ EC6C9F Chengdu Volans Technology
 0016E1 SiliconStor
 0016E2 American Fibertek
 001713 Tiger NetCom
-0016CD Hiji High-tech
+0016CD HIJI High-tech
 0016EF Koko Fitness
 0016FD Jaty Electronics
 001678 Shenzhen Baoan Gaoke Electronics
@@ -28038,24 +29265,23 @@ EC6C9F Chengdu Volans Technology
 00167E Diboss.co.
 00167B Haver&Boecker
 001679 eOn Communications
-0016A3 Ingeteam Transmission&Distribution
 0016A0 Auto-Maskin
 00165D AirDefense
 00165B Grip Audio
-001667 A-TEC Subsystem
+001667 A-tec Subsystem
 00164A Vibration Technology Limited
 001645 Power Distribution
-00163F Crete Systems
+00163F CReTE Systems
 00163D Tsinghua Tongfang Legend Silicon Tech.
 00162D STNet
-001627 Embedded-logic Design AND More Gmbh
-00163A Yves Technology
+001627 embedded-logic Design AND MORE GmbH
+00163A YVES Technology
 001638 Tecom
 001633 Oxford Diagnostics
 0015EC Boca Devices
 0015EF NEC Tokin
 0015E4 Zimmer Elektromedizin
-001622 BBH Systems Gmbh
+001622 BBH Systems GMBH
 001613 LibreStream Technologies
 00160F Badger Meter
 001604 Sigpro
@@ -28080,18 +29306,18 @@ EC6C9F Chengdu Volans Technology
 001595 Quester Tangent
 001587 Takenaka Seisakusho
 00151A Hunter Engineering Company
-001514 Hu Zhou Nava Networks&electronics
+001514 Hu Zhou NAVA Networks&Electronics
 001516 Uriel Systems
 001545 Seecode
 001543 Aberdeen Test Center
 001541 StrataLight Communications
-001569 Peco II
-001564 Behringer Spezielle Studiotechnik Gmbh
+001569 PECO II
+001564 Behringer Spezielle Studiotechnik GmbH
 001563 Cisco Systems
 001561 JJPlus
 001571 Nolan Systems
 001565 Xiamen Yealink Network Technology
-001538 RFID
+001538 Rfid
 00152E PacketHop
 001558 Foxconn
 00151F Multivision Intelligent Surveillance (Hong Kong)
@@ -28134,7 +29360,7 @@ EC6C9F Chengdu Volans Technology
 001443 Consultronics Europe
 001460 Kyocera Wireless
 0013F5 Akimbi Systems
-0013F1 Amod Technology
+0013F1 AMOD Technology
 0013E7 Halcro
 0013EA Kamstrup A/S
 0013E1 Iprobe AB
@@ -28143,23 +29369,23 @@ EC6C9F Chengdu Volans Technology
 0013C1 Asoka USA
 0013C0 Trix Tecnologia Ltda.
 00141F SunKwang Electronics
-001412 S-TEC electronics AG
+001412 S-tec electronics AG
 001411 Deutschmann Automation GmbH & KG
 001405 OpenIB
-004501 Midmark Rtls
+004501 Midmark RTLS
 001403 Renasis
 001401 Rivertree Networks
 0013D9 Matrix Product Development
 0013CC Tall Maple Systems
 001394 Infohand
-001389 Redes de Telefona Mvil
+001389 Redes de Telefonía Móvil
 00138C Kumyoung.Co.Ltd
 0013A1 Crow Electronic Engeneering
 00139C Exavera Technologies
 001355 Tomen Cyber-business Solutions
 001357 Soyal Technology
 001360 Cisco Systems
-00138E Foab Elektronik AB
+00138E FOAB Elektronik AB
 001376 Tabor Electronics
 00135D Nttpc Communications
 001352 Naztec
@@ -28182,7 +29408,7 @@ EC6C9F Chengdu Volans Technology
 001347 Red Lion Controls
 00132E ITian Coporation
 001339 CCV Deutschland GmbH
-001329 Vsst
+001329 VSST
 00132B Phoenix Digital
 00130B Mextal
 00130D Galileo Avionica
@@ -28195,11 +29421,11 @@ EC6C9F Chengdu Volans Technology
 0012C2 Apex Electronics Factory
 0012BE Astek
 0012E1 Alliant Networks
-0012C5 V-Show  Technology (China)
+0012C5 V-Show Technology (China)
 0012A0 NeoMeridian Sdn Bhd
 001286 Endevco
 001263 Data Voice Technologies GmbH
-001270 Nges Denro Systems
+001270 NGES Denro Systems
 00126E Seidel Elektronik GmbH Nfg.KG
 00126F Rayson Technology
 00125C Green Hills Software
@@ -28207,7 +29433,7 @@ EC6C9F Chengdu Volans Technology
 00122D SiNett
 001274 NIT lab
 001253 AudioDev AB
-00124C Bbwm
+00124C BBWM
 001255 NetEffect Incorporated
 001244 Cisco Systems
 00122C Soenen Controls N.V.
@@ -28224,7 +29450,6 @@ EC6C9F Chengdu Volans Technology
 001201 Cisco Systems
 0011EE Estari
 001200 Cisco Systems
-0011E5 KCodes
 0011DE Eurilogic
 0011C8 Powercom
 0011B8 Liebherr - Elektronik GmbH
@@ -28241,19 +29466,19 @@ EC6C9F Chengdu Volans Technology
 00119D Diginfo Technology
 00119C EP&T Energy
 00119A Alkeria srl
-0011C1 4P Mobile Data Processing
+0011C1 4P Mobile DATA Processing
 0011B2 2001 Technology
 0011AF Medialink-i
 00115E ProMinent Dosiertechnik GmbH
 00117C e-zy.net
-001139 Stoeber Antriebstechnik Gmbh + KG.
+001139 Stoeber Antriebstechnik GmbH + KG.
 00113E JL
 001138 Taishin
 001136 Goodrich Sensor Systems
 00114B Francotyp-Postalia GmbH
 001147 Secom-IndustryLTD.
 00114A Kayaba Industry
-001142 E-smartcom
+001142 e-SMARTCOM
 001120 Cisco Systems
 001118 BLX IC Design
 001107 RGB Networks
@@ -28281,11 +29506,11 @@ EC6C9F Chengdu Volans Technology
 000F83 Brainium Technologies
 000F84 Astute Networks
 000F5C Day One Digital Media Limited
-000F52 York Refrigeration, Marine & Controls
+000F52 YORK Refrigeration, Marine & Controls
 000F4C Elextech
 000F93 Landis+Gyr
 000F94 Genexis BV
-000F6C Addi-data Gmbh
+000F6C Addi-data GmbH
 000F8F Cisco Systems
 000F7D Xirrus
 000F76 Digital Keystone
@@ -28294,7 +29519,7 @@ EC6C9F Chengdu Volans Technology
 000F17 Insta Elektro GmbH
 000F1E Chengdu KT Electricof High & New Technology
 000F15 Icotera A/S
-000F39 Iris Sensors
+000F39 IRIS Sensors
 000F3E CardioNet
 000F3F Big Bear Networks
 000F35 Cisco Systems
@@ -28303,7 +29528,7 @@ EC6C9F Chengdu Volans Technology
 000F23 Cisco Systems
 000F22 Helius
 000F24 Cisco Systems
-000EFC Jtag Technologies
+000EFC JTAG Technologies
 000EFE EndRun Technologies
 000F2C Uplogix
 000F2B Greenbell Systems
@@ -28312,7 +29537,7 @@ EC6C9F Chengdu Volans Technology
 000F08 Indagon Oy
 000F04 cim-usa
 000F42 Xalyo Systems
-000EA5 Blip Systems
+000EA5 BLIP Systems
 000EA0 NetKlass Technology
 000EE4 BOE Technology Group
 000EDE Remec
@@ -28323,7 +29548,7 @@ EC6C9F Chengdu Volans Technology
 000EB8 Iiga
 000EBE B&B Electronics Manufacturing
 000EBB Everbee Networks
-000ECE S.I.T.T.I.
+000ECE S.i.t.t.i.
 000ED4 Cresitt Industrie
 000ED6 Cisco Systems
 000ED8 Positron Access Solutions
@@ -28359,9 +29584,9 @@ EC6C9F Chengdu Volans Technology
 000DB3 SDO Communication Corperation
 000DAE Samsung Heavy Industries
 000DB2 Ammasso
-000E0D Hesch Schrder GmbH
+000E0D Hesch Schröder GmbH
 000DF6 Technology Thesaurus
-000DFF Chenming Mold Industry
+000DFF Chenming MOLD Industry
 000DC7 Cosmic Engineering
 000DC2 Private
 000DBF TekTone Sound & Signal Mfg.
@@ -28372,16 +29597,15 @@ EC6C9F Chengdu Volans Technology
 000D60 IBM
 000D67 Ericsson
 000D5F Minds
-000D9C Elan GmbH & KG
-000D98 S.W.A.C. Schmitt-Walter Automation Consult GmbH
+000D98 S.w.a.c. Schmitt-Walter Automation Consult GmbH
 000D8C Shanghai Wedone Digital
-000D94 Afar Communications
+000D94 AFAR Communications
 000DAA S.A.Tehnology
 000DA6 Universal Switching
 000D8D Prosoft Technology
 000D84 Makus
 000D73 Technical Support
-000D69 TMT&D
+000D69 Tmt&d
 000DA2 Infrant Technologies
 000D68 Vinci Systems
 000D64 Comag Handels AG
@@ -28394,7 +29618,7 @@ EC6C9F Chengdu Volans Technology
 000D34 Shell International Exploration and Production
 000D32 DispenseSource
 000CF6 Sitecom Europe BV
-000CF2 Gamesa Elica
+000CF2 Gamesa Eólica
 000D2E Matsushita Avionics Systems
 000D28 Cisco Systems
 000D4D Ninelanes
@@ -28409,12 +29633,12 @@ EC6C9F Chengdu Volans Technology
 000C90 Octasic
 000C8C Kodicom
 000CC2 ControlNet (India) Private Limited
-000C94 United Electronic Industries, (EUI)
+000C94 United Electronic Industries, (eui)
 000C9B EE Solutions
 000CE1 The Open Group
-000CDC Becs Technology
+000CDC BECS Technology
 000CC5 Nextlink
-000CDE ABB Stotz-kontakt Gmbh
+000CDE ABB Stotz-kontakt GmbH
 000CBF Holy Stone Ent.
 000C4D Curtiss-Wright Controls Avionics & Electronics
 000C44 Automated Interfaces
@@ -28456,7 +29680,7 @@ EC6C9F Chengdu Volans Technology
 000C00 BEB Industrie-Elektronik AG
 000BF3 BAE Systems
 000BED ELM
-000B91 Aglaia Gesellschaft fr Bildverarbeitung und Kommunikation mbH
+000B91 Aglaia Gesellschaft für Bildverarbeitung und Kommunikation mbH
 000B97 Matsushita Electric Industrial
 000B92 Ascom Danmark A/S
 000B9A Shanghai Ulink Telecom Equipment
@@ -28485,7 +29709,7 @@ EC6C9F Chengdu Volans Technology
 000AEE GCD Hard- & Software GmbH
 000AD8 IPCserv Technology
 000AD7 Origin Electric
-000B38 Knrr GmbH
+000B38 Knürr GmbH
 000B32 Vormetric
 000B07 Voxpath Networks
 000B04 Volktek
@@ -28509,10 +29733,10 @@ EC6C9F Chengdu Volans Technology
 000A96 Mewtel Technology
 000A82 Tatsuta System Electronics
 000AD3 Initech
-000AC8 Zpsys,ltd. (planning&management)
+000AC8 Zpsys,ltd. (Planning&Management)
 000AC6 Overture Networks.
 000AAB Toyota Technical Development
-000AB4 Etic Telecommunications
+000AB4 ETIC Telecommunications
 000A7A Kyoritsu Electric
 000A9C Server Technology
 000A75 Caterpillar
@@ -28522,7 +29746,7 @@ EC6C9F Chengdu Volans Technology
 000A41 Cisco Systems
 000A36 Synelec Telecom Multimedia
 000A48 Albatron Technology
-000A3E Eads Telecom
+000A3E EADS Telecom
 000A59 HW server
 000A54 Laguna Hills
 000A4F Brain Boxes Limited
@@ -28543,7 +29767,7 @@ EC6C9F Chengdu Volans Technology
 0009C8 Sinagawa Tsushin Keisou Service
 0009B7 Cisco Systems
 0009B2 L&F
-0009F3 Well Communication
+0009F3 WELL Communication
 0009EF Vocera Communications
 0009C4 Medicore
 0009D9 Neoscale Systems
@@ -28553,7 +29777,7 @@ EC6C9F Chengdu Volans Technology
 0009F0 Shimizu Technology
 0009E4 K Tech Infosystem
 000972 Securebase
-000978 Aiji System
+000978 AIJI System
 000973 Lenten Technology
 000975 fSONA Communications
 000977 Brunner Elektronik AG
@@ -28561,12 +29785,12 @@ EC6C9F Chengdu Volans Technology
 000942 Wireless Technologies
 000945 Palmmicro Communications
 00093E C&I Technologies
-000940 Agfeo Gmbh & KG
+000940 Agfeo GmbH & KG
 00097F Vsecure 2000
 000980 Power Zenith
 0009A0 Microtechno
 00099B Western Telematic
-000990 Acksys Communications & Systems
+000990 Acksys Communications & systems
 000953 Linkage System IntegrationLtd.
 00094C Communication Weaver
 00096E Giant Electronics
@@ -28576,13 +29800,13 @@ EC6C9F Chengdu Volans Technology
 0008F9 Artesyn Embedded Technologies
 0008F4 Bluetake Technology
 0008F7 Hitachi, Semiconductor & Integrated Circuits Gr
-000920 Epox Computer
+000920 EpoX Computer
 000922 TST Biometrics GmbH
 000916 Listman Home Technologies
 000911 Cisco Systems
 000912 Cisco Systems
 000908 VTech Technology
-00090B MTL  Instruments PLC
+00090B MTL Instruments PLC
 00093B Hyundai Networks
 000934 Dream-Multimedia-Tv GmbH
 000931 Future Internet
@@ -28601,10 +29825,10 @@ EC6C9F Chengdu Volans Technology
 00089D UHD-Elektronik
 0008CF Nippon Koei Power Systems
 0008CB Zeta Broadband
-0008D3 Hercules TechnologiesS.
+0008D3 Hercules Technologiess.
 0008D0 Musashi Engineering
 0008BA Erskine Systems
-0008B5 TAI Guen Enterprise
+0008B5 TAI GUEN Enterprise
 0008B7 HIT Incorporated
 0008A9 SangSang Technology
 0008C8 Soneticom
@@ -28612,7 +29836,7 @@ EC6C9F Chengdu Volans Technology
 00088F Advanced Digital Technology
 00088B Tropic Networks
 00086B Mipsys
-00087F Spaun Electronic Gmbh & KG
+00087F Spaun electronic GmbH & KG
 000886 Hansung Teliann
 000858 Novatechnology
 000850 Arizona Instrument
@@ -28629,7 +29853,7 @@ EC6C9F Chengdu Volans Technology
 0007D7 Caporis Networks AG
 0007D4 Zhejiang Yutong Network Communication
 0007CE Cabletime Limited
-0007D3 Spgprints
+0007D3 SPGPrints
 000813 Diskbank
 00080F Proximion Fiber Optics AB
 000812 GM-2
@@ -28640,12 +29864,12 @@ EC6C9F Chengdu Volans Technology
 0007E0 Palm
 0007FA ITT
 0007F6 Qqest Software Systems
-0007FB Giga Stream Umts Technologies Gmbh
+0007FB Giga Stream UMTS Technologies GmbH
 00085D Mitel
-000855 Nasa-goddard Space Flight Center
+000855 NASA-Goddard Space Flight Center
 00085A IntiGate
 000817 EmergeCore Networks
-000815 Cats
+000815 CATS
 00082A Powerwallz Network Security
 0007AC Eolring
 0007AA Quantum Data
@@ -28664,10 +29888,10 @@ EC6C9F Chengdu Volans Technology
 000790 Tri-M Technologies (s) Limited
 00078D NetEngines
 00078A Mentor Data System
-000792 Stron Electronic GmbH
+000792 Sütron Electronic GmbH
 0007B2 Transaccess
 0007AD Pentacon GmbH Foto-und Feinwerktechnik
-0007D0 Automat Engenharia de Automao Ltda.
+0007D0 Automat Engenharia de Automação Ltda.
 00076A Nexteye
 0006E6 DongYang Telecom
 0006DC Syabas Technology (Amquest)
@@ -28772,12 +29996,12 @@ EC6C9F Chengdu Volans Technology
 0004F8 Qualicable TV Industria E Com.
 0004F5 SnowShore Networks
 0004F2 Polycom
-0004F3 FS Forth-systeme Gmbh
+0004F3 FS Forth-systeme GmbH
 0004ED Billion Electric
 0004E7 Lightpointe Communications
 0004E6 Banyan Network Private Limited
 0004DE Cisco Systems
-0004A2 L.S.I. Japan
+0004A2 L.s.i. Japan
 00049B Cisco Systems
 000499 Chino
 00048E Ohm Tech Labs
@@ -28790,7 +30014,7 @@ EC6C9F Chengdu Volans Technology
 000490 Optical Access
 0004E1 Infinior Microsystems
 0004C2 Magnipix
-000486 ITTC, University of Kansas
+000486 Ittc, University of Kansas
 00048B Poscon
 000484 Amann GmbH
 000478 G. Star Technology
@@ -28804,7 +30028,7 @@ EC6C9F Chengdu Volans Technology
 000411 Inkra Networks
 000410 Spinnaker Networks
 000412 WaveSmith Networks
-000442 Nact
+000442 NACT
 000445 LMS Skalar Instruments GmbH
 00044E Cisco Systems
 000452 RocketLogix
@@ -28842,13 +30066,13 @@ EC6C9F Chengdu Volans Technology
 000353 Mitac
 000356 Wincor Nixdorf International GmbH
 00034F Sur-Gard Security
-00037B Idec Izumi
+00037B IDEC Izumi
 000367 Jasmine Networks
 00036A Mainnet
 00036B Cisco Systems
 00036C Cisco Systems
 00038F Weinschel
-000384 Aeta
+000384 AETA
 000387 Blaze Network Products
 000381 Ingenico International
 000340 Floware Wireless Systems
@@ -28858,16 +30082,16 @@ EC6C9F Chengdu Volans Technology
 000339 Eurologic Systems
 000331 Cisco Systems
 000330 Imagenics,
-00034A Rias
+00034A RIAS
 0002CF ZyGate Communications
 0002D1 Vivotek
 0002C2 Net Vision Telecom
 0002B6 Acrosser Technology
 0002B1 Anritsu
-0002AD Hoya
+0002AD HOYA
 0002AE Scannex Electronics
 000304 Pacific Broadband Communications
-000301 Exfo
+000301 EXFO
 0002FD Cisco Systems
 000300 Barracuda Networks
 0002BD Bionet
@@ -28889,7 +30113,7 @@ EC6C9F Chengdu Volans Technology
 00024B Cisco Systems
 00024D Mannesman Dematic Colby
 000250 Geyser Networks
-000248 Pilz GmbH &
+000248 Pilz GmbH
 00024C SiByte
 00025A Catena Networks
 00026E NeGeN Access
@@ -28908,7 +30132,7 @@ EC6C9F Chengdu Volans Technology
 0001F3 QPS
 0001E4 Sitera
 0001E3 Siemens AG
-0001EB C-COM
+0001EB C-com
 0001F2 Mark of the Unicorn
 0001D9 Sigma
 0001C5 Simpler Networks
@@ -28929,12 +30153,12 @@ EC6C9F Chengdu Volans Technology
 00017B Heidelberger Druckmaschinen AG
 00019C JDS Uniphase
 0001A3 Genesys Logic
-000182 Dica Technologies AG
+000182 DICA Technologies AG
 000189 Refraction Technology
 000193 Hanbyul Telecom
 0030F5 Wild Lab.
 00015D Oracle
-000173 Amcc
+000173 AMCC
 00016C Foxconn
 000175 Radiant Communications
 0001AF Artesyn Embedded Technologies
@@ -28948,7 +30172,7 @@ EC6C9F Chengdu Volans Technology
 000145 Winsystems
 000137 IT Farm
 00013C TIW Systems
-000133 Kyowa Electronic Instruments C
+000133 Kyowa Electronic Instruments
 0001A5 Nextcomm
 000190 Smk-m
 00014C Berkeley Process Control
@@ -28963,7 +30187,7 @@ EC6C9F Chengdu Volans Technology
 00B069 Honewell Oy
 00B0C2 Cisco Systems
 00B03B HiQ Networks
-000127 Open Networks
+000127 OPEN Networks
 00010E Bri-Link Technologies
 003037 Packard Bell Nec Services
 003057 QTelNet
@@ -28972,13 +30196,13 @@ EC6C9F Chengdu Volans Technology
 0030A2 Lightner Engineering
 003042 DeTeWe-Deutsche Telephonwerke
 00B0C7 Tellabs Operations
-00B02A Orsys Gmbh
+00B02A Orsys GmbH
 000104 Dvico
 000106 Tews Datentechnik GmbH
 000109 Nagano Japan Radio
-00029C 3com
+00029C 3COM
 00B019 UTC CCS
-00306F Seyeon TECH.
+00306F Seyeon Tech.
 00303D IVA
 0030F4 Stardot Technologies
 003052 Elastic Networks
@@ -29002,40 +30226,40 @@ EC6C9F Chengdu Volans Technology
 003025 Checkout Computer Systems
 003012 Digital Engineering
 0030C6 Control Solutions
-0030D6 MSC Vertriebs Gmbh
-003041 Saejin T & M
+0030D6 MSC Vertriebs GMBH
+003041 Saejin T &
 00308C Quantum
 0030E3 Sedona Networks
-0030BF Multidata Gmbh
-00D00F Speech Design Gmbh
+0030BF Multidata GMBH
+00D00F Speech Design GMBH
 003058 API Motion
 003034 SET Engineering
-00304A Fraunhofer Ipms
+00304A Fraunhofer IPMS
 00308D Pinnacle Systems
 0030A6 Vianet Technologies
 00D0BF Pivotal Technologies
 00303C Onnto
 003024 Cisco Systems
 0030F6 Securelogix
-00D02F Vlsi Technology
+00D02F VLSI Technology
 0030D8 Sitek
 003016 Ishida
 00D0B1 Omega Electronics SA
 00D016 SCM Microsystems
-00D043 Zonal Retail Data Systems
-00D0C1 Harmonic Data Systems
+00D043 Zonal Retail DATA Systems
+00D0C1 Harmonic DATA Systems
 00D0AC Commscope
-00D07C Koyo Electronics
+00D07C KOYO Electronics
 00D0BC Cisco Systems
 00D0CB Dasan
 00D019 Dainippon Screen Corporate
-00D035 Behavior TECH. Computer
+00D035 Behavior Tech. Computer
 00D0DB Mcquay International
-00D070 Long Well Electronics
-00D029 Wakefern Food
+00D070 LONG WELL Electronics
+00D029 Wakefern FOOD
 00D0C3 Vivid Technology PTE
 00D013 Primex Aerospace Company
-00D0A3 Vocal DATA
+00D0A3 Vocal Data
 00D07E Keycorp
 00D020 AIM System
 00D0C8 Prevas A/S
@@ -29047,13 +30271,13 @@ EC6C9F Chengdu Volans Technology
 00D051 O2 Micro
 00D0BB Cisco Systems
 00D06E Trendview Recorders
-00D05C Kathrein Technotrend Gmbh
+00D05C Kathrein TechnoTrend GmbH
 00D0EA Nextone Communications
 00D064 Multitel
 00D05E Stratabeam Technology
 00D0AA Chase Communications
 00D05D Intelliworxx
-00D0A1 Oskar Vierling Gmbh + KG
+00D0A1 Oskar Vierling GMBH + KG
 00D006 Cisco Systems
 00D02A Voxent Systems
 00D08F Ardent Technologies
@@ -29068,16 +30292,16 @@ EC6C9F Chengdu Volans Technology
 005049 Arbor Networks
 00500D Satori Electoric
 0050A3 TransMedia Communications
-0050A4 IO TECH
+0050A4 IO Tech
 00505C Tundo
 0050B3 Voiceboard
 00508C RSI Systems
-0050E1 NS Tech Electronics SDN BHD
+0050E1 NS TECH Electronics SDN BHD
 0050DE Signum Systems
 005075 Kestrel Solutions
-0050ED Anda Networks
+0050ED ANDA Networks
 005096 Salix Technologies
-005012 CBL - Gmbh
+005012 CBL - GMBH
 0050F2 Microsoft
 00504A Elteco A.S.
 0050C1 Gemflex Networks
@@ -29091,24 +30315,24 @@ EC6C9F Chengdu Volans Technology
 0090DD Miharu Communications
 009028 Nippon Signal
 00907D Lake Communications
-0090C9 Dpac Technologies
+0090C9 DPAC Technologies
 00507B Merlot Communications
 0050CD Digianswer A/S
 00502D Accel
 00503A Datong Electronics
 005087 Terasaki Electric
 005026 Cosystems
-00902C Data & Control Equipment
-00901D PEC (nz)
+00902C DATA & Control Equipment
+00901D PEC (NZ)
 009097 Sycamore Networks
 009025 BAE Systems Australia (Electronic Systems)
 00904C Epigram
 009084 Atech System
 00906A Turnstone Systems
-009087 Itis
+009087 ITIS
 009051 Ultimate Technology
 009026 Advanced Switching Communications
-0090D3 Giesecke & Devrient Gmbh
+0090D3 Giesecke & Devrient GmbH
 009067 WalkAbout Computers
 00902A Communication Devices
 00900D Overland Storage
@@ -29123,13 +30347,13 @@ EC6C9F Chengdu Volans Technology
 009091 DigitalScape
 00907E Vetronix
 009050 Teleste
-00904D Spec
+00904D SPEC
 0090FD CopperCom
 009039 Shasta Networks
 0090FC Network Computing Devices
 009014 Rotork Instruments
 00908D Vickers Electronics Systems
-009042 ECCS
+009042 Eccs
 009033 Innovaphone AG
 009002 Allgon AB
 0010D4 Storage Computer
@@ -29138,7 +30362,7 @@ EC6C9F Chengdu Volans Technology
 00108A TeraLogic
 001024 Nagoya Electric Works
 0010D6 Exelis
-001048 Htrc Automation
+001048 HTRC Automation
 001097 WinNet Metropolitan Communications Systems
 001085 Polaris Communications
 00100C ITO
@@ -29149,19 +30373,19 @@ EC6C9F Chengdu Volans Technology
 0001FE Digital Equipment
 0090BE Ibc/integrated Business Computers
 00103C IC Ensemble
-001019 Sirona Dental Systems Gmbh & KG
+001019 Sirona Dental Systems GmbH & KG
 0090DE Cardkey Systems
 00906B Applied Resources
 0010E2 ArrayComm
 0010D2 Nitto Tsushinki
-0010D9 IBM Japan, Fujisawa Mt+d
+0010D9 IBM Japan, Fujisawa MT+D
 009066 Troika Networks
 001094 Performance Analysis Broadband, Spirent plc
-001050 Rion
+001050 RION
 00109C M-system
 0010CE Volamp
 0010B2 Coactive Aesthetics
-00105F Zodiac Data Systems
+00105F Zodiac DATA Systems
 00103E Netschools
 0010CB Facit K.K.
 0010E0 Oracle
@@ -29180,10 +30404,10 @@ EC6C9F Chengdu Volans Technology
 001089 WebSonic
 0010E6 Applied Intelligent Systems
 00103B Hippi Networking Forum
-00E083 Jato Technologies
-00E072 Lynk
+00E083 JATO Technologies
+00E072 LYNK
 00E0AD EES Technology
-00E094 Osai SRL
+00E094 OSAI SRL
 00E032 Misys Financial Systems
 00E0C0 Seiwa Electric MFG.
 00E0D1 Telsis Limited
@@ -29194,14 +30418,14 @@ EC6C9F Chengdu Volans Technology
 00E0D9 Tazmo
 00E055 Ingenieria Electronica Comercial Inelcom
 00E0B4 Techno Scope
-00E071 Epis Microcomputer
+00E071 EPIS Microcomputer
 00E066 ProMax Systems
 00E093 Ackfin Networks
 00E042 Pacom Systems
 00E0EB Digicom Systems, Incorporated
 00E01C Cradlepoint
 00E027 DUX
-00E04B Jump Industrielle Computertechnik Gmbh
+00E04B JUMP Industrielle Computertechnik GmbH
 00E097 Carrier Access
 00E089 ION Networks
 00E070 DH Technology
@@ -29209,13 +30433,13 @@ EC6C9F Chengdu Volans Technology
 00E024 Gadzoox Networks
 00605B IntraServer Technology
 0060D7 Ecole Polytechnique Federale DE Lausanne (epfl)
-00E0BA Berghof Automationstechnik Gmbh
+00E0BA Berghof Automationstechnik GmbH
 00E021 Freegate
-00E05B West END Systems
+00E05B WEST END Systems
 00E044 Lsics
-00E0CA Best Data Products
+00E0CA BEST DATA Products
 00E0A7 IPC Information Systems
-00E062 Host Engineering
+00E062 HOST Engineering
 00E0CE ARN
 00E05F e-Net
 00E01F Avidia Systems
@@ -29223,7 +30447,7 @@ EC6C9F Chengdu Volans Technology
 00E060 Sherwood
 00E06A Kapsch AG
 00E001 Strand Lighting Limited
-00E0D8 Lanbit Computer
+00E0D8 LANBit Computer
 00E0E7 Raytheon E-systems
 00E03C AdvanSys
 00E073 National Amusement Network
@@ -29240,7 +30464,7 @@ EC6C9F Chengdu Volans Technology
 006019 Roche Diagnostics
 006059 Technical Communications
 006003 Teraoka Weigh System PTE
-00607A DVS Gmbh
+00607A DVS GMBH
 0060F3 Performance Analysis Broadband, Spirent plc
 00607C WaveAccess
 0060A0 Switched Network Technologies
@@ -29252,14 +30476,14 @@ EC6C9F Chengdu Volans Technology
 006073 Redcreek Communications
 0060FD NetICs
 0060CB Hitachi Zosen
-0060C8 Kuka Welding Systems & Robots
+0060C8 KUKA Welding Systems & Robots
 006023 Pericom Semiconductor
 006063 Psion Dacom PLC.
 006031 HRK Systems
 00600E Wavenet International
 0060A3 Continuum Technology
 00603D 3CX
-0060ED Ricardo Test Automation
+0060ED Ricardo TEST Automation
 006012 Power Computing
 00604D MMC Networks
 0060F7 Datafusion Systems
@@ -29275,15 +30499,15 @@ EC6C9F Chengdu Volans Technology
 006095 Accu-time Systems
 00608A Citadel Computer
 006093 Varian
-00A03F Computer Society Microprocessor & Microprocessor Standards C
+00A03F Computer Society Microprocessor & Microprocessor Standards
 00A02D 1394 Trade Association
 00A07C Tonyang Nylon
 00A09A Nihon Kohden America
 00A093 B/E Aerospace
 00A078 Marconi Communications
-00A0BF Wireless Data Group Motorola
+00A0BF Wireless DATA Group Motorola
 00A05F BTG Electronics Design BV
-00A0CD DR. Johannes Heidenhain Gmbh
+00A0CD DR. Johannes Heidenhain GmbH
 00A0DA Integrated Systems Technology
 00A02A Trancell Systems
 00A01C Nascent Networks
@@ -29303,13 +30527,13 @@ EC6C9F Chengdu Volans Technology
 00A047 Integrated Fitness
 00A032 GES Singapore PTE.
 00A0E3 XKL Systems
-00A014 Csir
-00A015 Wyle
+00A014 CSIR
+00A015 WYLE
 00A06A Verilink
 00A018 Creative Controllers
 00A0FE Boston Technology
 00A0EB Encore Networks
-00A07D Seeq Technology
+00A07D SEEQ Technology
 00A0D9 Convex Computer
 00A070 Coastcom
 0020DE Japan Digital Laborat'yltd
@@ -29319,13 +30543,13 @@ EC6C9F Chengdu Volans Technology
 0020D7 Japan Minicomputer Systems
 0020C3 Counter Solutions
 002047 Steinbrecher
-0020D5 Vipa Gmbh
+0020D5 VIPA GMBH
 00201A MRV Communications
 0020F2 Oracle
 0020B8 Prime Option
-0020AD Linq Systems
+0020AD LINQ Systems
 00207D Advanced Computer Applications
-00202F Zeta Communications
+00202F ZETA Communications
 00209A THE 3DO Company
 002062 Scorpion Logic
 002081 Titan Electronics
@@ -29339,27 +30563,27 @@ EC6C9F Chengdu Volans Technology
 00207E Finecom
 00204E Network Security Systems
 0020CA Digital Ocean
-002095 Riva Electronics
+002095 RIVA Electronics
 0020FB Octel Communications
 002070 Hynet
 0020BE LAN Access
-00203F Juki
+00203F JUKI
 0020A9 White Horse Industrial
 002096 Invensys
-00204A Pronet Gmbh
+00204A Pronet GMBH
 0020FF Symmetrical Technologies
 002044 Genitech
 0020EF USC
 002030 Analog & Digital Systems
-0020AC Interflex Datensysteme Gmbh
+0020AC Interflex Datensysteme GMBH
 0020D8 Nortel Networks
 002066 General Magic
 002001 DSP Solutions
-0020BF Aehr Test Systems
+0020BF AEHR TEST Systems
 002053 Huntsville Microsystems
 0020A1 Dovatron
 00C02F Okuma
-00C01E LA Francaise DES Jeux
+00C01E LA Francaise DES JEUX
 00C0E1 Sonic Solutions
 002036 BMC Software
 0020F8 Carrera Computers
@@ -29371,8 +30595,8 @@ EC6C9F Chengdu Volans Technology
 00C0A4 Unigraf OY
 00C029 Nexans Deutschland GmbH - ANS
 00C0FA Canary Communications
-00C03A Men-mikro Elektronik Gmbh
-00C040 Ecci
+00C03A Men-mikro Elektronik GMBH
+00C040 ECCI
 00C01C Interlink Communications
 00C042 Datalux
 00C071 Areanex Communications
@@ -29397,7 +30621,7 @@ EC6C9F Chengdu Volans Technology
 00C07E Kubota Electronic
 00C0DD QLogic
 00C01B Socket Communications
-00406F Sync Research
+00406F SYNC Research
 0040F3 Netcor
 00404B Maple Computer Systems
 004033 Addtron Technology
@@ -29405,13 +30629,13 @@ EC6C9F Chengdu Volans Technology
 00C0C7 Sparktrum Microsystems
 00C0C4 Computer Operational
 00C012 Netspan
-0040AD SMA Regelsysteme Gmbh
+0040AD SMA Regelsysteme GMBH
 00406D Lanco
-0040CD Tera Microsystems
+0040CD TERA Microsystems
 0040F5 OEM Engines
 004039 Optec Daiichi Denko
-004079 Juko Manufacture Company
-00C020 Arco Electronic, Control
+004079 JUKO Manufacture Company
+00C020 ARCO Electronic, Control
 00C0E7 Fiberdata AB
 00C05F Fine-pal Company Limited
 0040AE Delta Controls
@@ -29430,7 +30654,7 @@ EC6C9F Chengdu Volans Technology
 00405C Future Systems
 004061 Datatech Enterprises
 00008C Alloy Computer Products (Australia)
-0040B9 Macq Electronique SA
+0040B9 MACQ Electronique SA
 0040BB Goldstar Cable
 0040B1 Codonics
 0040F8 Systemhaus Discom
@@ -29442,8 +30666,8 @@ EC6C9F Chengdu Volans Technology
 0040C5 Micom Communications
 004020 CommScope
 004048 SMD Informatica
-00407C Qume
-00407F Flir Systems
+00407C QUME
+00407F FLIR Systems
 00402D Harris Adacom
 0080A6 Republic Technology
 0040DE Elsag Datamat spa
@@ -29451,14 +30675,14 @@ EC6C9F Chengdu Volans Technology
 008032 Access
 0080CF Embedded Performance
 008090 Microtek International
-004044 Qnix Computer
+004044 QNIX Computer
 0080C4 Document Technologies
 00805B Condor Systems
 008043 Networld
 0040DF Digalog Systems
 004009 Tachibana Tectron
 0040A0 Goldstar
-0040FC IBR Computer Technik Gmbh
+0040FC IBR Computer Technik GMBH
 0080AF Allumer
 008084 THE Cloud
 0080F3 SUN Electronics
@@ -29482,14 +30706,14 @@ EC6C9F Chengdu Volans Technology
 00804F Daikin Industries
 008005 Cactus Computer
 00806D Century Systems
-008094 Alfa Laval Automation AB
+008094 ALFA Laval Automation AB
 000041 ICE
 000086 Megahertz
-000092 Cogent Data Technologies
+000092 Cogent DATA Technologies
 000058 Racore Computer Products
 008074 Fisher Controls
 008030 Nexus Electronics
-000055 Commissariat A L`energie ATOM.
+000055 Commissariat A L`energie Atom.
 0080C9 Alberta Microelectronic Centre
 00800C Videcom Limited
 00807D Equinox Systems
@@ -29497,39 +30721,38 @@ EC6C9F Chengdu Volans Technology
 0080EE Thomson CSF
 00808E Radstone Technology
 008096 Human Designed Systems
-0080DA Bruel & Kjaer Sound & Vibration Measurement A/S
 00803E Synernetics
 0080CE Broadcast Television Systems
-00801A Bell Atlantic
+00801A BELL Atlantic
 0080DE Gipsi
-008002 Satelcom (uk)
-008064 Wyse Technology
+008002 Satelcom (UK)
+008064 WYSE Technology
 008048 Compex Incorporated
 008085 H-three Systems
 00804C Contec
-00808F C. Itoh Electronics
+00808F C. ITOH Electronics
 000052 Intrusion.com
 0080FF SOC. DE Teleinformatique RTC
-0000F7 Youth Keep Enterprise
-0000C7 Arix
+0000F7 Youth KEEP Enterprise
+0000C7 ARIX
 0000D1 Adaptec Incorporated
-000016 DU Pont Pixel Systems
-0000E1 Grid Systems
+000016 DU PONT Pixel Systems
+0000E1 GRID Systems
 000081 Bay Networks
 000029 IMC Networks
 00000A Omron Tateisi Electronics
 00000D Fibronics
 000024 Connect AS
-000067 Soft * RITE
+000067 SOFT * Rite
 0000D2 SBE
 000037 Oxford Metrics Limited
 0000FB Rechner ZUR Kommunikation
-0000E2 Acer Technologies
-0000BA SIIG
+0000E2 ACER Technologies
+0000BA Siig
 00002A TRW - Sedd/inp
 00002C Autotote Limited
 000083 Tadpole Technology PLC
-0000F3 Gandalf Data Limited
+0000F3 Gandalf DATA Limited
 0000B0 Rnd-rad Network Devices
 0000CF Hayes Microcomputer Products
 000056 DR. B. Struck
@@ -29540,12 +30763,12 @@ EC6C9F Chengdu Volans Technology
 0000AF Canberra Industries
 000076 Abekas Video System
 080055 Stanford Telecomm.
-080053 Middle East TECH. University
+080053 Middle EAST Tech. University
 08008E Tandem Computers
 080084 Tomen Electronics
 080085 Elxsi
 080082 Veritas Software
-080080 AES Data
+080080 AES DATA
 080077 TSL Communications
 080074 Casio Computer
 08006E Masscomp
@@ -29553,22 +30776,22 @@ EC6C9F Chengdu Volans Technology
 080063 Plessey
 08007B Sanyo Electric
 08007C Vitalink Communications
-0000DF Bell & Howell PUB SYS DIV
+0000DF BELL & Howell PUB SYS DIV
 0000F9 Quotron Systems
 080060 Industrial Networking
 08004C Hydra Computer Systems
 080047 Sequent Computer Systems
 08004A Banyan Systems
 080044 David Systems
-080041 Racal-milgo Information SYS..
+080041 Racal-milgo Information Sys..
 080035 Microfive
 080032 Tigan Incorporated
 08008D Xyvision
 080015 STC Business Systems
-080066 Agfa
+080066 AGFA
 080004 Cromemco Incorporated
 0001C8 Conrad
-08003F Fred Koschara Enterprises
+08003F FRED Koschara Enterprises
 08000B Unisys
 00DD01 Ungermann-bass
 00DD06 Ungermann-bass
@@ -29580,8 +30803,8 @@ AA0003 Digital Equipment
 00003E Simpact
 00DD02 Ungermann-bass
 00DD04 Ungermann-bass
-026086 Logic Replacement TECH.
-080030 Cern
+026086 Logic Replacement Tech.
+080030 CERN
 74DA88 Tp-link Technologies
 CC32E5 Tp-link Technologies
 1C3BF3 Tp-link Technologies
@@ -29589,12 +30812,12 @@ CC32E5 Tp-link Technologies
 301B97 Lierda Science & Technology Group
 2CD2E3 Guangzhou Aoshi Electronic
 1459C3 Creative Chips GmbH
-A0D86F Argo AI
-E4671E Shen Zhen NUO XIN Cheng Technology
+A0D86F ARGO AI
+E4671E SHEN ZHEN NUO XIN Cheng Technology
 682719 Microchip Technology
 24C17A Beijing Iactive Network
 1C9C8C Juniper Networks
-A4C939 Guangdong Oppo Mobile Telecommunications
+A4C939 Guangdong OPPO Mobile Telecommunications
 34D772 Xiamen Yudian Automation Technology
 C0DCDA Samsung Electronics
 04B429 Samsung Electronics
@@ -29616,18 +30839,17 @@ A0946A Shenzhen Xgtec Technology
 388E7A Autoit
 4C710C Cisco Systems
 4C710D Cisco Systems
-9C31C3 BSkyB
 6C24A6 vivo Mobile Communication
-9C5F5A Guangdong Oppo Mobile Telecommunications
+9C5F5A Guangdong OPPO Mobile Telecommunications
 E447B3 zte
 FCDB21 Samsara Networks
 607771 Texas Instruments
 D8CF89 Beijing DoSee Science and Technology
 04AAE1 Beijing Microvision Technology
-44DC4E Itel Mobile Limited
+44DC4E ITEL Mobile Limited
 382A19 Technica Engineering GmbH
-74D654 Gint
-B4E8C9 Xada Technologies
+74D654 GINT
+B4E8C9 XADA Technologies
 7C210E Cisco Systems
 942DDC Samsung Electronics
 54F294 Huawei Device
@@ -29655,7 +30877,7 @@ ACBD0B Leimac
 E0CCF8 Xiaomi Communications
 98524A Technicolor CH USA
 3868A4 Samsung Electronics
-B4A5AC Guangdong Oppo Mobile Telecommunications
+B4A5AC Guangdong OPPO Mobile Telecommunications
 1C784E China Mobile Iot Limited company
 843E79 Shenzhen Belon Technology
 B81904 Nokia Shanghai Bell
@@ -29675,7 +30897,7 @@ A4B439 Cisco Systems
 E81B4B amnimo
 CCF411 Google
 9C2DCF Shishi Tongyun Technology(Chengdu)Co.
-9424B8 Gree Electric Appliances, OF Zhuhai
+9424B8 GREE Electric Appliances, OF Zhuhai
 C803F5 Ruckus Wireless
 000D0A Barco Projection Systems NV
 C467D1 Huawei Technologies
@@ -29683,13 +30905,13 @@ C467D1 Huawei Technologies
 C8C465 Huawei Technologies
 1C4363 Huawei Technologies
 94292F New H3C Technologies
-D49AA0 Vnpt Technology
+D49AA0 VNPT Technology
 F80FF9 Google
 8C5AC1 Huawei Device
 A85AE0 Huawei Device
 A4B61E Huawei Device
-C4FE5B Guangdong Oppo Mobile Telecommunications
-C03937 Gree Electric Appliances, OF Zhuhai
+C4FE5B Guangdong OPPO Mobile Telecommunications
+C03937 GREE Electric Appliances, OF Zhuhai
 B44C3B Zhejiang Dahua Technology
 40A2DB Amazon Technologies
 4C6C13 IoT Company Solucoes Tecnologicas Ltda
@@ -29724,7 +30946,7 @@ F82E8E Nanjing Kechen Electric
 B4C9B9 Sichuan AI-Link Technology
 F0463B Comcast Cable
 68D79A Ubiquiti Networks
-1C63BF Shenzhen Broadtel  Telecom
+1C63BF Shenzhen Broadtel Telecom
 AC3651 Jiangsu Hengtong Terahertz Technology
 684A76 eero
 688FC9 Zhuolian (Shenzhen) Communication
@@ -29740,7 +30962,7 @@ B48107 Shenzhen Chuangwei-rgb Electronics
 706655 AzureWave Technology
 647C34 Ubee Interactive, Limited
 6C38A1 Ubee Interactive, Limited
-78530D Shenzhen Skyworth  Digital  Technology
+78530D Shenzhen Skyworth Digital Technology
 0C48C6 Celestica
 A42985 Sichuan AI-Link Technology
 78AC44 Dell
@@ -29762,7 +30984,6 @@ C01692 China Mobile Group Device
 7076DD OxyGuard Internation A/S
 94E9EE Huawei Device
 28E34E Huawei Technologies
-D452EE BSkyB
 E023FF Fortinet
 8C59DC ASR Microelectronics (Shanghai)
 18828C Arcadyan
@@ -29771,7 +30992,7 @@ E023FF Fortinet
 78B8D6 Zebra Technologies
 BC4A56 Cisco Systems
 6C61F4 SFR
-F490CB Ieee Registration Authority
+F490CB IEEE Registration Authority
 00107F Crestron Electronics
 001B85 MAN Energy Solutions
 58493B Palo Alto Networks
@@ -29814,12 +31035,12 @@ EC6CB5 zte
 C0B101 zte
 140152 Samsung Electronics
 BC33AC Silicon Laboratories
-94FBA7 Ieee Registration Authority
+94FBA7 IEEE Registration Authority
 988E79 Qudelix
 98F621 Xiaomi Communications
 C03EBA Dell
 C0395A Zhejiang Dahua Technology
-2064CB Guangdong Oppo Mobile Telecommunications
+2064CB Guangdong OPPO Mobile Telecommunications
 F05501 Huawei Device
 7CF2DD Vence
 D0768F Calix
@@ -29843,7 +31064,7 @@ B46921 Intel Corporate
 F8F21E Intel Corporate
 74A7EA Amazon Technologies
 4C7CD9 Apple
-F0D7AF Ieee Registration Authority
+F0D7AF IEEE Registration Authority
 7CB27D Intel Corporate
 04ED33 Intel Corporate
 5C80B6 Intel Corporate
@@ -29900,11 +31121,11 @@ D89ED4 Fiberhome Telecommunication Technologies
 E079C4 iRay Technology Company Limited
 884067 infomark
 AC9572 Jovision Technology
-40D25F Itel Mobile Limited
+40D25F ITEL Mobile Limited
 A8032A Espressif
 0019F5 Imagination Technologies
 00CBBD Cambridge Broadband Networks Group
-5894A2 Ketek Gmbh
+5894A2 Ketek GmbH
 4C2219 Yuanfudao HK Limted
 54D9C6 Huawei Device
 308AF7 Huawei Device
@@ -29914,7 +31135,7 @@ D8EF42 Huawei Device
 18AA0F Huawei Device
 B0A460 Intel Corporate
 AC9A96 Maxlinear
-8C7086 Gesellschaft fr Sonder-EDV-Anlagen mbH
+8C7086 Gesellschaft für Sonder-EDV-Anlagen mbH
 1C28AF Aruba, a Hewlett Packard Enterprise Company
 E4246C Zhejiang Dahua Technology
 E8EB1B Microchip Technology
@@ -29924,11 +31145,11 @@ E8EB1B Microchip Technology
 44227C Huawei Technologies
 CCB182 Huawei Technologies
 48902F LG Electronics (Mobile Communications)
-28B77C Ieee Registration Authority
+28B77C IEEE Registration Authority
 28C21F Samsung Electro-mechanics(thailand)
 5C7D7D Technicolor CH USA
 F4BFA8 Juniper Networks
-C0619A Ieee Registration Authority
+C0619A IEEE Registration Authority
 C42B44 Huawei Device
 F8A26D Canon
 74427F AVM Audiovisuelles Marketing und Computersysteme GmbH
@@ -29956,9 +31177,8 @@ A0FBC5 Apple
 30A998 Huawei Device
 007D60 Apple
 ECC302 Humax
-98C97C Shenzhen iComm Semiconductor
-00C343 E-T-A Circuit Breakers
-58208A Ieee Registration Authority
+00C343 E-t-a Circuit Breakers
+58208A IEEE Registration Authority
 0090D2 Artel Video Systems
 F0AA0B Arra Networks/ Spectramesh
 945641 Palo Alto Networks
@@ -29983,7 +31203,7 @@ F06426 Extreme Networks
 703A2D Shenzhen V-Link Technology
 1C45C2 Huizhou City Sunsin lntelligent Technology
 7C4E09 Shenzhen Skyworth Wireless Technology
-EC7E91 Itel Mobile Limited
+EC7E91 ITEL Mobile Limited
 FC9643 Juniper Networks
 A8B088 eero
 001A65 Seluxit
@@ -30011,7 +31231,7 @@ A46DA4 Huawei Technologies
 2494CB Arris Group
 786A1F Arris Group
 8C7A15 Ruckus Wireless
-8411C2 Ieee Registration Authority
+8411C2 IEEE Registration Authority
 28AD18 Hui Zhou Gaoshengda Technology
 24A487 Huawei Device
 C45A86 Huawei Device
@@ -30030,7 +31250,7 @@ A86E4E Huawei Device
 945F34 Renesas Electronics (Penang) Sdn. Bhd.
 603CEE LG Electronics (Mobile Communications)
 2C4A11 Ciena
-1C4C48 Itel Mobile Limited
+1C4C48 ITEL Mobile Limited
 C4CB54 Fibocom Auto
 102D31 Shenzhen Americas Trading Company
 2C0786 Huawei Device
@@ -30047,7 +31267,7 @@ FC62B9 Alpsalpine
 48F07B Alpsalpine
 00145A Westermo Neratec AG
 1CD1BA Fiberhome Telecommunication Technologies
-A899DC I-top Desing Technology
+A899DC i-TOP Desing Technology
 B07B25 Dell
 84EAED Roku
 0012AD Vivavis AG
@@ -30087,10 +31307,10 @@ DCD7A0 Huawei Device
 383D5B Fiberhome Telecommunication Technologies
 A062FB Hisense Visual Technology
 9877E7 Kaonmedia
-78D4F1 Ieee Registration Authority
+78D4F1 IEEE Registration Authority
 B01656 Huawei Technologies
 047975 Honor Device
-DC9020 Ruru TEK Private Limited
+DC9020 RURU TEK Private Limited
 3810F0 Aruba, a Hewlett Packard Enterprise Company
 F88F07 Samsung Electronics
 14EB08 Huawei Technologies
@@ -30140,7 +31360,6 @@ EC63D7 Intel Corporate
 20B730 TeconGroup
 488899 Shenzhen SuperElectron Technology
 DCB131 Shenzhen Huaruian Technology
-843B10 Lv switch
 94A4F9 Huawei Technologies
 6C3491 Huawei Technologies
 E84D74 Huawei Technologies
@@ -30163,22 +31382,22 @@ F4A80D Wistron InfoComm(Kunshan)Co.
 04C29B Aura Home
 143B42 Realfit(Shenzhen) Intelligent Technology
 EC2E98 AzureWave Technology
-38F3AB Lcfc(hefei) Electronics Technology
+38F3AB LCFC(HeFei) Electronics Technology
 50AE86 Linkintec
 38B3F7 Huawei Device
 84E986 Huawei Device
 AC1F0F Texas Instruments
 74D285 Texas Instruments
-601592 Ieee Registration Authority
+601592 IEEE Registration Authority
 10C9CA Ace Technology
-BCFAB8 GuangzhouShiyuanElectronicTechnologyCompanyLimited
+BCFAB8 Guangzhou Shiyuan Electronic Technology Company Limited
 D47798 Cisco Systems
 A04A5E Microsoft
 EC0273 Aruba, a Hewlett Packard Enterprise Company
 F4B1C2 Zhejiang Dahua Technology
 A4DAD4 Yamato Denki
 109497 Logitech Hong Kong
-00141D Keba Industrial Automation Germany Gmbh
+00141D KEBA Industrial Automation Germany GmbH
 E0DA90 Huawei Technologies
 A4A46B Huawei Technologies
 A0D7A0 Huawei Device
@@ -30190,7 +31409,7 @@ F02F4B Apple
 60A4B7 TP-Link Limited
 60C5E6 Skullcandy
 38F3FB Asperiq
-A45802 Shin-il Tech
+A45802 Shin-il TECH
 38AFD0 Nevro
 00A00E Netscout Systems
 30A612 ShenZhen Hugsun Technology
@@ -30216,7 +31435,7 @@ C01B23 Sichuan Tianyi Comheart Telecom
 68DDD9 HMD Global Oy
 3C195E Samsung Electronics
 6C9466 Intel Corporate
-4C3B6C Garo AB
+4C3B6C GARO AB
 FC372B Sichuan Tianyi Comheart Telecom
 7CCC1F Sichuan Tianyi Comheart Telecom
 5C4A1F Sichuan Tianyi Comheart Telecom
@@ -30244,7 +31463,7 @@ CCB5D1 Beijing Xiaomi Mobile Software
 F4C02F BlueBite
 98F083 Huawei Technologies
 8C64A2 OnePlus Technology (Shenzhen)
-D05475 Savi Controls
+D05475 SAVI Controls
 88A0BE Huawei Technologies
 949010 Huawei Technologies
 28FBAE Huawei Technologies
@@ -30264,7 +31483,7 @@ AC7A42 iConnectivity
 88FCA6 devolo AG
 489EBD HP
 080037 Fujifilm Business Innovation
-888E7F Atop
+888E7F ATOP
 E8EDD6 Fortinet
 003059 Kontron Europe GmbH
 547787 Earda Technologies
@@ -30288,7 +31507,7 @@ B4527D Sony
 44746C Sony
 283F69 Sony
 00219E Sony
-A0C4A5 Sygn House
+A0C4A5 SYGN House
 6881E0 Huawei Technologies
 4CD629 Huawei Technologies
 F0C478 Huawei Technologies
@@ -30309,7 +31528,7 @@ AC49DB Apple
 68F38E Juniper Networks
 745D43 BSH Hausgeraete GmbH
 70A56A Shenzhen C-Data Technology
-785F36 Shenzhen Skyworth  Digital  Technology
+785F36 Shenzhen Skyworth Digital Technology
 A01842 Comtrend
 303FBB Hewlett Packard Enterprise
 EC94D5 Juniper Networks
@@ -30332,7 +31551,7 @@ D48660 Arcadyan
 B83BCC Xiaomi Communications
 88D199 Vencer
 CCE236 Hangzhou Yaguan Technology
-204181 Esyse Gmbh Embedded Systems Engineering
+204181 Esyse GmbH Embedded Systems Engineering
 DCBB96 Full Solution Telecom
 74765B Quectel Wireless Solutions
 B437D8 D-Link (Shanghai) Limited
@@ -30351,7 +31570,7 @@ A031DB Huawei Technologies
 2C3557 Eliiy Power
 080042 Macnica
 546F71 uAvionix
-54EF33 Shenzhen Bilian Electronicltd
+54EF33 Shenzhen Bilian Electronic，ltd
 141973 Beijing Yunyi Times Technology
 5C75C6 China Mobile Group Device
 4448B9 MitraStar Technology
@@ -30363,12 +31582,12 @@ E86E44 zte
 00E7E3 zte
 9C54C2 New H3C Technologies
 78E9CF Tellescom Industria E Comercio EM Telecomunicacao
-A09F7A D-link Middle East Fzco
+A09F7A D-Link Middle East FZCO
 001132 Synology Incorporated
 9009D0 Synology Incorporated
 5C5230 Apple
 645A36 Apple
-28D244 Lcfc(hefei) Electronics Technology
+28D244 LCFC(HeFei) Electronics Technology
 B42046 eero
 2032C6 Apple
 C81CFE Zebra Technologies
@@ -30414,7 +31633,7 @@ D09CAE vivo Mobile Communication
 B4AC8C Bern University of Applied Sciences
 B894E7 Xiaomi Communications
 34B98D Xiaomi Communications
-304F00 Guangdong Oppo Mobile Telecommunications
+304F00 Guangdong OPPO Mobile Telecommunications
 98C8B8 vivo Mobile Communication
 540E2D vivo Mobile Communication
 708F47 vivo Mobile Communication
@@ -30424,7 +31643,354 @@ C06B55 Motorola Mobility, a Lenovo Company
 FC1D2A vivo Mobile Communication
 78670E Wistron Neweb
 643216 Weidu Technology (Beijing)
+B01C0C Shenzhen Chuangwei-rgb Electronics
+68403C Fiberhome Telecommunication Technologies
+903E7F Fiberhome Telecommunication Technologies
+940230 Logitech
+14C0A1 UCloud Technology
+C03653 eero
+9460D5 Aruba, a Hewlett Packard Enterprise Company
 080205 Huawei Technologies
+68E478 Qingdao Haier Technology
+4C445B Intel Corporate
+C8CA79 Ciena
+843B10 Lvswitches
+E09D13 Samsung Electronics
+30C6F7 Espressif
+DC0E96 Palo Alto Networks
+042084 zte
+B45F84 zte
+9CC2C4 Inspur Electronic Information Industry
+00DF1D Cisco Systems
+A00F37 Cisco Systems
+1097BD Espressif
+BC6EE2 Intel Corporate
+387A0E Intel Corporate
+787264 IEEE Registration Authority
+88231F Fibocom Wireless
+A4DE26 Sumitomo Electric Industries
+301A30 Mako Networks
+C48BA3 Cisco Meraki
+140A29 Tiinlab
+C0F9D2 arkona technologies GmbH
+146102 Alps Alpine
+A02919 Dell
+241281 China Mobile Group Device
+D4EEDE Sichuan Tianyi Comheart Telecom
+C08B05 Huawei Technologies
+307BC9 Shenzhen Bilian Electronic，ltd
+50C0F0 Artek Microelectronics
+046865 Apple
+DC5392 Apple
+1CB3C9 Apple
+FCAA81 Apple
+609316 Apple
+646D2F Apple
+5C9666 Sony Interactive Entertainment
+24CE33 Amazon Technologies
+7C726E Ericsson AB
+549F06 Nokia Shanghai Bell
+68A878 GeoWAN
+38A91C New H3C Technologies
+94B34F Ruckus Wireless
+F4700C IEEE Registration Authority
+409B21 Nokia
+FC777B Hitron Technologies.
+14172A Fiberhome Telecommunication Technologies
+005FBF Toshiba
+E8A72F Microsoft
+D405DE eero
+FC0FE7 Microchip Technology
+C85CCC Beijing Xiaomi Mobile Software
+70FD88 Nanjing Jiahao Technology
+4873CB Tiinlab
+38384B vivo Mobile Communication
+789FAA Huawei Device
+98192C Edgecore Networks
+88A4C2 LCFC(Hefei) Electronics Technology
+AC8B6A China Mobile IOT Company Limited
+E07E5F Renesas Electronics (Penang) Sdn. Bhd.
+38BEAB AltoBeam (China)
+341343 GE Lighting
+B89EA6 Spbec-miningltd
+AC50DE Cloud Network Technology Singapore PTE.
+08C8C2 GN Audio A/S
+185880 Arcadyan
+A01C87 Unionman Technology
+3083D2 Motorola Mobility, a Lenovo Company
+00DDB6 New H3C Technologies
+B08B92 zte
+782184 Espressif
+94944A Particle Industries
+2CA327 Oraimo Technology Limited
+1466B7 Advanced Design Technology
+B8F255 Universal Electronics
+CC3F1D HMS Industrial Networks SLU
+5C49FA Shenzhen Guowei Shidai Communication Equipement
+EC656E The Things Industries
+10AEA5 Duskrise
+587DB6 Northern Data AG
+5C8E8B Shenzhen Linghai Electronics
+78EB46 Huawei Technologies
+C416C8 Huawei Technologies
+E4DCCC Huawei Technologies
+3CA161 Huawei Technologies
+9075BC Nokia Shanghai Bell
+C0F87F Cisco Systems
+4C53FD Amazon Technologies
+3C8B7F Cisco Systems
+0011E5 KCodes
+A083B4 HeNet
+04FF08 Huawei Device
+00A45F Huawei Device
+FCE26C Apple
+485AEA Fiberhome Telecommunication Technologies
+848102 Fiberhome Telecommunication Technologies
+54E005 Fiberhome Telecommunication Technologies
+4C7975 Apple
+1C7125 Apple
+34FE77 Apple
+98B785 Shenzhen 10Gtek Transceivers, Limited
+ECDA59 New H3C Technologies
+74B7E6 Zegna-Daidong Limited
+6CE5C9 Apple
+10B1DF Cloud Network Technology Singapore PTE.
+F4F647 zte
+E88175 zte
+40F4FD Unionman Technology
+9C0B05 eero
+78F238 Samsung Electronics
+64D0D6 Samsung Electronics
+DC9758 Sichuan AI-Link Technology
+40F6BC Amazon Technologies
+20AF1B SteelSeries ApS
+7C7716 Zyxel Communications
+943FBB JSC RPC Istok named after Shokin
+50E7B7 vivo Mobile Communication
+F4F70C Avang - neterbit
+E0FFF1 Texas Instruments
+F4442C Shenzhen SuperElectron Technology
+F0BE25 Dongguan Cannice Precision Manufacturing
+0080DA Hottinger Brüel & Kjær A/S
+704CB6 Shenzhen SuperElectron Technology
+549B49 NEC Platforms
+882510 Aruba, a Hewlett Packard Enterprise Company
+448C00 Realme Chongqing Mobile Telecommunications
+D0E828 Radiant Industries Incorporated
+74EF4B Guangdong OPPO Mobile Telecommunications
+107636 Earda Technologies
+18C293 Laird Connectivity
+000D9C K.A. Schmersal GmbH & KG
+244CAB Espressif
+E04102 zte
+D84008 Huawei Technologies
+6C047A Huawei Technologies
+6C558D Huawei Technologies
+78482C Start USA
+7C45D0 Shenzhen Wewins Wireless
+A42A95 D-Link International
+30CBC7 Cambium Networks Limited
+482E72 Cisco Systems
+885046 LEAR
+70041D Espressif
+886F29 Pocketbook International SA
+744687 Kingsignal Technology
+BC2247 New H3C Technologies
+0826AE IEEE Registration Authority
+8C477F NambooSolution
+7CDAC3 Sichuan Tianyi Comheart Telecom
+8C17B6 Huawei Device
+B82B68 Huawei Device
+2CF295 Huawei Device
+E0BB0C Synertau
+149BD7 MULI Muwai Furniture Qidong
+AC77B9 Nanjing Yufei Intelligent Control Technology
+A85BB7 Apple
+3C5D29 Zhejiang Tmall Technology
+68FCCA Samsung Electronics
+6CD719 Fiberhome Telecommunication Technologies
+80015C Synaptics
+BC6193 Xiaomi Communications
+947FD8 Shenzhen Skyworth Digital Technology
+C854A4 Infinix mobility limited
+EC71DB Reolink Innovation Limited
+F8E57E Cisco Systems
+3053C1 Cresyn
+385B44 Silicon Laboratories
+943469 Silicon Laboratories
+AC330B Japan Computer Vision
+3462B4 Renesas Electronics (Penang) Sdn. Bhd.
+CCEB18 OOO "tss"
+6C2408 LCFC(Hefei) Electronics Technology
+EC6073 Tp-link Technologies
+74DDCB China Leadshine Technology
+104D15 Viaanix
+50A015 Shenzhen Yipingfang Network Technology
+B0AFF7 Shenzhen Yipingfang Network Technology
+7085C4 Ruijie Networks
+5CC563 Hunan Fn-link Technology Limited
+A0092E zte
+14755B Intel Corporate
+A8B13B HP
+C43875 Sonos
+68B691 Amazon Technologies
+20898A Shenzhen Skyworth Digital Technology
+DCA956 Guangdong OPPO Mobile Telecommunications
+4827C5 Huawei Technologies
+BCD206 Huawei Technologies
+CC827F Advantech Technology (china)
+F84E58 Samsung Electronics
+B47064 Samsung Electronics
+4C2E5E Samsung Electronics
+645DF4 Samsung Electronics
+D81068 Murata Manufacturing
+5C045A Company NA Stage & Light
+883F0C system a.v.
+C8BE35 Extreme Networks
+78AF08 Intel Corporate
+F4E204 Coyote System
+58C356 EM Microelectronic
+A0EDFB Quectel Wireless Solutions
+B02347 Shenzhen Giant Microelectronics Company Limited
+CCDD58 Robert Bosch GmbH
+D4E053 Aruba, a Hewlett Packard Enterprise Company
+88FC5D Cisco Systems
+F4C88A Intel Corporate
+183C98 Shenzhen Hengyi Technology
+787104 Sichuan Tianyi Comheart Telecom
+64C582 China Mobile Group Device
+50284A Intel Corporate
+5CA4F4 zte
+9409C9 Alpsalpine
+246C60 Huawei Device
+98C97C Shenzhen iComm Semiconductor
+303EA7 Intel Corporate
+28A331 Sierra Wireless
+EC6260 Espressif
+B06E72 Realme Chongqing Mobile Telecommunications
+607D09 Luxshare Precision Industry
+1834AF Kaonmedia
+28827C Bosch Automative products(Suzhou)Co.,Ltd Changzhou Branch
+28F5D1 Arris Group
+10E177 Arris Group
+90D473 vivo Mobile Communication
+08EBF6 Huawei Technologies
+CC3E79 Arris Group
+0016A3 Ingeteam
+F06C5D Xiaomi Communications
+24CF24 Beijing Xiaomi Mobile Software
+C8F09E Espressif
+DC5475 Espressif
+0C7BC8 Cisco Meraki
+286F40 Tonly Technology
+0C86C7 Jabil Circuit (Guangzhou) Limited
+1C0D7D Apple
+14F287 Apple
+585595 Apple
+14946C Apple
+1C5974 IEEE Registration Authority
+74604C RØDE
+40B02F Miele & Cie. KG
+B47D76 KNS Group
+C0AD97 Tecno Mobile Limited
+70A983 Cisco Systems
+BCFAEB Cisco Systems
+1866F0 Jupiter Systems
+BCC7DA Earda Technologies
+848553 Biznes Systema Telecom
+580032 Genexis
+D88863 Huawei Technologies
+C03E50 Huawei Technologies
+806036 Huawei Technologies
+4C5369 YanFeng Visteon(ChongQing) Automotive Electronic
+74767D shenzhen kexint technology
+B038E2 Wanan Hongsheng ElectronicLtd
+E048D8 Guangzhi Wulian Technology(Guangzhou)
+F8E4A4 Fiberhome Telecommunication Technologies
+A0C98B Nokia Solutions and Networks GmbH & KG
+18BB1C Huawei Device
+B8F0B9 zte
+805B65 LG Innotek
+4C9D22 ACES
+88C9E8 Sony
+00738D Shenzhen Tinno Mobile Technology
+D4430E Zhejiang Dahua Technology
+F85E0B Realme Chongqing Mobile Telecommunications
+44D3AD Shenzhen Tinno Mobile Technology
+94D331 Xiaomi Communications
+34DD04 Minut AB
+601E98 Axevast Technology
+A8F7D9 Mist Systems
+5C8C30 Taicang T&W Electronics
+2C9D65 vivo Mobile Communication
+448816 Cisco Systems
+68D927 Huawei Technologies
+90F970 Huawei Technologies
+04CAED Huawei Technologies
+68EE88 Shenzhen Tinno Mobile Technology
+543D92 Wireless-tek Technology Limited
+9826AD Quectel Wireless Solutions
+E8AC23 Huawei Technologies
+2C3B70 AzureWave Technology
+3886F7 Google
+F4227A Guangdong Seneasy Intelligent Technology
+8C5109 IEEE Registration Authority
+DC8DB7 ATW Technology
+A475B9 Samsung Electronics
+80549C Samsung Electronics
+1CF8D0 Samsung Electronics
+6C60D0 Huawei Device
+640E6A Seco-larm USA
+68E154 SiMa.ai
+702084 Hon Hai Precision Industry
+28C13C Hon Hai Precision Industry
+18AA1E Shenzhen Skyworth Digital Technology
+9C31C3 SKY UK Limited
+D452EE SKY UK Limited
+1CA0B8 Hon Hai Precision Industry
+E8EF05 MIND TECH International Limited
+902106 SKY UK Limited
+D8FFC3 Shenzhen 3snic information technology company Limited
+F08756 Zyxel Communications
+18C300 Nokia
+D44D77 Nokia
+4827E2 Espressif
+F46D3F Intel Corporate
+58B38F New H3C Technologies
+40E171 Jiangsu Huitong Group
+6C724A Onkyo Technology K.K.
+DC0539 Cisco Systems
+8C255E VoltServer
+E0F318 Sichuan Tianyi Comheart Telecom
+C464F2 Infinix mobility limited
+B01F47 Heights Telecom
+282947 Chipsea Technologies (Shenzhen)
+ACBCB5 Apple
+082573 Apple
+AC007A Apple
+F01FC7 Apple
+B88F27 Realme Chongqing Mobile Telecommunications
+88200D Apple
+BC1541 Nokia
+946DAE Mellanox Technologies
+E4A634 Universal Electronics
+2C8D37 Virtium
+506391 Huawei Technologies
+E8A34E Huawei Technologies
+041892 Huawei Technologies
+14656A Huawei Technologies
+ACB687 Arcadyan
+6CB7E2 Huawei Technologies
+C475EA Huawei Technologies
+9025F2 Huawei Technologies
+387C76 Universal Global Scientific Industrial
+40FDF3 Ampak Technology
+ECE61D Huawei Device
+486DBB Vestel Elektronik San ve Tic. A.S.
+4C63AD Huawei Device
+DCDB27 Huawei Device
+CC96E5 Dell
+0084ED Lexmark International
 525400 QEMU virtual NIC
 B0C420 Bochs virtual NIC
 DEADCA PearPC virtual NIC


### PR DESCRIPTION
The `nmap-mac-prefixes` has not been updated in 10 months (since Aug 6, 2021; [2f8b4e2](https://github.com/nmap/nmap/commit/2f8b4e20a1995ada3f6d4fb4c1dcf070992c927a)). The source data format has also changed, making the former Perl script `make-mac-prefixes.pl` incompatible with it. The corresponding data can currently be found from IEEE MA-L Assignments (CSV) data set, as described in https://standards.ieee.org/products-programs/regauth/.

This PR adds a new Python script `make-mac-prefixes.py` for updating the prefixes. The format produced is not exactly the same, but based on the same aims. The updated `nmap-mac-prefixes` is produced with this script.

```
$ curl https://standards-oui.ieee.org/oui/oui.csv | ./make-mac-prefixes.py > nmap-mac-prefixes 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2889k  100 2889k    0     0   432k      0  0:00:06  0:00:06 --:--:--  593k
# Found 31988 registed OUIs.
# Added 5 unregisted OUIs.
```

Ref. question on the nmap-dev mailing list https://seclists.org/nmap-dev/2022/q2/6