### PR TITLE
Fixes to support libressl 

### DIFF
--- a/libssh2/src/openssl.h
+++ b/libssh2/src/openssl.h
@@ -57,8 +57,8 @@
 #include <openssl/pem.h>
 #include <openssl/rand.h>
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-    !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x30500000L)
 # define HAVE_OPAQUE_STRUCTS 1
 #endif
 

--- a/nping/Crypto.cc
+++ b/nping/Crypto.cc
@@ -70,7 +70,8 @@
 #include <openssl/evp.h>
 #include <openssl/err.h>
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined LIBRESSL_VERSION_NUMBER
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x30500000L)
 #define HAVE_OPAQUE_EVP_PKEY 1
 #define FUNC_EVP_MD_CTX_init EVP_MD_CTX_reset
 #define FUNC_EVP_MD_CTX_cleanup EVP_MD_CTX_reset

--- a/nse_openssl.cc
+++ b/nse_openssl.cc
@@ -13,7 +13,8 @@
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined LIBRESSL_VERSION_NUMBER
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x30500000L)
 #define HAVE_OPAQUE_STRUCTS 1
 #define FUNC_EVP_MD_CTX_init EVP_MD_CTX_reset
 #define FUNC_EVP_MD_CTX_cleanup EVP_MD_CTX_reset

--- a/nse_ssl_cert.cc
+++ b/nse_ssl_cert.cc
@@ -80,7 +80,8 @@
 #include <openssl/evp.h>
 #include <openssl/err.h>
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined LIBRESSL_VERSION_NUMBER
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x30500000L)
 /* Technically some of these things were added in 0x10100006
  * but that was pre-release. */
 #define HAVE_OPAQUE_STRUCTS 1


### PR DESCRIPTION
Support for libressl was missing causing number of build errors. Following files were changed:

libssh2/src/openssl.h
nping/Crypto.cc
nse_openssl.cc
nse_ssl_cert.cc

The mentioned errors were encountered when nmap was built with libressl3.5-libcrypto libressl3.5-libssl libressl3.5-libtls libraries for apline 3.16.2 based container. They were not present when building with libssl3 (openssl ) library.
