### PR TITLE
Inconsistent results of tableaux tcopy and shallow_tcopy

### DIFF
--- a/nselib/tableaux.lua
+++ b/nselib/tableaux.lua
@@ -15,19 +15,18 @@ local tcopy_local
 --- Recursively copy a table.
 --
 -- Uses simple assignment to copy keys and values from a table, recursing into
--- subtables as necessary.
+-- subtables as necessary. The keys are iterated over with next(), not pairs(),
+-- resulting in a "raw" copy of the input.
 -- @param t the table to copy
 -- @return a deep copy of the table
 function tcopy (t)
   local tc = {}
-  local k, v = next(t)
-  while k ~= nil do
+  for k, v in next, t do
     if type(v) == "table" then
       tc[k] = tcopy_local(v)
     else
       tc[k] = v
     end
-    k, v = next(t, k)
   end
   return tc
 end
@@ -38,14 +37,14 @@ tcopy_local = tcopy
 -- Iterates over the keys of a table and copies their values into a new table.
 -- If any values are tables, they are copied by reference only, and modifying
 -- the copy will modify the original table value as well.
+-- The keys are iterated over with next(), not pairs(), resulting in a "raw"
+-- copy of the input.
 -- @param t the table to copy
 -- @return a shallow copy of the table
 function shallow_tcopy(t)
-  local k = next(t)
   local out = {}
-  while k ~= nil do
-    out[k] = t[k]
-    k = next(t, k)
+  for k, v in next, t do
+    out[k] = v
   end
   return out
 end
@@ -77,15 +76,13 @@ function contains(t, item, array)
   return false, nil
 end
 
---- Returns the keys of a table as an array
+--- Returns the raw keys of a table as an array
 -- @param t The table
 -- @return A table of keys
 function keys(t)
   local ret = {}
-  local k = next(t)
-  while k ~= nil do
+  for k in next, t do
     ret[#ret+1] = k
-    k = next(t, k)
   end
   return ret
 end


### PR DESCRIPTION
Function `tableaux.tcopy` produces a full/deep copy of a given table, while `tableaux.shallow_tcopy` produces a shallow copy.

A user might naturally assume that results from these two functions are identical for flat tables (tables that do not contain nested tables). However, this is not guaranteed. The reason is that the two functions iterate over the table differently: `tcopy` is using `pairs`, while `shallow_tcopy` is using `next`. When `pairs` is used, the actual iterations are determined by a `__pairs` metamethod, not necessarily relying on `next`.

This PR updates `tableaux.tcopy` to use `next` to achieve consistency with `shallow_tcopy`. It will be merged in after March 1st unless concerns are raised.
