### PR TITLE
Add ZMTP (ZeroMQ) service detection probe and NSE script

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -5277,8 +5277,11 @@ match zeo-monitor m|^ZEO monitor server version ([\w._-]+)\n.*\n\nStorage: \d+\n
 match zos-commserver m|^EZY1315E \d\d/\d\d/\d\d \d\d:\d\d:\d\d INVALID TRANID=\r\n\r\n PARTNER INET ADDR=[\d.]+ PORT=   \d+                                      | p|IBM z/OS Communications Server| o|z/OS| cpe:/o:ibm:z%2fos/
 
 # http://rfc.zeromq.org/spec:15
-# This is a backwards-compatible handshake
-match zmtp m|^\xff\0\0\0\0\0\0\0\x01\x7f$| p/ZeroMQ ZMTP 2.0/
+# ZMTP signature: 0xFF + 8 padding bytes + 0x7F. Padding may contain identity
+# length for backward compat (can be 0x0A = \n, so 's' flag is required).
+# Original match required exactly 10 bytes ($), but 2.0 servers send more
+# (revision + socket-type + identity frame). Use 's' flag for \n in padding.
+match zmtp m|^\xff.{8}\x7f|s p/ZeroMQ ZMTP/
 
 ##############################NEXT PROBE##############################
 # ZMTP 3.x (ZeroMQ Message Transport Protocol)
@@ -5291,7 +5294,8 @@ ports 41459,50051,56441,30000-65535
 
 # ZMTP response: 64-byte greeting starting with signature 0xFF...0x7F
 # Catches all ZMTP versions (2.0, 3.0, 3.1+). NSE script handles detailed parsing.
-match zmtp m|^\xff.{8}\x7f| p/ZeroMQ ZMTP/
+# 's' flag: padding bytes may contain 0x0A (\n) when identity length == 10.
+match zmtp m|^\xff.{8}\x7f|s p/ZeroMQ ZMTP/
 
 # http://www.space-walrus.com/games/Minebuilder
 # Very general, so leaving it here at the end


### PR DESCRIPTION
## Summary

- Add a `ZMTPGreeting` service probe that sends a ZMTP 3.1 greeting and detects ZeroMQ services
- Add `zmtp-info.nse` NSE script that performs full ZMTP handshake and extracts detailed metadata
- Fix the existing ZMTP 2.0 match on the NULL probe (remove `$` anchor, add `s` flag)

### What the NSE script extracts

| ZMTP Version | Information extracted |
|---|---|
| **3.x NULL** | Version, mechanism, as-server, socket-type, identity, resource, custom metadata |
| **3.x CURVE/PLAIN** | Protocol detected (server closes after mechanism mismatch, by design) |
| **2.0** | Version, socket-type, identity |

For ZMTP 3.x with NULL mechanism, the script performs a READY handshake (presenting as DEALER) to extract metadata properties from the server's READY command. It handles the common case where the server piggybacks its READY response on the greeting in the same TCP segment.

### Service probe changes

The existing NULL probe match `m|^\xff\0\0\0\0\0\0\0\x01\x7f$|` had two issues:
1. The `$` anchor prevented matching ZMTP 2.0 servers that send more than 10 bytes (revision + socket-type + identity frame follow the signature)
2. The `.` metacharacter doesn't match `\n` (0x0A) by default, which appears in the signature padding when a server's identity length is 10 (backward-compat field)

Both are fixed by replacing with `m|^\xff.{8}\x7f|s` (the `s` flag makes `.` match all bytes including `\n`).

### Example output

```
PORT      STATE SERVICE VERSION
5555/tcp  open  zmtp    ZeroMQ ZMTP 3.1 (mechanism: NULL; socket: REP)
| zmtp-info:
|   protocol: ZMTP
|   version: 3.1
|   mechanism: NULL
|   as-server: false
|_  socket-type: REP

5556/tcp  open  zmtp    ZeroMQ ZMTP 2.0 (socket: DEALER)
| zmtp-info:
|   protocol: ZMTP
|   version: 2.0
|   socket-type: DEALER
|_  identity: old-node
```

## Test plan

Tested against 19 ZeroMQ servers covering all protocol variants. Test lab script (requires `pyzmq`):

<details>
<summary>zmq_test_lab.py - 19 ZMTP servers (click to expand)</summary>

