### PR TITLE
Modify rdp-ntlm-info usage to include -sV option

### DIFF
--- a/scripts/rdp-ntlm-info.nse
+++ b/scripts/rdp-ntlm-info.nse
@@ -17,7 +17,7 @@ information to include NetBIOS, DNS, and OS build version.
 
 ---
 -- @usage
--- nmap -p 3389 --script rdp-ntlm-info <target>
+-- nmap -p 3389 --script rdp-ntlm-info <target> -sV
 --
 -- @output
 -- 3389/tcp open     ms-wbt-server syn-ack ttl 128 Microsoft Terminal Services


### PR DESCRIPTION
Updated usage example to include -sV flag for version detection.

Reason

```
reelix@reelix-cachy  ~  sudo nmap -p 3222 --script=rdp-ntlm-info 88.99.241.111 -Pn
Starting Nmap 7.99 ( https://nmap.org ) at 2026-05-04 00:40 +0200
Nmap scan report for static.111.241.99.88.clients.your-server.de (88.99.241.111)
Host is up (0.20s latency).

PORT     STATE SERVICE
3222/tcp open  glbp

Nmap done: 1 IP address (1 host up) scanned in 0.27 seconds
reelix@reelix-cachy  ~  sudo nmap -p 3222 --script=rdp-ntlm-info 88.99.241.111 -sV -Pn
Starting Nmap 7.99 ( https://nmap.org ) at 2026-05-04 00:40 +0200
Nmap scan report for static.111.241.99.88.clients.your-server.de (88.99.241.111)
Host is up (0.20s latency).

PORT     STATE SERVICE       VERSION
3222/tcp open  ms-wbt-server Microsoft Terminal Services
| rdp-ntlm-info: 
|   Target_Name: WIN-63J1LTE6KJ8
|   NetBIOS_Domain_Name: WIN-63J1LTE6KJ8
|   NetBIOS_Computer_Name: WIN-63J1LTE6KJ8
|   DNS_Domain_Name: WIN-63J1LTE6KJ8
|   DNS_Computer_Name: WIN-63J1LTE6KJ8
|   Product_Version: 10.0.20348
|_  System_Time: 2026-05-03T22:40:56+00:00
Service Info: OS: Windows; CPE: cpe:/o:microsoft:windows

```