### PR TITLE
Support LibreSSL 3.5

### DIFF
--- a/nping/Crypto.cc
+++ b/nping/Crypto.cc
@@ -70,7 +70,7 @@
 #include <openssl/evp.h>
 #include <openssl/err.h>
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined LIBRESSL_VERSION_NUMBER
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER >= 0x3050000fL
 #define HAVE_OPAQUE_EVP_PKEY 1
 #define FUNC_EVP_MD_CTX_init EVP_MD_CTX_reset
 #define FUNC_EVP_MD_CTX_cleanup EVP_MD_CTX_reset

--- a/nse_openssl.cc
+++ b/nse_openssl.cc
@@ -13,7 +13,7 @@
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined LIBRESSL_VERSION_NUMBER
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER >= 0x3050000fL
 #define HAVE_OPAQUE_STRUCTS 1
 #define FUNC_EVP_MD_CTX_init EVP_MD_CTX_reset
 #define FUNC_EVP_MD_CTX_cleanup EVP_MD_CTX_reset

--- a/nse_ssl_cert.cc
+++ b/nse_ssl_cert.cc
@@ -80,7 +80,7 @@
 #include <openssl/evp.h>
 #include <openssl/err.h>
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined LIBRESSL_VERSION_NUMBER
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER >= 0x3050000fL
 /* Technically some of these things were added in 0x10100006
  * but that was pre-release. */
 #define HAVE_OPAQUE_STRUCTS 1


### PR DESCRIPTION
Opaque structs matching OpenSSL 1.1 are now available in LibreSSL 3.5 and newer.

Gentoo Issue: https://github.com/gentoo/libressl/issues/459

I am unsure if its preferable to drop support for LibreSSL versions older than 3.5 or if the current patch is preferable?