### PR TITLE
Preserve HTTP pipeline global options

### DIFF
--- a/nselib/comm.lua
+++ b/nselib/comm.lua
@@ -247,6 +247,7 @@ end
 -- @param data The first data payload of the connection. Optional if
 --             <code>opts.recv_before</code> is true.
 -- @param opts Options, such as timeout
+--             Note that opts.proto will get set to correctOpt (see below)
 -- @return sd The socket descriptor, or nil on error
 -- @return response The response received for the payload, or an error message
 -- @return correctOpt Correct option for connection guess

--- a/nselib/http.lua
+++ b/nselib/http.lua
@@ -2000,7 +2000,7 @@ function pipeline_go(host, port, all_requests)
   local req = all_requests[1]
   req.options.header = force_header(req.options.header, "Connection", "keep-alive")
   local reqstr = build_request(host, port, req.method, req.path, req.options)
-  local socket, partial, bopt = comm.tryssl(host, port, reqstr, pipeline_comm_opts)
+  local socket, partial, bopt = comm.tryssl(host, port, reqstr, tableaux.tcopy(pipeline_comm_opts))
   if not socket then
     return nil
   end


### PR DESCRIPTION
Function `http.pipeline_go()` is passing its *global* connection options to `comm.tryssl()`. However, this function has an undocumented side-effect of modifying the provided options, which can result in assertion failures when `http.pipeline_go()` gets called more than once in a single scan:
https://github.com/nmap/nmap/blob/3d99250c8311a7e72e4ab8f00cce283880910de9/nselib/comm.lua#L257
The PR resolves the issue by:
* Passing *a temporary copy* of the global options to `comm.tryssl()`
* Documenting the side-effect

The PR will be committed after October 1, 2024, unless concerns are raised.