### PR TITLE
Updating service FastCGI on port tcp/9000 and adding corresponding probe

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -16775,3 +16775,14 @@ ports 34555
 Probe UDP BECKHOFF_ADS q|\x03\x66\x14\x71\0\0\0\0\x01\0\0\0\0\0\0\0\x01\x01\x10\x27\0\0\0\0|
 rarity 8
 ports 48899
+
+##############################NEXT PROBE##############################
+# FastCGI protocol
+# Request ID 1: FGCI_BEGIN_REQUEST + FGCI_STDIN without params
+Probe TCP fast-cgi-get q|\x01\x01\x00\x01\x00\x08\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x01\x04\x00\x01\x00\x00\x00\x00\x01\x05\x00\x01\x00\x00\x00\x00|
+rarity 7
+# port 9000 by default, 19000 for fastcgi-for-donet
+ports 9000,19000
+
+match fcgi m|^(.)\x06\0\x01.{4,}X-Powered-By:\x20?([^\r\n]+).*\r\n\r\n.*(.)\x03\0\x01.{4,}|si v/FastCGI $2/
+match fcgi m|^(.)\x06\0\x01.{4,}\r\n\r\n.*(.)\x03\0\x01.{4,}|s v/FastCGI generic protocol v$I(1, ">")/

--- a/nmap-services
+++ b/nmap-services
@@ -12124,7 +12124,7 @@ canto-roboflow	8998/tcp	0.000000	# Canto RoboFlow Control
 unknown	8998/udp	0.000661
 bctp	8999/tcp	0.000076	# Brodos Crypto Trade Protocol
 bctp	8999/udp	0.000000	# Brodos Crypto Trade Protocol
-cslistener	9000/tcp	0.002129
+fastcgi	9000/tcp	0.001213	# Fast-CGI
 cslistener	9000/udp	0.001652	# CSlistener
 tor-orport	9001/tcp	0.001216	# etlservicemgr | Tor ORPort | ETL Service Manager
 etlservicemgr	9001/udp	0.001652	# ETL Service Manager


### PR DESCRIPTION
* Changed default service on port tcp/9000 from `cslistener` to `fcgi` because FastCGI is a lot more met in engagement than an IDE listening. I found nothing else than debug protocol DBGP (XDebug) as a reference for `cslistener`.
* Added a corresponding probe for FastCGI with FGCI_BEGIN_REQUEST + FGCI_STDIN without params, then try to capture X-Powered-By HTTP header if present to show underlying technology