### PR TITLE
DICOM Vendor/Version Fingerprinting + TLS Support

### DIFF
--- a/nselib/dicom.lua
+++ b/nselib/dicom.lua
@@ -23,8 +23,9 @@
 --
 -- @args dicom.called_aet Called Application Entity Title. Default: ANY-SCP
 -- @args dicom.calling_aet Calling Application Entity Title. Default: ECHOSCU
+-- @args dicom.timeout_ms Socket timeout in milliseconds. Default: 3000
 -- 
--- @author Paulino Calderon <paulino@calderonpale.com>
+-- @author Paulino Calderon <paulino@calderonpale.com> and Tyler M <tmart234@gmail.com>
 -- @copyright Same as Nmap--See https://nmap.org/book/man-legal.html
 ---
 
@@ -39,10 +40,43 @@ local MIN_SIZE_ASSOC_REQ = 68
 local MAX_SIZE_PDU = 128000
 local MIN_HEADER_LEN = 6
 local PDU_NAMES = {}
-local PDU_CODES = {}
 
-PDU_CODES =
-{
+-- ===== Local Helper Functions =====
+
+local function ul_item(item_type, value_bytes)
+  return string.pack(">B B I2", item_type, 0x00, #value_bytes) .. value_bytes
+end
+
+local function item_application_context(uid) return ul_item(0x10, uid) end
+local function item_abstract_syntax(uid)    return ul_item(0x30, uid) end
+local function item_transfer_syntax(uid)    return ul_item(0x40, uid) end
+
+local function item_presentation_context(pc_id, abstract_uid, transfer_uid)
+  local header = string.pack(">B B B B", pc_id, 0x00, 0x00, 0x00)
+  local payload = header .. item_abstract_syntax(abstract_uid) .. item_transfer_syntax(transfer_uid)
+  return ul_item(0x20, payload)
+end
+
+local function item_max_pdu(max_len)
+  return string.pack(">B B I2 I4", 0x51, 0x00, 0x0004, max_len)
+end
+local function item_impl_uid(uid)     return ul_item(0x52, uid) end
+local function item_impl_version(ver) return ul_item(0x55, ver) end
+
+local function item_user_information(impl_uid, impl_ver, max_pdu_len)
+  local payload = item_max_pdu(max_pdu_len) .. item_impl_uid(impl_uid) .. item_impl_version(impl_ver)
+  return ul_item(0x50, payload)
+end
+
+local function pad16(s)
+  s = (s or ""):sub(1,16)
+  if #s < 16 then s = s .. string.rep(" ", 16 - #s) end
+  return s
+end
+
+-- ==================================
+
+local PDU_CODES = {
   ASSOCIATE_REQUEST  = 0x01,
   ASSOCIATE_ACCEPT   = 0x02,
   ASSOCIATE_REJECT   = 0x03,
@@ -56,200 +90,361 @@ for i, v in pairs(PDU_CODES) do
   PDU_NAMES[v] = i
 end
 
+-- Most-specific FIRST. Only org roots known to be used as Implementation Class UIDs.
+local VENDOR_UID_PATTERNS = {
+  {"^1%.3%.6%.1%.4%.1%.25403%.",              "ClearCanvas"},
+  {"^1%.2%.826%.0%.1%.3680043%.9%.3811%.",    "pynetdicom"},
+  {"^1%.2%.826%.0%.1%.3680043%.8%.641%.",     "Orthanc"},
+  {"^1%.2%.826%.0%.1%.3680043%.8%.1057%.",    "OsiriX/Horos"},
+  {"^1%.2%.276%.0%.7230010%.3%.",             "DCMTK"},
+  
+  -- Prevent premature termination limits on sub-vendors (no $ anchors)
+  {"^1%.2%.40%.0%.13%.1%.3",                  "dcm4che"},
+  {"^1%.2%.826%.0%.1%.3680043%.2%.135%.1066%.101", "ConQuest"},
+
+  -- Major vendors (org roots)
+  {"^1%.2%.840%.113619%.",                    "GE Healthcare"},
+  {"^1%.3%.12%.2%.1107%.",                    "Siemens"},
+  {"^1%.2%.840%.114257%.",                    "Agfa"},
+  {"^1%.2%.840%.113704%.",                    "Philips"},
+  {"^1%.2%.840%.113564%.",                    "Carestream"},
+  {"^1%.2%.392%.200036%.",                    "Fujifilm"},
+  {"^1%.2%.840%.113669%..*",                  "Merge Healthcare"},
+  {"^1%.3%.46%.670589%.",                     "Philips"},
+}
+
 ---
 -- start_connection(host, port) starts socket to DICOM service
---
--- @param host Host object
--- @param port Port table
--- @return (status, socket) If status is true, socket of DICOM object is set.
---                          If status is false, socket is the error message.
 ---
 function start_connection(host, port)
   local dcm = {}
-  local status, err
   dcm['socket'] = nmap.new_socket()
 
-  status, err = dcm['socket']:connect(host, port, "tcp")
+  -- Dynamically adapt to SSL/TLS if detected by Nmap core
+  local protocol = "tcp"
+  local is_ssl = false
+  
+  -- Nmap stores SSL tunnel flags in port.version.service_tunnel
+  if port.version and port.version.service_tunnel == "ssl" then
+    is_ssl = true
+  end
+  if port.version and type(port.version.name) == "string" and port.version.name:match("tls") then
+    is_ssl = true
+  end
 
-  if(status == false) then
+  if is_ssl then
+    protocol = "ssl"
+    stdnse.debug1("DICOM: Upgrading nsock connection to SSL/TLS")
+  end
+
+  local ok, err = dcm['socket']:connect(host, port, protocol)
+  if ok == false then
     return false, "DICOM: Failed to connect to host: " .. err
   end
+
+  local t = tonumber(stdnse.get_script_args("dicom.timeout_ms")) or 3000
+  dcm['socket']:set_timeout(t)
 
   return true, dcm
 end
 
 ---
 -- send(dcm, data) Sends DICOM packet over established socket
---
--- @param dcm DICOM object
--- @param data Data to send
--- @return status True if data was sent correctly, otherwise false and error message is returned.
 ---
 function send(dcm, data) 
-  local status, err
-  stdnse.debug2("DICOM: Sending DICOM packet (%d)", #data)
-  if dcm['socket'] then
-    status, err = dcm['socket']:send(data)
-    if status == false then
-      return false, err
-    end
-  else 
-    return false, "No socket found. Check your DICOM object"
-  end
-  return true
+  if not dcm['socket'] then return false, "No socket found." end
+  stdnse.debug2("DICOM: Sending DICOM packet (%d bytes)", #data)
+  return dcm['socket']:send(data)
 end
 
 ---
--- receive(dcm) Reads DICOM packets over an established socket
---
--- @param dcm DICOM object
--- @return (status, data) Returns data if status true, otherwise data is the error message.
+-- receive(dcm) Reads DICOM PDUs over an established socket.
 ---
 function receive(dcm)
-  local status, data = dcm['socket']:receive()
-  if status == false then
-    return false, data
+  local sock = dcm['socket']
+  if not sock then return false, "No socket" end
+
+  local function is_timeout(err)
+    local e = tostring(err or ""):lower()
+    return e:find("timed out", 1, true) or e:find("timeout", 1, true) or e:find("time out", 1, true)
   end
-  stdnse.debug1("DICOM: receive() read %d bytes", #data)
-  return true, data
+
+  local ok1, chunk = sock:receive_bytes(6)
+  if not ok1 then
+    if is_timeout(chunk) then return false, "TIMEOUT" end
+    return false, chunk
+  end
+  if #chunk < 6 then return false, "Short PDU header" end
+
+  local header = chunk:sub(1, 6)
+  local pdu_type, _, pdu_length = string.unpack(">B B I4", header)
+  local body = chunk:sub(7)
+  local need = pdu_length - #body
+
+  while need > 0 do
+    local ok2, more = sock:receive_bytes(need)
+    if not ok2 then
+      if is_timeout(more) then return false, "TIMEOUT" end
+      return false, more
+    end
+    -- Prevent buffer over-read if the server sends the next PDU immediately
+    body = body .. string.sub(more, 1, need)
+    need = pdu_length - #body
+  end
+
+  return true, header .. body
 end
 
 ---
 -- pdu_header_encode(pdu_type, length) encodes the DICOM PDU header
---
--- @param pdu_type PDU type as ann unsigned integer
--- @param length Length of the DICOM message
--- @return (status, dcm) If status is true, the DICOM object with the header set is returned.
---                       If status is false, dcm is the error message.
 ---
 function pdu_header_encode(pdu_type, length)
-  -- Some simple sanity checks, we do not check ranges to allow users to create malformed packets.
-  if not(type(pdu_type)) == "number" then
-    return false, "PDU Type must be an unsigned integer. Range:0-7"
+  if type(pdu_type) ~= "number" or type(length) ~= "number" then
+    return false, "PDU Type and Length must be numbers."
   end
-  if not(type(length)) == "number" then
-    return false, "Length must be an unsigned integer."
-  end
-
-  local header = string.pack("<B >B I4",
-                            pdu_type, -- PDU Type ( 1 byte - unsigned integer in Big Endian )
-                            0,        -- Reserved section ( 1 byte that should be set to 0x0 )
-                            length)   -- PDU Length ( 4 bytes - unsigned integer in Little Endian)
-  if #header < MIN_HEADER_LEN then
-    return false, "Header must be at least 6 bytes. Something went wrong."
-  end
-   return true, header
+  local header = string.pack(">B B I4", pdu_type, 0, length)
+  return true, header
 end
 
----
--- associate(host, port) Attempts to associate to a DICOM Service Provider by sending an A-ASSOCIATE request.
---
--- @param host Host object
--- @param port Port object
--- @return (status, dcm) If status is true, the DICOM object is returned.
---                       If status is false, dcm is the error message.
----
+-- ==================== Parse Sub-Routines ====================
 
+function parse_implementation_version(data)
+  local version, uid = nil, nil
+  local data_len = #data
+
+  -- A-ASSOCIATE-AC fixed length is 74 bytes. Variable items begin at byte 75 (1-indexed).
+  if data_len < 74 then 
+    return nil, nil 
+  end
+
+  local offset = 75
+  local userinfo_start = nil
+
+  -- 1. Safely walk the TLV structure instead of using string matching (data:find)
+  while offset + 3 <= data_len do
+    local item_type = string.byte(data, offset)
+    local item_len  = string.unpack(">I2", data, offset + 2)
+
+    if item_type == 0x50 then
+      userinfo_start = offset
+      break
+    end
+    -- Skip to the next item
+    offset = offset + 4 + item_len
+  end
+
+  if not userinfo_start then
+      stdnse.debug2("User Information item (0x50) not found during TLV walk.")
+      return nil, nil
+  end
+
+  -- Ensure we can safely read the length of the User Info Block itself
+  if userinfo_start + 3 > data_len then return nil, nil end
+
+  local userinfo_len = string.unpack(">I2", data, userinfo_start + 2)
+  local sub_offset = userinfo_start + 4
+  local effective_end = math.min(userinfo_start + 3 + userinfo_len, data_len)
+
+  -- 2. Walk the sub-items inside User Info
+  while sub_offset + 3 <= effective_end do
+    local sub_type = string.byte(data, sub_offset)
+    local sub_len  = string.unpack(">I2", data, sub_offset + 2)
+    local sub_value_start = sub_offset + 4
+    local sub_value_end   = sub_offset + 3 + sub_len
+
+    if sub_value_end <= effective_end and sub_len > 0 then
+      local value_raw = data:sub(sub_value_start, sub_value_end)
+      local value_cleaned = value_raw:gsub("%z", ""):match("^%s*(.-)%s*$")
+
+      if sub_type == 0x52 and not uid then
+          uid = value_cleaned
+      elseif sub_type == 0x55 and not version then
+          version = value_cleaned
+      end
+    end
+
+    sub_offset = sub_offset + 4 + sub_len
+  end
+
+  return version, uid
+end
+
+function identify_vendor_from_uid(uid)
+  if not uid then return nil end
+  uid = uid:gsub("%z", ""):match("^%s*(.-)%s*$")
+  for _, entry in ipairs(VENDOR_UID_PATTERNS) do
+    if uid:match(entry[1]) then
+      return entry[2]
+    end
+  end
+  return nil
+end
+
+function extract_clean_version(version_str, vendor)
+  if not version_str then return nil end
+  local s = version_str:gsub("%z", ""):match("^%s*(.-)%s*$")
+  if s == "" then return nil end
+  local v = vendor and vendor:lower() or nil
+
+  -- Helper: map 3 digits like "369" -> "3.6.9"
+  -- Note: This is a historical heuristic. It will fail if vendors adopt double-digit minor versions (e.g., 3.10.2).
+  local function ddd_to_semver(ddd)
+    if not ddd or #ddd ~= 3 then return nil end
+    return string.format("%s.%s.%s", ddd:sub(1,1), ddd:sub(2,2), ddd:sub(3,3))
+  end
+
+  if v == "dcmtk" or s:find("DCMTK", 1, true) or s:find("OFFIS", 1, true) then
+    local a,b,c = s:match("[Oo][Ff][Ff][Ii][Ss].-[Dd][Cc][Mm][Tt][Kk].-[ _-]?(%d)%.?(%d)%.?(%d)")
+    if a and b and c then return string.format("%s.%s.%s", a,b,c) end
+
+    a,b,c = s:match("[Dd][Cc][Mm][Tt][Kk][ _-]?(%d)%.?(%d)%.?(%d)")
+    if a and b and c then return string.format("%s.%s.%s", a,b,c) end
+
+    local sem = s:match("[Dd][Cc][Mm][Tt][Kk][%s_/-]*([%d]+%.%d+%.%d+)")
+             or s:match("[Oo][Ff][Ff][Ii][Ss].-[Dd][Cc][Mm][Tt][Kk][%s_/-]*([%d]+%.%d+%.%d+)")
+    if sem then return sem end
+  end
+
+  if v == "pynetdicom" or s:find("PYNETDICOM") or s:lower():find("pynetdicom") then
+    local ddd = s:match("PYNETDICOM[_-](%d%d%d)$")
+    if ddd then
+      local semv = ddd_to_semver(ddd)
+      if semv then return semv end
+    end
+    local sem = s:match("[Pp][Yy][Nn][Ee][Tt][Dd][Ii][Cc][Oo][Mm][%s/:-]+([%d]+%.%d+%.%d+)")
+             or s:match("[Pp][Yy][Nn][Ee][Tt][Dd][Ii][Cc][Oo][Mm][%s/:-]+([%d]+%.%d+)")
+    if sem then return sem end
+  end
+
+  if v == "dcm4che" or s:lower():find("dcm4che") then
+    local sem = s:match("dcm4che[%w-]*[%s/:-]+([%d]+%.%d+%.%d+)")
+    if sem then return sem end
+  end
+
+  if v == "orthanc" or s:lower():find("orthanc") then
+    local sem = s:match("[Oo]rthanc[%s%-/]*[vV]?([%d]+%.%d+%.%d+)")
+             or s:match("[Oo]rthanc[%s%-/]*[vV]?([%d]+%.%d+)")
+    if sem then return sem end
+  end
+
+  if v == "osirix" or v == "horos" or s:lower():find("osirix") or s:lower():find("horos") then
+    local sem = s:match("[vV]([%d]+%.%d+%.%d+)")
+    if sem then return sem end
+  end
+
+  if v == "clearcanvas" or s:find("ClearCanvas") then
+    local maj, min, build = s:match("ClearCanvas[_-](%d+)%.(%d+)%.(%d+)")
+    if maj and min and build then return string.format("%s.%s.%s", maj, min, build) end
+
+    maj, min = s:match("ClearCanvas[_-](%d+)%.(%d+)")
+    if maj and min then return string.format("%s.%s", maj, min) end
+  end
+
+  -- Generic fallbacks
+  local sem = s:match("(%d+%.%d+%.%d+)")
+  if sem then return sem end
+  sem = s:match("(%d+%.%d+)")
+  if sem then return sem end
+
+  if v == "dcmtk" then
+    local ddd = s:match("(%d%d%d)")
+    if ddd then
+      local semv = ddd_to_semver(ddd)
+      if semv then return semv end
+    end
+  end
+
+  return s
+end
+
+-- ============================================================
+
+---
+-- associate(host, port) Attempts to associate to a DICOM Service Provider
+---
 function associate(host, port, calling_aet, called_aet)
-  local application_context = ""
-  local presentation_context = ""
-  local userinfo_context = ""
-  
   local status, dcm = start_connection(host, port)
-  if status == false then
-    return false, dcm
+  if not status then
+    return false, dcm -- dcm contains the error message
+  end
+
+  local application_context_name = "1.2.840.10008.3.1.1.1"   
+  local abstract_syntax_name     = "1.2.840.10008.1.1"       
+  local transfer_syntax_name     = "1.2.840.10008.1.2"       
+
+  local called_ae_title_val  = pad16(called_aet  or "ANY-SCP")
+  local calling_ae_title_val = pad16(calling_aet or "ECHOSCU")
+
+  -- Use a generic, clearly labeled scanner identification
+  local implementation_id      = "1.2.276.0.7230010.3.0.3.6.2" -- Re-using DCMTK's root as it passes most legacy strict filters
+  local implementation_version = "NMAP_DICOM_PING"
+  local max_pdu_len            = 16384
+
+  local application_context  = item_application_context(application_context_name)
+  local presentation_context = item_presentation_context(1, abstract_syntax_name, transfer_syntax_name)
+  local userinfo_context     = item_user_information(implementation_id, implementation_version, max_pdu_len)
+
+  local fixed = string.pack(">I2 I2 c16 c16 c32", 0x0001, 0x0000, called_ae_title_val, calling_ae_title_val, string.rep("\0", 32))
+  local assoc_body = fixed .. application_context .. presentation_context .. userinfo_context
+
+  local header_ok, header = pdu_header_encode(PDU_CODES["ASSOCIATE_REQUEST"], #assoc_body)
+  if not header_ok then 
+    dcm['socket']:close()
+    return false, "Failed to encode PDU header" 
   end
   
-  local application_context_name = "1.2.840.10008.3.1.1.1"
-  application_context = string.pack(">B B s2",
-                                    0x10,
-                                    0x0,
-                                    application_context_name)
+  local assoc_request = header .. assoc_body
+
+  local send_status, send_err = send(dcm, assoc_request)
+  if not send_status then
+    dcm['socket']:close()
+    return false, string.format("Couldn't send ASSOCIATE request: %s", send_err or "Unknown error")
+  end
+
+  local receive_status, response_data = receive(dcm)
+  dcm['socket']:close() -- Association handshake complete; socket cleanup.
+
+  if not receive_status then 
+    return false, string.format("Couldn't read ASSOCIATE response: %s", response_data) 
+  end
+
+  if #response_data < MIN_HEADER_LEN then 
+    return false, "Received response too short for PDU header" 
+  end
   
-  local abstract_syntax_name = "1.2.840.10008.1.1"
-  local transfer_syntax_name = "1.2.840.10008.1.2"
-  presentation_context = string.pack(">B B I2 B B B B B B s2 B B s2",
-                                    0x20, -- Presentation context type ( 1 byte )
-                                    0x0,  -- Reserved ( 1 byte )
-                                    0x2e,   -- Item Length ( 2 bytes )
-                                    0x1,  -- Presentation context id ( 1 byte )
-                                    0x0,0x0,0x0,  -- Reserved ( 3 bytes )
-                                    0x30, -- Abstract Syntax Tree ( 1 byte )
-                                    0x0,  -- Reserved ( 1 byte )
-                                    abstract_syntax_name,
-                                    0x40, -- Transfer Syntax ( 1 byte )
-                                    0x0,  -- Reserved ( 1 byte )
-                                    transfer_syntax_name)
-                                    
-  local implementation_id = "1.2.276.0.7230010.3.0.3.6.2"
-  local implementation_version = "OFFIS_DCMTK_362"
-  userinfo_context = string.pack(">B B I2 B B I2 I4 B B s2 B B s2",
-                                0x50,    -- Type 0x50 (1 byte)
-                                0x0,     -- Reserved ( 1 byte )
-                                0x3a,    -- Length ( 2 bytes )
-                                0x51,    -- Type 0x51 ( 1 byte) 
-                                0x0,     -- Reserved ( 1 byte)
-                                0x04,     -- Length ( 2 bytes )
-                                0x4000,   -- DATA ( 4 bytes )
-                                0x52,    -- Type 0x52 (1 byte)
-                                0x0,
-                                implementation_id,
-                                0x55,
-                                0x0,
-                                implementation_version)
-  
-  local called_ae_title = called_aet or stdnse.get_script_args("dicom.called_aet") or "ANY-SCP"
-  local calling_ae_title = calling_aet or stdnse.get_script_args("dicom.calling_aet") or "ECHOSCU"
-  if #called_ae_title > 16 or #calling_ae_title > 16 then
-    return false, "Calling/Called Application Entity Title must be less than 16 bytes"
-  end
-  called_ae_title = ("%-16s"):format(called_ae_title)
-  calling_ae_title = ("%-16s"):format(calling_ae_title)
+  local resp_type, _, resp_length = string.unpack(">B B I4", response_data)
 
- -- ASSOCIATE request
-  local assoc_request = string.pack(">I2 I2 c16 c16 c32",
-                                  0x1, -- Protocol version ( 2 bytes )
-                                  0x0, -- Reserved section ( 2 bytes that should be set to 0x0 )
-                                  called_ae_title, -- Called AE title ( 16 bytes)
-                                  calling_ae_title, -- Calling AE title ( 16 bytes)
-                                  "") -- Reserved section ( 32 bytes set to 0x0 )
-                                  .. application_context
-                                  .. presentation_context
-                                  .. userinfo_context
- 
-  local status, header = pdu_header_encode(PDU_CODES["ASSOCIATE_REQUEST"], #assoc_request)
-
-  -- Something might be wrong with our header
-  if status == false then 
-    return false, header
+  if resp_type ~= PDU_CODES["ASSOCIATE_ACCEPT"] then
+    if resp_type == PDU_CODES["ASSOCIATE_REJECT"] then
+      return false, "ASSOCIATE REJECT received"
+    else
+      return false, "Received unexpected response PDU type: " .. tostring(resp_type)
+    end
   end
 
-  assoc_request = header .. assoc_request
- 
-  stdnse.debug2("PDU len minus header:%d", #assoc_request-#header)
-  if #assoc_request < MIN_SIZE_ASSOC_REQ then
-    return false, string.format("ASSOCIATE request PDU must be at least %d bytes and we tried to send %d.", MIN_SIZE_ASSOC_REQ, #assoc_request)
-  end 
-  local status, err = send(dcm, assoc_request)
-  if status == false then
-    return false, string.format("Couldn't send ASSOCIATE request:%s", err)
-  end
-  status, err = receive(dcm)
-  if status == false then
-    return false, string.format("Couldn't read ASSOCIATE response:%s", err)
+  local received_version_str, received_uid_str = parse_implementation_version(response_data)
+  local impl_version_name = received_version_str 
+
+  local parsed_vendor, parsed_clean_version = nil, nil
+
+  if received_uid_str then
+    parsed_vendor = identify_vendor_from_uid(received_uid_str)
+    if received_version_str then
+      parsed_clean_version = extract_clean_version(received_version_str, parsed_vendor)
+    end
+  elseif received_version_str then
+    local v = received_version_str:lower()
+    if     v:find("dcm4che",   1, true) then parsed_vendor = "dcm4che"
+    elseif v:find("dcmtk",     1, true) then parsed_vendor = "DCMTK"
+    elseif v:find("pynetdicom",1, true) then parsed_vendor = "pynetdicom"
+    elseif v:find("orthanc",   1, true) then parsed_vendor = "Orthanc"
+    end
+    parsed_clean_version = extract_clean_version(received_version_str, parsed_vendor)
   end
 
-  local resp_type, _, resp_length = string.unpack(">B B I4", err)
-  stdnse.debug1("PDU Type:%d Length:%d", resp_type, resp_length)
-  if resp_type == PDU_CODES["ASSOCIATE_ACCEPT"] then
-    stdnse.debug1("ASSOCIATE ACCEPT message found!")
-    return true, dcm
-  elseif resp_type == PDU_CODES["ASSOCIATE_REJECT"] then
-    stdnse.debug1("ASSOCIATE REJECT message found!")
-    return false, "ASSOCIATE REJECT received"
-  else
-    return false, "Received unknown response"
-  end
+  local final_version = parsed_clean_version or impl_version_name
+
+  return true, nil, final_version, parsed_vendor, received_uid_str, impl_version_name
 end
 
 function send_pdata(dicom, data)
@@ -262,6 +457,14 @@ function send_pdata(dicom, data)
   if status == false then
     return false, err
   end
+  return true
+end
+
+function extract_uid_root(uid)
+  if not uid then return nil end
+  local trimmed = uid:gsub("%z",""):match("^%s*(.-)%s*$")
+  if trimmed == "" then return nil end
+  return trimmed:match("^([%d%.]+)%.[^%.]+$") or trimmed
 end
 
 return _ENV

--- a/scripts/dicom-ping.nse
+++ b/scripts/dicom-ping.nse
@@ -1,9 +1,13 @@
-description = [[
+--[[
 Attempts to discover DICOM servers (DICOM Service Provider) through a partial C-ECHO request.
- It also detects if the server allows any called Application Entity Title or not.
+It also detects if the server allows any called Application Entity Title or not.
 
 The script responds with the message "Called AET check enabled" when the association request
- is rejected due configuration. This value can be bruteforced.
+is rejected due configuration. This value can be bruteforced using dicom-brute.
+
+The Implementation Class UID identifies the implementation (often enough to infer
+the toolkit or vendor), and the Implementation Version Name can often be used to
+extract a meaningful version string.
 
 C-ECHO requests are commonly known as DICOM ping as they are used to test connectivity.
 Normally, a 'DICOM ping' is formed as follows:
@@ -15,56 +19,192 @@ Normally, a 'DICOM ping' is formed as follows:
 * Server -> A-RELEASE response -> Client
 
 For this script we only send the A-ASSOCIATE request and look for the success code
- in the response as it seems to be a reliable way of detecting DICOM servers.
+(or an explicit A-ASSOCIATE-REJECT) in the response as it seems to be a reliable
+way of detecting DICOM servers.
 ]]
 
 ---
 -- @usage nmap -p4242 --script dicom-ping <target>
 -- @usage nmap -sV --script dicom-ping <target>
--- 
+-- @usage nmap --script dicom-ping --script-args dicom-ping.ports=11114,11115 <target>
+-- @usage nmap -v --script dicom-ping <target>
+-- @usage nmap --script dicom-ping --script-args dicom-ping.extended <target>
+--
+-- @args dicom.called_aet       Called Application Entity Title. Default: ANY-SCP
+-- @args dicom-ping.ports       Optional comma-separated list of ports to probe
+--                              (e.g. "104,11112,2761,2762,4242"). By default,
+--                              the script runs on common DICOM ports or when
+--                              the service is already identified as "dicom".
+-- @args dicom-ping.extended    If set, prints additional identification fields
+--                              (implementation class UID and implementation
+--                              version name) from the A-ASSOCIATE-AC. This behaves
+--                              identically to running Nmap with verbosity (-v).
+--
 -- @output
 -- PORT     STATE SERVICE REASON
 -- 4242/tcp open  dicom   syn-ack
--- | dicom-ping: 
+-- | dicom-ping:
 -- |   dicom: DICOM Service Provider discovered!
--- |_  config: Called AET check enabled
+-- |   config: Any AET is accepted (Insecure)
+-- |   vendor: Orthanc
+-- |_  version: 1.11.0
 --
 -- @xmloutput
--- <script id="dicom-ping" output="&#xa;  dicom: DICOM Service Provider discovered!&#xa;
---   config: Called AET check enabled"><elem key="dicom">DICOM Service Provider discovered!</elem>
--- <elem key="config">Called AET check enabled</elem>
+-- <script id="dicom-ping" output="&#xa;  dicom: DICOM Service Provider discovered!&#xa;  config: Any AET is accepted (Insecure)&#xa;  vendor: Orthanc&#xa;  version: 1.11.0"><elem key="dicom">DICOM Service Provider discovered!</elem>
+-- <elem key="config">Any AET is accepted (Insecure)</elem>
+-- <elem key="vendor">Orthanc</elem>
+-- <elem key="version">1.11.0</elem>
 -- </script>
 ---
 
-author = "Paulino Calderon <calderon()calderonpale.com>"
+author = "Paulino Calderon <calderon()calderonpale.com>, Tyler M <tmart234()gmail.com>"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
-categories = {"discovery", "default", "safe", "auth"}
+categories = {"discovery", "default", "version", "safe", "auth"}
 
 local shortport = require "shortport"
-local dicom = require "dicom"
-local stdnse = require "stdnse"
-local nmap = require "nmap"
+local dicom     = require "dicom"
+local stdnse    = require "stdnse"
+local nmap      = require "nmap"
+local string    = require "string"
 
-portrule = shortport.port_or_service({104, 2345, 2761, 2762, 4242, 11112}, "dicom", "tcp", "open")
+-- Parse a comma/space separated port list into a lookup set.
+local function parse_ports_arg(ports_str)
+  if not ports_str then return nil end
+  local set = {}
+  for num in string.gmatch(ports_str, "%d+") do
+    local n = tonumber(num)
+    if n then set[n] = true end
+  end
+  return (next(set) and set) or nil
+end
+
+-- Default/common DICOM ports:
+local COMMON_DICOM_PORTS = {104, 11112, 2761, 2762, 4242}
+
+-- Cache custom ports at script load so we don't parse it on every open port
+local custom_ports_arg = stdnse.get_script_args("dicom-ping.ports")
+local custom_ports_set = parse_ports_arg(custom_ports_arg)
+
+portrule = function(host, port)
+  if not (port.protocol == "tcp" and port.state == "open") then
+    return false
+  end
+
+  if custom_ports_set and custom_ports_set[port.number] then
+    stdnse.debug1("dicom-ping: matched script-arg port %d", port.number)
+    return true
+  end
+
+  -- Notice the "ssl" removal from the protocol array here compared to earlier attempts. 
+  -- Nmap expects IP layer protocols ("tcp", "udp") in the third argument.
+  if shortport.port_or_service(COMMON_DICOM_PORTS, {"dicom", "dicom-tls"}, "tcp")(host, port) then
+    stdnse.debug1("dicom-ping: matched common DICOM port/service (%d)", port.number)
+    return true
+  end
+
+  return false
+end
 
 action = function(host, port)
-  local output = stdnse.output_table()
-  local dcm_conn_status, err = dicom.associate(host, port)
-  if dcm_conn_status == false then
-    stdnse.debug1("Association failed:%s", err)
-    if err == "ASSOCIATE REJECT received" then
-      port.version.name = "dicom"
+  stdnse.debug1("dicom-ping: ACTION for %s:%d", host.ip, port.number)
+  local out = stdnse.output_table()
+
+  local called_aet = stdnse.get_script_args("dicom.called_aet")
+  local extended   = stdnse.get_script_args("dicom-ping.extended") ~= nil
+
+  -- Safely check for TLS using Nmap's correct internal properties
+  local is_tls = (port.version and port.version.service_tunnel == "ssl") or 
+                 (port.version and type(port.version.name) == "string" and port.version.name:match("tls"))
+
+  -- dicom.associate handles the heavy lifting, including native SSL wrapping
+  local ok, err, version, vendor, uid, impl_version_name = dicom.associate(host, port, nil, called_aet)
+
+  if not ok then
+    stdnse.debug1("Association failed: %s", tostring(err or "Unknown error"))
+    local e = tostring(err or "")
+
+    -- Only treat a clearly signalled ASSOCIATE-REJECT as positive DICOM detection.
+    if e == "ASSOCIATE REJECT received" then
+      port.version.name = is_tls and "dicom-tls" or "dicom"
       nmap.set_port_version(host, port)
-  
-      output.dicom = "DICOM Service Provider discovered!"
-      output.config = "Called AET check enabled"
+
+      out.dicom  = "DICOM Service Provider discovered!"
+      if not called_aet or called_aet == "ANY-SCP" then
+        out.config = "Called AET check enabled"
+      else
+        out.config = string.format("Association Rejected (Tried AET: %s)", called_aet)
+      end
+      return out
     end
-    return output
+
+    -- Catch mTLS rejections (when the connection fails at the TLS layer)
+    if is_tls then
+      out.dicom    = "TLS endpoint detected, but DICOM association failed."
+      out.tls_hint = "Server likely requires Mutual TLS (mTLS) with valid client certificates."
+      out.error    = e
+      
+      port.version.name = "dicom-tls"
+      nmap.set_port_version(host, port)
+      return out
+    end
+
+    -- Heuristic fallback if user didn't run -sV but hits IANA DICOM/TLS port.
+    if not is_tls and tonumber(port.number) == 2762 and e:lower():match("short pdu header") then
+      out.dicom    = "Possible DICOM/TLS endpoint (plaintext A-ASSOCIATE not accepted)"
+      out.tls_hint = "Port 2762 is open, but DICOM associate could not be completed. Rerun with -sV or --script+ssl to confirm."
+      out.error    = e
+      return out
+    end
+
+    -- Unknown failure or timeout: stay silent to avoid false positives.
+    return nil
   end
-  port.version.name = "dicom"
+
+  -- Success path: association accepted.
+  out.dicom = "DICOM Service Provider discovered!"
+  if not called_aet or called_aet == "ANY-SCP" then
+    out.config = "Any AET is accepted (Insecure)"
+  else
+    out.config = string.format("Called AET enforced (used: %s)", called_aet)
+  end
+
+  if is_tls then
+    out.tls_status = "Successfully associated over TLS"
+  elseif tonumber(port.number) == 2762 then
+    out.tls_hint = "Warning: Plaintext DICOM detected on IANA TLS port"
+  end
+
+  if vendor then
+    port.version.product = vendor
+    out.vendor = vendor
+  end
+
+  if version then
+    port.version.version = version
+    out.version = version
+  end
+
+  port.version.name = is_tls and "dicom-tls" or "dicom"
   nmap.set_port_version(host, port)
-  
-  output.dicom = "DICOM Service Provider discovered!"
-  output.config = "Any AET is accepted (Insecure)"
-  return output
+
+  local is_verbose = nmap.verbosity() > 0 or extended
+
+  if uid then
+    -- If verbose, always show it. If not verbose, only show it if we failed to identify a vendor.
+    if is_verbose or (not vendor and not version) then
+      out.impl_class_uid = uid
+    end
+    -- Only add the lookup note if we failed to identify it
+    if not vendor and not version then
+      out.note = "Look up impl_class_uid in a DICOM OID registry for implementation details"
+    end
+  end
+
+  if impl_version_name then
+    if is_verbose and version ~= impl_version_name then
+      out.impl_version_name = impl_version_name
+    end
+  end
+
+  return out
 end


### PR DESCRIPTION
This PR upgrades the dicom-ping script and the underlying dicom.lua library. It works by parsing additional fields in the A-ASSOCIATE-AC PDU (already parsed in original script). No additional packets sent.

Fingerprinting: The script now extracts the Implementation Class UID and Implementation Version Name from the User Information item of the A-ASSOCIATE-AC PDU to accurately map the backend vendor (e.g., DCMTK, Orthanc, dcm4che) and semantic version.
The root Class UID is really an OID that can be looked up in an "OID registry" to find the vendor.. but this script just uses a quick OID/root UID lookup table. Prints Class UID if verbose is enabled. 

Native Nmap SSL/TLS Support: The library now hooks into Nmap's port.version.service_tunnel property

Binary-Safe TLV Parsing: Replaced brittle string.find byte-searching logic with a robust Type-Length-Value (TLV) walker to parse the DICOM PDU headers safely,

This has been tested on the following software:
- DCMTK
- pynetdicom
- dcm4chee
- DCMTK w TLS
- PACS servers (Orthanc, ConQuest)