### PR TITLE
fix: array icmp_advert_entry_addr may out of bound

### DIFF
--- a/nping/NpingOps.cc
+++ b/nping/NpingOps.cc
@@ -1895,7 +1895,7 @@ bool NpingOps::issetICMPTransmitTimestamp(){
 
 
 int NpingOps::addICMPAdvertEntry(struct in_addr addr, u32 pref ){
-  if( this->icmp_advert_entry_count > MAX_ICMP_ADVERT_ENTRIES )
+  if( this->icmp_advert_entry_count >= MAX_ICMP_ADVERT_ENTRIES )
     return OP_FAILURE;
   this->icmp_advert_entry_addr[this->icmp_advert_entry_count] = addr;
   this->icmp_advert_entry_pref[this->icmp_advert_entry_count] = pref;


### PR DESCRIPTION
when proxy_count=128, array icmp_advert_entry_addr and icmp_advert_entry_pref will out of bound.