### PR TITLE
Make the ncat http proxy listen only on the specified address

### DIFF
--- a/ncat/ncat_main.c
+++ b/ncat/ncat_main.c
@@ -887,10 +887,10 @@ int main(int argc, char *argv[])
             }
         }
         o.target = argv[optind];
-        /* resolve hostname only if o.proxytype == NULL
+        /* resolve hostname only if o.proxytype == NULL or o.listen == 1
          * targetss contains data already and you don't want remove them
          */
-        if( !o.proxytype
+        if( (!o.proxytype || o.listen)
                 && (rc = resolve_multi(o.target, 0, targetaddrs, o.af)) != 0)
 
             bye("Could not resolve hostname \"%s\": %s.", o.target, gai_strerror(rc));


### PR DESCRIPTION
 Currently, `ncat -l <host_or_address>` will only listen on the specified IP address, while `ncat --proxy-type http -l <host_or_address>` will listen on any IP address.

This patch will make ncat listen on it specified address also if running as a http proxy server.