### PR TITLE
Fix issue #3326

### DIFF
--- a/libnetutil/netutil.cc
+++ b/libnetutil/netutil.cc
@@ -3127,15 +3127,27 @@ icmpbad:
   } else {
     /* UNKNOWN PROTOCOL **********************************************************/
     const char *hdrstr;
-
     hdrstr = nexthdrtoa(hdr.proto, 1);
-    if (hdrstr == NULL || *hdrstr == '\0') {
-      Snprintf(protoinfo, sizeof(protoinfo), "Unknown protocol (%d) %s > %s: %s",
-        hdr.proto, srchost, dsthost, ipinfo);
+
+    /* Check if the ip version is 6 using the hdr struct*/
+    if (hdr.version == 6) {
+      /* It's an IPv6 packet */
+      if (hdrstr == NULL || *hdrstr == '\0') {
+        Snprintf(protoinfo, sizeof(protoinfo), "IPv6 (nh=%d) %s > %s: %s",
+          hdr.proto, srchost, dsthost, ipinfo);
+      } else {
+        Snprintf(protoinfo, sizeof(protoinfo), "IPv6 (nh=%s/%d) %s > %s: %s",
+          hdrstr, hdr.proto, srchost, dsthost, ipinfo);
+      }
     } else {
-      Snprintf(protoinfo, sizeof(protoinfo), "%s (%d) %s > %s: %s",
-        hdrstr, hdr.proto, srchost, dsthost, ipinfo);
-    }
+      if (hdrstr == NULL || *hdrstr == '\0') {
+        Snprintf(protoinfo, sizeof(protoinfo), "Unknown protocol (%d) %s > %s: %s",
+          hdr.proto, srchost, dsthost, ipinfo);
+      } else {
+        Snprintf(protoinfo, sizeof(protoinfo), "%s (%d) %s > %s: %s",
+          hdrstr, hdr.proto, srchost, dsthost, ipinfo);
+      }
+    } 
   }
 
   return protoinfo;


### PR DESCRIPTION
I read the source code and, from my understanding, the current output appears to be intentional. The ```ipv4``` value being shown seems to refer to the next header, i.e., the protocol of the packet encapsulated within the outer packet, which in this case is IPv6.
Since the user has explicitly specified ```-6``` in the command, it seems reasonable to assume that the outgoing packets are expected to be in IPv6 format rather than IPv4.
That said, I understand how this could lead to confusion. To improve clarity, I have added a fix in [the else statement at line 3127](https://github.com/Adv2924/nmap/blob/6dac43b5d892e5566f4d1d911573403e9f86bb96/libnetutil/netutil.cc#L3127) in libnetutil/netutil.cc, which checks whether hdr.version is set to 6 and updates the logging accordingly.