### PR TITLE
Improve tests for finding libpcre2

### DIFF
--- a/configure
+++ b/configure
@@ -7300,7 +7300,8 @@ fi
 
 # If they didn't specify it, we try to find it
 if test $have_pcre != yes -a $requested_included_pcre != yes ; then
-  ac_fn_c_check_header_compile "$LINENO" "pcre2.h" "ac_cv_header_pcre2_h" "$ac_includes_default"
+  ac_fn_c_check_header_compile "$LINENO" "pcre2.h" "ac_cv_header_pcre2_h" "#define PCRE2_CODE_UNIT_WIDTH 8
+"
 if test "x$ac_cv_header_pcre2_h" = xyes
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for pcre2_compile_8 in -lpcre2-8" >&5
@@ -7344,7 +7345,8 @@ then :
 fi
 
 else $as_nop
-  ac_fn_c_check_header_compile "$LINENO" "pcre2/pcre2.h" "ac_cv_header_pcre2_pcre2_h" "$ac_includes_default"
+  ac_fn_c_check_header_compile "$LINENO" "pcre2/pcre2.h" "ac_cv_header_pcre2_pcre2_h" "#define PCRE2_CODE_UNIT_WIDTH 8
+"
 if test "x$ac_cv_header_pcre2_pcre2_h" = xyes
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for pcre2_compile_8 in -lpcre2-8" >&5
@@ -7385,13 +7387,12 @@ printf "%s\n" "$ac_cv_lib_pcre2_8_pcre2_compile_8" >&6; }
 if test "x$ac_cv_lib_pcre2_8_pcre2_compile_8" = xyes
 then :
   have_pcre=yes
-      printf "%s\n" "#define HAVE_PCRE2_PCRE2_H 1" >>confdefs.h
+
+printf "%s\n" "#define HAVE_PCRE2_PCRE2_H 1" >>confdefs.h
 
 fi
 
-
 fi
-
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -529,12 +529,17 @@ AC_HELP_STRING([--with-libpcre=included], [Always use the version included with 
 # If they didn't specify it, we try to find it
 if test $have_pcre != yes -a $requested_included_pcre != yes ; then
   AC_CHECK_HEADER(pcre2.h,
-    AC_CHECK_LIB(pcre2-8, pcre2_compile_8, [have_pcre=yes ]),
-    [AC_CHECK_HEADER(pcre2/pcre2.h,
-     [AC_CHECK_LIB(pcre2-8, pcre2_compile_8, [have_pcre=yes
-      AC_DEFINE(HAVE_PCRE2_PCRE2_H, 1)])]
-    )]
-  )
+    AC_CHECK_LIB(pcre2-8,
+      pcre2_compile_8,
+      [have_pcre=yes ]),
+    AC_CHECK_HEADER(pcre2/pcre2.h,
+      AC_CHECK_LIB(pcre2-8,
+        pcre2_compile_8,
+        [have_pcre=yes
+        AC_DEFINE(HAVE_PCRE2_PCRE2_H, 1, [Using system pcre2/pcre2.h])]),
+      [],
+      [#define PCRE2_CODE_UNIT_WIDTH 8]),
+    [#define PCRE2_CODE_UNIT_WIDTH 8])
 fi
 
 # If we still don't have it, we use our own


### PR DESCRIPTION
This PR tweaks recently committed c6ffdbf7ae35e397b663f787fc4934f01458f945 as follows:
* Restores definition of `PCRE2_CODE_UNIT_WIDTH` in `AC_CHECK_HEADER(pcre2.h,...)` to allow the header test to compile correctly. (See [pcre2api man page](https://www.pcre.org/current/doc/html/pcre2api.html#SEC13) for details.)
* Adds the same definition to `AC_CHECK_HEADER(pcre2/pcre2.h,...)`
* Adds description to `AC_DEFINE(HAVE_PCRE2_PCRE2_H,...)` to prevent a build error. (See the first paragraph in [Autoheader Macros](https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Autoheader-Macros.html) for details.)

The PR will be committed after  September 1, 2024, unless concerns are raised.