### PR TITLE
Add rudimentary NSE support for 802.1Q / 802.1ad VLAN tags

### DIFF
--- a/nsock/src/nsock_pcap.h
+++ b/nsock/src/nsock_pcap.h
@@ -58,6 +58,7 @@
 #ifdef HAVE_PCAP
 
 #include "pcap.h"
+#include "ethertype.h"
 
 #include <string.h>
 #include <stdarg.h>


### PR DESCRIPTION
The PR implements the following changes:
* NSock `nse_readpcap()` will include VLAN tags in `*l2_data`, as opposed to `*l3_data`. Parsers can now assume that IP headers start at `*l3_data` even for tagged Ethernet frames.
* NSE `packet.Frame:new()` will parse VLAN tags and capture the result in list `frame.vlans`. Each element is a table containing the expected fields: TPID, CPC, DEI, and VID (all in lowercase).
* NSE `packet.Frame:build_ether_frame()` takes an an optional parameter in the form of the list above to build 802.1Q / 802.1ad headers. Incomplete VLAN specifications use the following defaults:
    * TPID is set to C-TAG for the inner-most VLAN, S-TAG otherwise.
    * TCI fields CPC, DEI, and VID are all set to 0.

This PR will *not* be automatically committed without a go-ahead from @fyodor or @bonsaiviking.