### PR TITLE
Fix out of bounds reads in packet parsing

### DIFF
--- a/libnetutil/HopByHopHeader.cc
+++ b/libnetutil/HopByHopHeader.cc
@@ -169,7 +169,7 @@ int HopByHopHeader::validate(){
         +-+-+-+-+-+-+-+-+  */
         case EXTOPT_PAD1:
           curr_pnt++; /* Skip one octet */
-          bytes_left++;
+          bytes_left--;
         break;
 
         /* PadN

--- a/libnetutil/PacketParser.cc
+++ b/libnetutil/PacketParser.cc
@@ -123,7 +123,8 @@ const char *PacketParser::header_type2string(int val){
 #define MAX_HEADERS_IN_PACKET 32
 pkt_type_t *PacketParser::parse_packet(const u8 *pkt, size_t pktlen, bool eth_included){
   if(PKTPARSERDEBUG)printf("%s(%p, %lu)\n", __func__, pkt, (long unsigned)pktlen);
-  static pkt_type_t this_packet[MAX_HEADERS_IN_PACKET+1]; /* Packet structure array   */
+  static pkt_type_t this_packet[MAX_HEADERS_IN_PACKET+2]; /* Packet structure array   */
+                                   /* +1 for RAW packet, +1 for 0 length guard */
   u8 current_header=0;             /* Current array position of "this_packet" */
   const u8 *curr_pkt=pkt;          /* Pointer to current part of the packet   */
   size_t curr_pktlen=pktlen;       /* Remaining packet length                 */
@@ -582,6 +583,7 @@ pkt_type_t *PacketParser::parse_packet(const u8 *pkt, size_t pktlen, bool eth_in
         //if(expected==HEADER_TYPE_DNS){
         //}else if(expected==HEADER_TYPE_HTTP){
         //}... ETC
+        /* current_header could be MAX_HEADERS_IN_PACKET already */
         this_packet[current_header].length=curr_pktlen;
         this_packet[current_header++].type=HEADER_TYPE_RAW_DATA;
         curr_pktlen=0;
@@ -594,6 +596,7 @@ pkt_type_t *PacketParser::parse_packet(const u8 *pkt, size_t pktlen, bool eth_in
   if (unknown_hdr==true){
     if(curr_pktlen>0){
         if(PKTPARSERDEBUG)puts("Unknown layer found. Treating it as raw data.");
+        /* current_header could be MAX_HEADERS_IN_PACKET already */
         this_packet[current_header].length=curr_pktlen;
         this_packet[current_header++].type=HEADER_TYPE_RAW_DATA;
     }

--- a/tests/fuzz_PacketParser.cc
+++ b/tests/fuzz_PacketParser.cc
@@ -1,0 +1,26 @@
+#include "../libnetutil/PacketParser.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+__AFL_FUZZ_INIT();
+
+int main(int argc, char **argv)
+{
+#ifdef __AFL_HAVE_MANUAL_CONTROL
+	__AFL_INIT();
+#endif
+
+	unsigned char *buf = __AFL_FUZZ_TESTCASE_BUF;
+
+	while (__AFL_LOOP(1000)) {
+		int len = __AFL_FUZZ_TESTCASE_LEN;
+		if (len < 1) continue;
+
+		PacketElement *p = PacketParser::split(buf, len, true /*eth_included*/);
+		PacketParser::freePacketChain(p);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Should be straightforward. I do not think these have any security impact, but reading out of bounds isn't nice.

This was found with AFL and the test code included in last commit.

Btw, while doing this, I have also come across another out of bounds read in DNS code, which is already described in https://tomerfry.github.io/2023/05/26/Fuzzing-NMAP-With-AFL++.html
From my experiments it's an over-read in input buffer to DNS::Packet::parseFromBuffer(). I haven't analysed it enough to figure out the root cause, hence no patch.