### PR TITLE
Formatting error

### DIFF
--- a/nping/docs/nping.1
+++ b/nping/docs/nping.1
@@ -83,8 +83,7 @@ The newest version of Nping can be obtained with Nmap at
 \m[blue]\fB\%https://nmap.org\fR\m[]\&. The newest version of this man page is available at
 \m[blue]\fB\%https://nmap.org/book/nping-man.html\fR\m[]\&.
 
-\-\->
-  .SH "OPTIONS SUMMARY"
+.SH "OPTIONS SUMMARY"
 .PP
 This options summary is printed when Nping is run with no arguments\&. It helps people remember the most common options, but is no substitute for the in\-depth documentation in the rest of this manual\&. Some obscure options aren\*(Aqt even included here\&.
 .sp


### PR DESCRIPTION
Fix for formatting error in manpage:

<img width="315" alt="image" src="https://github.com/nmap/nmap/assets/438188/6cf70054-4e0f-4bfa-ab73-fbe1d6ae4395">
