### PR TITLE
Fix for issue #2896

### DIFF
--- a/protocols.cc
+++ b/protocols.cc
@@ -191,7 +191,7 @@ const struct nprotoent *nmap_getprotbynum(int num) {
   if (nmap_protocols_init() == -1)
     return NULL;
 
-  assert(num >= 0 && num < UCHAR_MAX);
+  assert(num >= 0 && num <= UCHAR_MAX);
   return protocol_table[num];
 }
 


### PR DESCRIPTION
Credit to @Eponymous-One for finding the solution,

An issue was arising within the protocols.cc file where the following call within function nmap_getprotbynum:
```c
//Line 194
assert(num >= 0 && num < UCHAR_MAX);
```

Was causing nmap to core dump
Resolving the issue by ensuring assert is checking it is actually hitting UCHAR_MAX and not 1 char short of UCHAR_MAX via:
```c
assert(num >= 0 && num <= UCHAR_MAX);
```