### PR TITLE
Add the option to preload stdnse.make_buffer with data

### DIFF
--- a/nselib/ftp.lua
+++ b/nselib/ftp.lua
@@ -34,34 +34,8 @@ connect = function(host, port, opts)
   if not socket then
     return socket, (ERROR_MESSAGES[ret] or 'unspecified error')
   end
-  local buffer = stdnse.make_buffer(socket, crlf_pattern)
-  local pos = 1
-  -- Should we just pass the output of buffer()?
-  local usebuf = false
-  -- Since we already read the first chunk of banner from the socket,
-  -- we have to supply it line-by-line to read_reply.
-  local code, message = read_reply(function()
-      if usebuf then
-        -- done reading the initial banner; pass along the socket buffer.
-        return buffer()
-      end
-      -- Look for CRLF
-      local i, j = ret:find(crlf_pattern, pos)
-      if not i then
-        -- Didn't find it! Grab another chunk (up to CRLF) and return it
-        usebuf = true
-        local chunk = buffer()
-        return ret:sub(pos) .. chunk
-      end
-      local oldpos = pos
-      -- start the next search just after CRLF
-      pos = j + 1
-      if pos >= #ret then
-        -- We consumed the whole thing! Start calling buffer() next.
-        usebuf = true
-      end
-      return ret:sub(oldpos, i - 1)
-    end)
+  local buffer = stdnse.make_buffer(socket, crlf_pattern, ret)
+  local code, message = read_reply(buffer)
   return socket, code, message, buffer
 end
 

--- a/nselib/stdnse.lua
+++ b/nselib/stdnse.lua
@@ -197,12 +197,19 @@ end
 -- not followed by the separator. Once an error or EOF is reached, it returns
 -- <code>nil, msg</code>. <code>msg</code> is what is returned by
 -- <code>nmap.receive_lines</code>.
+-- In some situations, initial data gets read from a socket before being able to
+-- create a buffer with <code>make_buffer()</code>, such as when the connection
+-- is initiated with <code>comm.tryssl()</code>, instead of just simple
+-- <code>socket:connect()</code>. This data can be passed or "returned" to
+-- <code>make_buffer()</code>, as if it was never read, and later retrieved from
+-- the newly created buffer.
 -- @param socket Socket for the buffer.
--- @param sep Separator for the buffered reads.
+-- @param sep Separator pattern for the buffered reads.
+-- @param data Data initializing the buffer (optional).
 -- @return Data from socket reads or <code>nil</code> on EOF or error.
 -- @return Error message, as with <code>receive_lines</code>.
-function make_buffer(socket, sep)
-  local point, left, buffer, done, msg = 1, "";
+function make_buffer(socket, sep, buffer)
+  local point, left, done, msg = 1, "";
   local function self()
     if done then
       return nil, msg; -- must be nil for stdnse.lines (below)


### PR DESCRIPTION
Function `stdnse.make_buffer` provides a very convenient method for reading from a socket in predictable chunks separated by a given pattern, such as one line at a time. This works well when the socket is connected with `<socket>:connect` but the benefit tends to get substantially reduced when some of the data is incidentally already received from the socket before `stdnse.make_buffer` has a chance to be called. One such example is when a socket is connected with `comm.tryssl`, which returns not just the connected socket but also data read by initial `<socket>:receive`. A user is then left with extracting the chunks from this initial data and gluing them together with subsequent reads from the buffer created with `stdnse.make_buffer`. The code would generally look something like this:
```lua
local socket, data = comm.tryssl(...)
local sep = "\r?\n"
local pos = 1
while pos <= #data do
  local p, q = data:find(sep, pos)
  if not p then break end
  process_line(data:sub(pos, p - 1))
  pos = q + 1
end
local buf = stdnse.make_buffer(socket, sep)
while true do
  local line = buf()
  if not line then break end
  if data then
    line = data:sub(pos) .. line
    data = nil
  end
  process_line(line)
end
``` 
This patch is implementing a third parameter for `stdnse.make_buffer`, allowing this initial, incidentally read data to be returned to the buffer and making it available for subsequent reads. The code then gets substantially simpler:
```lua
local socket, data = comm.tryssl(...)
local buf = stdnse.make_buffer(socket, "\r?\n", data)
while true do
  local line = buf()
  if not line then break end
  process_line(line)
end
``` 
This PR will be merged in after February 1 unless concerns are raised.