### PR TITLE
Inform probe of HP's other PJL port

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -15935,7 +15935,7 @@ fallback DNS-SD
 # http://h20000.www2.hp.com/bc/docs/support/SupportManual/bpl13208/bpl13208.pdf
 # http://h20000.www2.hp.com/bc/docs/support/SupportManual/bpl13207/bpl13207.pdf
 Probe TCP hp-pjl q|\x1b%-12345X@PJL INFO ID\x0d\x0a\x1b%-12345X\x0d\x0a|
-ports 9100-9107
+ports 9100-9107,9999
 rarity 9
 
 # Most printers respond with the printer version in quotes


### PR DESCRIPTION
Some HP printers (at the least, LaserJet Pro CP1525nw and LaserJet CP2025dn) listen for PJL on a secondary port, `9999`. This PR adds that port to the PJL probe list, so it gets caught earlier in the process and doesn't cause the device to churn out as many pages. Quick adhoc testing showed the page output drop from about 100 down to 10 or so.

FWIW, this appears to be a pretty rare issue, and I couldn't find anywhere in the printer manuals describing this; most of the research actually pointed me to [this thread from the 2009 mailing list](https://seclists.org/nmap-dev/2009/q3/792).