### PR TITLE
Add one more username prompt pattern for telnet

### DIFF
--- a/scripts/telnet-brute.nse
+++ b/scripts/telnet-brute.nse
@@ -68,6 +68,7 @@ local is_username_prompt = function (str)
   local lcstr = str:lower()
   return lcstr:find("%f[%w]username%s*:%s*$")
       or lcstr:find("%f[%w]login%s*:%s*$")
+      or lcstr:find("%f[%w]login as%s*:%s*$")
 end
 
 


### PR DESCRIPTION
I have [Ericsson t093g-model-i](https://device.report/ericsson-ab/t093g-model-i) WIFI modem.
And it has telnet server with  `Login as: ` username prompt.
To brute force it I had to modify `telnet-brute.nse` script.

As alternative for adding one more `str:find` call I can imaging adding `username_prompt` and `password_prompt` as `--script-args` for `telnet-brute.nse`.
