### PR TITLE
Replaced function packlen with packsize in knx-gateway-discover script

### DIFF
--- a/scripts/knx-gateway-discover.nse
+++ b/scripts/knx-gateway-discover.nse
@@ -93,7 +93,7 @@ local knxParseSearchResponse = function(ips, results, knxMessage)
   end
 
   local message_format = '>B c1 c4 I2 BBB c1 I2 c2 c6 c4 c6 c30 BB'
-  if #knxMessage - pos + 1 < string.packlen(message_format) then
+  if #knxMessage - pos + 1 < string.packsize(message_format) then
     stdnse.debug1("Message too short for KNX message")
     return
   end


### PR DESCRIPTION
This a patch for a bug in the knx-gateway-discover script  and it fails because the function packlen does not exists in Line 96. 

Nmap version used: 
```
Nmap version 7.94 ( https://nmap.org )
Platform: x86_64-pc-linux-gnu
Compiled with: liblua-5.4.6 openssl-3.1.2 libssh2-1.11.0 libz-1.3 libpcre-8.45 libpcap-1.10.4 nmap-libdnet-1.12 ipv6
Compiled without:
Available nsock engines: epoll poll select
```

The fix was tested against a KNX setup: 

```
NSE: Starting knx-gateway-discover.
NSE: Finished knx-gateway-discover.
Completed NSE at 07:13, 3.20s elapsed
Pre-scan script results:
| knx-gateway-discover: 
|   172.1.0.193: 
|     Header: 
|       Header length: 6
|       Protocol version: 16
|       Service type: SEARCH_RESPONSE (0x0202)
|       Total length: 78
|     Body: 
|       HPAI: 
|         Protocol code: 01
|         IP address: 172.1.0.193
|         Port: 3671
|       DIB_DEV_INFO: 
|         Description type: Device Information
|         KNX medium: KNX TP1
|         Device status: 00
|         KNX address: 15.15.15
|         Project installation identifier: 0000
|         Decive serial: 00010052178f
|         Multicast address: 0.0.0.0
|         Device MAC address: 00:0e:8c:00:b9:d7
|         Device friendly name: IP-Schnittstelle Secure 
|       DIB_SUPP_SVC_FAMILIES: 
|         KNXnet/IP Core version 2
|         KNXnet/IP Device Management version 2
|         KNXnet/IP Tunnelling version 2
|_        KNXnet/IP Remote Configuration and Diagnosis version 1
NSE: Script Post-scanning.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 07:13
Completed NSE at 07:13, 0.00s elapsed
```

