### PR TITLE
Catch errors when connecting to SSH servers in ssh-publickey-acceptance.nse. Fixes #1014

### DIFF
--- a/scripts/ssh-publickey-acceptance.nse
+++ b/scripts/ssh-publickey-acceptance.nse
@@ -131,7 +131,7 @@ function action (host, port)
         if helper:connect_pcall(host, port) then
           successes = successes + 1
           if not helper:publickey_auth(usernames[j], privatekeys[i], passphrases[i] or "") then
-            stdnse.verbose("Failed to authenticate key " .. privatekey[i])
+            stdnse.verbose("Failed to authenticate key " .. privatekeys[i] .. privatekeys[i] .. " for user " .. usernames[j] .. " on host " .. host.ip .. ":" .. host.port)
           else
             table.insert(r, "Key " .. privatekeys[i] .. " accepted for user " .. usernames[j])
             stdnse.verbose("Found accepted key: " .. privatekeys[i] .. " for user " .. usernames[j] .. " on host " .. host.ip .. ":" .. host.port)

--- a/scripts/ssh-publickey-acceptance.nse
+++ b/scripts/ssh-publickey-acceptance.nse
@@ -66,7 +66,7 @@ function action (host, port)
           local status, err = helper:publickey_canauth(usernames[j], result)
           if status then
             table.insert(r, "Key " .. publickeys[i] .. " accepted for user " .. usernames[j])
-            stdnse.verbose("Found accepted key: " .. publickeys[i] .. " for user " .. usernames[j] .. " on host " .. host.ip .. ":" .. host.port)
+            stdnse.verbose("Found accepted key: " .. publickeys[i] .. " for user " .. usernames[j] .. " on host " .. host.ip .. ":" .. port.number)
           elseif err then
             stdnse.debug("Error in publickey_canauth: %s", err)
           end
@@ -131,10 +131,10 @@ function action (host, port)
         if helper:connect_pcall(host, port) then
           successes = successes + 1
           if not helper:publickey_auth(usernames[j], privatekeys[i], passphrases[i] or "") then
-            stdnse.verbose("Failed to authenticate key " .. privatekeys[i] .. privatekeys[i] .. " for user " .. usernames[j] .. " on host " .. host.ip .. ":" .. host.port)
+            stdnse.verbose("Failed to authenticate key " .. privatekeys[i] .. privatekeys[i] .. " for user " .. usernames[j] .. " on host " .. host.ip .. ":" .. port.number)
           else
             table.insert(r, "Key " .. privatekeys[i] .. " accepted for user " .. usernames[j])
-            stdnse.verbose("Found accepted key: " .. privatekeys[i] .. " for user " .. usernames[j] .. " on host " .. host.ip .. ":" .. host.port)
+            stdnse.verbose("Found accepted key: " .. privatekeys[i] .. " for user " .. usernames[j] .. " on host " .. host.ip .. ":" .. port.number)
           end
           helper:disconnect()
         else

--- a/scripts/ssh-publickey-acceptance.nse
+++ b/scripts/ssh-publickey-acceptance.nse
@@ -61,7 +61,7 @@ function action (host, port)
         local status, result = helper:read_publickey(publickeys[i])
         if not status then
           stdnse.verbose("Error reading key: " .. result)
-        elseif helper:connect(host, port) then
+        elseif helper:connect_pcall(host, port) then
           successes = successes + 1
           local status, err = helper:publickey_canauth(usernames[j], result)
           if status then
@@ -100,7 +100,7 @@ function action (host, port)
       local msg = sections[3]
       stdnse.debug("Checking key: " .. key .. " for user " .. user)
       key = base64.dec(key)
-      if helper:connect(host, port) then
+      if helper:connect_pcall(host, port) then
         successes = successes + 1
         if helper:publickey_canauth(user, key) then
           table.insert(r, msg)
@@ -128,7 +128,7 @@ function action (host, port)
     for j = 1, #usernames do
       for i = 1, #privatekeys do
         stdnse.debug("Checking key: " .. privatekeys[i] .. " for user " .. usernames[j])
-        if helper:connect(host, port) then
+        if helper:connect_pcall(host, port) then
           successes = successes + 1
           if not helper:publickey_auth(usernames[j], privatekeys[i], passphrases[i] or "") then
             stdnse.verbose "Failed to authenticate"

--- a/scripts/ssh-publickey-acceptance.nse
+++ b/scripts/ssh-publickey-acceptance.nse
@@ -66,7 +66,7 @@ function action (host, port)
           local status, err = helper:publickey_canauth(usernames[j], result)
           if status then
             table.insert(r, "Key " .. publickeys[i] .. " accepted for user " .. usernames[j])
-            stdnse.verbose("Found accepted key: " .. publickeys[i] .. " for user " .. usernames[j])
+            stdnse.verbose("Found accepted key: " .. publickeys[i] .. " for user " .. usernames[j] .. " on host " .. host.ip .. ":" .. host.port)
           elseif err then
             stdnse.debug("Error in publickey_canauth: %s", err)
           end
@@ -131,11 +131,10 @@ function action (host, port)
         if helper:connect_pcall(host, port) then
           successes = successes + 1
           if not helper:publickey_auth(usernames[j], privatekeys[i], passphrases[i] or "") then
-            stdnse.verbose "Failed to authenticate"
+            stdnse.verbose("Failed to authenticate key " .. privatekey[i])
           else
             table.insert(r, "Key " .. privatekeys[i] .. " accepted for user " .. usernames[j])
-            stdnse.verbose("Found accepted key: " .. privatekeys[i] .. " for user " .. usernames[j])
-
+            stdnse.verbose("Found accepted key: " .. privatekeys[i] .. " for user " .. usernames[j] .. " on host " .. host.ip .. ":" .. host.port)
           end
           helper:disconnect()
         else


### PR DESCRIPTION
ssh-publickey-acceptance.nse attempts to connect to remote SSH servers, and if it cannot connect, it tries a total of three times per host. However, connect() raises an exception, thus bailing completely on the host. connect_plist() returns the status however, and the re-attempts will occur.

I have also changed the verbose message about acepted keys to include the host. I have also included the privatekey name in case of failure to use the key.