### PR TITLE
Allow crypto IVs with leading zero

### DIFF
--- a/nse_openssl.cc
+++ b/nse_openssl.cc
@@ -387,10 +387,10 @@ static int l_encrypt(lua_State *L) /** encrypt( string algorithm, string key, st
 
   size_t key_len, iv_len, data_len;
   const unsigned char *key = (unsigned char *) luaL_checklstring( L, 2, &key_len );
-  const unsigned char *iv = (unsigned char *) luaL_optlstring( L, 3, "", &iv_len );
+  const unsigned char *iv = (unsigned char *) luaL_optlstring( L, 3, NULL, &iv_len );
   const unsigned char *data = (unsigned char *) luaL_checklstring( L, 4, &data_len );
   int padding = lua_toboolean( L, 5 );
-  if (iv[0] == '\0')
+  if (!iv_len)
     iv = NULL;
 
 #if HAVE_OPAQUE_STRUCTS
@@ -449,10 +449,10 @@ static int l_decrypt(lua_State *L) /** decrypt( string algorithm, string key, st
 
   size_t key_len, iv_len, data_len;
   const unsigned char *key = (unsigned char *) luaL_checklstring( L, 2, &key_len );
-  const unsigned char *iv = (unsigned char *) luaL_optlstring( L, 3, "", &iv_len );
+  const unsigned char *iv = (unsigned char *) luaL_optlstring( L, 3, NULL, &iv_len );
   const unsigned char *data = (unsigned char *) luaL_checklstring( L, 4, &data_len );
   int padding = lua_toboolean( L, 5 );
-  if (iv[0] == '\0')
+  if (!iv_len)
     iv = NULL;
 
 #if HAVE_OPAQUE_STRUCTS


### PR DESCRIPTION
The NSE wrapper for OpenSSL is currently testing for null IV by inspecting the first byte, as if the IV was a null-terminated string, as opposed to an arbitrary byte sequence:
https://github.com/nmap/nmap/blob/fbadb5256b93ffbdb77345827c885e81708ed3df/nse_openssl.cc#L393-L394
The impact of this misinterpretation is that both `openssl.encrypt()` and `openssl.decrypt()` are sporadically producing incorrect results.

The PR will be committed after September 13, 2024, unless concerns are raised.