### PR TITLE
Add "Script timed out" to output.

### DIFF
--- a/nse_main.lua
+++ b/nse_main.lua
@@ -1053,7 +1053,8 @@ local function run (threads_iter)
     for co, thread in pairs(waiting) do
       if thread:timed_out() then
         waiting[co], all[co], num_threads = nil, nil, num_threads-1;
-        thread:d("%THREAD_AGAINST timed out")
+        thread:d("%THREAD_AGAINST timed out");
+        thread:set_output("Script timed out");
         thread:close(timeouts, "timed out");
       elseif not thread.worker then
         orphans = false


### PR DESCRIPTION
[Problem Statement]
There are cases when NSE scripts timeout. Without such indication from output, it's hard to quantify the results, understand impact, tune the script configuration, especially when having batch scanning against a large number of endpoints.
 
[Fix]
Adding "Script timed out" to structured output (e.g. xml) helps the programmatic analysis of Nmap report in batch.