### PR TITLE
Add NATS server version detection (and fix MongoDB misidentification)

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -2105,6 +2105,9 @@ match mwti-rpc m=^Welcome MWTI RPC Communication Server Version ([\w._-]+) \[(?:
 
 softmatch napster m|^1$|
 
+# NATS messaging system; the server sends an INFO {...} JSON banner including its version on connect (default port 4222)
+match nats m|^INFO \{"server_id":"\w+".*?"version":"([\d][\w.+-]*)"|s p/NATS server/ v/$1/ cpe:/a:linuxfoundation:nats-server:$1/
+
 # Ncat --chat mode, since 4.85BETA4
 match ncat-chat m|^<announce> [\d.:a-f]+ is connected as <\w+>\.\n<announce> already connected: (.*?)\.\n| p/Ncat chat/ i/users: $1/
 


### PR DESCRIPTION
This adds a `Probe TCP NULL` match for the **NATS** messaging server (https://nats.io), which sends an `INFO {...}` JSON banner containing its version immediately on connect (default port 4222).

```
match nats m|^INFO \{"server_id":"\w+".*?"version":"([\d][\w.+-]*)"|s p/NATS server/ v/$1/ cpe:/a:linuxfoundation:nats-server:$1/
```

### Also fixes a misidentification

Before this, the loose catch-all `match mongodb m|^.*version.....([\.\d]+)|` matches the NATS banner and reports it as a (non-existent) **MongoDB 14.2**. The new NULL-probe match fires first and identifies it correctly.

### Validation

Tested with `nmap -sV` against `nats:latest` (2.14.2), `nats:2.10`, and `nats:2.9` in Docker.

Before:
```
PORT     STATE SERVICE VERSION
4222/tcp open  mongodb MongoDB 14.2
```

After:
```
PORT     STATE SERVICE VERSION
4222/tcp open  nats    NATS server 2.14.2
```

- Version extraction confirmed across 2.9.x / 2.10.x / 2.14.x (the server always emits `server_id` as the first JSON key and a `version` field). The capture `([\d][\w.+-]*)` also preserves pre-release tags (e.g. `2.11.0-RC.2`).
- No false positives: the `^INFO {"server_id":"` anchor did not match `redis` or `nginx` when tested.
- CPE uses the NVD vendor/product `cpe:2.3:a:linuxfoundation:nats-server`.

Sample banner:
```
INFO {"server_id":"ND4J...","server_name":"...","version":"2.14.2","proto":1,"git_commit":"...","go":"go1.26.3",...} \r\n
```