### PR TITLE
Fix url.parse_query: Lua error on every call, plus incomplete HTML decoding (#3324)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -92,6 +92,10 @@ o [NSE] Fixed url.parse_query, which raised a Lua error on every call due to
   passing the query string as the gsub pattern. Plus-to-space decoding is
   restored.
 
+o [NSE][GH#3324] url.parse_query no longer performs incomplete HTML entity
+  decoding (&amp; &lt; &gt;) that could mis-split query strings. Callers that
+  need HTML decoding should do it explicitly.
+
 o [Ncat][GH#3005] Correctly report listening port number. `ncat -l -p 0` will
   cause Ncat to listen on an ephemeral port, but it was reporting itself as
   listening on port 0.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -88,6 +88,10 @@ o Fixed an issue where Nmap OS scan trusts a packet's ip_len to size a CRC32
   computation over TCP RST payload data, which may result in reading arbitrary
   heap data. Reported by Michael Bommarito.
 
+o [NSE] Fixed url.parse_query, which raised a Lua error on every call due to
+  passing the query string as the gsub pattern. Plus-to-space decoding is
+  restored.
+
 o [Ncat][GH#3005] Correctly report listening port number. `ncat -l -p 0` will
   cause Ncat to listen on an ephemeral port, but it was reporting itself as
   listening on port 0.

--- a/nselib/url.lua
+++ b/nselib/url.lua
@@ -379,7 +379,7 @@ function parse_query(query)
   query = string.gsub(query, "&([ampltg]+);", entities)
 
   local parsed = {}
-  for qseg in query:gsub(query, "%+", " "):gmatch("[^&]+") do
+  for qseg in query:gsub("%+", " "):gmatch("[^&]+") do
     local k, v = qseg:match("^([^=]*)=?(.*)")
     parsed[unescape(k)] = unescape(v)
   end
@@ -510,6 +510,21 @@ for _, t in ipairs(test_urls) do
   end
   test_suite:add_test(unittest.equal(build(t._res), t._url), "build test url")
   test_suite:add_test(unittest.equal(build(result), t._url), "parse/build round trip")
+end
+
+-- parse_query tests. {query, expected name/value table}
+local parse_query_tests = {
+                           {"foo=1&bar=2", {foo = "1", bar = "2"}},
+                           {"a+b=c+d",     {["a b"] = "c d"}},
+                           {"a%20b=c%26d", {["a b"] = "c&d"}},
+                          }
+for k, v in ipairs(parse_query_tests) do
+  local query, expected = table.unpack(v)
+  local result = parse_query(query)
+  for name, value in pairs(expected) do
+    test_suite:add_test(unittest.equal(result[name], value),
+                        ("parse_query #%d (%q) %q"):format(k, query, name))
+  end
 end
 
 

--- a/nselib/url.lua
+++ b/nselib/url.lua
@@ -354,11 +354,6 @@ function build_path(parsed, unsafe)
   return table.concat(path)
 end
 
-local entities = {
-  ["amp"] = "&",
-  ["lt"] = "<",
-  ["gt"] = ">"
-}
 ---
 -- Breaks a query string into name/value pairs.
 --
@@ -372,12 +367,6 @@ local entities = {
 -- <code>table["name"]</code> = <code>value</code>.
 -----------------------------------------------------------------------------
 function parse_query(query)
-
-  -- TODO: https://github.com/nmap/nmap/issues/3324
-  --       This opportunistic HTML decoding is problematic because
-  --       it might accidentally decode what should not be decoded.
-  query = string.gsub(query, "&([ampltg]+);", entities)
-
   local parsed = {}
   for qseg in query:gsub("%+", " "):gmatch("[^&]+") do
     local k, v = qseg:match("^([^=]*)=?(.*)")
@@ -517,6 +506,8 @@ local parse_query_tests = {
                            {"foo=1&bar=2", {foo = "1", bar = "2"}},
                            {"a+b=c+d",     {["a b"] = "c d"}},
                            {"a%20b=c%26d", {["a b"] = "c&d"}},
+                           -- names/values must not be HTML-entity-decoded (#3324)
+                           {"kt;=11&lt;=22", {["kt;"] = "11", ["lt;"] = "22"}},
                           }
 for k, v in ipairs(parse_query_tests) do
   local query, expected = table.unpack(v)


### PR DESCRIPTION
## Summary

`nselib/url.parse_query` currently has two bugs on adjacent lines:

1. **It raises a Lua error on every call (regression).** Commit `9371dd1c6` ("Simplify url.parse_query") inlined the plus-to-space decode as `query:gsub(query, "%+", " ")`, which passes the *query string* as the gsub **pattern** and `" "` as the **count** argument. Under the bundled Lua 5.4 this raises `bad argument #3 to 'gsub' (number expected, got string)` for any input, so `parse_query` is unusable. Every caller is affected: `http-open-redirect`, `http-sql-injection`, `http-rfi-spider`, `http-unsafe-output-escaping`.

2. **Incomplete HTML entity decoding (#3324).** Before parsing, the query was run through `string.gsub(query, "&([ampltg]+);", entities)`, decoding only `&amp;`, `&lt;`, `&gt;`. This is undocumented and incomplete (no decimal/hex references, no other named entities) and mis-splits input: `parse_query("kt;=11&lt;=22")` returned `{["kt;"]="11<=22"}` instead of `{["kt;"]="11", ["lt;"]="22"}`.

## Changes

- **Commit 1** restores the intended `query:gsub("%+", " ")`.
- **Commit 2** removes the entity decoding and the now-unused `entities` table. No caller relies on it — all four pass `url.parse(...).query` directly. Callers that need HTML decoding should do it explicitly.
- Both commits add `parse_query` unit tests (the library had none) and a CHANGELOG entry. The fixes are split so they can be reviewed/applied independently.

## Verification (Lua 5.4, matching the bundled interpreter)

| input | before | after |
|---|---|---|
| `foo=1&bar=2` | `bad argument #3 to 'gsub'` | `{foo="1", bar="2"}` |
| `a+b=c+d` | `bad argument #3 to 'gsub'` | `{["a b"]="c d"}` |
| `kt;=11&lt;=22` | `bad argument #3 to 'gsub'` (and pre-regression: `{["kt;"]="11<=22"}`) | `{["kt;"]="11", ["lt;"]="22"}` |
| `a%20b=c%26d` | — | `{["a b"]="c&d"}` (`%XX` unescaping unchanged) |

`luac5.4 -p nselib/url.lua` is clean; the new cases are added to `url`'s existing `unittest` suite.
