### PR TITLE
Replaces legacy API URL, encode post request in json and parse response for result.

### DIFF
--- a/scripts/http-google-malware.nse
+++ b/scripts/http-google-malware.nse
@@ -4,6 +4,7 @@ local shortport = require "shortport"
 local stdnse = require "stdnse"
 local string = require "string"
 local table = require "table"
+local json = require "json"
 
 description = [[
 Checks if hosts are on Google's blacklist of suspected malware and phishing
@@ -50,8 +51,8 @@ local APIKEY = ""
 --Builds Google Safe Browsing query
 --@param apikey Api key
 --@return Url
-local function build_qry(apikey, url)
-  return string.format("https://sb-ssl.google.com/safebrowsing/api/lookup?client=%s&apikey=%s&appver=1.5.2&pver=3.0&url=%s", SCRIPT_NAME, apikey, url)
+local function build_qry(apikey)
+  return string.format("http://safebrowsing.googleapis.com/v4/threatMatches:find?key=%s", apikey)
 end
 
 local function fail (err) return stdnse.format_output(false, err) end
@@ -79,12 +80,49 @@ action = function(host, port)
   end
 
   stdnse.debug1("Checking host %s", target_url)
-  local qry = build_qry(apikey, target_url)
-  local req = http.get_url(qry, {any_af=true})
+
+--Create the payload for POST request and convert to JSON
+  local obj = {
+    ["client"] = {
+      ["clientId"] = "nmap",
+      ["clientVersion"] = "7.9.3"
+    },
+    ["threatInfo"] = {
+      ["threatTypes"] = {"MALWARE", "SOCIAL_ENGINEERING"},
+      ["platformTypes"] = {"ANY_PLATFORM"},
+      ["threatEntryTypes"] = {"URL"},
+      ["threatEntries"] = {
+        {["url"] = target_url }
+      }
+    }
+  }
+  local payload = json.generate(obj)
+
+--Build the query with API key and send request to API
+  local qry = build_qry(apikey)
+  local status, cert = ssl.getCertificate("google.com", 443)
+  stdnse.debug2(cert)
+  local req, err = http.post(qry, 80, payload)
+  if err ~= nil then
+    return fail("could not connect to API")
+  end
   stdnse.debug2("%s", qry)
 
+  local ok, resp = json.parse(req.body)
+
+--The API responds with an empty body if no URL is found to be malicious
+  if ( ok == false ) then
+    stdnse.debug2(req.body)
+    return fail("could not parse JSON response")
+  end
+--The JSON body is empty if URL is safe
+  if ( resp == nil ) then
+    output_lns[#output_lns+1] = "Host is safe to browse."
+    return table.concat(output_lns, "\n")
+  end
+  
   if ( req.status > 400 ) then
-    return fail("Request failed (invalid API key?)")
+    return fail("Request failed")
   end
 
   --The Safe Lookup API responds with a type when site is on the lists


### PR DESCRIPTION
Tested the JSON request by printing out the generated body and running on Postman, giving accurate responses back from API. However, some points are left:

- An issue remains, which is testing it as a NSE script since the Nmap distribution installed in my system `fails to support SSL` somehow.
- The API only accepts HTTPS connections even though the URL is given as http;//, which makes it tricky to test it without removing nmap and fixing the issue with SSL in my system.

The SSL problem is related to a single system, so I have pushed this branch in confidence that it works based on external tests. In the meantime, this commit is expected to fix the issue or even help others working on the same issue.