### PR TITLE
Add configure test for presence of python setuptools

### DIFF
--- a/configure
+++ b/configure
@@ -6520,6 +6520,18 @@ printf "%s\n" "$am_cv_python_pyexecdir" >&6; }
 
 
 
+if $HAVE_PYTHON ; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for python setuptools" >&5
+printf %s "checking for python setuptools... " >&6; }
+  if $PYTHON -c 'import setuptools' 2>/dev/null ; then
+    have_setuptools=yes
+  else
+    have_setuptools=no
+  fi
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $have_setuptools" >&5
+printf "%s\n" "$have_setuptools" >&6; }
+fi
+
 NDIFFDIR=ndiff
 
 # Do they want Ndiff?
@@ -6532,15 +6544,15 @@ else $as_nop
   with_ndiff=check
 fi
 
-if $HAVE_PYTHON ; then : ;
+if $HAVE_PYTHON && test "$have_setuptools" = "yes" ; then : ;
 else
   if test "$with_ndiff" = "check" ; then
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Not building Ndiff because Python was not found" >&5
-printf "%s\n" "$as_me: WARNING: Not building Ndiff because Python was not found" >&2;}
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Not building Ndiff because Python with setuptools was not found" >&5
+printf "%s\n" "$as_me: WARNING: Not building Ndiff because Python with setuptools was not found" >&2;}
   elif test "$with_ndiff" = "yes"; then
     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "--with-ndiff requires Python
+as_fn_error $? "--with-ndiff requires Python with setuptools
 See \`config.log' for more details" "$LINENO" 5; }
   fi
   with_ndiff=no

--- a/configure.ac
+++ b/configure.ac
@@ -233,16 +233,26 @@ CHECK_IPV6_IPPROTO_RAW
 m4_define_default([_AM_PYTHON_INTERPRETER_LIST],[python3 python])
 AM_PATH_PYTHON([3], [HAVE_PYTHON=true], [HAVE_PYTHON=false])
 
+if $HAVE_PYTHON ; then
+  AC_MSG_CHECKING([for python setuptools])
+  if $PYTHON -c 'import setuptools' 2>/dev/null ; then
+    have_setuptools=yes
+  else
+    have_setuptools=no
+  fi
+  AC_MSG_RESULT([$have_setuptools])
+fi
+
 NDIFFDIR=ndiff
 
 # Do they want Ndiff?
 AC_ARG_WITH(ndiff, AC_HELP_STRING([--without-ndiff], [Skip installation of the Ndiff utility]), [], [with_ndiff=check])
-if $HAVE_PYTHON ; then : ;
+if $HAVE_PYTHON && test "$have_setuptools" = "yes" ; then : ;
 else
   if test "$with_ndiff" = "check" ; then
-    AC_MSG_WARN([Not building Ndiff because Python was not found])
+    AC_MSG_WARN([Not building Ndiff because Python with setuptools was not found])
   elif test "$with_ndiff" = "yes"; then
-    AC_MSG_FAILURE([--with-ndiff requires Python])
+    AC_MSG_FAILURE([--with-ndiff requires Python with setuptools])
   fi
   with_ndiff=no
 fi


### PR DESCRIPTION
The PR updates `configure.ac` to check whether python module `setuptools` is present and to stop the Ndiff build if this test fails.

The PR will be committed after September 6, 2024, unless concerns are raised.