### PR TITLE
Fix EC_METHOD compilation error with OpenSSL 1.1.x

### DIFF
--- a/nse_ssl_cert.cc
+++ b/nse_ssl_cert.cc
@@ -497,7 +497,7 @@ int lua_push_ecdhparams(lua_State *L, EVP_PKEY *pubkey) {
      * Just mark as UNKNOWN. */
     lua_pushstring(L, "UNKNOWN");
 #elif HAVE_OPAQUE_STRUCTS
-    nid = EC_GROUP_get_field_type(group);
+    nid = EC_METHOD_get_field_type(EC_GROUP_method_of(group));
     if (nid == NID_X9_62_prime_field) {
       lua_pushstring(L, "explicit_prime");
     }


### PR DESCRIPTION
## Problem
Commit 1b3ca45 introduced a compilation error with OpenSSL 1.1.x:
```
nse_ssl_cert.cc:500:11: error: 'EC_GROUP_get_field_type' was not declared in this scope
```

The function `EC_GROUP_get_field_type()` does not exist in OpenSSL 1.1.x, only in OpenSSL 3.0+.

## To Reproduce
```dockerfile
FROM python:3.11.0

RUN apt-get -y update && \
    apt-get -y install git curl make build-essential autoconf libssl-dev

RUN git clone https://github.com/nmap/nmap.git
WORKDIR /nmap
RUN git checkout 1b3ca45054cd1e569f5fc0da59fceaa7a518b631

RUN ./configure --without-zenmap
RUN make  # Fails with: 'EC_GROUP_get_field_type' was not declared
```

## Solution
Changed line 500 to use `EC_METHOD_get_field_type(EC_GROUP_method_of(group))`, which is the correct method for OpenSSL 1.1.x and was used before commit 1b3ca45.

## Root Cause Analysis
The code structure is:
```c
#if OPENSSL_VERSION_NUMBER >= 0x30000000L
  // OpenSSL 3.0+ code (returns before reaching line 500)
#elif !defined(OPENSSL_NO_EC)
  // OpenSSL 1.1.x code
  #elif HAVE_OPAQUE_STRUCTS
    nid = EC_GROUP_get_field_type(group);  // Line 500 - ERROR
```

Since OpenSSL 3.0+ returns before reaching line 500, this line is **only executed on OpenSSL 1.1.x**, where `EC_GROUP_get_field_type()` does not exist.

## Testing
Tested compilation on:
- ✅ Debian Bullseye with OpenSSL 1.1.1w (Docker: `python:3.11.0`)
- ✅ Compilation succeeds after fix
- ✅ `make` completes successfully

## Related
- Introduced in: 1b3ca45054cd1e569f5fc0da59fceaa7a518b631
- Affects: Users building nmap from source with OpenSSL 1.1.x