### PR TITLE
zenmap: further Python 3 compatibility fixes

### DIFF
--- a/zenmap/setup.py
+++ b/zenmap/setup.py
@@ -215,13 +215,13 @@ class my_install(install):
 #!/usr/bin/env python3
 import errno, os, os.path, sys
 
-print 'Uninstall %(name)s %(version)s'
+print('Uninstall %(name)s %(version)s')
 
 answer = raw_input('Are you sure that you want to uninstall '
     '%(name)s %(version)s? (yes/no) ')
 
 if answer != 'yes' and answer != 'y':
-    print 'Not uninstalling.'
+    print('Not uninstalling.')
     sys.exit(0)
 
 """ % {'name': APP_DISPLAY_NAME, 'version': VERSION}
@@ -237,8 +237,8 @@ if answer != 'yes' and answer != 'y':
                     # This should never happen (everything gets installed
                     # inside the root), but if it does, be safe and don't
                     # delete anything.
-                    uninstaller += ("print '%s was not installed inside "
-                        "the root %s; skipping.'\n" % (output, self.root))
+                    uninstaller += ("print('%s was not installed inside "
+                        "the root %s; skipping.')\n" % (output, self.root))
                     continue
                 output = path_strip_prefix(output, self.root)
                 assert os.path.isabs(output)
@@ -262,24 +262,24 @@ for path in INSTALLED_FILES:
         dirs.append(path)
 # Delete the files.
 for file in files:
-    print "Removing '%s'." % file
+    print("Removing '%s'." % file)
     try:
         os.remove(file)
     except OSError as e:
-        print >> sys.stderr, '  Error: %s.' % str(e)
+        print('  Error: %s.' % str(e), file=sys.stderr)
 # Delete the directories. First reverse-sort the normalized paths by
 # length so that child directories are deleted before their parents.
 dirs = [os.path.normpath(dir) for dir in dirs]
 dirs.sort(key = len, reverse = True)
 for dir in dirs:
     try:
-        print "Removing the directory '%s'." % dir
+        print("Removing the directory '%s'." % dir)
         os.rmdir(dir)
     except OSError as e:
         if e.errno == errno.ENOTEMPTY:
-            print "Directory '%s' not empty; not removing." % dir
+            print("Directory '%s' not empty; not removing." % dir)
         else:
-            print >> sys.stderr, str(e)
+            print(str(e), file=sys.stderr)
 """
 
         uninstaller_file = open(uninstaller_filename, 'w')
@@ -419,7 +419,7 @@ for dir in dirs:
         with open(INSTALLED_FILES_NAME, "w") as f:
             for output in self.get_installed_files():
                 assert "\n" not in output
-                print >> f, output
+                print(output, file=f)
 
 
 class my_uninstall(Command):


### PR DESCRIPTION
Without this, we get:
```
Traceback (most recent call last):
  File "/var/tmp/portage/net-analyzer/nmap-9999/work/nmap-9999/zenmap/setup.py", line 584, in <module>
    setup(**setup_args)
  File "/usr/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 185, in setup
    return run_commands(dist)
  File "/usr/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
    dist.run_commands()
  File "/usr/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.10/site-packages/setuptools/dist.py", line 1208, in run_command
    super().run_command(command)
  File "/usr/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
    cmd_obj.run()
  File "/var/tmp/portage/net-analyzer/nmap-9999/work/nmap-9999/zenmap/setup.py", line 188, in run
    self.write_installed_files()
  File "/var/tmp/portage/net-analyzer/nmap-9999/work/nmap-9999/zenmap/setup.py", line 419, in write_installed_files
    print >> f, output
TypeError: unsupported operand type(s) for >>: 'builtin_function_or_method' and '_io.TextIOWrapper'. Did you mean "print(<message>, file=<output_stream>)"?
make: *** [Makefile:372: install-zenmap] Error 1
```

This is because Python 3 doesn't support Python 2-style print without parentheses, or specifying the output file in that manner.

Signed-off-by: Sam James <sam@gentoo.org>