### PR TITLE
Fix issue #2848: Support multiple CPEs of the same type

### DIFF
--- a/service_scan.h
+++ b/service_scan.h
@@ -113,9 +113,9 @@ struct MatchDetails {
   const char *devicetype;
 
   // CPE identifiers for application, OS, and hardware type.
-  const char *cpe_a;
-  const char *cpe_o;
-  const char *cpe_h;
+  std::vector<const char *> cpe_a;
+  std::vector<const char *> cpe_o;
+  std::vector<const char *> cpe_h;
 };
 
 /**********************  CLASSES     ***********************************/
@@ -182,9 +182,7 @@ class ServiceProbeMatch {
                   char *version, size_t versionlen, char *info, size_t infolen,
                   char *hostname, size_t hostnamelen, char *ostype, size_t ostypelen,
                   char *devicetype, size_t devicetypelen,
-                  char *cpe_a, size_t cpe_alen,
-                  char *cpe_h, size_t cpe_hlen,
-                  char *cpe_o, size_t cpe_olen) const;
+                  struct MatchDetails *MD) const;
 };
 
 


### PR DESCRIPTION
PROBLEM:
When service-probes defines multiple CPE entries of the same part type (e.g., two application CPEs like Apache and PHP), only the last one was stored as the CPE loop overwrote the single buffer for each type.

ROOT CAUSE:
- MatchDetails structure used single const char* for cpe_a/h/o
- ServiceNFO class used single char arrays for cpe_*_matched
- CPE processing loop reused the same buffer, overwriting previous values
- Only the last CPE of each type was retained

SOLUTION:
- Changed MatchDetails to use std::vector<const char *> for cpe_a/h/o
- Changed ServiceNFO to use std::vector<char *> for cpe_*_matched
- Updated CPE processing loop to allocate new buffers for each CPE
- Added proper memory management (free in destructors and SSL reset)
- Updated all copying/transfer logic to iterate vectors

VERIFICATION:
Tested against servers with Apache + PHP and confirmed XML output now shows multiple <cpe> tags as expected:
  <cpe>cpe:/a:apache:http_server:2.4.34</cpe>
  <cpe>cpe:/a:php:php:7.3.20</cpe>

FILES MODIFIED:
- service_scan.h: MatchDetails structure
- service_scan.cc: ServiceNFO class, getVersionStr, testMatch, processMatch, processResults, and cleanup code