### PR TITLE
Add OPC UA TCP service detection

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -16774,3 +16774,12 @@ ports 34555
 Probe UDP BECKHOFF_ADS q|\x03\x66\x14\x71\0\0\0\0\x01\0\0\0\0\0\0\0\x01\x01\x10\x27\0\0\0\0|
 rarity 8
 ports 48899
+##############################NEXT PROBE##############################
+# OPC UA TCP HEL message
+Probe TCP HelRequest q|\x48\x45\x4c\x46\x37\x00\x00\x00\x00\x00\x00\x00\x00\x20\x00\x00\x00\x20\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x17\x00\x00\x00\x6f\x70\x63\x2e\x74\x63\x70\x3a\x2f\x2f\x6e\x6d\x61\x70\x2e\x6f\x72\x67\x3a\x31\x33\x33\x37|
+rarity 6
+ports 49320,62541,4897,53530,48050,4885,4840,4855,26543
+
+# Possible OPC UA TCP responses to HEL message
+match opc-ua-tcp m|^ACKF|
+match opc-ua-tcp m|^ERRF|

--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -14939,6 +14939,26 @@ match distccd m|^DONE00000001.*CRITICAL! distcc seems to have invoked itself rec
 match distccd m|^[\w._-]+DONE[\w._-]+ .*ERROR: attempt to use unknown compiler aborted: ([\w._-]+)\n|s p/distccd/ i/broken: compiler $1 doesn't exist/
 
 ##############################NEXT PROBE##############################
+Probe TCP OPCUA q|HELF\x2e\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x02\x00\x00\x00\x00\x40\x00\x80\x00\x00\x0e\x00\x00\x00opc.tcp://nmap|
+rarity 6
+ports 49320,62541,4897,53530,48050,4885,4840,4855,26543
+sslports 4843
+match opcua m|^ACKF\x1c\x00\x00\x00\x00\x00\x00\x00|s p/OPC UA Binary Connection Protocol/
+match opcua m|^ERRF..\x00\x00(....)..\x00\x00([ -~]*)|s p/OPC UA Binary Connection Protocol/ i/Error $I(1, "<") $2/
+
+##############################NEXT PROBE##############################
+Probe UDP KNX q|\x06\x10\x02\x03\x00\x0e\x08\x01\x00\x00\x00\x00\x00\x00|
+rarity 7
+ports 3671
+match knxip m|^\x06\x10\x02\x04..\x36\x01\x02.....................([ -~]*)|s d/KNXnet-IP GW/ p/$1/
+
+##############################NEXT PROBE##############################
+Probe TCP KNX q|\x06\x10\x02\x03\x00\x0e\x08\x02\x00\x00\x00\x00\x00\x00|
+rarity 7
+ports 3671
+match knxip m|^\x06\x10\x02\x04..\x36\x01\x02.....................([ -~]*)|s d/KNXnet-IP GW/ p/$1/
+
+##############################NEXT PROBE##############################
 # Java Remote Method Invocation, version 2, stream protocol
 # https://docs.oracle.com/javase/9/docs/specs/rmi/protocol.html
 Probe TCP JavaRMI q|\x4a\x52\x4d\x49\0\x02\x4b|
@@ -16774,12 +16794,3 @@ ports 34555
 Probe UDP BECKHOFF_ADS q|\x03\x66\x14\x71\0\0\0\0\x01\0\0\0\0\0\0\0\x01\x01\x10\x27\0\0\0\0|
 rarity 8
 ports 48899
-##############################NEXT PROBE##############################
-# OPC UA TCP HEL message
-Probe TCP HelRequest q|\x48\x45\x4c\x46\x37\x00\x00\x00\x00\x00\x00\x00\x00\x20\x00\x00\x00\x20\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x17\x00\x00\x00\x6f\x70\x63\x2e\x74\x63\x70\x3a\x2f\x2f\x6e\x6d\x61\x70\x2e\x6f\x72\x67\x3a\x31\x33\x33\x37|
-rarity 6
-ports 49320,62541,4897,53530,48050,4885,4840,4855,26543
-
-# Possible OPC UA TCP responses to HEL message
-match opc-ua-tcp m|^ACKF|
-match opc-ua-tcp m|^ERRF|

--- a/nmap-services
+++ b/nmap-services
@@ -7140,8 +7140,8 @@ casanswmgmt	3669/tcp	0.000076	# CA SAN Switch Management
 casanswmgmt	3669/udp	0.000330	# CA SAN Switch Management
 smile	3670/tcp	0.000076	# SMILE TCP/UDP Interface
 smile	3670/udp	0.000330	# SMILE TCP/UDP Interface
-efcp	3671/tcp	0.000000	# e Field Control (EIBnet)
-efcp	3671/udp	0.000330	# e Field Control (EIBnet)
+knxip	3671/tcp	0.000000	# KNXnet/IP(EIBnet/IP)
+knxip	3671/udp	0.000330	# KNXnet/IP(EIBnet/IP)
 lispworks-orb	3672/tcp	0.000076	# LispWorks ORB
 lispworks-orb	3672/udp	0.000330	# LispWorks ORB
 mediavault-gui	3673/tcp	0.000000	# Openview Media Vault GUI


### PR DESCRIPTION
Add OPC UA TCP service detection

Send HEL message with invalid EndpointURI and expect either ACK or ERR as response [1].
Ports are default ports on popular OPC UA software [2].
Rarity based on gut feeling.

References:
1. https://reference.opcfoundation.org/Core/Part6/v104/docs/7
2. https://claroty.com/team82/research/opc-ua-deep-dive-series-a-one-of-a-kind-opc-ua-exploit-framework