### PR TITLE
fix(nselib/url): scope path params to segment per RFC 3986 s3.3

### DIFF
--- a/nselib/url.lua
+++ b/nselib/url.lua
@@ -215,11 +215,11 @@ function parse(url, default)
     parsed.authority = n
     return ""
   end)
-  -- get params
-  url = string.gsub(url, "%;(.*)", function(p)
-    parsed.params = p
-    return ""
-  end)
+  -- get params (RFC 3986 s3.3: parameters are scoped to individual path
+  -- segments, not the entire remaining path). Capture the first occurrence
+  -- and strip all occurrences so the path is reconstructed correctly.
+  parsed.params = url:match("%;([^/]*)")
+  url = url:gsub("%;[^/]*", "")
 
   -- path is whatever was left
   parsed.path = url


### PR DESCRIPTION
## Problem

`url.parse()` uses ```%;(.*)``` to extract path parameters, which consumes everything after the first semicolon — including subsequent path segments.

For `/aa/bb;cc/dd;ee/` it produces:
- `path` = `/aa/bb` ❌ (expected `/aa/bb/dd/`)
- `params` = `cc/dd;ee/` ❌ (expected `cc`)

This was reported in issue #3318 by @nnposter with full RFC analysis.

## Root Cause

[RFC 3986 section 3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3) states that path parameters (semicolon-delimited) are scoped to **individual path segments**, not the entire remaining path.

## Fix

Change the pattern from `%;(.*)` (greedy, eats slashes) to `%;([^/]*)` (stops at next slash):

```lua
-- Before
url = string.gsub(url, "%;(.*)", function(p)
  parsed.params = p
  return ""
end)

-- After  
parsed.params = url:match("%;([^/]*)")
url = url:gsub("%;[^/]*", "")
```

## Test Cases

| Input | Before path | After path | Before params | After params |
|-------|-------------|------------|---------------|--------------|
| `/aa/bb;cc/dd;ee/` | `/aa/bb` ❌ | `/aa/bb/dd/` ✅ | `cc/dd;ee/` ❌ | `cc` ✅ |
| `/simple;param` | `/simple` ✅ | `/simple` ✅ | `param` ✅ | `param` ✅ |
| `/no-params/here` | `/no-params/here` ✅ | `/no-params/here` ✅ | `nil` ✅ | `nil` ✅ |

Fixes #3318.