### PR TITLE
remove vLAN tags for DHCP discover script

### DIFF
--- a/scripts/broadcast-dhcp-discover.nse
+++ b/scripts/broadcast-dhcp-discover.nse
@@ -184,9 +184,14 @@ local function dhcp_listener(sock, iface, macaddr, options, timeout, xid, result
   local now = start_time
   while( now - start_time < timeout ) do
     sock:set_timeout(timeout - (now - start_time))
-    local status, _, _, data = sock:pcap_receive()
+    local status, _, l2_data, data = sock:pcap_receive()
 
     if ( status ) then
+      -- do we have a vlan tag to be removed?
+      local f = packet.Frame:new( l2_data )
+      if ( 0x8100 == f.ether_type and 4 <= #data ) then
+        data = string.sub( data, 5, -1)
+      end
       local p = packet.Packet:new( data, #data )
       if ( p and p.udp_dport ) then
         local data = data:sub(p.udp_offset + 9)


### PR DESCRIPTION
The `broadcast-dhcp-discover` script fails to report/dissect DHCP offers if the packet has a vLAN tag:

```
[root@lx-test-01 ~]# nmap --script /usr/share/nmap/scripts/broadcast-dhcp-discover.nse 
Starting Nmap 7.92 ( https://nmap.org ) at 2024-04-18 13:09 CEST
WARNING: No targets were specified, so 0 hosts scanned.
Nmap done: 0 IP addresses (0 hosts up) scanned in 10.20 seconds
[root@lx-test-01 ~]#
```
![dhcp_offer_with_vlan_tag](https://github.com/nmap/nmap/assets/6852091/51109722-c6ba-4646-8176-74552241a543)

Whereas with this fix the packet is properly dissected by removing the tag if one is found:

```
[root@lx-test-01 ~]# nmap --script /root/nmap/scripts/broadcast-dhcp-discover.nse
Starting Nmap 7.92 ( https://nmap.org ) at 2024-04-18 13:10 CEST
Pre-scan script results:
| broadcast-dhcp-discover: 
|   Response 1 of 1: 
|     Interface: enp98s0
|     IP Offered: 129.129.240.213
|     DHCP Message Type: DHCPOFFER
|     Server Identifier: 129.129.190.11
|     Subnet Mask: 255.255.255.0
|     Router: 129.129.240.1
|     Domain Name Server: 129.129.190.11, 129.129.230.11
|     Domain Name: psi.ch
|_    IP Address Lease Time: 1h00m00s
WARNING: No targets were specified, so 0 hosts scanned.
Nmap done: 0 IP addresses (0 hosts up) scanned in 10.20 seconds
[root@lx-test-01 ~]# 
```

And it still works fine on networks where there is no vLAN tag:
```
[root@lx-test-02 ~]# nmap --script /root/nmap/scripts/broadcast-dhcp-discover.nse 
Starting Nmap 7.92 ( https://nmap.org ) at 2024-04-18 13:15 CEST
Pre-scan script results:
| broadcast-dhcp-discover: 
|   Response 1 of 2: 
|     Interface: ens192
|     IP Offered: 10.129.160.247
|     DHCP Message Type: DHCPOFFER
|     Server Identifier: 129.129.190.11
|     Subnet Mask: 255.255.255.0
|     Router: 10.129.160.1
|     Domain Name Server: 129.129.190.11, 129.129.230.11
|     Domain Name: psi.ch
|     IP Address Lease Time: 1h00m00s
|   Response 2 of 2: 
|     Interface: ens192
|     IP Offered: 10.129.160.247
|     DHCP Message Type: DHCPOFFER
|     Server Identifier: 129.129.190.11
|     Subnet Mask: 255.255.255.0
|     Router: 10.129.160.1
|     Domain Name Server: 129.129.190.11, 129.129.230.11
|     Domain Name: psi.ch
|_    IP Address Lease Time: 1h00m00s
WARNING: No targets were specified, so 0 hosts scanned.
Nmap done: 0 IP addresses (0 hosts up) scanned in 10.14 seconds
[root@lx-test-02 ~]# 
```