### PR TITLE
Support Linux capabilities for non-root raw packet scanning

### DIFF
--- a/NmapOps.cc
+++ b/NmapOps.cc
@@ -224,8 +224,13 @@ void NmapOps::Initialize() {
     isr00t = 1;
   else if (getenv("NMAP_UNPRIVILEGED"))
     isr00t = 0;
-  else
-    isr00t = !(geteuid());
+  else {
+#ifdef __linux__
+    isr00t = (geteuid() == 0) || have_net_capabilities();
+#else
+    isr00t = (geteuid() == 0);
+#endif
+  }
 #endif
   have_pcap = true;
   debugging = 0;

--- a/nbase/nbase.h
+++ b/nbase/nbase.h
@@ -522,6 +522,12 @@ extern int addrset_contains(const struct addrset *set, const struct sockaddr *sa
 
 #include "nbase_ipv6.h"
 
+#ifdef __linux__
+/* Returns non-zero if the process has CAP_NET_RAW effective.
+ * See nbase_misc.c for details. */
+int have_net_capabilities(void);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/nbase/nbase_misc.c
+++ b/nbase/nbase_misc.c
@@ -843,3 +843,29 @@ const char *sockaddr_storage_iptop(const struct sockaddr_storage * addr, char * 
     return NULL;
   }}
 }
+
+/* Returns non-zero if the process has CAP_NET_RAW in its effective capability
+ * set.  Handles setcap deployments where the binary runs as a non-root UID:
+ *   sudo setcap cap_net_raw=ep /usr/bin/nmap
+ * CAP_NET_RAW is sufficient for the raw sockets and pcap packet capture nmap
+ * performs (promiscuous mode via PACKET_MR_PROMISC on an AF_PACKET socket
+ * requires only CAP_NET_RAW).
+ * Uses /proc/self/status to avoid a libcap dependency. */
+#ifdef __linux__
+int have_net_capabilities(void) {
+  FILE *f = fopen("/proc/self/status", "r");
+  if (!f)
+    return 0;
+  char line[256];
+  uint64_t capeff = 0;
+  while (fgets(line, sizeof(line), f)) {
+    if (strncmp(line, "CapEff:", 7) == 0) {
+      sscanf(line + 7, "%" SCNx64, &capeff);
+      break;
+    }
+  }
+  fclose(f);
+  /* CAP_NET_RAW=13 */
+  return (capeff & (UINT64_C(1) << 13)) != 0;
+}
+#endif /* __linux__ */

--- a/nping/NpingOps.cc
+++ b/nping/NpingOps.cc
@@ -137,8 +137,13 @@ NpingOps::NpingOps() {
     isr00t=true;
   else if (getenv("NMAP_UNPRIVILEGED") || getenv("NPING_UNPRIVILEGED"))
     isr00t=false;
-  else
-    isr00t = !(geteuid());
+  else {
+#ifdef __linux__
+    isr00t = (geteuid() == 0) || have_net_capabilities();
+#else
+    isr00t = (geteuid() == 0);
+#endif
+  }
 #endif
 
     /* Payloads */


### PR DESCRIPTION
Nmap previously required root (`geteuid()==0`) for any scan type that uses raw sockets. On Linux, setcap(8) can grant the necessary access without a full root UID:

```bash
  sudo setcap cap_net_raw=ep /usr/bin/nmap
```
Add `have_net_capabilities()` to `nbase/nbase_misc.c`, which reads `CapEff` from `/proc/self/status` and tests for `CAP_NET_RAW` (bit 13). Both `NmapOps::Initialize()` and `NpingOps::Initialize()` now set `isr00t` when either `geteuid()==0` or `CAP_NET_RAW` is effective, suppressing the "You requested a scan type which requires root privileges." error.

CAP_NET_RAW is sufficient for raw sockets and promiscuous capture via `PACKET_MR_PROMISC` on an `AF_PACKET` socket. The capability check is Linux-only (`#ifdef __linux__`); all other platforms retain their existing behaviour.