### PR TITLE
Implement support for arbitrary separator in stdnse tohex()

### DIFF
--- a/nselib/stdnse.lua
+++ b/nselib/stdnse.lua
@@ -314,11 +314,14 @@ function tohex( s, options )
   -- format hex if we got a separator
   if separator then
     local group = options.group or 2
-    local subs = 0
-    local pat = "(%x)(" .. rep("[^:]", group) .. ")%f[\0:]"
-    repeat
-      hex, subs = gsub(hex, pat, "%1:%2")
-    until subs == 0
+    local extra = (group - #hex % group) % group
+    if extra > 0 then
+      -- pad the input to make it an exact multiple of the group size
+      hex = rep("0", extra) .. hex
+    end
+    hex = gsub(hex, rep(".", group), "%0" .. gsub(separator, "%%", "%%%%"))
+    -- remove the padding and trim the last separator
+    hex = sub(hex, extra + 1, -(#separator + 1))
   end
 
   return hex


### PR DESCRIPTION
Function `tohex()` in `stdnse` is documented to support arbitrary separator for groups of hex digits. However, the actual code uses hard-coded colon as the separator, ignoring the corresponding input option. One manifestation of this gap is #2744 . This PR aligns the `tohex()` implementation with the documentation.

As a side benefit, the function is now significantly faster, particularly with larger inputs. With the default group size of 2, the improvement is 2.6x for strings of 4 characters, 9.9x for 16, 39.3x for 64, and 122.5x for 256.

The PR will be committed after August 25, 2024, unless concerns are raised.