### PR TITLE
Added new ALPN IDs, updated from IANA (Tue, 28 Nov 2023 21:55:21 GMT)

### DIFF
--- a/scripts/tls-alpn.nse
+++ b/scripts/tls-alpn.nse
@@ -163,7 +163,7 @@ action = function(host, port)
   local alpn_protos = {
     -- IANA-registered names
     -- https://www.iana.org/assignments/tls-extensiontype-values/alpn-protocol-ids.csv
-    -- Last-Modified: Thu, 31 Oct 2019 22:30:11 GMT
+    -- Last-Modified: Tue, 28 Nov 2023 21:55:21 GMT
     "http/0.9",
     "http/1.0",
     "http/1.1",
@@ -194,6 +194,9 @@ action = function(host, port)
     "nntp",
     "nnsp",
     "doq",
+    "sip/2",
+    "tds/8.0",
+    "dicom",
     -- Other sources
     "grpc-exp", -- gRPC, see grpc.io
   }


### PR DESCRIPTION
```shell
curl -sL https://www.iana.org/assignments/tls-extensiontype-values/alpn-protocol-ids.csv |
    perl -nE 'say $& if /(?<=\"\").*(?=\"\")/' |
    sort > iana
< nmap/scripts/tls-alpn.nse perl -nE 'say $& if m!(?<=")[\w/\.\-]+(?=",)!' |
    sort > nmap.alpn
diff iana nmap.alpn | grep '<'

< dicom
< sip/2
< tds/8.0
```