### PR TITLE
Treat ftp-brute banner errors as connection failures

### DIFF
--- a/scripts/ftp-brute.nse
+++ b/scripts/ftp-brute.nse
@@ -60,7 +60,15 @@ Driver = {
     if not realsocket then
       return false, brute.Error:new( "Couldn't connect to host: " .. (code or message) )
     end
+    if not code then
+      realsocket:close()
+      return false, brute.Error:new( "Invalid response from host: " .. message)
+    end
     self.socket.socket = realsocket
+    if not (code >= 200 and code < 400) then
+      ftp.close(self.socket)
+      return false, brute.Error:new( "Error response from host: " .. code)
+    end
     return true
   end,
 


### PR DESCRIPTION
Script `ftp-brute` currently proceeds with a login attempt even if the FTP banner is invalid or indicates an error. In one real-world example, the script sends the `USER` command even when the server returns an invalid banner *and* closes the connection right afterwards.

This patch modifies the driver class to treat invalid banners and/or error status codes as if the connection failed in the `connect` method, so the `login` method does not get called. It will be merged in after February 1 unless concerns are raised.

