### PR TITLE
ncat/ncat_listen.c fix ncat exited when using --recv-only under nohup situation

### DIFF
--- a/ncat/ncat_listen.c
+++ b/ncat/ncat_listen.c
@@ -292,7 +292,13 @@ int ncat_listen()
             bye("Unable to open any listening sockets.");
     }
 
-    add_fd(&client_fdlist, STDIN_FILENO);
+    if (!o.recvonly) {
+        add_fd(&client_fdlist, STDIN_FILENO);
+        if (o.debug)
+            logdebug("Added stdin fd %d to list\n", STDIN_FILENO);
+    } else if (o.debug) {
+        logdebug("Skipping stdin in recv-only mode\n");
+    }
 
     init_fdlist(&broadcast_fdlist, o.conn_limit);
 
@@ -597,7 +603,7 @@ static void post_handle_connection(struct fdinfo *sinfo)
             netexec(sinfo, o.cmdexec);
     } else {
         /* Now that a client is connected, pay attention to stdin. */
-        if (!stdin_eof)
+        if (!stdin_eof && !o.recvonly)
             checked_fd_set(STDIN_FILENO, &master_readfds);
         if (!o.sendonly) {
             /* add to our lists */


### PR DESCRIPTION
original issue:
nohup /usr/local/bin/ncat -vvv --recv-only -l 10000 -k > /var/log/ncat.log 2>&1

I try to send two connection, but the second would failed. 
```
ncat --send-only 172.16.61.254 10000 -p 20000 < /tmp/1024.pkt 
ncat --send-only 172.16.61.254 10000 -p 20000 < /tmp/1024.pkt 
Ncat: Connection refused.

check the debug output
 tail -f /var/log/ncat.log
nohup: ignoring input
Ncat: Version 7.92 ( https://nmap.org/ncat )
NCAT DEBUG: Initialized fdlist with 103 maxfds
Ncat: Listening on :::20
NCAT DEBUG: Added fd 3 to list, nfds 1, maxfd 3
Ncat: Listening on 0.0.0.0:20
NCAT DEBUG: Added fd 4 to list, nfds 2, maxfd 4
NCAT DEBUG: Added fd 0 to list, nfds 3, maxfd 4
NCAT DEBUG: Initialized fdlist with 100 maxfds
NCAT DEBUG: selecting, fdmax 4
NCAT DEBUG: select returned 1 fds ready
NCAT DEBUG: fd 4 is ready
Ncat: Connection from 172.16.61.2.
Ncat: Connection from 172.16.61.2:5000.
NCAT DEBUG: Added fd 5 to list, nfds 4, maxfd 5
NCAT DEBUG: Added fd 5 to list, nfds 1, maxfd 5
NCAT DEBUG: selecting, fdmax 5
NCAT DEBUG: select returned 2 fds ready
NCAT DEBUG: fd 0 is ready
NCAT DEBUG: Error reading from stdin: Bad file descriptor

```
In fact, when --recv-only is specified, ncat should not open the standard input terminal.