### PR TITLE
fix: SMB version detection (issue #2744)

### DIFF
--- a/nselib/stdnse.lua
+++ b/nselib/stdnse.lua
@@ -315,9 +315,9 @@ function tohex( s, options )
   if separator then
     local group = options.group or 2
     local subs = 0
-    local pat = "(%x)(" .. rep("[^:]", group) .. ")%f[\0:]"
+    local pat = "(%x)(" .. rep("[^" .. separator .. "]", group) .. ")%f[\0" .. separator .. "]"
     repeat
-      hex, subs = gsub(hex, pat, "%1:%2")
+      hex, subs = gsub(hex, pat, "%1" .. separator .. "%2")
     until subs == 0
   end
 


### PR DESCRIPTION
- Fixes SMB server version formatting issue in nmap 7.93+.
- This commit fixes the root cause by changing `tohex` function.
- `stdnse.tohex` is called from smb2 scripts to generate the name of the version.
- See GH issue #2744 for further details.