### PR TITLE
Include stdbool.h for bool data type

### DIFF
--- a/nsock/src/engine_iocp.c
+++ b/nsock/src/engine_iocp.c
@@ -66,6 +66,7 @@
 #include "nsock_pcap.h"
 #endif
 
+#include <stdbool.h>
 
 /* --- ENGINE INTERFACE PROTOTYPES --- */
 static int iocp_init(struct npool *nsp);


### PR DESCRIPTION

    This fixes the following compiler error with mingw gcc.

    nmap/nsock/src/engine_iocp.c:734:3: error: unknown type name 'bool'
      734 |   bool eov_done = true;
          |   ^~~~
    nmap/nsock/src/engine_iocp.c:734:19: error: 'true' undeclared (first use in this function)
      734 |   bool eov_done = true;
          |                   ^~~~
    nmap/nsock/src/engine_iocp.c:739:18: error: 'false' undeclared (first use in this function)
      739 |       eov_done = false;
          |                  ^~~~~

