### PR TITLE
Restore full Samba version detection

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -14114,7 +14114,7 @@ match netbios-ssn m=^\0\0\0.\xffSMBr\0\0\0\0\x88..\0\0[-\w. ]*\0+@\x06\0\0\x01\0
 match netbios-ssn m|^\0\0\0.\xffSMBr\0\0\0\0\x88..\0\0\0\0\0\0\0\0\0\0\0\0\0\0@\x06\0\0\x01\0\x11\x06\0..\0\x01\0..\0\0...\0..\0\0|s p/Samba smbd/ v/3.X - 4.X/ cpe:/a:samba:samba/
 # Samba 2.2.8a on Linux 2.4.20
 match netbios-ssn m|^\x83\0\0\x01\x81$| p/Samba smbd/ cpe:/a:samba:samba/
-match netbios-ssn m|^\0\0\0.\xffSMBr\0\0\0\0\x88..\0\0\0\0\0\0\0\0\0\0\0\0\0\0@\x06\0\0\x01\0\x01\xff\xff\0\0$|s p/Samba smbd/ v/4/ cpe:/a:samba:samba:4/
+match netbios-ssn m|^\0\0\0.\xffSMBr\0\0\0\0\x88..\0\0\0\0\0\0\0\0\0\0\0\0\0\0@\x06\0\0\x01\0\x01\xff\xff\0\0.*[Ss][Aa][Mm][Bb][Aa] (\d+[\.\d]+).*$|s p/Samba smbd/ v/$1/ cpe:/a:samba:samba:$1/
 # DAVE 4.1 enhanced windows networks services for Mac on Mac OS X
 match netbios-ssn m|^\0\0\0.\xffSMBr\x02\0Y\0\x98\x01.\0\0\0\0\0\0\0\0\0\0\0\0\0\0@\x06\0\0\x01\0\0\x07\0|s p/Thursby DAVE Windows filesharing/ i/Runs on Macintosh systems/ o/Mac OS/ cpe:/o:apple:mac_os/a
 # Windows Session Service - 139/tcp - Formerly Window 98 match, actually matches Win 98 through Windows 8 / 2012 R2


### PR DESCRIPTION
## Summary
This PR restores the ability to detect the full Samba version (e.g., 4.6.2) instead of just the major version (4).

## Problem
In recent nmap versions (7.98+), the SMB service detection for Samba servers only shows the major version number (e.g., "Samba smbd 4") instead of the full version (e.g., "Samba smbd 4.6.2"):

**Expected (nmap 7.94):**


**Actual (nmap 7.98):**


## Root Cause
The match line in nmap-service-probes was changed from capturing the full version to a static "v/4" in commit 27fc66778.

## Fix
Modified the match line to capture the actual Samba version from the SMB response using regex  which matches version strings like "4.6.2", "4.11.0", "3.6.25", etc.