### PR TITLE
Add configure test for presence of python setuptools

### DIFF
--- a/configure
+++ b/configure
@@ -6520,6 +6520,18 @@ printf "%s\n" "$am_cv_python_pyexecdir" >&6; }
 
 
 
+if $HAVE_PYTHON ; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for python setuptools" >&5
+printf %s "checking for python setuptools... " >&6; }
+  if $PYTHON -c 'import setuptools' 2>/dev/null ; then
+    have_setuptools=yes
+  else
+    have_setuptools=no
+  fi
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $have_setuptools" >&5
+printf "%s\n" "$have_setuptools" >&6; }
+fi
+
 NDIFFDIR=ndiff
 
 # Do they want Ndiff?
@@ -6532,15 +6544,15 @@ else $as_nop
   with_ndiff=check
 fi
 
-if $HAVE_PYTHON ; then : ;
+if $HAVE_PYTHON && test "$have_setuptools" = "yes" ; then : ;
 else
   if test "$with_ndiff" = "check" ; then
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Not building Ndiff because Python was not found" >&5
-printf "%s\n" "$as_me: WARNING: Not building Ndiff because Python was not found" >&2;}
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Not building Ndiff because Python with setuptools was not found" >&5
+printf "%s\n" "$as_me: WARNING: Not building Ndiff because Python with setuptools was not found" >&2;}
   elif test "$with_ndiff" = "yes"; then
     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "--with-ndiff requires Python
+as_fn_error $? "--with-ndiff requires Python with setuptools
 See \`config.log' for more details" "$LINENO" 5; }
   fi
   with_ndiff=no

--- a/configure
+++ b/configure
@@ -7300,7 +7300,8 @@ fi
 
 # If they didn't specify it, we try to find it
 if test $have_pcre != yes -a $requested_included_pcre != yes ; then
-  ac_fn_c_check_header_compile "$LINENO" "pcre2.h" "ac_cv_header_pcre2_h" "$ac_includes_default"
+  ac_fn_c_check_header_compile "$LINENO" "pcre2.h" "ac_cv_header_pcre2_h" "#define PCRE2_CODE_UNIT_WIDTH 8
+"
 if test "x$ac_cv_header_pcre2_h" = xyes
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for pcre2_compile_8 in -lpcre2-8" >&5
@@ -7344,7 +7345,8 @@ then :
 fi
 
 else $as_nop
-  ac_fn_c_check_header_compile "$LINENO" "pcre2/pcre2.h" "ac_cv_header_pcre2_pcre2_h" "$ac_includes_default"
+  ac_fn_c_check_header_compile "$LINENO" "pcre2/pcre2.h" "ac_cv_header_pcre2_pcre2_h" "#define PCRE2_CODE_UNIT_WIDTH 8
+"
 if test "x$ac_cv_header_pcre2_pcre2_h" = xyes
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for pcre2_compile_8 in -lpcre2-8" >&5
@@ -7385,13 +7387,12 @@ printf "%s\n" "$ac_cv_lib_pcre2_8_pcre2_compile_8" >&6; }
 if test "x$ac_cv_lib_pcre2_8_pcre2_compile_8" = xyes
 then :
   have_pcre=yes
-      printf "%s\n" "#define HAVE_PCRE2_PCRE2_H 1" >>confdefs.h
+
+printf "%s\n" "#define HAVE_PCRE2_PCRE2_H 1" >>confdefs.h
 
 fi
 
-
 fi
-
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -233,16 +233,26 @@ CHECK_IPV6_IPPROTO_RAW
 m4_define_default([_AM_PYTHON_INTERPRETER_LIST],[python3 python])
 AM_PATH_PYTHON([3], [HAVE_PYTHON=true], [HAVE_PYTHON=false])
 
+if $HAVE_PYTHON ; then
+  AC_MSG_CHECKING([for python setuptools])
+  if $PYTHON -c 'import setuptools' 2>/dev/null ; then
+    have_setuptools=yes
+  else
+    have_setuptools=no
+  fi
+  AC_MSG_RESULT([$have_setuptools])
+fi
+
 NDIFFDIR=ndiff
 
 # Do they want Ndiff?
 AC_ARG_WITH(ndiff, AC_HELP_STRING([--without-ndiff], [Skip installation of the Ndiff utility]), [], [with_ndiff=check])
-if $HAVE_PYTHON ; then : ;
+if $HAVE_PYTHON && test "$have_setuptools" = "yes" ; then : ;
 else
   if test "$with_ndiff" = "check" ; then
-    AC_MSG_WARN([Not building Ndiff because Python was not found])
+    AC_MSG_WARN([Not building Ndiff because Python with setuptools was not found])
   elif test "$with_ndiff" = "yes"; then
-    AC_MSG_FAILURE([--with-ndiff requires Python])
+    AC_MSG_FAILURE([--with-ndiff requires Python with setuptools])
   fi
   with_ndiff=no
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -529,12 +529,17 @@ AC_HELP_STRING([--with-libpcre=included], [Always use the version included with 
 # If they didn't specify it, we try to find it
 if test $have_pcre != yes -a $requested_included_pcre != yes ; then
   AC_CHECK_HEADER(pcre2.h,
-    AC_CHECK_LIB(pcre2-8, pcre2_compile_8, [have_pcre=yes ]),
-    [AC_CHECK_HEADER(pcre2/pcre2.h,
-     [AC_CHECK_LIB(pcre2-8, pcre2_compile_8, [have_pcre=yes
-      AC_DEFINE(HAVE_PCRE2_PCRE2_H, 1)])]
-    )]
-  )
+    AC_CHECK_LIB(pcre2-8,
+      pcre2_compile_8,
+      [have_pcre=yes ]),
+    AC_CHECK_HEADER(pcre2/pcre2.h,
+      AC_CHECK_LIB(pcre2-8,
+        pcre2_compile_8,
+        [have_pcre=yes
+        AC_DEFINE(HAVE_PCRE2_PCRE2_H, 1, [Using system pcre2/pcre2.h])]),
+      [],
+      [#define PCRE2_CODE_UNIT_WIDTH 8]),
+    [#define PCRE2_CODE_UNIT_WIDTH 8])
 fi
 
 # If we still don't have it, we use our own


### PR DESCRIPTION
The PR updates `configure.ac` to check whether python module `setuptools` is present and to stop the Ndiff build if this test fails.

The PR will be committed after September 6, 2024, unless concerns are raised.