### PR TITLE
Add less-than method to facilitate object sorting

### DIFF
--- a/ndiff/ndiff.py
+++ b/ndiff/ndiff.py
@@ -423,6 +423,9 @@ class ScriptResult(object):
 
     def __ne__(self, other):
         return not self.__eq__(other)
+        
+    def __lt__(self, other):
+        return self.id < other.id
 
     def get_lines(self):
         result = []


### PR DESCRIPTION
The `ScriptResult` class in nmap/ndiff/ndiff.py is not specifying a `__lt__` (less-than) method by which the precedence of its instances could be compared when sorting.

This can lead to an error on the `sort` method call in line 1420. 
`self.current_port.script_results.sort()`

The error occurs when multiple script results are exported to xml and parsed by the underlying xml.sax library.