### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
           prepare: |
             export PATH=/usr/sbin:/usr/pkg/sbin:/usr/pkg/bin:$PATH
             export PKG_PATH="http://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r | cut -d_ -f1)/All"
-            pkg_add gcc13 clang autoconf automake pkgconf libpcap libnet gmake dbus
+            pkg_add -u gcc13 clang autoconf automake pkgconf libpcap libnet gmake dbus
           run: |
             ./configure
             gmake


### PR DESCRIPTION
Build was failing with "pkg_add: A different version of glib2-2.84.4nb1 is already installed: glib2-2.84.4"

This PR will hopefully trigger a build event to verify that adding the `-u` option to pkg_add resolves the issue.