### PR TITLE
Update python-wrap.bat to avoid premature closing of if statement

### DIFF
--- a/mswin32/python-wrap.bat
+++ b/mswin32/python-wrap.bat
@@ -12,7 +12,7 @@ rem (excluding extension).
 set PROG=%~dpn0.py
 
 if not exist "%PROG%" (
-	echo Cannot run %PROG%
+	echo Cannot run !PROG!
 	echo because that file does not exist.
 	exit /B 1
 )
@@ -46,3 +46,4 @@ GOTO:EXEC
 :EXEC
 rem This command chaining allows the exit code to propagate.
 endlocal & "%PYTHON%" "%PROG%" %*
+


### PR DESCRIPTION
In python-wrap.bat, a closing parenthesis in %PROG% on line 15 will close the block started on line 14 even if %PROG% also first contains an opening parenthesis.  This can be avoided by using !PROG! which delays the expansion until after the line 14-18 block is read.
Fixes nmap/nmap#2733

Why this is a problem in ndiff.bat:
PROG=C:\Program Files (x86)\Nmap\ndiff.py
if not exist "%PROG%" (
    echo Cannot run C:\Program Files (x86
)                          <-- if statement is closed
\Nmap\ndiff.py  <-- unexpected at this time
