### PR TITLE
Added service probes for KNX + OPC UA 

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -14945,6 +14945,7 @@ rarity 7
 ports 4840
 sslports 4843
 match opcua m|^ACKF\x1c\x00\x00\x00\x00\x00\x00\x00|s p/OPC UA Binary Connection Protocol/
+match opcua m|^ERRF..\x00\x00\x00\x00|s p/OPC UA Binary Connection Protocol/
 
 ##############################NEXT PROBE##############################
 Probe UDP KNX q|\x06\x10\x02\x03\x00\x0e\x08\x01\x00\x00\x00\x00\x00\x00|

--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -14945,19 +14945,19 @@ rarity 7
 ports 4840
 sslports 4843
 match opcua m|^ACKF\x1c\x00\x00\x00\x00\x00\x00\x00|s p/OPC UA Binary Connection Protocol/
-match opcua m|^ERRF..\x00\x00\x00\x00|s p/OPC UA Binary Connection Protocol/
+match opcua m|^ERRF..\x00\x00(....)..\x00\x00([ -~]*)|s p/OPC UA Binary Connection Protocol/ i/Error $I(1, "<") $2/
 
 ##############################NEXT PROBE##############################
 Probe UDP KNX q|\x06\x10\x02\x03\x00\x0e\x08\x01\x00\x00\x00\x00\x00\x00|
 rarity 7
 ports 3671
-match knxip m|^\x06\x10\x02\x04..\x36\x01\x02.....................([-\w :.]+)|s d/KNXnet-IP GW/ p/$1/
+match knxip m|^\x06\x10\x02\x04..\x36\x01\x02.....................([ -~]*)|s d/KNXnet-IP GW/ p/$1/
 
 ##############################NEXT PROBE##############################
 Probe TCP KNX q|\x06\x10\x02\x03\x00\x0e\x08\x02\x00\x00\x00\x00\x00\x00|
 rarity 7
 ports 3671
-match knxip m|^\x06\x10\x02\x04..\x36\x01\x02.....................([-\w :.]+)|s d/KNXnet-IP GW/ p/$1/
+match knxip m|^\x06\x10\x02\x04..\x36\x01\x02.....................([ -~]*)|s d/KNXnet-IP GW/ p/$1/
 
 ##############################NEXT PROBE##############################
 # Java Remote Method Invocation, version 2, stream protocol

--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -14940,6 +14940,25 @@ match distccd m|^DONE00000001.*CRITICAL! distcc seems to have invoked itself rec
 match distccd m|^[\w._-]+DONE[\w._-]+ .*ERROR: attempt to use unknown compiler aborted: ([\w._-]+)\n|s p/distccd/ i/broken: compiler $1 doesn't exist/
 
 ##############################NEXT PROBE##############################
+Probe TCP OPCUA q|HELF\x2e\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x02\x00\x00\x00\x00\x40\x00\x80\x00\x00\x0e\x00\x00\x00opc.tcp://nmap|
+rarity 7
+ports 4840
+sslports 4843
+match opcua m|^ACKF\x1c\x00\x00\x00\x00\x00\x00\x00|s p/OPC UA Binary Connection Protocol/
+
+##############################NEXT PROBE##############################
+Probe UDP KNX q|\x06\x10\x02\x03\x00\x0e\x08\x01\x00\x00\x00\x00\x00\x00|
+rarity 7
+ports 3671
+match knxip m|^\x06\x10\x02\x04..\x36\x01\x02.....................([-\w :.]+)|s d/KNXnet-IP GW/ p/$1/
+
+##############################NEXT PROBE##############################
+Probe TCP KNX q|\x06\x10\x02\x03\x00\x0e\x08\x02\x00\x00\x00\x00\x00\x00|
+rarity 7
+ports 3671
+match knxip m|^\x06\x10\x02\x04..\x36\x01\x02.....................([-\w :.]+)|s d/KNXnet-IP GW/ p/$1/
+
+##############################NEXT PROBE##############################
 # Java Remote Method Invocation, version 2, stream protocol
 # https://docs.oracle.com/javase/9/docs/specs/rmi/protocol.html
 Probe TCP JavaRMI q|\x4a\x52\x4d\x49\0\x02\x4b|

--- a/nmap-services
+++ b/nmap-services
@@ -7140,8 +7140,8 @@ casanswmgmt	3669/tcp	0.000076	# CA SAN Switch Management
 casanswmgmt	3669/udp	0.000330	# CA SAN Switch Management
 smile	3670/tcp	0.000076	# SMILE TCP/UDP Interface
 smile	3670/udp	0.000330	# SMILE TCP/UDP Interface
-efcp	3671/tcp	0.000000	# e Field Control (EIBnet)
-efcp	3671/udp	0.000330	# e Field Control (EIBnet)
+knxip	3671/tcp	0.000000	# KNXnet/IP(EIBnet/IP)
+knxip	3671/udp	0.000330	# KNXnet/IP(EIBnet/IP)
 lispworks-orb	3672/tcp	0.000076	# LispWorks ORB
 lispworks-orb	3672/udp	0.000330	# LispWorks ORB
 mediavault-gui	3673/tcp	0.000000	# Openview Media Vault GUI


### PR DESCRIPTION
Added service probes for KNX + OPC UA and first time submitting service probes :-). 

KNX: Sends a DeviceDesc packet with NAT ip and port (0.0.0.0:0). This allows scanning of internet facing KNX devices as well as internal ones. Tested on 1 internal network and 2K public devices. Additional the service for port 3671 was renamed to knxip because EIBnetIP is a the less common service compared to KNX (successor for EIB). The matching rule can extract the FriendlyName but can not extract the vendor via the MAC. The probe for TCP is different by one byte which is the knx header flag for TCP. 

Example output (snippet)
```
Nmap scan report for 130.xxx.xxx.xx
Host is up (0.060s latency).

PORT     STATE SERVICE VERSION
3671/tcp open  knxip   IP Router Secure N 146
Service Info: Device: KNXnet-IP GW

Nmap scan report for 130.xxx.xxx.xx
Host is up (0.069s latency).

PORT     STATE SERVICE VERSION
3671/tcp open  knxip   MDT VisuControl Easy
Service Info: Device: KNXnet-IP GW

Nmap scan report for 139.xxx.xxx.xx
Host is up (0.087s latency).

PORT     STATE SERVICE VERSION
3671/tcp open  knxip   bOS KNX Server
Service Info: Device: KNXnet-IP GW
```

OPC UA: Sends a OPC UA Hello message and tests if the response is a ACK or ERR message. Tested on a local open62541 server and tested on public opcua servers (https://github.com/node-opcua/node-opcua/wiki/publicly-available-OPC-UA-Servers-and-Clients). Detects only the OPC UA protocol and direct server version detection is not possible. 

Example output (snippet): 
```
Nmap scan report for opcuaserver.com (173.183.147.103)
Host is up (0.042s latency).
Not shown: 8 filtered tcp ports (no-response)
Some closed ports may be reported as filtered due to --defeat-rst-ratelimit
PORT      STATE SERVICE VERSION
4840/tcp  open  opcua   OPC UA Binary Connection Protocol
48010/tcp open  opcua   OPC UA Binary Connection Protocol
```

Both were tested on the following nmap version:
```
Nmap version 7.94 ( https://nmap.org )
Platform: x86_64-pc-linux-gnu
Compiled with: liblua-5.4.6 openssl-3.1.2 libssh2-1.11.0 libz-1.3 libpcre-8.45 libpcap-1.10.4 nmap-libdnet-1.12 ipv6
Compiled without:
Available nsock engines: epoll poll select
``` 