### PR TITLE
service_scan: increase probe file line buffer and add truncation error

### DIFF
--- a/service_scan.cc
+++ b/service_scan.cc
@@ -1327,7 +1327,7 @@ void parse_nmap_service_probe_file(AllProbes *AP, const char *filename) {
     lineno++;
     size_t linelen = strnlen(line, sizeof(line));
     if (linelen == sizeof(line) - 1 && line[linelen - 1] != '\n' && !feof(fp))
-      fatal("Line %d of %s is too long (limit is %d characters)", lineno, filename, (int)(sizeof(line) - 2));
+      fatal("Line %d of %s is too long (limit is %d characters)", lineno, filename, (int)(sizeof(line) - 1));
 
     if (*line == '\n' || *line == '#')
       continue;

--- a/service_scan.cc
+++ b/service_scan.cc
@@ -1314,7 +1314,7 @@ void ServiceProbe::addMatch(const char *match, int lineno) {
    (servicematch) which use this */
 void parse_nmap_service_probe_file(AllProbes *AP, const char *filename) {
   ServiceProbe *newProbe = NULL;
-  char line[2048];
+  char line[16384];
   int lineno = 0;
   FILE *fp;
 
@@ -1325,6 +1325,9 @@ void parse_nmap_service_probe_file(AllProbes *AP, const char *filename) {
 
   while(fgets(line, sizeof(line), fp)) {
     lineno++;
+    size_t linelen = strnlen(line, sizeof(line));
+    if (linelen == sizeof(line) - 1 && line[linelen - 1] != '\n' && !feof(fp))
+      fatal("Line %d of %s is too long (limit is %d characters)", lineno, filename, (int)(sizeof(line) - 2));
 
     if (*line == '\n' || *line == '#')
       continue;


### PR DESCRIPTION
The line buffer in parse_nmap_service_probe_file() is 2048 bytes. fgets() silently truncates anything longer without any indication that data was lost. When this happens with a Probe line, the rest of the token is read as the next line and triggers a fatal "unexpected Probe token" error -- not very helpful for figuring out what went wrong.

This came up with the QUIC UDP probe, which is longer than 2047 bytes. Instead of a clear "this line is too long" message you just get a confusing parse failure.

The fix bumps the buffer to 16 KB (plenty of headroom for any realistic probe definition) and adds a check right after fgets() that detects when the buffer was filled without reaching a newline. If that happens while not at EOF, it's a definitive truncation and we emit a fatal error with the line number and the actual limit, making future overflows obvious instead of silent.

Fixes #3201