### PR TITLE
add smb2-os-discovery.nse

### DIFF
--- a/scripts/tls-alpn.nse
+++ b/scripts/tls-alpn.nse
@@ -163,7 +163,7 @@ action = function(host, port)
   local alpn_protos = {
     -- IANA-registered names
     -- https://www.iana.org/assignments/tls-extensiontype-values/alpn-protocol-ids.csv
-    -- Last-Modified: Thu, 31 Oct 2019 22:30:11 GMT
+    -- Last-Modified: Sat, 16 Mar 2024 02:22:45 GMT
     "http/0.9",
     "http/1.0",
     "http/1.1",
@@ -194,6 +194,9 @@ action = function(host, port)
     "nntp",
     "nnsp",
     "doq",
+    "sip/2",
+    "tds/8.0",
+    "dicom",
     -- Other sources
     "grpc-exp", -- gRPC, see grpc.io
   }


### PR DESCRIPTION
This script is used to determine the operating system, computer name, domain name, and current
time over the SMB2 protocol (ports 445 or 139).

You can use it with the command:
`nmap --script smb2-os-discovery.nse  -p445 127.0.0.1`

This script solves problems related to using smb2 to detect the operating system, such as the following two issues:
[https://github.com/nmap/nmap/issues/901](url)
[https://github.com/nmap/nmap/issues/2445](url)