### PR TITLE
Only schedule non-empty username+password for retry

### DIFF
--- a/nselib/brute.lua
+++ b/nselib/brute.lua
@@ -1532,10 +1532,12 @@ BruteSocket = {
 
       local thread_data = Engine.getThreadData(coroutine.running())
 
-      engine.retry_accounts[#engine.retry_accounts + 1] = {
-        username = thread_data.username,
-        password = thread_data.password,
-      }
+      if thread_data.username or thread_data.password then
+        engine.retry_accounts[#engine.retry_accounts + 1] = {
+          username = thread_data.username,
+          password = thread_data.password,
+        }
+      end
 
       thread_data.connection_error = true
       thread_data.con_error_reason = err


### PR DESCRIPTION
When `doAuthenticate` function fails during connection, `thread_data.username` and `thread_data.password` variables are still empty.

Later, when `BruteSocket`'s `checkStatus` is invoked, it tries to save those values for later retry. However, as both username and password are still empty at this point, `retry_accounts` will have a `nil, nil` item.

When this item is picked up in the next invocation of `doAuthenticate`, as both username and password are `nil`, `initial_accounts_exhausted` is set to true, and the scanning stops.

This change adds a condition, to only add a new item to `retry_accounts` in the `checkStatus` function, if either the username or the password is not `nil`.