```python
"""
Comprehensive ZMQ test lab for nmap ZMTP detection testing.
Tests ZMTP 3.x (NULL, PLAIN, CURVE) and raw ZMTP 2.0 servers.

Usage:
    pip install pyzmq
    python zmq_test_lab.py
    # Then in another terminal:
    nmap --script zmtp-info -sV -p 45001-45007,45010,45011,45020,45021,45030,45031,45040-45045 127.0.0.1
"""
import zmq
import threading
import time
import socket
import struct
import sys


def zmq_server(sock_type, port, name, **opts):
    ctx = zmq.Context()
    sock = ctx.socket(sock_type)
    if opts.get("identity"):
        sock.identity = opts["identity"].encode()
    if opts.get("curve_server"):
        server_public, server_secret = zmq.curve_keypair()
        sock.curve_publickey = server_public
        sock.curve_secretkey = server_secret
        sock.curve_server = True
    if opts.get("plain_server"):
        sock.plain_server = True
    try:
        sock.bind(f"tcp://127.0.0.1:{port}")
    except zmq.ZMQError as e:
        print(f"[{name}] FAILED to bind port {port}: {e}", file=sys.stderr)
        return
    print(f"[{name}] Listening on tcp://127.0.0.1:{port}")
    while True:
        try:
            if sock_type == zmq.PUB:
                sock.send(b"heartbeat")
                time.sleep(1)
            else:
                msg = sock.recv(flags=zmq.NOBLOCK)
                if sock_type in (zmq.REP,):
                    sock.send(b"ok")
        except zmq.Again:
            time.sleep(0.1)
        except Exception:
            time.sleep(0.1)


def zmtp2_server(port, name, sock_type_byte, identity=b""):
    """Raw ZMTP 2.0 server (manual TCP implementation)."""
    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
    try:
        srv.bind(("127.0.0.1", port))
    except OSError as e:
        print(f"[{name}] FAILED to bind port {port}: {e}", file=sys.stderr)
        return
    srv.listen(5)
    print(f"[{name}] Listening on tcp://127.0.0.1:{port} (raw ZMTP 2.0)")
    while True:
        conn, addr = srv.accept()
        try:
            conn.settimeout(5)
            try:
                conn.recv(1024)
            except socket.timeout:
                pass
            signature = b"\xff" + struct.pack(">Q", len(identity) + 1) + b"\x7f"
            revision = b"\x01"
            stype = bytes([sock_type_byte])
            greeting = signature + revision + stype
            id_frame = b"\x00" + bytes([len(identity)]) + identity
            conn.sendall(greeting + id_frame)
            time.sleep(2)
        except Exception:
            pass
        finally:
            conn.close()


servers = [
    # ZMTP 3.x NULL mechanism - all common socket types
    ("3.x NULL REP",       lambda: zmq_server(zmq.REP,    45001, "3.x NULL REP")),
    ("3.x NULL PULL",      lambda: zmq_server(zmq.PULL,   45002, "3.x NULL PULL")),
    ("3.x NULL ROUTER",    lambda: zmq_server(zmq.ROUTER, 45003, "3.x NULL ROUTER")),
    ("3.x NULL PUB",       lambda: zmq_server(zmq.PUB,    45004, "3.x NULL PUB")),
    ("3.x NULL PUSH",      lambda: zmq_server(zmq.PUSH,   45005, "3.x NULL PUSH")),
    ("3.x NULL DEALER",    lambda: zmq_server(zmq.DEALER, 45006, "3.x NULL DEALER")),
    ("3.x NULL PAIR",      lambda: zmq_server(zmq.PAIR,   45007, "3.x NULL PAIR")),
    # ZMTP 3.x NULL with identity
    ("3.x NULL REP+ID",    lambda: zmq_server(zmq.REP,    45010, "3.x NULL REP+ID",
                                               identity="worker-42")),
    ("3.x NULL DEALER+ID", lambda: zmq_server(zmq.DEALER, 45011, "3.x NULL DEALER+ID",
                                               identity="backend-node-7")),
    # ZMTP 3.x CURVE mechanism
    ("3.x CURVE REP",     lambda: zmq_server(zmq.REP,    45020, "3.x CURVE REP",
                                              curve_server=True)),
    ("3.x CURVE ROUTER",  lambda: zmq_server(zmq.ROUTER, 45021, "3.x CURVE ROUTER",
                                              curve_server=True)),
    # ZMTP 3.x PLAIN mechanism
    ("3.x PLAIN REP",     lambda: zmq_server(zmq.REP,    45030, "3.x PLAIN REP",
                                              plain_server=True)),
    ("3.x PLAIN ROUTER",  lambda: zmq_server(zmq.ROUTER, 45031, "3.x PLAIN ROUTER",
                                              plain_server=True)),
    # Raw ZMTP 2.0 servers
    ("2.0 REP",           lambda: zmtp2_server(45040, "2.0 REP", 4)),
    ("2.0 PUB",           lambda: zmtp2_server(45041, "2.0 PUB", 1)),
    ("2.0 ROUTER",        lambda: zmtp2_server(45042, "2.0 ROUTER", 6)),
    ("2.0 PULL",          lambda: zmtp2_server(45043, "2.0 PULL", 7)),
    ("2.0 REP+ID",        lambda: zmtp2_server(45044, "2.0 REP+ID", 4, identity=b"legacy-1")),
    ("2.0 DEALER+ID",     lambda: zmtp2_server(45045, "2.0 DEALER+ID", 5, identity=b"old-node")),
]

threads = []
for name, fn in servers:
    t = threading.Thread(target=fn, daemon=True, name=name)
    t.start()
    threads.append(t)

time.sleep(0.5)
print(f"\n=== ZMQ Test Lab: {len(servers)} servers running ===")
print("ZMTP 3.x NULL:    45001-45007 (REP, PULL, ROUTER, PUB, PUSH, DEALER, PAIR)")
print("ZMTP 3.x NULL+ID: 45010-45011 (REP w/ worker-42, DEALER w/ backend-node-7)")
print("ZMTP 3.x CURVE:   45020-45021 (REP, ROUTER)")
print("ZMTP 3.x PLAIN:   45030-45031 (REP, ROUTER)")
print("ZMTP 2.0 raw:     45040-45045 (REP, PUB, ROUTER, PULL, REP+ID, DEALER+ID)")
print("\nPress Ctrl+C to stop.")

try:
    while True:
        time.sleep(1)
except KeyboardInterrupt:
    print("\nStopping.")
```

