### PR TITLE
docs(ndiff): document using Ndiff as a Python XML-parsing module

### DIFF
--- a/ndiff/docs/ndiff.1
+++ b/ndiff/docs/ndiff.1
@@ -371,6 +371,67 @@ If the script is saved as
 .RE
 .\}
 .sp
+.SH "USING NDIFF AS A PYTHON MODULE"
+.PP
+Since version 6\&.45, Ndiff installs as a Python module named ndiff in addition to the command\-line program\&. The module can be used as a standalone parser for Nmap\*(Aqs XML output (the \fB\-oX\fR format), independent of the diffing functionality, which makes it a convenient way to process scan results from Python\&.
+.PP
+The \fIScan\fR class represents a single Nmap run\&. Load a scan from an XML file with \fIload_from_file\fR (or from any file\-like object with \fIload\fR), then inspect the parsed objects:
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+A \fIScan\fR has a list of \fIhosts\fR, along with \fIscanner\fR, \fIversion\fR, \fIargs\fR, \fIstart_date\fR, and \fIend_date\fR\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+A \fIHost\fR has a \fIstate\fR, a list of \fIaddresses\fR, a list of \fIhostnames\fR, and a \fIports\fR dictionary mapping each (number, protocol) spec to a \fIPort\fR\&. The \fIformat_name\fR method returns a human\-readable label for the host\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+A \fIPort\fR has a \fIspec\fR, a \fIstate\fR, and a \fIservice\fR; the \fIspec_string\fR and \fIstate_string\fR helpers format these for display\&.
+.RE
+.PP
+\fBExample\ \&4.\ \&Parsing Nmap XML with the ndiff module\fR
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+import ndiff
+
+scan = ndiff.Scan()
+scan.load_from_file("scan.xml")
+
+for host in scan.hosts:
+    print(host.format_name(), host.state)
+    for spec, port in sorted(host.ports.items()):
+        print(" ", port.spec_string(), port.state_string(), port.service.name)
+.fi
+.if n \{\
+.RE
+.\}
+.PP
+This interface is shared with Ndiff\*(Aqs own diffing code and has not been formally declared a stable API, so it may change between releases\&.
+.sp
 .SH "EXIT CODE"
 .PP
 The exit code indicates whether the scans are equal\&.

--- a/ndiff/docs/ndiff.xml
+++ b/ndiff/docs/ndiff.xml
@@ -354,6 +354,62 @@ ln -sf scan-$date.xml scan-prev.xml
     </para>
   </refsect1>
 
+  <refsect1 id="ndiff-man-python">
+    <title>Using Ndiff as a Python Module</title>
+
+    <para>
+    Since version 6.45, Ndiff installs as a Python module named
+    <literal>ndiff</literal> in addition to the command-line program. The
+    module can be used as a standalone parser for Nmap's XML output (the
+    <option>-oX</option> format), independent of the diffing functionality,
+    which makes it a convenient way to process scan results from Python.
+    </para>
+
+    <para>
+    The <classname>Scan</classname> class represents a single Nmap run. Load a
+    scan from an XML file with <function>load_from_file</function> (or from any
+    file-like object with <function>load</function>), then inspect the parsed
+    objects:
+    <itemizedlist spacing="compact">
+      <listitem><para>A <classname>Scan</classname> has a list of
+      <varname>hosts</varname>, along with <varname>scanner</varname>,
+      <varname>version</varname>, <varname>args</varname>,
+      <varname>start_date</varname>, and <varname>end_date</varname>.</para></listitem>
+      <listitem><para>A <classname>Host</classname> has a
+      <varname>state</varname>, a list of <varname>addresses</varname>, a list
+      of <varname>hostnames</varname>, and a <varname>ports</varname> dictionary
+      mapping each <literal>(number, protocol)</literal> spec to a
+      <classname>Port</classname>. The <function>format_name</function> method
+      returns a human-readable label for the host.</para></listitem>
+      <listitem><para>A <classname>Port</classname> has a
+      <varname>spec</varname>, a <varname>state</varname>, and a
+      <varname>service</varname>; the <function>spec_string</function> and
+      <function>state_string</function> helpers format these for
+      display.</para></listitem>
+    </itemizedlist>
+    </para>
+
+    <example id="ndiff-man-ex-python">
+      <title>Parsing Nmap XML with the ndiff module</title>
+<programlisting>
+import ndiff
+
+scan = ndiff.Scan()
+scan.load_from_file("scan.xml")
+
+for host in scan.hosts:
+    print(host.format_name(), host.state)
+    for spec, port in sorted(host.ports.items()):
+        print(" ", port.spec_string(), port.state_string(), port.service.name)
+</programlisting>
+    </example>
+
+    <para>
+    This interface is shared with Ndiff's own diffing code and has not been
+    formally declared a stable API, so it may change between releases.
+    </para>
+  </refsect1>
+
   <refsect1 id="ndiff-man-exit-code">
     <title>Exit Code</title>
 


### PR DESCRIPTION
Addresses #91.

## Summary

Since version 6.45, Ndiff installs as an importable Python module (`import ndiff`), which makes it usable as a standalone parser for Nmap's XML output (`-oX`). As #91 notes, the documentation was never updated to mention this, so users do not know the capability exists. This adds a **"Using Ndiff as a Python Module"** section to the Ndiff manual.

I am submitting this small docs addition directly as a PR (rather than a separate claim comment on the 2015 issue); happy to adjust placement or wording if a maintainer prefers it elsewhere.

## Changes

- `ndiff/docs/ndiff.xml` — new `<refsect1 id="ndiff-man-python">` section: describes the `Scan` / `Host` / `Port` parsing API and includes a worked example.
- `ndiff/docs/ndiff.1` — the equivalent hand-written troff for the same section, to keep the committed man page in sync with the DocBook source.

The section is placed after "Periodic Diffs" so the new example is purely additive (Example 4) and no existing example numbering shifts.

## Documented API (only the surface that was actually exercised)

```python
import ndiff

scan = ndiff.Scan()
scan.load_from_file("scan.xml")

for host in scan.hosts:
    print(host.format_name(), host.state)
    for spec, port in sorted(host.ports.items()):
        print(" ", port.spec_string(), port.state_string(), port.service.name)
```

## Verification

- Ran the documented snippet verbatim against a bundled `test-scans/*.xml`; it parses and prints hosts/ports as shown.
- `ndiff/docs/ndiff.xml` validates as well-formed XML.
- `nroff -man ndiff/docs/ndiff.1` renders with no errors; the new section formats correctly (bold heading/option, italic identifiers, bulleted attribute list, indented code block).
- Diff is additive only (117 insertions, 0 deletions); no man-page header/date/generator lines were touched.