### PR TITLE
Fix version detection in openflow-info.nse

### DIFF
--- a/scripts/openflow-info.nse
+++ b/scripts/openflow-info.nse
@@ -194,7 +194,7 @@ action = function(host, port)
 
   local supported_versions = {}
   for mask, version in pairs(openflow_versions) do
-    if mask & version_bitmap then
+    if (mask & version_bitmap) > 0 then
       table.insert(supported_versions, version)
     end
   end


### PR DESCRIPTION
`mask & version_bitmap` always returns true, so the script will always say the server support all OpenFlow versions.  
Use `(mask & version_bitmap) > 0` fixes that bug.