### PR TITLE
NpingOps.cc needs <limits.h> include on Solaris

### DIFF
--- a/nping/nping.h
+++ b/nping/nping.h
@@ -71,6 +71,7 @@
 #include <stdarg.h>
 #include <errno.h>
 #include <ctype.h>
+#include <limits.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 


### PR DESCRIPTION
Build on Solaris fails with the following error:
```
NpingOps.cc: In member function 'int NpingOps::getTotalProbes()':
NpingOps.cc:3058:13: error: 'INT_MAX' was not declared in this scope
 3058 |   if (tmp > INT_MAX) {
```
Adding `#include <limits.h>` fixes this issue. I am not 100% sure where to put the import in but `nping.h` seems like a good place.