### PR TITLE
Removed unused loop variable

### DIFF
--- a/nmap_dns.cc
+++ b/nmap_dns.cc
@@ -1192,7 +1192,6 @@ static void nmap_mass_rdns_core(Target **targets, int num_targets) {
 static void nmap_system_rdns_core(Target **targets, int num_targets) {
   char hostname[FQDN_LEN + 1] = "";
   char spmobuf[1024];
-  int i;
 
   for (int i=0; i < num_targets; i++)
   {


### PR DESCRIPTION
* introduced by c3b2b3dbed5c8b881acfe0d29e3a134c9a0b6dee
* made useless by 4201b294a837d1b7813ab7f97b310ca7b4b16c68
* found in makefile warnings debugs:

```
g++ -c -I./liblinear -I./libdnet-stripped/include  -I./nbase -I./nsock/include \
    -DHAVE_CONFIG_H -DNMAP_PLATFORM=\"x86_64-unknown-linux-gnu\" \
    -DNMAPDATADIR=\"/usr/local/share/nmap\" -D_FORTIFY_SOURCE=2 -g -O2 \
    -Wall -fno-strict-aliasing   nmap_dns.cc -o nmap_dns.o

nmap_dns.cc: In function ‘void nmap_system_rdns_core(Target**, int)’:
nmap_dns.cc:1195:7: warning: unused variable ‘i’ [-Wunused-variable]
 1195 |   int i;
      |       ^
```