### PR TITLE
nping/Crypto.cc: fix build with libressl >= 3.5.0

### DIFF
--- a/nping/Crypto.cc
+++ b/nping/Crypto.cc
@@ -70,7 +70,9 @@
 #include <openssl/evp.h>
 #include <openssl/err.h>
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined LIBRESSL_VERSION_NUMBER
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && \
+	((!defined LIBRESSL_VERSION_NUMBER) || \
+	(defined LIBRESSL_VERSION_NUMBER && LIBRESSL_VERSION_NUMBER >= 0x30500000L))
 #define HAVE_OPAQUE_EVP_PKEY 1
 #define FUNC_EVP_MD_CTX_init EVP_MD_CTX_reset
 #define FUNC_EVP_MD_CTX_cleanup EVP_MD_CTX_reset


### PR DESCRIPTION
Fix the following build failure with libressl >= 3.5.0:

```
Crypto.cc: In static member function 'static int Crypto::aes128_cbc_encrypt(u8*, size_t, u8*, u8*, size_t, u8*)':
Crypto.cc:139:26: error: aggregate 'EVP_CIPHER_CTX ctx' has incomplete type and cannot be defined
  139 |           EVP_CIPHER_CTX ctx;
      |                          ^~~

```

Fixes:
 - http://autobuild.buildroot.org/results/2e6eebbe2ed8305b88047bc92c19350c1ecada16

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>