### PR TITLE
Replaced locale.getdefaultlocale() with locale.getlocale()

### DIFF
--- a/zenmap/zenmapCore/I18N.py
+++ b/zenmap/zenmapCore/I18N.py
@@ -74,7 +74,7 @@ def get_locales():
             locales = val.split(":")
             break
     try:
-        loc, enc = locale.getdefaultlocale()
+        loc, enc = locale.getlocale()
         if loc is not None:
             locales.append(loc)
     except ValueError:


### PR DESCRIPTION
* part of #2780, fixes for `zenmap/zenmapCore/I18N.py`
* `locale.getdefaultlocale()` is [deprecated since Python 3.11](https://docs.python.org/3.13/whatsnew/3.13.html#pending-removal-in-python-3-15)
* `locale.getlocale()` provides the same output.