### PR TITLE
nse_libssh2.cc - callback fix

### DIFF
--- a/nse_libssh2.cc
+++ b/nse_libssh2.cc
@@ -579,7 +579,7 @@ static int l_read_publickey (lua_State *L) {
 
 static int publickey_canauth_cb (LIBSSH2_SESSION *session, unsigned char **sig,
     size_t *sig_len, const unsigned char *data, size_t data_len, void **abstract) {
-    return 0;
+    return 1;
 }
 
 static int publickey_canauth (lua_State *L, int status, lua_KContext ctx) {


### PR DESCRIPTION
Callback needs to return 1 to hit the callback error check immediately after it is called in userauth.c, since the user/key combination is confirmed at this point. 
Otherwise execution runs into memory corruption errors, with further authentication procedures not being implemented for publickey_canauth().