### PR TITLE
Mssql script fixes

### DIFF
--- a/nselib/mssql.lua
+++ b/nselib/mssql.lua
@@ -3331,10 +3331,12 @@ Helper =
         return nil
       end
       local output = {}
+      local count = 0
       for _, instance in ipairs(instances) do
         output[instance:GetName()] = process_instance(instance)
+        count = count + 1
       end
-      if #output > 0 then
+      if count > 0 then
         return outlib.sorted_by_key(output)
       end
       return nil

--- a/nselib/mssql.lua
+++ b/nselib/mssql.lua
@@ -3098,7 +3098,7 @@ Helper =
 
     rows = {}
 
-    while(true) do
+    while(true and pos < data:len()) do
       local rowtag
       rowtag, pos = string.unpack("B", data, pos )
 

--- a/nselib/mssql.lua
+++ b/nselib/mssql.lua
@@ -3203,8 +3203,8 @@ Helper =
     Helper.Discover( host )
 
     if ( port ) then
-      local status, instances = Helper.GetDiscoveredInstances(host, port)
-      if status then
+      local instances = Helper.GetDiscoveredInstances(host, port)
+      if instances then
         return true, instances
       else
         return false, "No SQL Server instance detected on this port"


### PR DESCRIPTION
This PR fixes 2 issues I ran into while trying to debug connection issues with a legacy SQL2000 server.

First commit corrects the return type expectation for a call made to `Helper.GetDiscoveredInstances`. The actual return is a single value, while the original expected return by the caller was a tuple. I corrected the caller to use only the single value.

The second commit fixes an issue I saw where the SqlServer returned no rows of data. The loop was being entered even though the `pos` var was already past the length of the data.