### PR TITLE
nsock: Fix compilation error with OPENSSL_NO_DTLS

### DIFF
--- a/nsock/src/nsock_connect.c
+++ b/nsock/src/nsock_connect.c
@@ -472,8 +472,12 @@ nsock_event_id nsock_connect_ssl(nsock_pool nsp, nsock_iod nsiod, nsock_ev_handl
 
   if (proto == IPPROTO_UDP)
   {
+#ifndef OPENSSL_NO_DTLS
     if (!ms->dtlsctx)
       nsock_pool_dtls_init(ms, 0);
+#else
+    fatal("%s called with no OpenSSL DTLS support", __func__);
+#endif
   }
   else
   {

--- a/nsock/src/nsock_core.c
+++ b/nsock/src/nsock_core.c
@@ -364,7 +364,14 @@ void handle_connect_result(struct npool *ms, struct nevent *nse, enum nse_status
     if (nse->type == NSE_TYPE_CONNECT_SSL &&
         nse->status == NSE_STATUS_SUCCESS) {
 #if HAVE_OPENSSL
-      sslctx = iod->lastproto == IPPROTO_UDP ? ms->dtlsctx : ms->sslctx;
+      if (iod->lastproto == IPPROTO_UDP)
+#ifndef OPENSSL_NO_DTLS
+        sslctx = ms->dtlsctx;
+#else
+        fatal("%s called with no OpenSSL DTLS support", __func__);
+#endif
+      else
+        sslctx = ms->sslctx;
       assert(sslctx != NULL);
       /* Reuse iod->ssl if present. If set, this is the second try at connection
          without the SSL_OP_NO_SSLv2 option set. */

--- a/nsock/src/nsock_pool.c
+++ b/nsock/src/nsock_pool.c
@@ -178,7 +178,9 @@ nsock_pool nsock_pool_new(void *userdata) {
 
 #if HAVE_OPENSSL
   nsp->sslctx = NULL;
+#ifndef OPENSSL_NO_DTLS
   nsp->dtlsctx = NULL;
+#endif
 #endif
 
   nsp->px_chain = NULL;


### PR DESCRIPTION
Commit ba26cc78f207 ("Replace check for DTLS_client_method with OPENSSL_NO_DTLS") made DTLS support depend on the openssl define directly but leave some use of dtlsctx not guarded by ifdef.

Fix this by adding to the remaining use of dtlsctx ifdef guard and return fatal print for running function with unsupported OpenSSL feature.

Fixes: ba26cc78f207 ("Replace check for DTLS_client_method with OPENSSL_NO_DTLS")