### PR TITLE
Add support for building with AWS-LC (Add one ifdef)

### DIFF
--- a/nsock/src/nsock_ssl.c
+++ b/nsock/src/nsock_ssl.c
@@ -111,7 +111,7 @@ static SSL_CTX *ssl_init_helper(const SSL_METHOD *method) {
   if (nsock_ssl_state == NSOCK_SSL_STATE_UNINITIALIZED)
   {
     nsock_ssl_state = NSOCK_SSL_STATE_INITIALIZED;
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined LIBRESSL_VERSION_NUMBER
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined LIBRESSL_VERSION_NUMBER || defined OPENSSL_IS_AWSLC
     SSL_load_error_strings();
     SSL_library_init();
 #else


### PR DESCRIPTION
Hello, 

I am opening this PR to add support for AWS Libcrypto (AWS-LC - https://github.com/aws/aws-lc), an open-source cryptographic and ssl library. This PR attaches an `OPENSSL_IS_AWSLC` macro to an existing ifdef for libressl and older version of OpenSSL. This macro will allow AWS-LC to build with mainline nmap without any patches. We verify this build in our CI [here](https://github.com/aws/aws-lc/blob/8a9ebcfdcf8bb4a685ca83646265ea0aab85c3c8/tests/ci/cdk/cdk/codebuild/github_ci_integration_omnibus.yaml#L343).

Associated Github Issue: https://github.com/nmap/nmap/issues/3044

Thank You!