### PR TITLE
ncat: use SHA-256 signatures for certificate with --ssl

### DIFF
--- a/ncat/ncat_connect.c
+++ b/ncat/ncat_connect.c
@@ -130,7 +130,7 @@ static int verify_callback(int ok, X509_STORE_CTX *store)
     /* Print the subject, issuer, and fingerprint depending on the verbosity
        level. */
     if ((!ok && o.verbose) || o.debug > 1) {
-        char digest_buf[SHA1_STRING_LENGTH + 1];
+        char digest_buf[SHA256_STRING_LENGTH + 1];
         char *fp;
 
         loguser("Subject: ");
@@ -140,9 +140,9 @@ static int verify_callback(int ok, X509_STORE_CTX *store)
         X509_NAME_print_ex_fp(stderr, X509_get_issuer_name(cert), 0, XN_FLAG_COMPAT);
         loguser_noprefix("\n");
 
-        fp = ssl_cert_fp_str_sha1(cert, digest_buf, sizeof(digest_buf));
+        fp = ssl_cert_fp_str_sha256(cert, digest_buf, sizeof(digest_buf));
         ncat_assert(fp == digest_buf);
-        loguser("SHA-1 fingerprint: %s\n", digest_buf);
+        loguser("SHA-256 fingerprint: %s\n", digest_buf);
     }
 
     if (!ok && o.verbose) {
@@ -236,7 +236,7 @@ static void connect_report(nsock_iod nsi)
         if (nsock_iod_check_ssl(nsi)) {
             X509 *cert;
             X509_NAME *subject;
-            char digest_buf[SHA1_STRING_LENGTH + 1];
+            char digest_buf[SHA256_STRING_LENGTH + 1];
             char *fp;
 
             loguser("SSL connection to %s.", peer_str);
@@ -256,9 +256,9 @@ static void connect_report(nsock_iod nsi)
 
             loguser_noprefix("\n");
 
-            fp = ssl_cert_fp_str_sha1(cert, digest_buf, sizeof(digest_buf));
+            fp = ssl_cert_fp_str_sha256(cert, digest_buf, sizeof(digest_buf));
             ncat_assert(fp == digest_buf);
-            loguser("SHA-1 fingerprint: %s\n", digest_buf);
+            loguser("SHA-256 fingerprint: %s\n", digest_buf);
         } else
 #endif
         {

--- a/ncat/ncat_ssl.c
+++ b/ncat/ncat_ssl.c
@@ -155,7 +155,7 @@ SSL_CTX *setup_ssl_listen(const SSL_METHOD *method)
     if (o.sslcert == NULL && o.sslkey == NULL) {
         X509 *cert;
         EVP_PKEY *key;
-        char digest_buf[SHA1_STRING_LENGTH + 1];
+        char digest_buf[SHA256_STRING_LENGTH + 1];
 
         if (o.verbose)
             loguser("Generating a temporary %d-bit RSA key. Use --ssl-key and --ssl-cert to use a permanent one.\n", DEFAULT_KEY_BITS);
@@ -163,9 +163,9 @@ SSL_CTX *setup_ssl_listen(const SSL_METHOD *method)
             bye("ssl_gen_cert(): %s.", ERR_error_string(ERR_get_error(), NULL));
         if (o.verbose) {
             char *fp;
-            fp = ssl_cert_fp_str_sha1(cert, digest_buf, sizeof(digest_buf));
+            fp = ssl_cert_fp_str_sha256(cert, digest_buf, sizeof(digest_buf));
             ncat_assert(fp == digest_buf);
-            loguser("SHA-1 fingerprint: %s\n", digest_buf);
+            loguser("SHA-256 fingerprint: %s\n", digest_buf);
         }
         if (SSL_CTX_use_certificate(sslctx, cert) != 1)
             bye("SSL_CTX_use_certificate(): %s.", ERR_error_string(ERR_get_error(), NULL));
@@ -581,7 +581,7 @@ static int ssl_gen_cert(X509 **cert, EVP_PKEY **key)
 #endif
 
     /* Sign it. */
-    if (X509_sign(*cert, *key, EVP_sha1()) == 0)
+    if (X509_sign(*cert, *key, EVP_sha256()) == 0)
         goto err;
 
     return 1;
@@ -595,19 +595,19 @@ err:
     return 0;
 }
 
-/* Calculate a SHA-1 fingerprint of a certificate and format it as a
+/* Calculate a SHA-256 fingerprint of a certificate and format it as a
    human-readable string. Returns strbuf or NULL on error. */
-char *ssl_cert_fp_str_sha1(const X509 *cert, char *strbuf, size_t len)
+char *ssl_cert_fp_str_sha256(const X509 *cert, char *strbuf, size_t len)
 {
-    unsigned char binbuf[SHA1_BYTES];
+    unsigned char binbuf[SHA256_BYTES];
     unsigned int n;
     char *p;
     unsigned int i;
 
-    if (len < SHA1_STRING_LENGTH + 1)
+    if (len < SHA256_STRING_LENGTH + 1)
         return NULL;
     n = sizeof(binbuf);
-    if (X509_digest(cert, EVP_sha1(), binbuf, &n) != 1)
+    if (X509_digest(cert, EVP_sha256(), binbuf, &n) != 1)
         return NULL;
 
     p = strbuf;

--- a/ncat/ncat_ssl.h
+++ b/ncat/ncat_ssl.h
@@ -69,9 +69,9 @@
 #define NCAT_CA_CERTS_FILE "ca-bundle.crt"
 
 enum {
-    SHA1_BYTES = 160 / 8,
-    /* 40 bytes for hex digits and 9 bytes for ' '. */
-    SHA1_STRING_LENGTH = SHA1_BYTES * 2 + (SHA1_BYTES / 2 - 1)
+    SHA256_BYTES = 256 / 8,
+    /* 64 bytes for hex digits and 15 bytes for ' '. */
+    SHA256_STRING_LENGTH = SHA256_BYTES * 2 + (SHA256_BYTES / 2 - 1)
 };
 
 /* These status variables are returned by ssl_handshake() to describe the
@@ -89,7 +89,7 @@ extern SSL *new_ssl(int fd);
 
 extern int ssl_post_connect_check(SSL *ssl, const char *hostname);
 
-extern char *ssl_cert_fp_str_sha1(const X509 *cert, char *strbuf, size_t len);
+extern char *ssl_cert_fp_str_sha256(const X509 *cert, char *strbuf, size_t len);
 
 extern int ssl_load_default_ca_certs(SSL_CTX *ctx);
 


### PR DESCRIPTION
SHA1 is deprecated and for example Fedora [1] have disabled support for it in their bundled crypto libraries.

[1]: https://lists.fedoraproject.org/archives/list/devel-announce@lists.fedoraproject.org/thread/7IAWTCLLNAS5P5ARUJ3LH3WZIHEX46JB/

With stock ncat in Fedora 41:

```
#  nc -k -l --ssl
Ncat: Version 7.92 ( https://nmap.org/ncat )
Ncat: Generating a temporary 2048-bit RSA key. Use --ssl-key and --ssl-cert to use a permanent one.
Ncat: ssl_gen_cert(): error:03000098:digital envelope routines::invalid digest. QUITTING.
```

After changes:
```
# ./ncat -k -l --ssl
Ncat: Version 7.95SVN ( https://nmap.org/ncat )
Ncat: Generating a temporary 2048-bit RSA key. Use --ssl-key and --ssl-cert to use a permanent one.
Ncat: SHA-256 fingerprint: 973E 4230 6808 C380 FF3A 95B8 9C1C 0A08 88C4 B3C1 6BE3 FC2D CCA3 D0FC 2768 423B
Ncat: Listening on [::]:31337
Ncat: Listening on 0.0.0.0:31337
```

Also changed the printing of fingerprint to be SHA-256:
```
# ./ncat --ssl 127.0.0.1 443 -v
Ncat: Version 7.95SVN ( https://nmap.org/ncat )
Ncat: Subject: CN=localhost
Ncat: Issuer: CN=localhost
Ncat: SHA-256 fingerprint: 6E9F E954 0BA7 8046 89F9 998C 4444 0629 77F7 D6A2 2D27 C35F FE0C 17E1 DE49 2E8C
Ncat: Certificate verification failed (self-signed certificate).
Ncat: SSL connection to 127.0.0.1:443.
Ncat: SHA-256 fingerprint: 6E9F E954 0BA7 8046 89F9 998C 4444 0629 77F7 D6A2 2D27 C35F FE0C 17E1 DE49 2E8C
```

OpenSSL s_client seems ok with this change:

```
# openssl s_client -connect localhost:443 --showcerts
Connecting to 127.0.0.1
CONNECTED(00000003)
Can't use SSL_get_servername
depth=0 CN=localhost
verify error:num=18:self-signed certificate
verify return:1
depth=0 CN=localhost
verify return:1
---
Certificate chain
 0 s:CN=localhost
   i:CN=localhost
   a:PKEY: rsaEncryption, 2048 (bit); sigalg: RSA-SHA256
   v:NotBefore: Apr 24 10:41:14 2025 GMT; NotAfter: Apr 24 10:41:14 2026 GMT
-----BEGIN CERTIFICATE-----
MIIDCzCCAfOgAwIBAgIEQHeg9DANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls
b2NhbGhvc3QwHhcNMjUwNDI0MTA0MTE0WhcNMjYwNDI0MTA0MTE0WjAUMRIwEAYD
VQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8
22dX1ZFn1qd7+Ek5qaPhpx24m7T3SxsoQZpo02R3uWC6rKrx3O0FWW6BtAH8fzwv
by9uocQsZtaEGQGQxTZjKGS8tL0u2c1D4wUKKSe31SUG/Youpmtt3IAAw+235MOQ
8ychr1FtSEgsL+L0SfmiAP3FUSonRGGD/dxpVr5eJAHWAo+ncBSV5XtKJY1DTLSu
kCPTUyqjR/8odFzTXtk85QpJL/rFKo/1Y/9aOzZQlJSxiLqzQnimUKDBuRrtgGe4
RDICZE49K6WF7rwC/Tes+fxgwZD2yJfHVpwjJ5fSUXVEVHVGzw0mh+IDIDHO6xro
galBu0YMMFCfARs/oLoNAgMBAAGjZTBjMBQGA1UdEQQNMAuCCWxvY2FsaG9zdDBL
BglghkgBhvhCAQ0EPhY8QXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgTmNhdC4g
U2VlIGh0dHBzOi8vbm1hcC5vcmcvbmNhdC8uMA0GCSqGSIb3DQEBCwUAA4IBAQCh
wEEPGVHE+xi0G+Zfb8oGtKgOnHHWlYn30sW04Lm7SfOPl6IUhF8SFB0YD/X0jUsB
eHpxL2IKw5c7e/v4jEFEm7i9Ly500haGroOm60Sw+/Af91jp5I3ZcokOp8mo3EuL
W2UIkbUocSX7f8756bqbmCbySs4R8b/1OFhYguN9g6cSJ3WpexeuCUoVvRI3YfID
mACkUJ0L6AtX+i9JbWMEVJIWe8ktRW7miWWKuE/8uAO+CrQn41+1TGCrFmHBkXiE
1++6ImShOvmk/q/YgzO0xky83ruVWT4dGEOi/TzpsygKPFr0TIlDvvIDgvTH4869
exT21L4WOyW6YyDJSZ1F
-----END CERTIFICATE-----
---
Server certificate
subject=CN=localhost
issuer=CN=localhost
---
No client certificate CA names sent
Peer signing digest: SHA256
Peer signature type: RSA-PSS
Server Temp Key: X25519, 253 bits
---
SSL handshake has read 1339 bytes and written 382 bytes
Verification error: self-signed certificate
---
New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
Server public key is 2048 bit
This TLS version forbids renegotiation.
Compression: NONE
Expansion: NONE
No ALPN negotiated
Early data was not sent
Verify return code: 18 (self-signed certificate)
---
---
Post-Handshake New Session Ticket arrived:
SSL-Session:
    Protocol  : TLSv1.3
    Cipher    : TLS_AES_256_GCM_SHA384
    Session-ID: 74C9799A20096B6D6F7789937BC3AFE06B32320DB65B0D9335BBBB7F75402904
    Session-ID-ctx:
    Resumption PSK: 4674FA1D03424248A6DAD03B5742E7405C2328C16A99D4C4063BD274322DCD6C8DFF946E5E45EE557BE491A1ACE151F7
    PSK identity: None
    PSK identity hint: None
    SRP username: None
    TLS session ticket lifetime hint: 7200 (seconds)
    TLS session ticket:
    0000 - 9e 00 b0 f2 0b 5d 62 5f-a4 05 47 05 5b c8 20 f7   .....]b_..G.[. .
    0010 - a8 fa d3 fc cb 75 5a 1a-5d 7a 14 dc d9 7b 5c f6   .....uZ.]z...{\.
    0020 - a5 0c 77 0d e0 5a 19 e5-df 1d 70 71 fe 0a af e4   ..w..Z....pq....
    0030 - 24 22 b4 b6 f0 ca a8 d6-d9 b7 46 1c 9f 86 65 de   $"........F...e.
    0040 - 80 5d 2b b9 fe 86 42 cb-88 e6 9b 6a 58 a5 59 e8   .]+...B....jX.Y.
    0050 - 35 4a db c8 b4 89 92 64-b1 d3 6b 8a 7e 1d ed b6   5J.....d..k.~...
    0060 - 63 5d ad 00 c9 10 a9 13-1b 35 c9 df 93 30 70 da   c].......5...0p.
    0070 - cb b2 9f f5 0f 7d c9 94-a5 72 97 23 38 10 8d 0d   .....}...r.#8...
    0080 - fd d5 ec 4e 89 2b 3b a7-d3 2c e8 cb 78 fc 5e 61   ...N.+;..,..x.^a
    0090 - 6c c0 4d f4 a6 43 5d 07-59 78 9c cb e8 a5 77 e2   l.M..C].Yx....w.
    00a0 - 57 e4 0f 3b 66 48 e3 3f-b7 fb 1b fc f9 aa 13 8a   W..;fH.?........
    00b0 - d0 38 33 c6 91 ff fa 2a-e2 e3 15 e5 1d 3b 87 47   .83....*.....;.G
    00c0 - 2f e3 f9 68 07 ef b5 ab-b8 4b 5c f0 21 ce 2f bd   /..h.....K\.!./.

    Start Time: 1745491313
    Timeout   : 7200 (sec)
    Verify return code: 18 (self-signed certificate)
    Extended master secret: no
    Max Early Data: 0
---
read R BLOCK
---
Post-Handshake New Session Ticket arrived:
SSL-Session:
    Protocol  : TLSv1.3
    Cipher    : TLS_AES_256_GCM_SHA384
    Session-ID: BAE637264B1B8CE7B116829E44D7B1E1A19764C4577EB648C04A8E02E05697EF
    Session-ID-ctx:
    Resumption PSK: AD8EC9BFB6DAA13A84B310DE03CE03C5E9DA29A691B85AFB6A175165CB3F0FD025F33D393E4555BD407D8ADB4A7C1728
    PSK identity: None
    PSK identity hint: None
    SRP username: None
    TLS session ticket lifetime hint: 7200 (seconds)
    TLS session ticket:
    0000 - 9e 00 b0 f2 0b 5d 62 5f-a4 05 47 05 5b c8 20 f7   .....]b_..G.[. .
    0010 - d8 34 12 82 54 60 e2 cb-4a 6f 7a 0a f9 92 09 fa   .4..T`..Joz.....
    0020 - eb d4 b9 c8 61 41 2b 96-41 14 3d cc 62 0c f9 23   ....aA+.A.=.b..#
    0030 - 07 65 b0 87 f5 39 f4 13-32 06 96 41 f1 4f d8 58   .e...9..2..A.O.X
    0040 - e6 d6 42 02 83 20 e0 bb-ca e9 68 e5 fb 48 ac 10   ..B.. ....h..H..
    0050 - 49 17 e6 9d 6c e2 8d 09-39 25 99 1a 78 6b 22 29   I...l...9%..xk")
    0060 - eb 1e f9 0f e8 4f ea b5-f4 e1 d4 0e 72 60 4f 8d   .....O......r`O.
    0070 - 7c 52 cd 51 0a a7 15 95-e7 7d f0 5c 00 98 ba 83   |R.Q.....}.\....
    0080 - 3e 9c 82 e3 7a cc a6 f2-ed e5 59 eb 3a 25 e4 37   >...z.....Y.:%.7
    0090 - 59 c9 b9 4e da de 0f db-43 32 8e ed 4c 46 19 ee   Y..N....C2..LF..
    00a0 - 0d e6 46 f8 bf c8 ef 80-45 bd de c1 e4 7d 93 2d   ..F.....E....}.-
    00b0 - 35 53 65 1b e9 e4 0e 03-ed 0c 05 96 46 24 0a 56   5Se.........F$.V
    00c0 - ae 93 f7 5a a6 b1 0e 02-ad 71 d1 b3 2d 83 f2 59   ...Z.....q..-..Y

    Start Time: 1745491313
    Timeout   : 7200 (sec)
    Verify return code: 18 (self-signed certificate)
    Extended master secret: no
    Max Early Data: 0
---
read R BLOCK
HTTP/1.1 404 Not Found
Date: Thu, 12 Aug 2021 13:38:12 GMT
Server: Apache/2.4.48 (Unix) LibreSSL/3.3.2
Strict-Transport-Security: max-age=63072000; includeSubdomains;
Content-Length: 0
closed
```