### PR TITLE
nmap-service-probe: Fixing LDAP's probe trailing 0

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -14742,8 +14742,8 @@ rarity 6
 ports 256,257,389,390,1702,3268,3892,11711
 sslports 636,637,3269,11712
 
-match ldap m|^0\x84\0\0..\x02\x01.*dsServiceName1\x84\0\0\0.\x04.CN=NTDS\x20Settings,CN=([^,]+),CN=Servers,CN=([^,]+),CN=Sites,CN=Configuration,DC=([^,]+),DC=([^,]+)0\x84\0|s p/Microsoft Windows Active Directory LDAP/ i/Domain: $3.$4, Site: $2/ o/Windows/ h/$1/ cpe:/o:microsoft:windows/a
-match ldap m|^0\x84\0\0..\x02\x01.*dsServiceName1\x84\0\0\0.\x04.CN=NTDS\x20Settings,CN=([^,]+),CN=Servers,CN=([^,]+),CN=Sites,CN=Configuration,DC=([^,]+),DC=([^,]+),DC=([^,]+)0\x84\0|s p/Microsoft Windows Active Directory LDAP/ i/Domain: $3.$4.$5, Site: $2/ o/Windows/ h/$1/ cpe:/o:microsoft:windows/a
+match ldap m|^0\x84\0\0..\x02\x01.*dsServiceName1\x84\0\0\0.\x04.CN=NTDS\x20Settings,CN=([^,]+),CN=Servers,CN=([^,]+),CN=Sites,CN=Configuration,DC=([^,]+),DC=([^,]+?)0\x84\0|s p/Microsoft Windows Active Directory LDAP/ i/Domain: $3.$4, Site: $2/ o/Windows/ h/$1/ cpe:/o:microsoft:windows/a
+match ldap m|^0\x84\0\0..\x02\x01.*dsServiceName1\x84\0\0\0.\x04.CN=NTDS\x20Settings,CN=([^,]+),CN=Servers,CN=([^,]+),CN=Sites,CN=Configuration,DC=([^,]+),DC=([^,]+),DC=([^,]+?)0\x84\0|s p/Microsoft Windows Active Directory LDAP/ i/Domain: $3.$4.$5, Site: $2/ o/Windows/ h/$1/ cpe:/o:microsoft:windows/a
 match ldap m|^0\x82..\x02\x01.*vmwPlatformServicesControllerVersion1\x07\x04\x05([\d.]+)0.\x04.*\nserverName1.\x04.cn=([\w._-]+)|s p/VMware vCenter or PSC LDAP/ v/$1/ h/$2/ cpe:/a:vmware:server/
 match ldap m|^0\x82..\x02\x01.*\nserverName1.\x04.cn=([\w._-]+).*vmwPlatformServicesControllerVersion1\x07\x04\x05([\d.]+)0.\x04|s p/VMware vCenter or PSC LDAP/ v/$1/ h/$2/ cpe:/a:vmware:server/
 match ldap m%^0\x82..\x02\x01.*\nserverName1c\x04acn=([\w._-]+).*vmw(?:AdministratorDN|DCAccountDN|DCAccountUPN)1%s p/VMware vCenter or PSC LDAP/ h/$1/ cpe:/a:vmware:server/
@@ -14759,8 +14759,8 @@ Probe UDP LDAPSearchReqUDP q|\x30\x84\x00\x00\x00\x2d\x02\x01\x07\x63\x84\x00\x0
 rarity 8
 ports 389
 
