### PR TITLE
Refactor script http-internal-ip-disclosure

### DIFF
--- a/scripts/http-internal-ip-disclosure.nse
+++ b/scripts/http-internal-ip-disclosure.nse
@@ -3,21 +3,25 @@ local ipOps = require "ipOps"
 local nmap = require "nmap"
 local shortport = require "shortport"
 local stdnse = require "stdnse"
-local table = require "table"
-local tableaux = require "tableaux"
+local target = require "target"
 local url = require "url"
 
 description =  [[
-Determines if the web server leaks its internal IP address when sending an HTTP/1.0 request without a Host header.
+Determines if the web server leaks its internal IP address when sending
+an HTTP/1.0 request without a Host header.
 
 Some misconfigured web servers leak their internal IP address in the response
 headers when returning a redirect response. This is a known issue for some
 versions of Microsoft IIS, but affects other web servers as well.
+
+If script argument <code>newtargets</code> is set, the script will
+add the found IP address as a new target into the scan queue. (See
+the documentation for NSE library <code>target</code> for details.)
 ]]
 
 ---
 -- @usage nmap --script http-internal-ip-disclosure <target>
--- @usage nmap --script http-internal-ip-disclosure --script-args http-internal-ip-disclosure.path=/path <target>
+-- @usage nmap --script http-internal-ip-disclosure --script-args http-internal-ip-disclosure.path=/mypath <target>
 --
 -- @args http-internal-ip-disclosure.path Path (or a table of paths) to probe
 --                                        Default: /
@@ -38,27 +42,21 @@ categories = { "vuln", "discovery", "safe" }
 
 portrule = shortport.http
 
-local function add_unique (tbl, val)
-  if not tableaux.contains(tbl, val) then
-    table.insert(tbl, val)
-  end
-end
-
 action = function(host, port)
   local patharg = stdnse.get_script_args(SCRIPT_NAME .. ".path") or "/"
   if type(patharg) ~= "table" then
     patharg = {patharg}
   end
-  local paths = {}
+  local paths = stdnse.output_table()
   for _, path in ipairs(patharg) do
-    add_unique(paths, path)
+    paths[path] = 1
   end
-  add_unique(paths, "/images")
+  paths["/images"] = 1
 
   local socket
   local bopt = nil
   local try = nmap.new_try(function () socket:close() end)
-  for _, path in ipairs(paths) do
+  for path in pairs(paths) do
     local req = "GET " .. path .. " HTTP/1.0\r\n\r\n"
     local resp
     if not bopt then
@@ -79,14 +77,18 @@ action = function(host, port)
 
     local loc = resp:lower():match("\nlocation:[ \t]+(%S+)")
     local lochost = url.parse(loc or "").host
-    if not lochost or lochost == "" then return end
-    -- remove any IPv6 enclosure
-    lochost = lochost:gsub("^%[(.*)%]$", "%1")
+    if lochost and lochost ~= "" then
+      -- remove any IPv6 enclosure
+      lochost = lochost:gsub("^%[(.*)%]$", "%1")
 
-    if ipOps.isPrivate(lochost) and ipOps.compare_ip(lochost, "ne", host.ip) then
-      local output = stdnse.output_table()
-      output["Internal IP Leaked"] = lochost
-      return output
+      if ipOps.isPrivate(lochost) and ipOps.compare_ip(lochost, "ne", host.ip) then
+        if target.ALLOW_NEW_TARGETS then
+          target.add(lochost)
+        end
+        local output = stdnse.output_table()
+        output["Internal IP Leaked"] = lochost
+        return output
+      end
     end
   end
 end


### PR DESCRIPTION
The patch updates the script behavior as follows:
* Adds support for HTTPS
* Adds support for IPv6
* Adds support for more than one path argument
* Properly identifies the Location header in the HTTP response
* Properly identifies the destination host in the Location header
* Leverages normalized IP address comparison
* Avoids processing the HTTP response body, possibly "endless"

It will be merged in after December 1 unless concerns are raised.