### PR TITLE
Fix libressl >= 3.5.0 build

### DIFF
--- a/libssh2/src/openssl.h
+++ b/libssh2/src/openssl.h
@@ -55,8 +55,9 @@
 #include <openssl/pem.h>
 #include <openssl/rand.h>
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-    !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && \
+    ((!defined LIBRESSL_VERSION_NUMBER) || \
+    (defined LIBRESSL_VERSION_NUMBER && LIBRESSL_VERSION_NUMBER >= 0x30500000L))
 # define HAVE_OPAQUE_STRUCTS 1
 #endif
 

--- a/ncat/ncat_ssl.c
+++ b/ncat/ncat_ssl.c
@@ -74,7 +74,9 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined LIBRESSL_VERSION_NUMBER
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && \
+    ((!defined LIBRESSL_VERSION_NUMBER) || \
+    (defined LIBRESSL_VERSION_NUMBER && LIBRESSL_VERSION_NUMBER >= 0x30500000L))
 #define HAVE_OPAQUE_STRUCTS 1
 #define FUNC_ASN1_STRING_data ASN1_STRING_get0_data
 #else

--- a/nping/Crypto.cc
+++ b/nping/Crypto.cc
@@ -70,7 +70,9 @@
 #include <openssl/evp.h>
 #include <openssl/err.h>
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined LIBRESSL_VERSION_NUMBER
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && \
+    ((!defined LIBRESSL_VERSION_NUMBER) || \
+    (defined LIBRESSL_VERSION_NUMBER && LIBRESSL_VERSION_NUMBER >= 0x30500000L))
 #define HAVE_OPAQUE_EVP_PKEY 1
 #define FUNC_EVP_MD_CTX_init EVP_MD_CTX_reset
 #define FUNC_EVP_MD_CTX_cleanup EVP_MD_CTX_reset

--- a/nse_openssl.cc
+++ b/nse_openssl.cc
@@ -21,7 +21,9 @@
 #include <openssl/ripemd.h>
 #include <openssl/sha.h>
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined LIBRESSL_VERSION_NUMBER
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && \
+    ((!defined LIBRESSL_VERSION_NUMBER) || \
+    (defined LIBRESSL_VERSION_NUMBER && LIBRESSL_VERSION_NUMBER >= 0x30500000L))
 #define HAVE_OPAQUE_STRUCTS 1
 #define FUNC_EVP_MD_CTX_init EVP_MD_CTX_reset
 #define FUNC_EVP_MD_CTX_cleanup EVP_MD_CTX_reset

--- a/nse_ssl_cert.cc
+++ b/nse_ssl_cert.cc
@@ -81,7 +81,9 @@
 #include <openssl/evp.h>
 #include <openssl/err.h>
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined LIBRESSL_VERSION_NUMBER
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && \
+    ((!defined LIBRESSL_VERSION_NUMBER) || \
+    (defined LIBRESSL_VERSION_NUMBER && LIBRESSL_VERSION_NUMBER >= 0x30500000L))
 /* Technically some of these things were added in 0x10100006
  * but that was pre-release. */
 #define HAVE_OPAQUE_STRUCTS 1


### PR DESCRIPTION
After looking into it, https://github.com/nmap/nmap/issues/2484
There are more opaque defines that need to be changed than
other people previously anticipated.