### PR TITLE
nse ipp lib - check http request status instead of response

### DIFF
--- a/nselib/ipp.lua
+++ b/nselib/ipp.lua
@@ -332,7 +332,7 @@ Helper = {
     request:addAttributeGroup(ag)
 
     local status, response = HTTP.Request( self.host, self.port, tostring(request) )
-    if ( not(response) ) then
+    if ( not(status) ) then
       return status, response
     end
 
@@ -387,7 +387,7 @@ Helper = {
     request:addAttributeGroup(ag)
 
     local status, response = HTTP.Request( self.host, self.port, tostring(request) )
-    if ( not(response) ) then
+    if ( not(status) ) then
       return status, response
     end
 


### PR DESCRIPTION
This fixes a bug in the NSE IPP library used by checks such as cups-info / cups-queue-info when the http request fails.

On error, HTTP.Request() returns one of the two conditions:
status=false, response="Unexpected response from server"
status=false, response="Failed to parse response"

Since response is always populated, the current gate for errors will never fire and instead passes it along as a valid response, causing crashes down the line. Checking status instead will correct this.

pre-fix crash behavior:
```
% nmap -p 631 --script cups-info a.b.c.d -d
[...]
NSE: Starting cups-info against a.b.c.d:631.
NSE: cups-info against a.b.c.d:631 threw an error!
/opt/homebrew/bin/../share/nmap/nselib/ipp.lua:333: attempt to call a nil value (method 'getAttributeGroups')
stack traceback:
        /opt/homebrew/bin/../share/nmap/nselib/ipp.lua:333: in method 'getPrinters'
        /opt/homebrew/bin/../share/nmap/scripts/cups-info.nse:59: in function </opt/homebrew/bin/../share/nmap/scripts/cups-info.nse:52>
        (...tail calls...)
```

