### PR TITLE
Refresh of script http-default-accounts

### DIFF
--- a/scripts/http-default-accounts.nse
+++ b/scripts/http-default-accounts.nse
@@ -478,7 +478,8 @@ end
 
 
 action = function(host, port)
-  local fingerprint_filename = stdnse.get_script_args("http-default-accounts.fingerprintfile") or "http-default-accounts-fingerprints.lua"
+  local fingerprint_filename = stdnse.get_script_args("http-default-accounts.fingerprintfile")
+                               or "http-default-accounts-fingerprints.lua"
   local catlist = stdnse.get_script_args("http-default-accounts.category")
   local namelist = stdnse.get_script_args("http-default-accounts.name")
   local basepath = stdnse.get_script_args("http-default-accounts.basepath") or "/"


### PR DESCRIPTION
Several improvements to the script implemented:
* Validation logic for the loaded fingerprint database is now more comprehensive.
* Testing of passwords associated with a specific fingerprint now stops as soon as the correct password for a given username is found. Testing the remaining passwords (for the same username) is a noisy waste of time in the vast majority of cases, sometimes resulting in an account lockout.
* The default `target_check` function is now only built when some of the loaded fingerprints lack their own. This avoids unnecessary web traffic to the target.

This PR will be merged in after April 1st unless concerns are raised.