</details>

### Test results (19/19 detected)

```
PORT      STATE SERVICE VERSION
45001/tcp open  zmtp    ZeroMQ ZMTP 3.1 (mechanism: NULL; socket: REP)
45002/tcp open  zmtp    ZeroMQ ZMTP 3.1 (mechanism: NULL; socket: PULL)
45003/tcp open  zmtp    ZeroMQ ZMTP 3.1 (mechanism: NULL; socket: ROUTER)
45004/tcp open  zmtp    ZeroMQ ZMTP 3.1 (mechanism: NULL; socket: PUB)
45005/tcp open  zmtp    ZeroMQ ZMTP 3.1 (mechanism: NULL; socket: PUSH)
45006/tcp open  zmtp    ZeroMQ ZMTP 3.1 (mechanism: NULL; socket: DEALER)
45007/tcp open  zmtp    ZeroMQ ZMTP 3.1 (mechanism: NULL; socket: PAIR)
45010/tcp open  zmtp    ZeroMQ ZMTP 3.1 (mechanism: NULL; socket: REP)
45011/tcp open  zmtp    ZeroMQ ZMTP 3.1 (mechanism: NULL; socket: DEALER)  [identity: backend-node-7]
45020/tcp open  zmtp    ZeroMQ ZMTP
45021/tcp open  zmtp    ZeroMQ ZMTP
45030/tcp open  zmtp    ZeroMQ ZMTP
45031/tcp open  zmtp    ZeroMQ ZMTP
45040/tcp open  zmtp    ZeroMQ ZMTP 2.0 (socket: REP)
45041/tcp open  zmtp    ZeroMQ ZMTP 2.0 (socket: PUB)
45042/tcp open  zmtp    ZeroMQ ZMTP 2.0 (socket: ROUTER)
45043/tcp open  zmtp    ZeroMQ ZMTP 2.0 (socket: PULL)
45044/tcp open  zmtp    ZeroMQ ZMTP 2.0 (socket: REP)     [identity: legacy-1]
45045/tcp open  zmtp    ZeroMQ ZMTP 2.0 (socket: DEALER)   [identity: old-node]
```

References:
- https://rfc.zeromq.org/spec/15/ (ZMTP 2.0)
- https://rfc.zeromq.org/spec/23/ (ZMTP 3.0)
- https://rfc.zeromq.org/spec/37/ (ZMTP 3.1)