### PR TITLE
TLS v1.3 cipher suite naming issue

### DIFF
--- a/libnetutil/netutil.cc
+++ b/libnetutil/netutil.cc
@@ -120,6 +120,8 @@ typedef unsigned __int8 u_int8_t;
 #endif
 
 #include "netutil.h"
+#include "../NmapOps.h"
+extern NmapOps o;
 
 #if HAVE_NET_IF_H
 #ifndef NET_IF_H /* This guarding is needed for at least some versions of OpenBSD */
@@ -3471,13 +3473,24 @@ int Sendto(const char *functionname, int sd,
       int err = socket_errno();
 
       numerrors++;
+      // Checking the debugging flag to not stop printing errors if -d2 or greater
+      if(o.debugging <= 1) {
         if(numerrors <= 10) {
-        netutil_error("sendto in %s: sendto(%d, packet, %d, 0, %s, %d) => %s",
+          netutil_error("sendto in %s: sendto(%d, packet, %d, 0, %s, %d) => %s",
               functionname, sd, len, inet_ntop_ez((struct sockaddr_storage *) to, sizeof(struct sockaddr_storage)), tolen,
               strerror(err));
-        netutil_error("Offending packet: %s", ippackethdrinfo(packet, len, LOW_DETAIL));
-        if (numerrors == 10) {
-          netutil_error("Omitting future %s error messages now that %d have been shown.  Use -d2 if you really want to see them.", __func__, numerrors);
+          netutil_error("Offending packet: %s", ippackethdrinfo(packet, len, LOW_DETAIL));
+          if (numerrors == 10) {
+            netutil_error("Omitting future %s error messages now that %d have been shown.  Use -d2 if you really want to see them.", __func__, numerrors);
+          }
+        }
+      }
+      else {
+        if(numerrors <= 100) {
+          netutil_error("sendto in %s: sendto(%d, packet, %d, 0, %s, %d) => %s",
+              functionname, sd, len, inet_ntop_ez((struct sockaddr_storage *) to, sizeof(struct sockaddr_storage)), tolen,
+              strerror(err));
+          netutil_error("Offending packet: %s", ippackethdrinfo(packet, len, LOW_DETAIL));
         }
       }
 #if WIN32

--- a/nselib/tls.lua
+++ b/nselib/tls.lua
@@ -820,7 +820,8 @@ CIPHERS = {
 -- symmetric ciphers, and cannot be used for TLS 1.2.  Similarly, TLS 1.2 and
 -- lower cipher suites cannot be used with TLS 1.3."
 -- We designate these as AKE (Authenticated Key Exchange) ciphersuites, in
--- order to simplify use of the cipher_info function.
+-- order to simplify use of the cipher_info function. But IANA does not have
+-- this "AKE_WITH" in their naming convention.
 TLS_AKE_WITH_AES_128_GCM_SHA256       = 0x1301,
 TLS_AKE_WITH_AES_256_GCM_SHA384       = 0x1302,
 TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 = 0x1303,


### PR DESCRIPTION
TLS v1.3, even when using the same ciper suites as previous versions, it mentioned "AKE_WITH" in their output. This, although meant to just make the user aware of Authenticated Key Exchange, may make people confused when comparing to IANA cipher suite list. 

So this PR simply updates the note stating that this is purely informational and does not follow IANA naming convention.