### PR TITLE
Fix http-google-malware.nse to Support Google Safe Browsing v4 API

### DIFF
--- a/scripts/http-google-malware.nse
+++ b/scripts/http-google-malware.nse
@@ -4,6 +4,8 @@ local shortport = require "shortport"
 local stdnse = require "stdnse"
 local string = require "string"
 local table = require "table"
+local json = require "json"
+local urlmod = require "url"
 
 description = [[
 Checks if hosts are on Google's blacklist of suspected malware and phishing
@@ -12,13 +14,16 @@ Browsing service.
 
 To do this the script queries the Google's Safe Browsing service and you need
 to have your own API key to access Google's Safe Browsing Lookup services. Sign
-up for yours at http://code.google.com/apis/safebrowsing/key_signup.html
+up for yours at https://developers.google.com/safe-browsing/v4/get-started
 
 * To learn more about Google's Safe Browsing:
-http://code.google.com/apis/safebrowsing/
+https://developers.google.com/safe-browsing/
 
 * To register and get your personal API key:
-http://code.google.com/apis/safebrowsing/key_signup.html
+https://developers.google.com/safe-browsing/v4/get-started
+
+* To make modifications to this file, use the following documentation:
+https://developers.google.com/safe-browsing/v4/lookup-api
 ]]
 
 ---
@@ -50,14 +55,34 @@ local APIKEY = ""
 --Builds Google Safe Browsing query
 --@param apikey Api key
 --@return Url
-local function build_qry(apikey, url)
-  return string.format("https://sb-ssl.google.com/safebrowsing/api/lookup?client=%s&apikey=%s&appver=1.5.2&pver=3.0&url=%s", SCRIPT_NAME, apikey, url)
+local function build_request_url(apikey)
+  return string.format("https://safebrowsing.googleapis.com/v4/threatMatches:find?key=%s", apikey)
 end
 
-local function fail (err) return stdnse.format_output(false, err) end
+local function build_request_body(url)
+  local body = {
+    client = {
+      clientId = "http-google-malware",
+      clientVersion = "1.0"
+    },
+    threatInfo = {
+      threatTypes = {"MALWARE", "SOCIAL_ENGINEERING"},
+      platformTypes = {"WINDOWS"},
+      threatEntryTypes = {"URL"},
+      threatEntries = {
+        { url = url }
+      }
+    }
+  }
+  return json.generate(body)
+end
+
+local function fail(err)
+  return stdnse.format_output(false, err)
+end
 
 ---
---MAIN
+-- MAIN
 ---
 action = function(host, port)
   local apikey = stdnse.get_script_args("http-google-malware.api") or APIKEY
@@ -65,7 +90,6 @@ action = function(host, port)
   local target
   local output_lns = {}
 
-  --Use the host IP if a hostname isn't available
   if not(host.targetname) then
     target = host.ip
   else
@@ -75,32 +99,52 @@ action = function(host, port)
   local target_url = stdnse.get_script_args("http-google-malware.url") or string.format("%s://%s", port.service, target)
 
   if string.len(apikey) < 25 then
-    return fail(("No API key found. Use the %s.api argument"):format(SCRIPT_NAME))
+    return fail(("No API key found. Use the %s.api argument"):format(_ENV.SCRIPT_NAME or "http-google-malware"))
   end
 
   stdnse.debug1("Checking host %s", target_url)
-  local qry = build_qry(apikey, target_url)
-  local req = http.get_url(qry, {any_af=true})
-  stdnse.debug2("%s", qry)
+  local body = build_request_body(target_url)
+  local url = build_request_url(apikey)
 
-  if ( req.status > 400 ) then
-    return fail("Request failed (invalid API key?)")
+  local parsed_url = urlmod.parse(url)
+  if not parsed_url or not parsed_url.host then
+    return fail("Failed to parse request URL")
   end
 
-  --The Safe Lookup API responds with a type when site is on the lists
-  if req.body then
-    if http.response_contains(req, "malware") then
-      output_lns[#output_lns+1] = "Host is known for distributing malware."
-      malware_found = true
-    end
-    if http.response_contains(req, "phishing") then
-      output_lns[#output_lns+1] = "Host is known for being used in phishing attacks."
-      malware_found = true
-    end
+  local response = http.generic_request({
+    method = "POST",
+    host = parsed_url.host,
+    port = parsed_url.port or 443,
+    path = parsed_url.path or "/v4/threatMatches:find",
+    ssl = true,
+    headers = {
+      ["Content-Type"] = "application/json"
+    },
+    body = body
+  })
+
+
+  stdnse.debug2("POST %s\nPayload: %s", url, body)
+
+  if not response then
+    return fail("HTTP request failed (no response received)")
   end
-  --For the verbose lovers
-  if req.status == 204 and nmap.verbosity() >= 2 and not(malware_found) then
-    output_lns[#output_lns+1] = "Host is safe to browse."
+
+  if response.status and response.status >= 400 then
+    return fail("Request failed (invalid API key or format)")
+  end
+
+  if response.body and #response.body > 0 then
+    if response.body:find("MALWARE") then
+      output_lns[#output_lns + 1] = "Host is known for distributing malware."
+      malware_found = true
+    end
+    if response.body:find("SOCIAL_ENGINEERING") then
+      output_lns[#output_lns + 1] = "Host is known for being used in phishing attacks."
+      malware_found = true
+    end
+  elseif nmap.verbosity() >= 2 and not malware_found then
+    output_lns[#output_lns + 1] = "Host is safe to browse."
   end
 
   if #output_lns > 0 then


### PR DESCRIPTION
## Changes Made
- Replaced the legacy GET-based API query with a properly structured POST request to `https://safebrowsing.googleapis.com/v4/threatMatches:find?key=API_KEY`, fixing issue #1474 

- Added `json` and `url` modules to:
  - Encode the request payload with `json.generate`
  - Parse the URL for `http.generic_request` to ensure valid hostname extraction
- Explicitly constructed HTTP fields: `host`, `port`, `path`, `ssl`, and `headers`, avoiding `url = string` ambiguities that caused prior crashes
- Improved error handling:
  - Missing or malformed URLs
  - Empty or 4xx responses
- Modernized response parsing, checking for `"MALWARE"` and `"SOCIAL_ENGINEERING"` in the JSON body and providing friendly output

## Bug Fixes
This resolves critical issues such as:
- `attempt to index a nil value (local 'hostname'`) from the `urlmod.ascii_hostname` logic in `http.lua`
- `bad argument #1 to 'for iterator'` caused by improper `headers` type
- Script failing silently or producing incomplete output