### PR TITLE
NSE Script fix: iec61850-mms.nse and method call in iec61850mms.lua

### DIFF
--- a/nselib/iec61850mms.lua
+++ b/nselib/iec61850mms.lua
@@ -736,7 +736,7 @@ MMSEncoder = {
     local sendstr = mmsStr
     sendstr = "\xa0"..self.encodeLength(#sendstr)..sendstr
     sendstr = "\x02\x01\x03"..sendstr
-    sendstr = self.encodeSeq(sendstr)
+    sendstr = self:encodeSeq(sendstr)
     sendstr = "\x61"..self.encodeLength(#sendstr)..sendstr --ISO8823
     sendstr = "\x01\x00\x01\x00"..sendstr                  --ISO8327 2x
     sendstr = "\x02\xf0\x80"..sendstr                      --ISO8073
@@ -974,7 +974,7 @@ MMSEncoder = {
     local value
     for k, v in pairs(message) do
       value = self.variableSpecification(self, v)
-      retstr[#retstr+1] = self.encodeSeq(value)
+      retstr[#retstr+1] = self:encodeSeq(value)
     end
 
     return table.concat(retstr)

--- a/scripts/iec61850-mms.nse
+++ b/scripts/iec61850-mms.nse
@@ -78,7 +78,7 @@ function searchTable(searchString, myTable)
 end
 
 -- Rules
-portrule = shortport.portnumber(102, "iso-tsap")
+portrule = shortport.port_or_service(102, "iso-tsap", "tcp")
 
 -- Actions
 action = function(host, port)


### PR DESCRIPTION
iec61850-mms.nse:
  Call to `shortport.portnumber(102, "iso-tsap")` was faulty. Instead of specifying the protocol in the second argument, the service was specified. Fixed it by calling `shortport.port_or_service` instead.

iec61850mms.lua:
  Calls to `self.encodeSeq` were wrong. `encodeSeq` from [`nselib/ans1.lua`](https://github.com/nmap/nmap/blob/master/nselib/asn1.lua#L271-L275) is a method requiring `self` as the first argument. Fixed it switching to `self:encodeSeq`. 