### PR TITLE
Detect effective POSIX capabilities automatically

### DIFF
--- a/NmapOps.cc
+++ b/NmapOps.cc
@@ -225,7 +225,7 @@ void NmapOps::Initialize() {
   else if (getenv("NMAP_UNPRIVILEGED"))
     isr00t = 0;
   else
-    isr00t = !(geteuid());
+    isr00t = !(geteuid()) || have_net_capabilities();
 #endif
   have_pcap = true;
   debugging = 0;

--- a/configure.ac
+++ b/configure.ac
@@ -1119,6 +1119,49 @@ AC_SUBST(NCAT_UNINSTALL)
 AC_SUBST(NCAT_CLEAN)
 AC_SUBST(NCAT_DIST_CLEAN)
 
+
+AC_ARG_WITH([capabilities],
+  [AS_HELP_STRING([--with-capabilities=(libcap/libcap-ng/yes/no/auto)],
+                  [Detect POSIX capabilities (default=auto)])],
+  [with_caps=$withval],
+  [with_caps=auto])
+
+have_caps=no
+if test $have_caps = no && ( test "x$with_caps" = "xlibcap-ng" ||  test "x$with_caps" = "xyes"  || test "x$with_caps" = "xauto" ); then
+  AC_CHECK_HEADERS([cap-ng.h])
+  AC_SEARCH_LIBS([capng_get_caps_process], [cap-ng])
+  if test "x$ac_cv_header_cap_ng_h" = "xno" -o "x$ac_cv_search_capng_get_caps_process" = "xno"; then
+    if test "x$with_caps" = "xlibcap-ng"; then
+      AC_MSG_ERROR([libcap-ng support was requested but not found])
+    fi
+  else
+    have_caps=libcap-ng
+    AC_DEFINE([HAVE_CAPABILITIES_LIBCAP_NG], [1], [Use libcap-ng support for POSIX capabilities])
+  fi
+fi
+if test $have_caps = no && ( test "x$with_caps" = "xlibcap" ||  test "x$with_caps" = "xyes" || test "x$with_caps" = "xauto" ); then
+  AC_CHECK_HEADERS([sys/capability.h])
+  AC_SEARCH_LIBS([cap_get_proc], [cap])
+  if test "x$ac_cv_header_sys_capability_h" = "xno" -o "x$ac_cv_search_cap_get_proc" = "xno"; then
+    if test "x$with_caps" = "xlibcap"; then
+      AC_MSG_ERROR([libcap support was requested but not found])
+    fi
+  else
+    have_caps=libcap
+    AC_DEFINE([HAVE_CAPABILITIES_LIBCAP], [1], [Use libcap support for POSIX capabilities])
+  fi
+fi
+AC_MSG_CHECKING([for POSIX capabilities])
+AC_MSG_RESULT([$have_caps])
+if test $have_caps = no; then
+  AC_DEFINE([HAVE_CAPABILITIES], [0], [Whether to use POSIX capabilities])
+  if test "x$with_caps" = "xyes"; then
+    AC_MSG_ERROR([Support for POSIX capabilities was requested but not found])
+  fi
+else
+  AC_DEFINE([HAVE_CAPABILITIES], [1], [Whether to use POSIX capabilities])
+fi
+
 AC_OUTPUT(Makefile libnetutil/Makefile)
 
 # Krad ASCII ART#!#@$!@#$

--- a/libnetutil/netutil.cc
+++ b/libnetutil/netutil.cc
@@ -137,6 +137,12 @@ typedef unsigned __int8 u_int8_t;
 #include <sys/resource.h>
 #endif
 
+#if HAVE_CAPABILITIES_LIBCAP_NG
+#include <cap-ng.h>
+#elif HAVE_CAPABILITIES_LIBCAP
+#include <sys/capability.h>
+#endif
+
 #include <stddef.h>
 
 #define NBASE_MAX_ERR_STR_LEN 1024  /* Max length of an error message */
@@ -4945,3 +4951,24 @@ int get_max_open_descriptors() {
 int max_sd() {
   return set_max_open_descriptors(-1);
 }
+
+
+/* Indicates if this process has necessary POSIX-ish Linux capabilities
+   to perform privileged network operations. */
+int have_net_capabilities () {
+ #if HAVE_CAPABILITIES_LIBCAP_NG
+  return !capng_get_caps_process() && capng_have_capability(CAPNG_EFFECTIVE, CAP_NET_RAW);
+ #elif HAVE_CAPABILITIES_LIBCAP
+  const cap_t caps = cap_get_proc();
+  cap_flag_value_t val;
+  int result;
+  if (caps == NULL)
+    return 0;
+  result = !cap_get_flag(caps, CAP_NET_RAW, CAP_EFFECTIVE, &val) && val == CAP_SET;
+  cap_free(caps);
+  return result;
+ #else
+  return 0;
+ #endif
+}
+

--- a/libnetutil/netutil.h
+++ b/libnetutil/netutil.h
@@ -589,4 +589,8 @@ int get_max_open_descriptors();
    max allowed  */
 int max_sd();
 
+/* Indicates if this process has necessary POSIX-ish Linux capabilities
+   to perform privileged network operations. */
+int have_net_capabilities ();
+
 #endif /* _NETUTIL_H_ */

--- a/nping/NpingOps.cc
+++ b/nping/NpingOps.cc
@@ -138,7 +138,7 @@ NpingOps::NpingOps() {
   else if (getenv("NMAP_UNPRIVILEGED") || getenv("NPING_UNPRIVILEGED"))
     isr00t=false;
   else
-    isr00t = !(geteuid());
+    isr00t = !(geteuid()) || have_net_capabilities();
 #endif
 
     /* Payloads */

--- a/nping/configure.ac
+++ b/nping/configure.ac
@@ -554,6 +554,50 @@ dnl Checks for library functions.
 AC_CHECK_FUNCS(strerror)
 #RECVFROM_ARG6_TYPE
 
+
+AC_ARG_WITH([capabilities],
+  [AS_HELP_STRING([--with-capabilities=(libcap/libcap-ng/yes/no/auto)],
+                  [Detect POSIX capabilities (default=auto)])],
+  [with_caps=$withval],
+  [with_caps=auto])
+
+have_caps=no
+if test $have_caps = no && ( test "x$with_caps" = "xlibcap-ng" ||  test "x$with_caps" = "xyes"  || test "x$with_caps" = "xauto" ); then
+  AC_CHECK_HEADERS([cap-ng.h])
+  AC_SEARCH_LIBS([capng_get_caps_process], [cap-ng])
+  if test "x$ac_cv_header_cap_ng_h" = "xno" -o "x$ac_cv_search_capng_get_caps_process" = "xno"; then
+    if test "x$with_caps" = "xlibcap-ng"; then
+      AC_MSG_ERROR([libcap-ng support was requested but not found])
+    fi
+  else
+    have_caps=libcap-ng
+    AC_DEFINE([HAVE_CAPABILITIES_LIBCAP_NG], [1], [Use libcap-ng support for POSIX capabilities])
+  fi
+fi
+if test $have_caps = no && ( test "x$with_caps" = "xlibcap" ||  test "x$with_caps" = "xyes" || test "x$with_caps" = "xauto" ); then
+  AC_CHECK_HEADERS([sys/capability.h])
+  AC_SEARCH_LIBS([cap_get_proc], [cap])
+  if test "x$ac_cv_header_sys_capability_h" = "xno" -o "x$ac_cv_search_cap_get_proc" = "xno"; then
+    if test "x$with_caps" = "xlibcap"; then
+      AC_MSG_ERROR([libcap support was requested but not found])
+    fi
+  else
+    have_caps=libcap
+    AC_DEFINE([HAVE_CAPABILITIES_LIBCAP], [1], [Use libcap support for POSIX capabilities])
+  fi
+fi
+AC_MSG_CHECKING([for POSIX capabilities])
+AC_MSG_RESULT([$have_caps])
+if test $have_caps = no; then
+  AC_DEFINE([HAVE_CAPABILITIES], [0], [Whether to use POSIX capabilities])
+  if test "x$with_caps" = "xyes"; then
+    AC_MSG_ERROR([Support for POSIX capabilities was requested but not found])
+  fi
+else
+  AC_DEFINE([HAVE_CAPABILITIES], [1], [Whether to use POSIX capabilities])
+fi
+
+
 AC_OUTPUT(Makefile)
 # Some ASCII ART#!#@$!@#$
 if test -f docs/leet-nping-ascii-art.txt; then


### PR DESCRIPTION
This is an implementation alternative to @ali-keys' PR #3333. Both implementations have the same core objective:

>If a Linux non-privileged user currently wants to run Nmap or Nping with features traditionally requiring root privileges, like SYN scan, it is instead possible to assign these binaries specific POSIX-ish capabilities, including `CAP_NET_RAW`, to compensate for the privilege gap.
>
>However, Nmap and Nping do not make any effort to detect that these capabilities might have been granted. A privileged operation is rejected outright, even if it would succeed, whenever the user is not UID 0.
>
 >This limitation can be worked around by using command line option `--privileged` or environment variables `NMAP_PRIVILEGED` and `NPING_PRIVILEGED`. While this works, it is not very convenient. The code should check for the capabilities on its own.

The difference between the two implementations is largely philosophical:
* The original #3333 avoids using relevant library routines and instead parses `/proc/self/status` to read the capabilities. The undeniable benefit is that is that this approach does not introduce any additional linked library. The downside is that it relies on parsing a virtual text file largely intended for ad-hoc consumption, lacking formal standardization, and interpreting it with hard-coded constants.
* In contrast, this PR deems the benefit of simpler, streamlined code with long-term ABI guarantees worth the cost of an additional linked library. (When leveraging library `libcap-ng`, the code is effectively a one-liner.)

This PR adds a new `--with-capabilities` option to `configure`, accepting values as follows:
* `libcap`: Link with this library for evaluating capabilities. Fail the configuration if it is not available.
* `libcap-ng`: Link with this library for evaluating capabilities. Fail the configuration if it is not available.
* `yes`: Link with whichever of the two libraries is available, preferring `libcap-ng`. Fail the configuration if neither is available.
* `no`: Do not evaluate capabilities; do not link with any additional library. (This is the current behavior.)
* `auto`: Link with whichever of the two libraries is available. Revert to the current behavior otherwise.

The default value is `auto`.
