### PR TITLE
add check against NULL  to avoid NULL deref

### DIFF
--- a/ncat/http_digest.c
+++ b/ncat/http_digest.c
@@ -152,6 +152,12 @@ static char *make_nonce(const struct timeval *tv)
     Snprintf(time_buf, sizeof(time_buf), "%lu.%06lu",
         (long unsigned) tv->tv_sec, (long unsigned) tv->tv_usec);
     md5 = EVP_MD_CTX_new();
+    // add check against NULL
+    if(!md5)
+    {
+        return NULL;
+    }
+
     EVP_DigestInit_ex(md5, EVP_md5(), NULL);
     EVP_DigestUpdate(md5, secret, sizeof(secret));
     EVP_DigestUpdate(md5, ":", 1);
@@ -180,6 +186,13 @@ static void make_response(char buf[EVP_MAX_MD_SIZE * 2 + 1],
 
     /* Calculate H(A1). */
     md5 = EVP_MD_CTX_new();
+    
+    // add check against NULL
+    if(!md5)
+    {
+        return NULL;
+    }
+
     EVP_DigestInit_ex(md5, md, NULL);
     EVP_DigestUpdate(md5, username, strlen(username));
     EVP_DigestUpdate(md5, ":", 1);

--- a/nping/Crypto.cc
+++ b/nping/Crypto.cc
@@ -249,7 +249,11 @@ u8 *Crypto::deriveKey(const u8 *from, size_t fromlen, size_t *final_len){
 
         if( EVP_MD_size(EVP_sha256()) != SHA256_HASH_LEN )
           nping_fatal(QT_2, "OpenSSL is broken. SHA256 len is %d\n", EVP_MD_size(EVP_sha256()) );
-
+        // add check against NULL
+        if(!ctx)
+        {
+            //log and exit
+        }
         /* Compute the SHA256 hash of the supplied buffer */
         EVP_DigestInit(ctx, EVP_sha256());
         EVP_DigestUpdate(ctx, from, fromlen);


### PR DESCRIPTION
add check before calling EVP_DigestInit_ex and EVP_DigestInit