### PR TITLE
Fix alignment related Bus Error on SPARC

### DIFF
--- a/tcpip.cc
+++ b/tcpip.cc
@@ -1492,13 +1492,13 @@ static bool accept_any (const unsigned char *p, const struct pcap_pkthdr *h, int
 }
 
 static bool accept_ip (const unsigned char *p, const struct pcap_pkthdr *h, int datalink, size_t offset) {
-  const struct ip *ip = NULL;
+  struct ip local;
 
   if (h->caplen < offset + sizeof(struct ip)) {
     return false;
   }
-  ip = (struct ip *) (p + offset);
-  switch (ip->ip_v) {
+  memcpy(&local, (p + offset), sizeof(struct ip));
+  switch (local.ip_v) {
     case 4:
     case 6:
       break;
@@ -1510,9 +1510,11 @@ static bool accept_ip (const unsigned char *p, const struct pcap_pkthdr *h, int 
   return true;
 }
 
-const u8 *readip_pcap(pcap_t *pd, unsigned int *len, long to_usec,
+u8 *readip_pcap(pcap_t *pd, unsigned int *len, long to_usec,
                   struct timeval *rcvdtime, struct link_header *linknfo, bool validate) {
   int datalink;
+  static u8 *alignedbuf = NULL;
+  static unsigned int alignedbufsz = 0;
   size_t offset = 0;
   struct pcap_pkthdr *head;
   const u8 *p;
@@ -1534,29 +1536,36 @@ const u8 *readip_pcap(pcap_t *pd, unsigned int *len, long to_usec,
     return NULL;
   }
 
-  *len = head->caplen - offset;
-  p += offset;
-
-  if (validate) {
-    if (!validatepkt(p, len)) {
-      *len = 0;
-      return NULL;
-    }
-  }
   if (offset && linknfo) {
     linknfo->datalinktype = datalink;
     linknfo->headerlen = offset;
     assert(offset <= MAX_LINK_HEADERSZ);
-    memcpy(linknfo->header, p - offset, MIN(sizeof(linknfo->header), offset));
+    memcpy(linknfo->header, p, MIN(sizeof(linknfo->header), offset));
   }
-  if (rcvdtime)
-    PacketTrace::trace(PacketTrace::RCVD, (u8 *) p, *len,
-        rcvdtime);
-  else
-    PacketTrace::trace(PacketTrace::RCVD, (u8 *) p, *len);
 
   *len = head->caplen - offset;
-  return p;
+  p += offset;
+
+  if (*len > alignedbufsz) {
+    alignedbuf = (u8 *) safe_realloc(alignedbuf, *len);
+    alignedbufsz = *len;
+  }
+  memcpy(alignedbuf, p, *len);
+
+  if (validate) {
+    if (!validatepkt((u8 *) alignedbuf, len)) {
+      *len = 0;
+      return NULL;
+    }
+  }
+  if (rcvdtime)
+    PacketTrace::trace(PacketTrace::RCVD, (u8 *) alignedbuf, *len,
+        rcvdtime);
+  else
+    PacketTrace::trace(PacketTrace::RCVD, (u8 *) alignedbuf, *len);
+
+  *len = head->caplen - offset;
+  return alignedbuf;
 }
 
 // Returns whether the packet receive time value obtained from libpcap

--- a/tcpip.cc
+++ b/tcpip.cc
@@ -1536,13 +1536,6 @@ u8 *readip_pcap(pcap_t *pd, unsigned int *len, long to_usec,
     return NULL;
   }
 
-  if (offset && linknfo) {
-    linknfo->datalinktype = datalink;
-    linknfo->headerlen = offset;
-    assert(offset <= MAX_LINK_HEADERSZ);
-    memcpy(linknfo->header, p, MIN(sizeof(linknfo->header), offset));
-  }
-
   *len = head->caplen - offset;
   p += offset;
 
@@ -1557,6 +1550,12 @@ u8 *readip_pcap(pcap_t *pd, unsigned int *len, long to_usec,
       *len = 0;
       return NULL;
     }
+  }
+  if (offset && linknfo) {
+    linknfo->datalinktype = datalink;
+    linknfo->headerlen = offset;
+    assert(offset <= MAX_LINK_HEADERSZ);
+    memcpy(linknfo->header, p - offset, MIN(sizeof(linknfo->header), offset));
   }
   if (rcvdtime)
     PacketTrace::trace(PacketTrace::RCVD, (u8 *) alignedbuf, *len,

--- a/tcpip.h
+++ b/tcpip.h
@@ -356,7 +356,7 @@ bool getNextHopMAC(const char *iface, const u8 *srcmac, const struct sockaddr_st
 const u8 *readipv4_pcap(pcap_t *pd, unsigned int *len, long to_usec,
                     struct timeval *rcvdtime, struct link_header *linknfo, bool validate);
 
-const u8 *readip_pcap(pcap_t *pd, unsigned int *len, long to_usec,
+u8 *readip_pcap(pcap_t *pd, unsigned int *len, long to_usec,
                   struct timeval *rcvdtime, struct link_header *linknfo, bool validate);
 
 /* Examines the given tcp packet and obtains the TCP timestamp option


### PR DESCRIPTION
This PR fixes #2173 - `Bus Error` that is a result of unaligned data after https://github.com/nmap/nmap/commit/4ffeb09ad3c51e44438b455bc327580934f6528d.

It brings back the static `alignedbuf` that is used to align the data for later use.

I don't like the additional `memcpy` in `accept_ip()` much, but this function is called before the alignment... (and it wasn't there at all before https://github.com/nmap/nmap/commit/4ffeb09ad3c51e44438b455bc327580934f6528d).
