### PR TITLE
Remove unused socket connect/close from ipp.Helper

### DIFF
--- a/nselib/ipp.lua
+++ b/nselib/ipp.lua
@@ -290,17 +290,11 @@ HTTP = {
 
 Helper = {
 
-  new = function(self, host, port, options)
-    local o = { host = host, port = port, options = options or {} }
+  new = function(self, host, port)
+    local o = { host = host, port = port }
     setmetatable(o, self)
     self.__index = self
     return o
-  end,
-
-  connect = function(self)
-    self.socket = nmap.new_socket()
-    self.socket:set_timeout(self.options.timeout or 10000)
-    return self.socket:connect(self.host, self.port)
   end,
 
   getPrinters = function(self)
@@ -411,10 +405,6 @@ Helper = {
     end
 
     return output
-  end,
-
-  close = function(self)
-    return self.socket:close()
   end,
 }
 

--- a/scripts/cups-info.nse
+++ b/scripts/cups-info.nse
@@ -1,7 +1,6 @@
 local ipp = require "ipp"
 local shortport = require "shortport"
 local stdnse = require "stdnse"
-local string = require "string"
 local table = require "table"
 
 description = [[
@@ -51,13 +50,8 @@ local verbose_states = {
 
 action = function(host, port)
 
-  local helper = ipp.Helper:new(host, port)
-  if ( not(helper:connect()) ) then
-    return stdnse.format_output(false, "Failed to connect to server")
-  end
-
-  local status, printers = helper:getPrinters()
-  if ( not(status) ) then
+  local status, printers = ipp.Helper:new(host, port):getPrinters()
+  if not status then
     return
   end
 

--- a/scripts/cups-queue-info.nse
+++ b/scripts/cups-queue-info.nse
@@ -35,13 +35,8 @@ categories = {"safe", "discovery"}
 portrule = shortport.port_or_service(631, "ipp", "tcp", "open")
 
 action = function(host, port)
-  local helper = ipp.Helper:new(host, port)
-  if ( not(helper:connect()) ) then
-    return stdnse.format_output(false, "Failed to connect to server")
-  end
-
-  local output = helper:getQueueInfo()
-  if ( output ) then
+  local output = ipp.Helper:new(host, port):getQueueInfo()
+  if output then
     return stdnse.format_output(true, output)
   end
 end


### PR DESCRIPTION
Each instance of `ipp.Helper` maintains an open socket to a target. However, this socket is never used inside the library or by the scripts that consume it. The library does not provide any documentation that could shed light on its purpose.

This patch removes this dead-wood code. It will be merged in after January 1 unless concerns are raised.