-match ldap m|^0\x84\0\0..\x02\x01.*dsServiceName1\x84\0\0\0.\x04.CN=NTDS\x20Settings,CN=([^,]+),CN=Servers,CN=([^,]+),CN=Sites,CN=Configuration,DC=([^,]+),DC=([^,]+)0\x84\0|s p/Microsoft Windows Active Directory LDAP/ i/Domain: $3.$4, Site: $2/ o/Windows/ h/$1/ cpe:/o:microsoft:windows/a
-match ldap m|^0\x84\0\0..\x02\x01.*dsServiceName1\x84\0\0\0.\x04.CN=NTDS\x20Settings,CN=([^,]+),CN=Servers,CN=([^,]+),CN=Sites,CN=Configuration,DC=([^,]+),DC=([^,]+),DC=([^,]+)0\x84\0|s p/Microsoft Windows Active Directory LDAP/ i/Domain: $3.$4.$5, Site: $2/ o/Windows/ h/$1/ cpe:/o:microsoft:windows/a
+match ldap m|^0\x84\0\0..\x02\x01.*dsServiceName1\x84\0\0\0.\x04.CN=NTDS\x20Settings,CN=([^,]+),CN=Servers,CN=([^,]+),CN=Sites,CN=Configuration,DC=([^,]+),DC=([^,]+?)0\x84\0|s p/Microsoft Windows Active Directory LDAP/ i/Domain: $3.$4, Site: $2/ o/Windows/ h/$1/ cpe:/o:microsoft:windows/a
+match ldap m|^0\x84\0\0..\x02\x01.*dsServiceName1\x84\0\0\0.\x04.CN=NTDS\x20Settings,CN=([^,]+),CN=Servers,CN=([^,]+),CN=Sites,CN=Configuration,DC=([^,]+),DC=([^,]+),DC=([^,]+?)0\x84\0|s p/Microsoft Windows Active Directory LDAP/ i/Domain: $3.$4.$5, Site: $2/ o/Windows/ h/$1/ cpe:/o:microsoft:windows/a
 
 # Ldap bind request, version 2, null DN, AUTH_TYPE simple, null password
 ##############################NEXT PROBE##############################


### PR DESCRIPTION
I noticed the issue in some HTB labs and just in case it was exclusive to them for some reason, I found some open ldap ports with shodan to verify.
Verify actual ldap domain:
```
ldapsearch -x -H "ldap://$ip" -b "" -s base dsServiceName
# extended LDIF
#
# LDAPv3
# base <> with scope baseObject
# filter: (objectclass=*)
# requesting: dsServiceName
#

#
dn:
dsServiceName: CN=NTDS Settings,CN=SRVAD,CN=Servers,CN=Default-First-Site-Name
 ,CN=Sites,CN=Configuration,DC=my_domain,DC=com,DC=pe

# search result
search: 2
result: 0 Success

# numResponses: 2
# numEntries: 1

```
Current Behavior:
```
nmap -sV -p 389 $ip -Pn
Starting Nmap 7.97 ( https://nmap.org ) at 2025-07-09 12:17 -1000
Nmap scan report for 20.106.226.71
Host is up (0.17s latency).

PORT    STATE SERVICE VERSION
389/tcp open  ldap    Microsoft Windows Active Directory LDAP (Domain: my_domain.com.pe0., Site: Default-First-Site-Name)
Service Info: Host: SRVAD; OS: Windows; CPE: cpe:/o:microsoft:windows
```

Post adjustment with the ?
```
nmap -sV -p 389 $ip -Pn
Starting Nmap 7.97 ( https://nmap.org ) at 2025-07-09 12:17 -1000
Nmap scan report for 20.106.226.71
Host is up (0.17s latency).

PORT    STATE SERVICE VERSION
389/tcp open  ldap    Microsoft Windows Active Directory LDAP (Domain: my_domain.com.pe., Site: Default-First-Site-Name)
Service Info: Host: SRVAD; OS: Windows; CPE: cpe:/o:microsoft:windows
```

This is likely a deeper issue with how the regex capture group is working, because in most regexes, the way it is currently written is entirely correct:
`match ldap m|^0\x84\0\0..\x02\x01.*dsServiceName1\x84\0\0\0.\x04.CN=NTDS\x20Settings,CN=([^,]+),CN=Servers,CN=([^,]+),CN=Sites,CN=Configuration,DC=([^,]+),DC=([^,]+)0\x84\0|s p/Microsoft Windows Active Directory LDAP/ i/Domain: $3.$4, Site: $2/ o/Windows/ h/$1/ cpe:/o:microsoft:windows/a
`
I've even done some packet captures to verify the payload, and any other engine would correctly separate the capture group from the 0. So there may be some unintended behavior causing it to capture the trailing 0 and use it as a delimiter.  It may be intended behavior and ideal for speed, but I haven't looked that the regex engine. But an addition of the `?` seemingly to tell it to not be greedy, provides the expected behavior. I suppose it goes mostly unnoticed because the match is to capture anything that isn't a comma, so the separators aren't included and a comma in the middle of a domain name may be more egregious than a trailing 0.

`match ldap m|^0\x84\0\0..\x02\x01.*dsServiceName1\x84\0\0\0.\x04.CN=NTDS\x20Settings,CN=([^,]+),CN=Servers,CN=([^,]+),CN=Sites,CN=Configuration,DC=([^,]+),DC=([^,]+?)0\x84\0|s p/Microsoft Windows Active Directory LDAP/ i/Domain: $3.$4, Site: $2/ o/Windows/ h/$1/ cpe:/o:microsoft:windows/a
`