### PR TITLE
fix racing between build-ncat and build-lua

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -159,7 +159,7 @@ build-netutil: libnetutil/Makefile
 	@echo Compiling libnetutil;
 	cd libnetutil && $(MAKE)
 
-build-ncat: $(NCATDIR)/Makefile build-nbase build-nsock $(NCATDIR)/ncat.h @PCAP_BUILD@
+build-ncat: $(NCATDIR)/Makefile build-nbase build-nsock build-lua $(NCATDIR)/ncat.h @PCAP_BUILD@
 	cd $(NCATDIR) && $(MAKE)
 
 build-lua: $(LIBLUADIR)/Makefile


### PR DESCRIPTION
There are two build-lua rules, one in Makefile.in, another in ncat/Makefile.in which is required by build-ncat

Build them may cause potential racing

Compiling liblua
make[1]: Entering directory 'path-to/nmap-7.95/liblua' Compiling liblua
make[2]: Entering directory 'path-to/nmap-7.95/liblua' make[2]: Leaving directory 'path-to/nmap-7.95/liblua' path-to/usr/bin/i686-wrsmllib32-linux/../../libexec/i686-wrsmllib32-linux/gcc/i686-wrsmllib32-linux/14.2.0/ld: ./../liblua/liblua.a: error adding symbols: no more archived files collect2: error: ld returned 1 exit status
make[1]: Leaving directory 'path-to/tmp/work/corei7-32-wrsmllib32-linux/lib32-nmap/7.95/nmap-7.95/liblua'

Explicitly make build-ncat depends on build-lua to avoid racing, after applying the patch
...
Compiling liblua
make[1]: Entering directory 'path-to/nmap-7.95/liblua' make[1]: Leaving directory 'path-to/nmap-7.95/liblua' Compiling liblua
make[2]: Entering directory 'path-to/nmap-7.95/liblua' make[2]: Leaving directory 'path-to/nmap-7.95/liblua' ...