### PR TITLE
Fix errors in comm.lua and nmap_dns.cc

### DIFF
--- a/libnetutil/netutil.h
+++ b/libnetutil/netutil.h
@@ -189,6 +189,7 @@ const void *ipv4_get_data(const struct ip *ip, unsigned int *len);
    The protocol is stored in *nxt. Returns NULL in case of error. */
 const void *ipv6_get_data(const struct ip6_hdr *ip6, unsigned int *len, u8 *nxt);
 const void *ipv6_get_data_any(const struct ip6_hdr *ip6, unsigned int *len, u8 *nxt);
+const void *ipv6_get_data_whole(const struct ip6_hdr *ip6, unsigned int *len, u8 *nxt);
 const void *icmp_get_data(const struct icmp_hdr *icmp, unsigned int *len);
 const void *icmpv6_get_data(const struct icmpv6_hdr *icmpv6, unsigned int *len);
 

--- a/nmap_dns.cc
+++ b/nmap_dns.cc
@@ -478,19 +478,17 @@ static void write_evt_handler(nsock_pool nsp, nsock_event evt, void *req_v) {
   request *req = (request *) req_v;
 
   req->curr_server->write_busy = 0;
+  req->curr_server->in_process.push_front(req);
+  record.tpreq = req;
+  record.server = req->curr_server;
+  records[req->id] = record;
+  do_possible_writes();
 
-  if (nse_status(evt) == NSE_STATUS_SUCCESS) {
-    req->curr_server->in_process.push_front(req);
-    record.tpreq = req;
-    record.server = req->curr_server;
-    records[req->id] = record;
-    do_possible_writes();
-  }
-  else {
+  if (nse_status(evt) != NSE_STATUS_SUCCESS) {
     if (o.debugging) {
-      log_write(LOG_STDOUT, "mass_dns: WRITE error: %s", nse_status2str(nse_status(evt)));
+      log_write(LOG_STDOUT, "mass_dns: WRITE error: %s\n", nse_status2str(nse_status(evt)));
     }
-    req->curr_server->to_process.push_front(req);
+    // req->curr_server->to_process.push_front(req);
   }
 
 }

--- a/nselib/comm.lua
+++ b/nselib/comm.lua
@@ -281,7 +281,7 @@ function tryssl(host, port, data, opts)
   end
   local best = "none"
   local sd, response, early_resp
-  for _, proto in { bestoption(our_port) } do
+  for _, proto in ipairs({ bestoption(our_port) }) do
     opts.proto = proto
     sd, response, early_resp = oops.raise(("%s failed"):format(proto),
       opencon(host, our_port, data, opts))

--- a/scan_engine_raw.cc
+++ b/scan_engine_raw.cc
@@ -170,7 +170,7 @@ void UltraProbe::setIP(const u8 *ippacket, u32 len, const probespec *pspec) {
     hdr = ip->ip_p;
   } else if (ip->ip_v == 6) {
     const struct ip6_hdr *ip6 = (const struct ip6_hdr *) ippacket;
-    data = ipv6_get_data_any(ip6, &len, &hdr);
+    data = ipv6_get_data_whole(ip6, &len, &hdr);
     assert(data != NULL);
     assert(len == (u32) ntohs(ip6->ip6_plen));
     probes.IP.ipid = ntohl(ip6->ip6_flow & IP6_FLOWLABEL_MASK);


### PR DESCRIPTION
1) Fix error: attempt to call a table value

Select an http related script such as ```http-title```.
error:

```bash
/root/nmap0/nselib/comm.lua:284: attempt to call a table value (for iterator 'for iterator')
stack traceback:
        /root/nmap0/nselib/comm.lua:284: in function 'comm.tryssl'
        (...tail calls...)
        /root/nmap0/nselib/http.lua:1357: in function </root/nmap0/nselib/http.lua:1339>
        (...tail calls...)
        /root/nmap0/nselib/http.lua:1776: in function 'http.get'
        /root/nmap0/scripts/http-title.nse:39: in function </root/nmap0/scripts/http-title.nse:36>
        (...tail calls...)

Completed NSE at 16:19, 0.04s elapsed
```

2) Fix Infinite loop in nmap_dns.cc
previous behavior: if nmap start mass_dns with a unreachable dns server(nsock_connect_udp error) then, mass_dns main loop never finish.