### PR TITLE
Update url.lua

### DIFF
--- a/nselib/url.lua
+++ b/nselib/url.lua
@@ -75,6 +75,11 @@ setmetatable(segment_set, { __index = hex_esc })
 -- @param s Binary string to be encoded.
 -- @return Escaped representation of string.
 local function protect_segment(s)
+  -- to prevent unexpected error when parsing the url
+  if not pcall(string.gsub, s, "([^A-Za-z0-9_.~-])", segment_set) then
+     return "e"
+  end
+  -- end of revision
   return string.gsub(s, "([^A-Za-z0-9_.~-])", segment_set)
 end
 


### PR DESCRIPTION
This error occur when trying to perform this command: nmap -d -p80,443 --script=http-sql-injection -d1 admin.zscaler.net

Without the above revision, the nmap can not continue processing with the error:

NSE: http-sql-injection against admin.zscaler.net (104.129.203.140:443) threw an error! /usr/local/bin/../share/nmap/nselib/url.lua:61: bad argument #1 to 'byte' (string expected, got table) stack traceback:
        [C]: in function 'string.byte'
        /usr/local/bin/../share/nmap/nselib/url.lua:61: in function </usr/local/bin/../share/nmap/nselib/url.lua:60>
        [C]: in function 'string.gsub'
        /usr/local/bin/../share/nmap/nselib/url.lua:82: in upvalue 'protect_segment'
        /usr/local/bin/../share/nmap/nselib/url.lua:360: in function 'url.build_path'
        /usr/local/bin/../share/nmap/nselib/url.lua:260: in function 'url.build'
        (...tail calls...)
        /usr/local/bin/../share/nmap/nselib/httpspider.lua:445: in method 'parse'
        /usr/local/bin/../share/nmap/nselib/httpspider.lua:418: in method 'new'
        /usr/local/bin/../share/nmap/nselib/httpspider.lua:377: in method 'parse'
        /usr/local/bin/../share/nmap/nselib/httpspider.lua:201: in method 'new'
        /usr/local/bin/../share/nmap/nselib/httpspider.lua:885: in function </usr/local/bin/../share/nmap/nselib/httpspider.lua:788>

This is because of the presence of malformed captured links like so below:

 https://admin.zscaler.net/js/n+"/"+r+".jpg",a.parentElement.onclick=function(e){return