### PR TITLE
fixed style of version name in zenmap

### DIFF
--- a/zenmap/zenmapCore/Version.py
+++ b/zenmap/zenmapCore/Version.py
@@ -1,1 +1,1 @@
-VERSION = "7.94SVN"
+VERSION = "7.94+svn"


### PR DESCRIPTION
I had troubles installing zenmap with x64, Debian 12.1, Python 3.11.2

`sudo python3 setup.py install`

> /usr/lib/python3/dist-packages/setuptools/dist.py:548: UserWarning: The version specified ('7.94SVN') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
>   warnings.warn(
> Traceback (most recent call last):
>   File "/home/XXX/Software/fork/nmap/zenmap/setup.py", line 585, in <module>
>     setup(**setup_args)
>   File "/usr/lib/python3/dist-packages/setuptools/_distutils/core.py", line 185, in setup
>     return run_commands(dist)
>            ^^^^^^^^^^^^^^^^^^
>   File "/usr/lib/python3/dist-packages/setuptools/_distutils/core.py", line 201, in run_commands
>     dist.run_commands()
>   File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 969, in run_commands
>     self.run_command(cmd)
>   File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 1213, in run_command
>     super().run_command(command)
>   File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 988, in run_command
>     cmd_obj.run()
>   File "/home/XXX/Software/fork/nmap/zenmap/setup.py", line 181, in run
>     install.run(self)
>   File "/usr/lib/python3/dist-packages/setuptools/_distutils/command/install.py", line 709, in run
>     self.run_command(cmd_name)
>   File "/usr/lib/python3/dist-packages/setuptools/_distutils/cmd.py", line 318, in run_command
>     self.distribution.run_command(command)
>   File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 1213, in run_command
>     super().run_command(command)
>   File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 988, in run_command
>     cmd_obj.run()
>   File "/usr/lib/python3/dist-packages/setuptools/command/install_scripts.py", line 21, in run
>     self.run_command("egg_info")
>   File "/usr/lib/python3/dist-packages/setuptools/_distutils/cmd.py", line 318, in run_command
>     self.distribution.run_command(command)
>   File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 1213, in run_command
>     super().run_command(command)
>   File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 987, in run_command
>     cmd_obj.ensure_finalized()
>   File "/usr/lib/python3/dist-packages/setuptools/_distutils/cmd.py", line 111, in ensure_finalized
>     self.finalize_options()
>   File "/usr/lib/python3/dist-packages/setuptools/command/egg_info.py", line 219, in finalize_options
>     parsed_version = parse_version(self.egg_version)
>                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/usr/lib/python3/dist-packages/pkg_resources/_vendor/packaging/version.py", line 266, in __init__
>     raise InvalidVersion(f"Invalid version: '{version}'")
> pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: '7.94SVN'

for me it seems like dist-packages does not accept the version naming `7.94SVN` however `7.94+svn` which imho also better suits semantic versioning: [https://semver.org/](https://semver.org/) works fine

this is also mentioned in #2714 and #2779