### PR TITLE
Fixes is_bit_set is repeated in bignum_methods at nse_openssl

### DIFF
--- a/nse_openssl.cc
+++ b/nse_openssl.cc
@@ -520,7 +520,6 @@ static const struct luaL_Reg bignum_methods[] = {
   { "is_bit_set", l_bignum_is_bit_set },
   { "set_bit", l_bignum_set_bit },
   { "clear_bit", l_bignum_clear_bit },
-  { "is_bit_set", l_bignum_is_bit_set },
   { "is_prime", l_bignum_is_prime },
   { "is_safe_prime", l_bignum_is_safe_prime },
   { "__gc", l_bignum_free },


### PR DESCRIPTION
https://github.com/nmap/nmap/blob/master/nse_openssl.cc#L520
https://github.com/nmap/nmap/blob/master/nse_openssl.cc#L523