### PR TITLE
Fix compiling on sparc solaris 11

### DIFF
--- a/charpool.cc
+++ b/charpool.cc
@@ -59,7 +59,9 @@
  ***************************************************************************/
 
 /* $Id$ */
-
+#if defined(__sun)
+#include <climits>
+#endif
 #include <stddef.h>
 #undef NDEBUG
 #include <assert.h>

--- a/nping/NpingOps.cc
+++ b/nping/NpingOps.cc
@@ -62,6 +62,10 @@
 #include "winfix.h"
 #endif
 
+#if defined(__sun)
+#include <climits>
+#endif
+
 #include "nping.h"
 #include "nbase.h"
 #include "NpingOps.h"


### PR DESCRIPTION
`gmake` resulted in
`charpool.cc:95:17: error: ‘CHAR_MAX’ was not declared in this scope`

this is what fixed it for me