### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up QEMU for ARM64
         if: matrix.arch == 'arm64'


### PR DESCRIPTION
Several workflow files reference GitHub Actions via mutable version tags (e.g. `@v4`, `@v3`) instead of full commit SHAs. This is a supply chain risk — a compromised action repository could silently alter CI behavior.

This PR pins each action to the exact commit SHA corresponding to the version tag, making the dependency immutable and auditable.

Recommended by [GitHub security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and [OpenSSF Scorecard](https://securityscorecards.dev/).