### PR TITLE
fix(nse): update http-google-malware to Safe Browsing API v4

### DIFF
--- a/docs/man-xlate/nmap-de.1
+++ b/docs/man-xlate/nmap-de.1
@@ -130,7 +130,7 @@ TARGET SPECIFICATION:
   \-\-excludefile <exclude_file>: Exclude list from file
 HOST DISCOVERY:
   \-sL: List Scan \- simply list targets to scan
-  \-sP: Ping Scan \- go no further than determining if host is online
+  \-sn: Ping Scan \- disable port scan
   \-PN: Treat all hosts as online \-\- skip host discovery
   \-PS/PA/PU[portlist]: TCP SYN/ACK or UDP discovery to given ports
   \-PE/PP/PM: ICMP echo, timestamp, and netmask request discovery probes
@@ -222,7 +222,7 @@ MISC:
   \-h: Print this help summary page\&.
 EXAMPLES:
   nmap \-v \-A scanme\&.nmap\&.org
-  nmap \-v \-sP 192\&.168\&.0\&.0/16 10\&.0\&.0\&.0/8
+  nmap \-v \-sn 192\&.168\&.0\&.0/16 10\&.0\&.0\&.0/8
   nmap \-v \-iR 10000 \-PN \-p 80
 SEE THE MAN PAGE (https://nmap\&.org/book/man\&.html) FOR MORE OPTIONS AND EXAMPLES
 .fi
@@ -313,9 +313,9 @@ bei Zielen in einem lokalen Ethernet\-Netzwerk standardmäßig erfolgt, selbst d
 \fB\-P*\fR\-Optionen angeben, weil sie fast immer schneller und effizienter ist\&.
 .PP
 Standardmäßig führt Nmap eine Host\-Erkennung und dann einen Port\-Scan auf jedem Host aus, den es als online erkennt\&. Das gilt auch dann, wenn Sie nicht standardmäßige Host\-Erkennungstypen wie UDP\-Testpakete (\fB\-PU\fR) angeben\&. Lesen Sie über die Option
-\fB\-sP\fR
+\fB\-sn\fR
 nach, um zu lernen, wie man nur eine Host\-Erkennung durchführt, oder über
-\fB\-PN\fR, um die Host\-Erkennung zu überspringen und einen Port\-Scan aller Zielhosts durchzuführen\&. Folgende Optionen steuern die Host\-Erkennung:
+\fB\-Pn\fR, um die Host\-Erkennung zu überspringen und einen Port\-Scan aller Zielhosts durchzuführen\&. Folgende Optionen steuern die Host\-Erkennung:
 .PP
 \fB\-sL\fR (List\-Scan)
 .RS 4
@@ -330,22 +330,27 @@ Da die Idee einfach die ist, eine Liste der Zielhosts auszugeben, lassen sich Op
 weiter\&.
 .RE
 .PP
-\fB\-sP\fR (Ping\-Scan)
+\fB\-sn\fR (Kein Port\-Scan)
 .RS 4
-Diese Option verlangt, dass Nmap nur einen Ping\-Scan (Host\-Erkennung) durchführt und dann die verfügbaren Hosts ausgibt, die auf den Scan geantwortet haben\&. Darüber hinaus werden keine weiteren Tests (z\&.B\&. Port\-Scans oder Betriebssystemerkennung) durchgeführt, außer bei Host\-Scripts mit der Nmap Scripting Engine und traceroute\-Tests, sofern Sie diese Optionen angegeben haben\&. Das ist eine Stufe aufdringlicher als ein List\-Scan und kann oft für dieselben Zwecke benutzt werden\&. Sie führt schnell eine schwache Aufklärung des Zielnetzwerks durch, ohne viel Aufmerksamkeit zu erregen\&. Für Angreifer ist es wertvoller, zu wissen, wie viele Hosts verfügbar sind, als die Liste aller IPs und Hostnamen aus einem List\-Scan zu kennen\&.
+Diese Option verlangt, dass Nmap nach der Host\-Erkennung keinen Port\-Scan durchführt und nur die verfügbaren Hosts ausgibt, die auf die Host\-Erkennungsprobes geantwortet haben\&. Dies wird oft als \(lqPing\-Scan\(rq bezeichnet, aber Sie können auch traceroute\-Tests und NSE\-Host\-Scripts anfordern\&. Das ist eine Stufe aufdringlicher als ein List\-Scan und kann oft für dieselben Zwecke benutzt werden\&. Sie führt schnell eine schwache Aufklärung des Zielnetzwerks durch, ohne viel Aufmerksamkeit zu erregen\&. Für Angreifer ist es wertvoller, zu wissen, wie viele Hosts verfügbar sind, als die Liste aller IPs und Hostnamen aus einem List\-Scan zu kennen\&.
 .sp
 Für Systemadministratoren ist diese Option oft ebenfalls wertvoll\&. Mit ihr kann man sehr leicht die verfügbaren Rechner in einem Netzwerk zählen oder die Server\-Verfügbarkeit überwachen\&. So etwas nennt man oft auch einen Ping\-Sweep, und es ist zuverlässiger als ein Pinging auf die Broadcast\-Adresse, weil viele Hosts auf Broadcast\-Anfragen nicht antworten\&.
 .sp
-Die Option
-\fB\-sP\fR
-sendet standardmäßig einen ICMP Echo\-Request und ein TCP\-ACK\-Paket an Port 80\&. Bei Ausführung ohne Sonderrechte wird nur ein SYN\-Paket (mit einem
-\fBconnect\fR\-Aufruf) an Port 80 an das Ziel gesendet\&. Wenn ein Benutzer mit Sonderrechten versucht, Ziele in einem lokalen Ethernet\-Netzwerk zu scannen, werden ARP\-Requests verwendet, es sei denn, die Option
+Die standardmäßige Host\-Erkennung mit
+\fB\-sn\fR
+besteht aus einem ICMP Echo\-Request, einem TCP\-SYN\-Paket an Port 443, einem TCP\-ACK\-Paket an Port 80 und einem ICMP\-Zeitstempel\-Request\&. Bei Ausführung ohne Sonderrechte werden nur SYN\-Pakete (mit einem
+\fBconnect\fR\-Aufruf) an Port 80 und 443 an das Ziel gesendet\&. Wenn ein Benutzer mit Sonderrechten versucht, Ziele in einem lokalen Ethernet\-Netzwerk zu scannen, werden ARP\-Requests verwendet, es sei denn, die Option
 \fB\-\-send\-ip\fR
 wird angegeben\&. Die Option
-\fB\-sP\fR
+\fB\-sn\fR
 kann mit allen Erkennungsmethoden (die Optionen
-\fB\-P*\fR, außer
-\fB\-PN\fR) kombiniert werden, um eine höhere Flexibilität zu erhalten\&. Falls zwischen dem Ausgangs\-Host, auf dem Nmap läuft, und dem Zielnetzwerk strenge Firewalls installiert sind, empfehlen sich diese fortgeschrittenen Methoden\&. Ansonsten könnten Hosts übersehen werden, wenn die Firewall Testanfragen oder Antworten darauf verwirft
+\fB\-P*\fR) kombiniert werden, um eine höhere Flexibilität zu erhalten\&. Falls zwischen dem Ausgangs\-Host, auf dem Nmap läuft, und dem Zielnetzwerk strenge Firewalls installiert sind, empfehlen sich diese fortgeschrittenen Methoden\&. Ansonsten könnten Hosts übersehen werden, wenn die Firewall Testanfragen oder Antworten darauf verwirft\&.
+.sp
+In früheren Versionen von Nmap war
+\fB\-sn\fR
+als
+\fB\-sP\fR
+bekannt\&.
 .RE
 .PP
 \fB\-PN\fR (Ping abschalten)
@@ -1160,7 +1165,7 @@ eine maximale Gruppengröße angegeben wird, wird Nmap diese nie überschreiten\
 \fB\-\-min\-hostgroup\fR
 eine minimale Größe angeben, versucht Nmap, die Gruppengröße oberhalb dieses Wertes zu belassen\&. Falls es auf einer gegebenen Schnittstelle nicht genug Zielhosts gibt, um dieses Minimum zu erfüllen, muss Nmap einen kleineren Wert benutzen\&. Es können auch beide gesetzt werden, um die Gruppengröße in einem bestimmten Bereich zu belassen, aber das ist selten gewünscht\&.
 .sp
-Diese Optionen haben während der Host\-Entdeckungsphase eines Scans keinen Effekt\&. Dazu gehören einfache Ping\-Scans (\fB\-sP\fR)\&. Die Host\-Entdeckung funktioniert immer in großen Gruppen von Hosts, um die Geschwindigkeit und Genauigkeit zu verbessern\&.
+Diese Optionen haben während der Host\-Entdeckungsphase eines Scans keinen Effekt\&. Dazu gehören einfache Ping\-Scans (\fB\-sn\fR)\&. Die Host\-Entdeckung funktioniert immer in großen Gruppen von Hosts, um die Geschwindigkeit und Genauigkeit zu verbessern\&.
 .sp
 Der Hauptnutzen dieser Optionen liegt darin, eine hohe minimale Gruppengröße anzugeben, damit der gesamte Scan schneller läuft\&. Häufig wird 256 gewählt, um ein Netzwerk in Brocken der Größe von Klasse C zu scannen\&. Bei einem Scan mit vielen Ports bringt eine größere Zahl vermutlich keine Vorteile\&. Bei Scans über nur wenige Ports können Gruppengrößen von 2048 oder mehr hilfreich sein\&.
 .RE

--- a/docs/man-xlate/nmap-man-de.xml
+++ b/docs/man-xlate/nmap-man-de.xml
@@ -161,7 +161,7 @@ TARGET SPECIFICATION:
   --excludefile &lt;exclude_file&gt;: Exclude list from file
 HOST DISCOVERY:
   -sL: List Scan - simply list targets to scan
-  -sP: Ping Scan - go no further than determining if host is online
+  -sn: Ping Scan - disable port scan
   -PN: Treat all hosts as online -- skip host discovery
   -PS/PA/PU[portlist]: TCP SYN/ACK or UDP discovery to given ports
   -PE/PP/PM: ICMP echo, timestamp, and netmask request discovery probes
@@ -253,7 +253,7 @@ MISC:
   -h: Print this help summary page.
 EXAMPLES:
   nmap -v -A scanme.nmap.org
-  nmap -v -sP 192.168.0.0/16 10.0.0.0/8
+  nmap -v -sn 192.168.0.0/16 10.0.0.0/8
   nmap -v -iR 10000 -PN -p 80
 SEE THE MAN PAGE (https://nmap.org/book/man.html) FOR MORE OPTIONS AND EXAMPLES
 </literallayout>
@@ -479,8 +479,8 @@ weil sie fast immer schneller und effizienter ist.</para>
 Port-Scan auf jedem Host aus, den es als online erkennt. Das gilt auch 
 dann, wenn Sie nicht standardmäßige Host-Erkennungstypen wie UDP-Testpakete 
 (<option>-PU</option>) angeben. Lesen Sie über die Option 
-<option>-sP</option> nach, um zu lernen, wie man nur eine Host-Erkennung 
-durchführt, oder über <option>-PN</option>, um die Host-Erkennung zu 
+<option>-sn</option> nach, um zu lernen, wie man nur eine Host-Erkennung 
+durchführt, oder über <option>-Pn</option>, um die Host-Erkennung zu 
 überspringen und einen Port-Scan aller Zielhosts durchzuführen. Folgende 
 Optionen steuern die Host-Erkennung:</para>
 
@@ -519,46 +519,47 @@ Funktionalität durchführen möchten, lesen Sie bei der Option
 
 <varlistentry>
 <term>
-<option>-sP</option> (Ping-Scan)
-<indexterm><primary><option>-sP</option></primary></indexterm>
+<option>-sn</option> (Kein Port-Scan)
+<indexterm><primary><option>-sn</option></primary></indexterm>
 <indexterm><primary>Ping-Scan</primary></indexterm>
 </term>
 <listitem>
-<para>Diese Option verlangt, dass Nmap nur einen Ping-Scan 
-(Host-Erkennung) durchführt und dann die verfügbaren Hosts 
-ausgibt, die auf den Scan geantwortet haben. 
-Darüber hinaus werden keine weiteren Tests (z.B. 
-Port-Scans oder Betriebssystemerkennung) durchgeführt, außer bei 
-Host-Scripts mit der Nmap Scripting Engine und traceroute-Tests, 
-sofern Sie diese Optionen angegeben haben. 
-Das ist eine Stufe aufdringlicher als ein List-Scan 
-und kann oft für dieselben Zwecke benutzt werden. Sie führt schnell eine 
-schwache Aufklärung des Zielnetzwerks durch, ohne viel Aufmerksamkeit zu 
-erregen. Für Angreifer ist es wertvoller, zu wissen, wie viele Hosts 
-verfügbar sind, als die Liste aller IPs und Hostnamen aus einem 
+<para>Diese Option verlangt, dass Nmap nach der Host-Erkennung keinen
+Port-Scan durchführt und nur die verfügbaren Hosts ausgibt,
+die auf die Host-Erkennungsprobes geantwortet haben.
+Dies wird oft als „Ping-Scan" bezeichnet, aber Sie können auch
+traceroute-Tests und NSE-Host-Scripts anfordern.
+Das ist eine Stufe aufdringlicher als ein List-Scan
+und kann oft für dieselben Zwecke benutzt werden. Sie führt schnell eine
+schwache Aufklärung des Zielnetzwerks durch, ohne viel Aufmerksamkeit zu
+erregen. Für Angreifer ist es wertvoller, zu wissen, wie viele Hosts
+verfügbar sind, als die Liste aller IPs und Hostnamen aus einem
 List-Scan zu kennen.</para>
 
-<para>Für Systemadministratoren ist diese Option oft ebenfalls wertvoll. 
-Mit ihr kann man sehr leicht die verfügbaren Rechner in einem Netzwerk 
-zählen oder die Server-Verfügbarkeit überwachen. So etwas nennt man oft auch 
-einen Ping-Sweep, und es ist zuverlässiger als ein Pinging auf die 
-Broadcast-Adresse, weil viele Hosts auf Broadcast-Anfragen nicht 
+<para>Für Systemadministratoren ist diese Option oft ebenfalls wertvoll.
+Mit ihr kann man sehr leicht die verfügbaren Rechner in einem Netzwerk
+zählen oder die Server-Verfügbarkeit überwachen. So etwas nennt man oft auch
+einen Ping-Sweep, und es ist zuverlässiger als ein Pinging auf die
+Broadcast-Adresse, weil viele Hosts auf Broadcast-Anfragen nicht
 antworten.</para>
 
-<para>Die Option <option>-sP</option> sendet standardmäßig einen 
-ICMP Echo-Request und ein TCP-ACK-Paket an Port 80. Bei Ausführung 
-ohne Sonderrechte wird nur ein SYN-Paket (mit einem 
-<function>connect</function>-Aufruf) an Port 80 an das Ziel gesendet. 
-Wenn ein Benutzer mit Sonderrechten versucht, Ziele in einem lokalen 
-Ethernet-Netzwerk zu scannen, werden ARP-Requests verwendet, es sei 
+<para>Die standardmäßige Host-Erkennung mit <option>-sn</option> besteht
+aus einem ICMP Echo-Request, einem TCP-SYN-Paket an Port 443, einem
+TCP-ACK-Paket an Port 80 und einem ICMP-Zeitstempel-Request. Bei Ausführung
+ohne Sonderrechte werden nur SYN-Pakete (mit einem
+<function>connect</function>-Aufruf) an Port 80 und 443 an das Ziel gesendet.
+Wenn ein Benutzer mit Sonderrechten versucht, Ziele in einem lokalen
+Ethernet-Netzwerk zu scannen, werden ARP-Requests verwendet, es sei
 denn, die Option <option>--send-ip</option> wird angegeben.
-Die Option <option>-sP</option> kann mit allen Erkennungsmethoden 
-(die Optionen <option>-P*</option>, außer <option>-PN</option>) 
-kombiniert werden, um eine höhere Flexibilität zu erhalten.
-Falls zwischen dem Ausgangs-Host, auf dem Nmap läuft, und dem Zielnetzwerk 
-strenge Firewalls installiert sind, empfehlen sich diese fortgeschrittenen 
-Methoden. Ansonsten könnten Hosts übersehen werden, wenn die Firewall 
-Testanfragen oder Antworten darauf verwirft</para>
+Die Option <option>-sn</option> kann mit allen Erkennungsmethoden
+(die Optionen <option>-P*</option>) kombiniert werden, um eine höhere
+Flexibilität zu erhalten. Falls zwischen dem Ausgangs-Host, auf dem Nmap
+läuft, und dem Zielnetzwerk strenge Firewalls installiert sind, empfehlen
+sich diese fortgeschrittenen Methoden. Ansonsten könnten Hosts übersehen
+werden, wenn die Firewall Testanfragen oder Antworten darauf verwirft.</para>
+
+<para>In früheren Versionen von Nmap war <option>-sn</option> als
+<option>-sP</option> bekannt.</para>
 
 </listitem>
 </varlistentry>
@@ -2411,7 +2412,7 @@ auch beide gesetzt werden, um die Gruppengröße in einem bestimmten
 Bereich zu belassen, aber das ist selten gewünscht.</para>
 
 <para>Diese Optionen haben während der Host-Entdeckungsphase eines Scans 
-keinen Effekt. Dazu gehören einfache Ping-Scans (<option>-sP</option>). 
+keinen Effekt. Dazu gehören einfache Ping-Scans (<option>-sn</option>). 
 Die Host-Entdeckung funktioniert immer in großen Gruppen von Hosts, 
 um die Geschwindigkeit und Genauigkeit zu verbessern.</para>
 

--- a/scripts/http-google-malware.nse
+++ b/scripts/http-google-malware.nse
@@ -1,4 +1,5 @@
 local http = require "http"
+local json = require "json"
 local nmap = require "nmap"
 local shortport = require "shortport"
 local stdnse = require "stdnse"
@@ -6,38 +7,33 @@ local string = require "string"
 local table = require "table"
 
 description = [[
-Checks if hosts are on Google's blacklist of suspected malware and phishing
-servers. These lists are constantly updated and are part of Google's Safe
-Browsing service.
+Checks if hosts are on Google's blacklist of suspected malware, phishing,
+and unwanted software. These lists are constantly updated and are part of
+Google's Safe Browsing service.
 
-To do this the script queries the Google's Safe Browsing service and you need
-to have your own API key to access Google's Safe Browsing Lookup services. Sign
-up for yours at http://code.google.com/apis/safebrowsing/key_signup.html
+To use this script you need a Google API key with the Safe Browsing API v4
+enabled. Get yours at https://developers.google.com/safe-browsing/v4/get-started
 
-* To learn more about Google's Safe Browsing:
-http://code.google.com/apis/safebrowsing/
-
-* To register and get your personal API key:
-http://code.google.com/apis/safebrowsing/key_signup.html
+* Safe Browsing API v4 documentation:
+  https://developers.google.com/safe-browsing/v4/lookup-api
 ]]
 
 ---
 -- @usage
--- nmap -p80 --script http-google-malware <host>
+-- nmap -p80 --script http-google-malware --script-args http-google-malware.api=<API_KEY> <target>
 --
 -- @output
 -- PORT   STATE SERVICE
 -- 80/tcp open  http
--- |_http-google-malware.nse: Host is known for distributing malware.
+-- |_http-google-malware: Host is known for distributing malware.
 --
 -- @args http-google-malware.url URL to check. Default: <code>http/https</code>://<code>host</code>
--- @args http-google-malware.api API key for Google's Safe Browsing Lookup service
+-- @args http-google-malware.api Google Safe Browsing API v4 key
 ---
 
 author = "Paulino Calderon <calderon@websec.mx>"
 license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 categories = {"malware", "discovery", "safe", "external"}
-
 
 portrule = shortport.http
 
@@ -47,60 +43,107 @@ portrule = shortport.http
 local APIKEY = ""
 ---#########################
 
---Builds Google Safe Browsing query
---@param apikey Api key
---@return Url
-local function build_qry(apikey, url)
-  return string.format("https://sb-ssl.google.com/safebrowsing/api/lookup?client=%s&apikey=%s&appver=1.5.2&pver=3.0&url=%s", SCRIPT_NAME, apikey, url)
+local API_HOST = "safebrowsing.googleapis.com"
+local API_PORT = {number = 443, service = "https", protocol = "tcp"}
+local API_PATH = "/v4/threatMatches:find"
+
+-- Builds the JSON POST body for the Safe Browsing v4 Lookup API.
+local function build_request_body(target_url)
+  return json.generate({
+    client = {
+      clientId = SCRIPT_NAME,
+      clientVersion = "1.0"
+    },
+    threatInfo = {
+      threatTypes      = {"MALWARE", "SOCIAL_ENGINEERING", "UNWANTED_SOFTWARE"},
+      platformTypes    = {"ANY_PLATFORM"},
+      threatEntryTypes = {"URL"},
+      threatEntries    = {{url = target_url}}
+    }
+  })
 end
 
-local function fail (err) return stdnse.format_output(false, err) end
+local function fail(err)
+  return stdnse.format_output(false, err)
+end
 
 ---
---MAIN
+-- MAIN
 ---
 action = function(host, port)
   local apikey = stdnse.get_script_args("http-google-malware.api") or APIKEY
   local malware_found = false
-  local target
   local output_lns = {}
 
-  --Use the host IP if a hostname isn't available
-  if not(host.targetname) then
+  local target
+  if not host.targetname then
     target = host.ip
   else
     target = host.targetname
   end
 
-  local target_url = stdnse.get_script_args("http-google-malware.url") or string.format("%s://%s", port.service, target)
+  local target_url = stdnse.get_script_args("http-google-malware.url")
+    or string.format("%s://%s", port.service, target)
 
-  if string.len(apikey) < 25 then
+  if #apikey < 25 then
     return fail(("No API key found. Use the %s.api argument"):format(SCRIPT_NAME))
   end
 
-  stdnse.debug1("Checking host %s", target_url)
-  local qry = build_qry(apikey, target_url)
-  local req = http.get_url(qry, {any_af=true})
-  stdnse.debug2("%s", qry)
+  stdnse.debug1("Checking URL: %s", target_url)
 
-  if ( req.status > 400 ) then
-    return fail("Request failed (invalid API key?)")
+  local body = build_request_body(target_url)
+  local path = API_PATH .. "?key=" .. apikey
+
+  stdnse.debug2("POST https://%s%s", API_HOST, API_PATH)
+  stdnse.debug2("Payload: %s", body)
+
+  local response = http.post(API_HOST, API_PORT, path,
+    {scheme = "https", header = {["Content-Type"] = "application/json"}, any_af = true},
+    nil, body)
+
+  if not response then
+    return fail("HTTP request failed (no response)")
   end
 
-  --The Safe Lookup API responds with a type when site is on the lists
-  if req.body then
-    if http.response_contains(req, "malware") then
-      output_lns[#output_lns+1] = "Host is known for distributing malware."
-      malware_found = true
-    end
-    if http.response_contains(req, "phishing") then
-      output_lns[#output_lns+1] = "Host is known for being used in phishing attacks."
-      malware_found = true
-    end
+  if response.status and response.status >= 400 then
+    return fail(("Request failed with status %d (invalid API key?)"):format(response.status))
   end
-  --For the verbose lovers
-  if req.status == 204 and nmap.verbosity() >= 2 and not(malware_found) then
-    output_lns[#output_lns+1] = "Host is safe to browse."
+
+  -- An empty body or bare "{}" means no threats found.
+  if not response.body or response.body:match("^%s*{%s*}%s*$") or #response.body == 0 then
+    if nmap.verbosity() >= 2 then
+      output_lns[#output_lns + 1] = "Host is safe to browse."
+    end
+  else
+    local ok, parsed = json.parse(response.body)
+    if not ok or type(parsed) ~= "table" then
+      stdnse.debug1("Failed to parse API response: %s", response.body)
+      return fail("Failed to parse API response")
+    end
+
+    if parsed.matches then
+      local seen = {}
+      for _, match in ipairs(parsed.matches) do
+        local threat = match.threatType
+        if threat and not seen[threat] then
+          seen[threat] = true
+          if threat == "MALWARE" then
+            output_lns[#output_lns + 1] = "Host is known for distributing malware."
+            malware_found = true
+          elseif threat == "SOCIAL_ENGINEERING" then
+            output_lns[#output_lns + 1] = "Host is known for being used in phishing attacks."
+            malware_found = true
+          elseif threat == "UNWANTED_SOFTWARE" then
+            output_lns[#output_lns + 1] = "Host is known for distributing unwanted software."
+            malware_found = true
+          end
+        end
+      end
+    end
+
+    if nmap.verbosity() >= 2 and not malware_found then
+      output_lns[#output_lns + 1] = "Host is safe to browse."
+    end
   end
 
   if #output_lns > 0 then


### PR DESCRIPTION
## Summary

Fixes #1474. Google deprecated the Safe Browsing v3 API endpoint (`sb-ssl.google.com/safebrowsing/api/lookup`). This updates the script to use the v4 Lookup API.

Note: PR #3128 attempted a similar fix but has a broken `http.generic_request` call (passes a single table instead of the required `host, port, method, path, options` arguments), used `platformTypes = {"WINDOWS"}` instead of `{"ANY_PLATFORM"}`, omitted the API key from the request path, and detected threats by string-searching the response body (which can false-positive since the request body also contains the threat type strings).

## Changes

- Switch from GET to POST with a JSON body (required by v4 API)
- Use `http.post(host, port, path, options, nil, body)` with the correct signature
- Set `platformTypes` to `ANY_PLATFORM` for full coverage
- Add `UNWANTED_SOFTWARE` threat type alongside `MALWARE` and `SOCIAL_ENGINEERING`
- Parse the JSON response with `json.parse()` instead of string-matching the body
- Deduplicate matched threat types in output
- Detect the "safe" case via empty/`{}` body instead of HTTP 204 (v4 returns 200 with empty body)
- Update documentation URLs from deprecated `code.google.com` to `developers.google.com`

## Verification

With a valid API key:

```bash
# Should report malware (Google's test URL for Safe Browsing)
nmap -p80 --script http-google-malware \
  --script-args "http-google-malware.api=<KEY>,http-google-malware.url=http://malware.testing.google.test/testing/malware/" \
  scanme.nmap.org

# Expected output:
# |_http-google-malware: Host is known for distributing malware.

# Clean host should produce no output (or "safe to browse" at -v2)
nmap -p80 --script http-google-malware \
  --script-args "http-google-malware.api=<KEY>" \
  scanme.nmap.org
```

Google provides `http://malware.testing.google.test/testing/malware/` as a permanent test URL that always returns a MALWARE match.