### PR TITLE
Update LPeg to version 1.1.0 and fix Windows build issues

### DIFF
--- a/libnetutil/massdns.cc
+++ b/libnetutil/massdns.cc
@@ -1600,8 +1600,8 @@ void DNS::ResolverImpl::etchosts_init(void) {
   char tpbuf[2048];
   int has_backslash;
 
-  if (!GetWindowsDirectory(windows_dir, sizeof(windows_dir)))
-    log_func(0, "Failed to determine your windows directory");
+  if (!GetWindowsDirectoryA(windows_dir, sizeof(windows_dir)))
+    fprintf(stderr, "Failed to determine your windows directory\n");
 
   // If it has a backslash it's C:\, otherwise something like C:\WINNT
   has_backslash = (windows_dir[strlen(windows_dir)-1] == '\\');

--- a/lpeg.c
+++ b/lpeg.c
@@ -1,7 +1,16 @@
 /*
-** $Id: lptypes.h,v 1.8 2013/04/12 16:26:38 roberto Exp $
+** LPeg 1.1.0 Amalgamated version for Nmap
+** Generated automatically by amalgamate_lpeg.py
+*/
+
+/* ==========================================================================
+** File: lptypes.h
+** ==========================================================================
+*/
+
+/*
 ** LPeg - PEG pattern matching for Lua
-** Copyright 2007, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
+** Copyright 2007-2023, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
 ** written by Roberto Ierusalimschy
 */
 
@@ -9,15 +18,14 @@
 #define lptypes_h
 
 
-#if !defined(LPEG_DEBUG)
-#define NDEBUG
-#endif
-
 #include <assert.h>
 #include <limits.h>
+#include <string.h>
+
+#include "lua.h"
 
 
-#define VERSION         "0.12"
+#define VERSION         "1.1.0"
 
 
 #define PATTERN_T	"lpeg-pattern"
@@ -25,36 +33,40 @@
 
 
 /*
-** compatibility with Lua 5.2
+** compatibility with Lua 5.1
 */
-#if (LUA_VERSION_NUM == 502)
+#if (LUA_VERSION_NUM == 501)
 
-#undef lua_equal
-#define lua_equal(L,idx1,idx2)  lua_compare(L,(idx1),(idx2),LUA_OPEQ)
+#define lp_equal	lua_equal
 
-#undef lua_getfenv
-#define lua_getfenv	lua_getuservalue
-#undef lua_setfenv
-#define lua_setfenv	lua_setuservalue
+#define lua_getuservalue	lua_getfenv
+#define lua_setuservalue	lua_setfenv
 
-#undef lua_objlen
-#define lua_objlen	lua_rawlen
+#define lua_rawlen		lua_objlen
 
-#undef luaL_register
-#define luaL_register(L,n,f) \
-	{ if ((n) == NULL) luaL_setfuncs(L,f,0); else luaL_newlib(L,f); }
+#define luaL_setfuncs(L,f,n)	luaL_register(L,NULL,f)
+#define luaL_newlib(L,f)	luaL_register(L,"lpeg",f)
 
+typedef size_t lua_Unsigned;
+
+#endif
+
+
+#if !defined(lp_equal)
+#define lp_equal(L,idx1,idx2)  lua_compare(L,(idx1),(idx2),LUA_OPEQ)
 #endif
 
 
 /* default maximum size for call/backtrack stack */
 #if !defined(MAXBACK)
-#define MAXBACK         100
+#define MAXBACK         400
 #endif
 
 
-/* maximum number of rules in a grammar */
-#define MAXRULES        200
+/* maximum number of rules in a grammar (limited by 'unsigned short') */
+#if !defined(MAXRULES)
+#define MAXRULES        1000
+#endif
 
 
 
@@ -81,6 +93,8 @@
 
 typedef unsigned char byte;
 
+typedef unsigned int uint;
+
 
 #define BITSPERCHAR		8
 
@@ -96,11 +110,11 @@ typedef struct Charset {
 
 #define loopset(v,b)    { int v; for (v = 0; v < CHARSETSIZE; v++) {b;} }
 
-/* access to charset */
-#define treebuffer(t)      ((byte *)((t) + 1))
+#define fillset(s,c)	memset(s,c,CHARSETSIZE)
+#define clearset(s)	fillset(s,0)
 
 /* number of slots needed for 'n' bytes */
-#define bytes2slots(n)  (((n) - 1) / sizeof(TTree) + 1)
+#define bytes2slots(n)  (((n) - 1u) / (uint)sizeof(TTree) + 1u)
 
 /* set 'b' bit in charset 'cs' */
 #define setchar(cs,b)   ((cs)[(b) >> 3] |= (1 << ((b) & 7)))
@@ -110,8 +124,8 @@ typedef struct Charset {
 ** in capture instructions, 'kind' of capture and its offset are
 ** packed in field 'aux', 4 bits for each
 */
-#define getkind(op)		((op)->i.aux & 0xF)
-#define getoff(op)		(((op)->i.aux >> 4) & 0xF)
+#define getkind(op)		((op)->i.aux1 & 0xF)
+#define getoff(op)		(((op)->i.aux1 >> 4) & 0xF)
 #define joinkindoff(k,o)	((k) | ((o) << 4))
 
 #define MAXOFF		0xF
@@ -126,72 +140,97 @@ typedef struct Charset {
 #define MAXPATTSIZE	(SHRT_MAX - 10)
 
 
-/* size (in elements) for an instruction plus extra l bytes */
-#define instsize(l)  (((l) + sizeof(Instruction) - 1)/sizeof(Instruction) + 1)
+/* size (in instructions) for l bytes (l > 0) */
+#define instsize(l) ((int)(((l) + (uint)sizeof(Instruction) - 1u) \
+			/ (uint)sizeof(Instruction)))
 
 
 /* size (in elements) for a ISet instruction */
-#define CHARSETINSTSIZE		instsize(CHARSETSIZE)
+#define CHARSETINSTSIZE		(1 + instsize(CHARSETSIZE))
 
 /* size (in elements) for a IFunc instruction */
 #define funcinstsize(p)		((p)->i.aux + 2)
 
 
 
-#define testchar(st,c)	(((int)(st)[((c) >> 3)] & (1 << ((c) & 7))))
+#define testchar(st,c)	((((uint)(st)[((c) >> 3)]) >> ((c) & 7)) & 1)
 
 
 #endif
 
-/*
-** $Id: lptree.h,v 1.2 2013/03/24 13:51:12 roberto Exp $
+
+
+/* ==========================================================================
+** File: lptree.h
+** ==========================================================================
 */
+
 
 #if !defined(lptree_h)
 #define lptree_h
 
 
+/* #include "lptypes.h" -- stripped */
 
 
 /*
 ** types of trees
 */
 typedef enum TTag {
-  TChar = 0, TSet, TAny,  /* standard PEG elements */
-  TTrue, TFalse,
-  TRep,
-  TSeq, TChoice,
-  TNot, TAnd,
-  TCall,
-  TOpenCall,
-  TRule,  /* sib1 is rule's pattern, sib2 is 'next' rule */
-  TGrammar,  /* sib1 is initial (and first) rule */
-  TBehind,  /* match behind */
-  TCapture,  /* regular capture */
-  TRunTime  /* run-time capture */
+  TChar = 0,  /* 'n' = char */
+  TSet,  /* the set is encoded in 'u.set' and the next 'u.set.size' bytes */
+  TAny,
+  TTrue,
+  TFalse,
+  TUTFR,  /* range of UTF-8 codepoints; 'n' has initial codepoint;
+             'cap' has length; 'key' has first byte;
+             extra info is similar for end codepoint */
+  TRep,  /* 'sib1'* */
+  TSeq,  /* 'sib1' 'sib2' */
+  TChoice,  /* 'sib1' / 'sib2' */
+  TNot,  /* !'sib1' */
+  TAnd,  /* &'sib1' */
+  TCall,  /* ktable[key] is rule's key; 'sib2' is rule being called */
+  TOpenCall,  /* ktable[key] is rule's key */
+  TRule,  /* ktable[key] is rule's key (but key == 0 for unused rules);
+             'sib1' is rule's pattern pre-rule; 'sib2' is next rule;
+             extra info 'n' is rule's sequential number */
+  TXInfo,  /* extra info */
+  TGrammar,  /* 'sib1' is initial (and first) rule */
+  TBehind,  /* 'sib1' is pattern, 'n' is how much to go back */
+  TCapture,  /* captures: 'cap' is kind of capture (enum 'CapKind');
+                ktable[key] is Lua value associated with capture;
+                'sib1' is capture body */
+  TRunTime  /* run-time capture: 'key' is Lua function;
+               'sib1' is capture body */
 } TTag;
-
-/* number of siblings for each tree */
-extern const byte numsiblings[];
 
 
 /*
 ** Tree trees
-** The first sibling of a tree (if there is one) is immediately after
-** the tree.  A reference to a second sibling (ps) is its position
-** relative to the position of the tree itself.  A key in ktable
-** uses the (unique) address of the original tree that created that
-** entry. NULL means no data.
+** The first child of a tree (if there is one) is immediately after
+** the tree.  A reference to a second child (ps) is its position
+** relative to the position of the tree itself.
 */
 typedef struct TTree {
   byte tag;
   byte cap;  /* kind of capture (if it is a capture) */
   unsigned short key;  /* key in ktable for Lua data (0 if no key) */
   union {
-    int ps;  /* occasional second sibling */
+    int ps;  /* occasional second child */
     int n;  /* occasional counter */
+    struct {
+      byte offset;  /* compact set offset (in bytes) */
+      byte size;  /* compact set size (in bytes) */
+      byte deflt;  /* default value */
+      byte bitmap[1];  /* bitmap (open array) */
+    } set;  /* for compact sets */
   } u;
 } TTree;
+
+
+/* access to charset */
+#define treebuffer(t)      ((t)->u.set.bitmap)
 
 
 /*
@@ -200,15 +239,14 @@ typedef struct TTree {
 */
 typedef struct Pattern {
   union Instruction *code;
-  int codesize;
   TTree tree[1];
 } Pattern;
 
 
-/* number of siblings for each tree */
+/* number of children for each tree */
 extern const byte numsiblings[];
 
-/* access to siblings */
+/* access to children */
 #define sib1(t)         ((t) + 1)
 #define sib2(t)         ((t) + (t)->u.ps)
 
@@ -219,26 +257,57 @@ extern const byte numsiblings[];
 
 #endif
 
-/*
-** $Id: lpcap.h,v 1.1 2013/03/21 20:25:12 roberto Exp $
+
+
+/* ==========================================================================
+** File: lpcap.h
+** ==========================================================================
 */
+
 
 #if !defined(lpcap_h)
 #define lpcap_h
 
 
+/* #include "lptypes.h" -- stripped */
 
 
 /* kinds of captures */
 typedef enum CapKind {
-  Cclose, Cposition, Cconst, Cbackref, Carg, Csimple, Ctable, Cfunction,
-  Cquery, Cstring, Cnum, Csubst, Cfold, Cruntime, Cgroup
+  Cclose,  /* not used in trees */
+  Cposition,
+  Cconst,  /* ktable[key] is Lua constant */
+  Cbackref,  /* ktable[key] is "name" of group to get capture */
+  Carg,  /* 'key' is arg's number */
+  Csimple,  /* next node is pattern */
+  Ctable,  /* next node is pattern */
+  Cfunction,  /* ktable[key] is function; next node is pattern */
+  Cacc,  /* ktable[key] is function; next node is pattern */
+  Cquery,  /* ktable[key] is table; next node is pattern */
+  Cstring,  /* ktable[key] is string; next node is pattern */
+  Cnum,  /* numbered capture; 'key' is number of value to return */
+  Csubst,  /* substitution capture; next node is pattern */
+  Cfold,  /* ktable[key] is function; next node is pattern */
+  Cruntime,  /* not used in trees (is uses another type for tree) */
+  Cgroup  /* ktable[key] is group's "name" */
 } CapKind;
 
 
+/*
+** An unsigned integer large enough to index any subject entirely.
+** It can be size_t, but that will double the size of the array
+** of captures in a 64-bit machine.
+*/
+#if !defined(Index_t)
+typedef uint Index_t;
+#endif
+
+#define MAXINDT		(~(Index_t)0)
+
+
 typedef struct Capture {
-  const char *s;  /* subject position */
-  short idx;  /* extra info about capture (group name, arg index, etc.) */
+  Index_t index;  /* subject position */
+  unsigned short idx;  /* extra info (group name, arg index, etc.) */
   byte kind;  /* kind of capture */
   byte siz;  /* size of full capture + 1 (0 = not a full capture) */
 } Capture;
@@ -248,10 +317,30 @@ typedef struct CapState {
   Capture *cap;  /* current capture */
   Capture *ocap;  /* (original) capture list */
   lua_State *L;
-  int ptop;  /* index of last argument to 'match' */
+  int ptop;  /* stack index of last argument to 'match' */
+  int firstcap;  /* stack index of first capture pushed in the stack */
   const char *s;  /* original string */
   int valuecached;  /* value stored in cache slot */
+  int reclevel;  /* recursion level */
 } CapState;
+
+
+#define captype(cap)    ((cap)->kind)
+
+#define isclosecap(cap) (captype(cap) == Cclose)
+#define isopencap(cap)  ((cap)->siz == 0)
+
+/* true if c2 is (any number of levels) inside c1 */
+#define capinside(c1,c2)  \
+	(isopencap(c1) ? !isclosecap(c2) \
+                       : (c2)->index < (c1)->index + (c1)->siz - 1)
+
+
+/**
+** Maximum number of captures to visit when looking for an 'open'.
+*/
+#define MAXLOP		20
+
 
 
 int runtimecap (CapState *cs, Capture *close, const char *s, int *rem);
@@ -261,25 +350,38 @@ int finddyncap (Capture *cap, Capture *last);
 #endif
 
 
-/*
-** $Id: lpvm.h,v 1.2 2013/04/03 20:37:18 roberto Exp $
+
+
+/* ==========================================================================
+** File: lpvm.h
+** ==========================================================================
 */
+
 
 #if !defined(lpvm_h)
 #define lpvm_h
 
+/* #include "lpcap.h" -- stripped */
+
+
+/*
+** About Character sets in instructions: a set is a bit map with an
+** initial offset, in bits, and a size, in number of instructions.
+** aux1 has the default value for the bits outsize that range.
+*/
 
 
 /* Virtual Machine's instructions */
 typedef enum Opcode {
   IAny, /* if no char, fail */
-  IChar,  /* if char != aux, fail */
-  ISet,  /* if char not in buff, fail */
+  IChar,  /* if char != aux1, fail */
+  ISet,  /* if char not in set, fail */
   ITestAny,  /* in no char, jump to 'offset' */
-  ITestChar,  /* if char != aux, jump to 'offset' */
-  ITestSet,  /* if char not in buff, jump to 'offset' */
-  ISpan,  /* read a span of chars in buff */
-  IBehind,  /* walk back 'aux' characters (fail if not possible) */
+  ITestChar,  /* if char != aux1, jump to 'offset' */
+  ITestSet,  /* if char not in set, jump to 'offset' */
+  ISpan,  /* read a span of chars in set */
+  IUTFR,  /* if codepoint not in range [offset, utf_to], fail */
+  IBehind,  /* walk back 'aux1' characters (fail if not possible) */
   IRet,  /* return from a rule */
   IEnd,  /* end of pattern */
   IChoice,  /* stack a choice; next fail will jump to 'offset' */
@@ -288,72 +390,137 @@ typedef enum Opcode {
   IOpenCall,  /* call rule number 'key' (must be closed to a ICall) */
   ICommit,  /* pop choice and jump to 'offset' */
   IPartialCommit,  /* update top choice to current position and jump */
-  IBackCommit,  /* "fails" but jump to its own 'offset' */
+  IBackCommit,  /* backtrack like "fail" but jump to its own 'offset' */
   IFailTwice,  /* pop one choice and then fail */
   IFail,  /* go back to saved state on choice and jump to saved offset */
   IGiveup,  /* internal use */
   IFullCapture,  /* complete capture of last 'off' chars */
   IOpenCapture,  /* start a capture */
   ICloseCapture,
-  ICloseRunTime
+  ICloseRunTime,
+  IEmpty  /* to fill empty slots left by optimizations */
 } Opcode;
 
 
-
+/*
+** All array of instructions has a 'codesize' as its first element
+** and is referred by a pointer to its second element, which is the
+** first actual opcode.
+*/
 typedef union Instruction {
   struct Inst {
     byte code;
-    byte aux;
-    short key;
+    byte aux1;
+    union {
+      short key;
+      struct {
+        byte offset;
+        byte size;
+      } set;
+    } aux2;
   } i;
   int offset;
+  uint codesize;
   byte buff[1];
 } Instruction;
 
 
-int getposition (lua_State *L, int t, int i);
-void printpatt (Instruction *p, int n);
+/* extract 24-bit value from an instruction */
+#define utf_to(inst)	(((inst)->i.aux2.key << 8) | (inst)->i.aux1)
+
+
+int charinset (const Instruction *i, const byte *buff, uint c);
 const char *match (lua_State *L, const char *o, const char *s, const char *e,
                    Instruction *op, Capture *capture, int ptop);
-int verify (lua_State *L, Instruction *op, const Instruction *p,
-            Instruction *e, int postable, int rule);
-void checkrule (lua_State *L, Instruction *op, int from, int to,
-                int postable, int rule);
 
 
 #endif
 
-/*
-** $Id: lpcode.h,v 1.5 2013/04/04 21:24:45 roberto Exp $
+
+
+/* ==========================================================================
+** File: lpcset.h
+** ==========================================================================
 */
+
+
+#if !defined(lpset_h)
+#define lpset_h
+
+/* #include "lpcset.h" -- stripped */
+/* #include "lpcode.h" -- stripped */
+/* #include "lptree.h" -- stripped */
+
+
+/*
+** Extra information for the result of 'charsettype'.  When result is
+** IChar, 'offset' is the character.  When result is ISet, 'cs' is the
+** supporting bit array (with offset included), 'offset' is the offset
+** (in bytes), 'size' is the size (in bytes), and 'delt' is the default
+** value for bytes outside the set.
+*/
+typedef struct {
+  const byte *cs;
+  int offset;
+  int size;
+  int deflt;
+} charsetinfo;
+
+
+int tocharset (TTree *tree, Charset *cs);
+Opcode charsettype (const byte *cs, charsetinfo *info);
+byte getbytefromcharset (const charsetinfo *info, int index);
+void tree2cset (TTree *tree, charsetinfo *info);
+
+#endif
+
+
+/* ==========================================================================
+** File: lpcode.h
+** ==========================================================================
+*/
+
 
 #if !defined(lpcode_h)
 #define lpcode_h
 
+#include "lua.h"
 
-int tocharset (TTree *tree, Charset *cs);
+/* #include "lptypes.h" -- stripped */
+/* #include "lptree.h" -- stripped */
+/* #include "lpvm.h" -- stripped */
+
 int checkaux (TTree *tree, int pred);
-int fixedlenx (TTree *tree, int count, int len);
+int fixedlen (TTree *tree);
 int hascaptures (TTree *tree);
 int lp_gc (lua_State *L);
-Instruction *compile (lua_State *L, Pattern *p);
-void reallocprog (lua_State *L, Pattern *p, int nsize);
+Instruction *compile (lua_State *L, Pattern *p, uint size);
+void freecode (lua_State *L, Pattern *p);
 int sizei (const Instruction *i);
 
 
 #define PEnullable      0
 #define PEnofail        1
 
+/*
+** nofail(t) implies that 't' cannot fail with any input
+*/
 #define nofail(t)	checkaux(t, PEnofail)
-#define nullable(t)	checkaux(t, PEnullable)
 
-#define fixedlen(t)     fixedlenx(t, 0, 0)
+/*
+** (not nullable(t)) implies 't' cannot match without consuming
+** something
+*/
+#define nullable(t)	checkaux(t, PEnullable)
 
 
 
 #endif
-/*
-** $Id: lpprint.h,v 1.1 2013/03/21 20:25:12 roberto Exp $
+
+
+/* ==========================================================================
+** File: lpprint.h
+** ==========================================================================
 */
 
 
@@ -361,15 +528,18 @@ int sizei (const Instruction *i);
 #define lpprint_h
 
 
+/* #include "lptree.h" -- stripped */
+/* #include "lpvm.h" -- stripped */
 
 
 #if defined(LPEG_DEBUG)
 
-void printpatt (Instruction *p, int n);
+void printpatt (Instruction *p);
 void printtree (TTree *tree, int ident);
 void printktable (lua_State *L, int idx);
 void printcharset (const byte *st);
-void printcaplist (Capture *cap, Capture *limit);
+void printcaplist (Capture *cap);
+void printinst (const Instruction *op, const Instruction *p);
 
 #else
 
@@ -377,7 +547,7 @@ void printcaplist (Capture *cap, Capture *limit);
 	luaL_error(L, "function only implemented in debug mode")
 #define printtree(tree,i)  \
 	luaL_error(L, "function only implemented in debug mode")
-#define printpatt(p,n)  \
+#define printpatt(p)  \
 	luaL_error(L, "function only implemented in debug mode")
 
 #endif
@@ -385,26 +555,166 @@ void printcaplist (Capture *cap, Capture *limit);
 
 #endif
 
-/*
-** $Id: lpcap.c,v 1.4 2013/03/21 20:25:12 roberto Exp $
-** Copyright 2007, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
+
+
+/* ==========================================================================
+** File: lpcset.c
+** ==========================================================================
 */
 
 
+/* #include "lptypes.h" -- stripped */
+/* #include "lpcset.h" -- stripped */
 
 
-#define captype(cap)	((cap)->kind)
+/*
+** Add to 'c' the index of the (only) bit set in byte 'b'
+*/
+static int onlybit (int c, int b) {
+  if ((b & 0xF0) != 0) { c += 4; b >>= 4; }
+  if ((b & 0x0C) != 0) { c += 2; b >>= 2; }
+  if ((b & 0x02) != 0) { c += 1; }
+  return c;
+}
 
-#define isclosecap(cap)	(captype(cap) == Cclose)
 
-#define closeaddr(c)	((c)->s + (c)->siz - 1)
+/*
+** Check whether a charset is empty (returns IFail), singleton (IChar),
+** full (IAny), or none of those (ISet). When singleton, 'info.offset'
+** returns which character it is. When generic set, 'info' returns
+** information about its range.
+*/
+Opcode charsettype (const byte *cs, charsetinfo *info) {
+  int low0, low1, high0, high1;
+  for (low1 = 0; low1 < CHARSETSIZE && cs[low1] == 0; low1++)
+    /* find lowest byte with a 1-bit */;
+  if (low1 == CHARSETSIZE)
+    return IFail;  /* no characters in set */
+  for (high1 = CHARSETSIZE - 1; cs[high1] == 0; high1--)
+    /* find highest byte with a 1-bit; low1 is a sentinel */;
+  if (low1 == high1) {  /* only one byte with 1-bits? */
+    int b = cs[low1];
+    if ((b & (b - 1)) == 0) {  /* does byte has only one 1-bit? */
+      info->offset = onlybit(low1 * BITSPERCHAR, b);  /* get that bit */
+      return IChar;  /* single character */
+    }
+  }
+  for (low0 = 0; low0 < CHARSETSIZE && cs[low0] == 0xFF; low0++)
+    /* find lowest byte with a 0-bit */;
+  if (low0 == CHARSETSIZE)
+    return IAny;  /* set has all bits set */
+  for (high0 = CHARSETSIZE - 1; cs[high0] == 0xFF; high0--)
+    /* find highest byte with a 0-bit; low0 is a sentinel */;
+  if (high1 - low1 <= high0 - low0) {  /* range of 1s smaller than of 0s? */
+    info->offset = low1;
+    info->size = high1 - low1 + 1;
+    info->deflt = 0;  /* all discharged bits were 0 */
+  }
+  else {
+    info->offset = low0;
+    info->size = high0 - low0 + 1;
+    info->deflt = 0xFF;  /* all discharged bits were 1 */
+  }
+  info->cs = cs + info->offset;
+  return ISet;
+}
 
-#define isfullcap(cap)	((cap)->siz != 0)
+
+/*
+** Get a byte from a compact charset. If index is inside the charset
+** range, get the byte from the supporting charset (correcting it
+** by the offset). Otherwise, return the default for the set.
+*/
+byte getbytefromcharset (const charsetinfo *info, int index) {
+  if (index < info->size)
+    return info->cs[index];
+  else return info->deflt;
+}
+
+
+/*
+** If 'tree' is a 'char' pattern (TSet, TChar, TAny, TFalse), convert it
+** into a charset and return 1; else return 0.
+*/
+int tocharset (TTree *tree, Charset *cs) {
+  switch (tree->tag) {
+    case TChar: {  /* only one char */
+      assert(0 <= tree->u.n && tree->u.n <= UCHAR_MAX);
+      clearset(cs->cs);  /* erase all chars */
+      setchar(cs->cs, tree->u.n);  /* add that one */
+      return 1;
+    }
+    case TAny: {
+      fillset(cs->cs, 0xFF);  /* add all characters to the set */
+      return 1;
+    }
+    case TFalse: {
+      clearset(cs->cs);  /* empty set */
+      return 1;
+    }
+    case TSet: {  /* fill set */
+      int i;
+      fillset(cs->cs, tree->u.set.deflt);
+      for (i = 0; i < tree->u.set.size; i++)
+        cs->cs[tree->u.set.offset + i] = treebuffer(tree)[i];
+      return 1;
+    }
+    default: return 0;
+  }
+}
+
+
+void tree2cset (TTree *tree, charsetinfo *info) {
+  assert(tree->tag == TSet);
+  info->offset = tree->u.set.offset;
+  info->size = tree->u.set.size;
+  info->deflt = tree->u.set.deflt;
+  info->cs = treebuffer(tree);
+}
+
+
+
+/* ==========================================================================
+** File: lpcap.c
+** ==========================================================================
+*/
+
+
+#include "lua.h"
+#include "lauxlib.h"
+
+/* #include "lpcap.h" -- stripped */
+/* #include "lpprint.h" -- stripped */
+/* #include "lptypes.h" -- stripped */
+
 
 #define getfromktable(cs,v)	lua_rawgeti((cs)->L, ktableidx((cs)->ptop), v)
 
 #define pushluaval(cs)		getfromktable(cs, (cs)->cap->idx)
 
+
+
+#define skipclose(cs,head)  \
+	if (isopencap(head)) { assert(isclosecap(cs->cap)); cs->cap++; }
+
+
+/*
+** Return the size of capture 'cap'. If it is an open capture, 'close'
+** must be its corresponding close.
+*/
+static Index_t capsize (Capture *cap, Capture *close) {
+  if (isopencap(cap)) {
+    assert(isclosecap(close));
+    return close->index - cap->index;
+  }
+  else
+    return cap->siz - 1;
+}
+
+
+static Index_t closesize (CapState *cs, Capture *head) {
+  return capsize(head, cs->cap);
+}
 
 
 /*
@@ -427,35 +737,40 @@ static int pushcapture (CapState *cs);
 
 /*
 ** Goes back in a list of captures looking for an open capture
-** corresponding to a close
+** corresponding to a close one.
 */
 static Capture *findopen (Capture *cap) {
   int n = 0;  /* number of closes waiting an open */
   for (;;) {
     cap--;
     if (isclosecap(cap)) n++;  /* one more open to skip */
-    else if (!isfullcap(cap))
+    else if (isopencap(cap))
       if (n-- == 0) return cap;
   }
 }
 
 
 /*
-** Go to the next capture
+** Go to the next capture at the same level.
 */
 static void nextcap (CapState *cs) {
   Capture *cap = cs->cap;
-  if (!isfullcap(cap)) {  /* not a single capture? */
+  if (isopencap(cap)) {  /* must look for a close? */
     int n = 0;  /* number of opens waiting a close */
     for (;;) {  /* look for corresponding close */
       cap++;
-      if (isclosecap(cap)) {
+      if (isopencap(cap)) n++;
+      else if (isclosecap(cap))
         if (n-- == 0) break;
-      }
-      else if (!isfullcap(cap)) n++;
     }
+    cs->cap = cap + 1;  /* + 1 to skip last close */
   }
-  cs->cap = cap + 1;  /* + 1 to skip last close (or entire single capture) */
+  else {
+    Capture *next;
+    for (next = cap + 1; capinside(cap, next); next++)
+      ;  /* skip captures inside current one */
+    cs->cap = next;
+  }
 }
 
 
@@ -467,22 +782,17 @@ static void nextcap (CapState *cs) {
 ** so the function never returns zero.
 */
 static int pushnestedvalues (CapState *cs, int addextra) {
-  Capture *co = cs->cap;
-  if (isfullcap(cs->cap++)) {  /* no nested captures? */
-    lua_pushlstring(cs->L, co->s, co->siz - 1);  /* push whole match */
-    return 1;  /* that is it */
+  Capture *head = cs->cap++;  /* original capture */
+  int n = 0;  /* number of pushed subvalues */
+  /* repeat for all nested patterns */
+  while (capinside(head, cs->cap))
+    n += pushcapture(cs);
+  if (addextra || n == 0) {  /* need extra? */
+    lua_pushlstring(cs->L, cs->s + head->index, closesize(cs, head));
+    n++;
   }
-  else {
-    int n = 0;
-    while (!isclosecap(cs->cap))  /* repeat for all nested patterns */
-      n += pushcapture(cs);
-    if (addextra || n == 0) {  /* need extra? */
-      lua_pushlstring(cs->L, co->s, cs->cap->s - co->s);  /* push whole match */
-      n++;
-    }
-    cs->cap++;  /* skip close entry */
-    return n;
-  }
+  skipclose(cs, head);
+  return n;
 }
 
 
@@ -497,19 +807,45 @@ static void pushonenestedvalue (CapState *cs) {
 
 
 /*
-** Try to find a named group capture with the name given at the top of
-** the stack; goes backward from 'cap'.
+** Checks whether group 'grp' is visible to 'ref', that is, 'grp' is
+** not nested inside a full capture that does not contain 'ref'.  (We
+** only need to care for full captures because the search at 'findback'
+** skips open-end blocks; so, if 'grp' is nested in a non-full capture,
+** 'ref' is also inside it.)  To check this, we search backward for the
+** inner full capture enclosing 'grp'.  A full capture cannot contain
+** non-full captures, so a close capture means we cannot be inside a
+** full capture anymore.
 */
-static Capture *findback (CapState *cs, Capture *cap) {
+static int capvisible (CapState *cs, Capture *grp, Capture *ref) {
+  Capture *cap = grp;
+  int i = MAXLOP;  /* maximum distance for an 'open' */
+  while (i-- > 0 && cap-- > cs->ocap) {
+    if (isclosecap(cap))
+      return 1;  /* can stop the search */
+    else if (grp->index - cap->index >= UCHAR_MAX)
+      return 1;  /* can stop the search */
+    else if (capinside(cap, grp))  /* is 'grp' inside cap? */
+      return capinside(cap, ref);  /* ok iff cap also contains 'ref' */
+  }
+  return 1;  /* 'grp' is not inside any capture */
+}
+
+
+/*
+** Try to find a named group capture with the name given at the top of
+** the stack; goes backward from 'ref'.
+*/
+static Capture *findback (CapState *cs, Capture *ref) {
   lua_State *L = cs->L;
+  Capture *cap = ref;
   while (cap-- > cs->ocap) {  /* repeat until end of list */
     if (isclosecap(cap))
       cap = findopen(cap);  /* skip nested captures */
-    else if (!isfullcap(cap))
-      continue; /* opening an enclosing capture: skip and get previous */
-    if (captype(cap) == Cgroup) {
+    else if (capinside(cap, ref))
+      continue;  /* enclosing captures are not visible to 'ref' */
+    if (captype(cap) == Cgroup && capvisible(cs, cap, ref)) {
       getfromktable(cs, cap->idx);  /* get group name */
-      if (lua_equal(L, -2, -1)) {  /* right group? */
+      if (lp_equal(L, -2, -1)) {  /* right group? */
         lua_pop(L, 2);  /* remove reference name and group name */
         return cap;
       }
@@ -541,11 +877,10 @@ static int backrefcap (CapState *cs) {
 */
 static int tablecap (CapState *cs) {
   lua_State *L = cs->L;
+  Capture *head = cs->cap++;
   int n = 0;
   lua_newtable(L);
-  if (isfullcap(cs->cap++))
-    return 1;  /* table is empty */
-  while (!isclosecap(cs->cap)) {
+  while (capinside(head, cs->cap)) {
     if (captype(cs->cap) == Cgroup && cs->cap->idx != 0) {  /* named group? */
       pushluaval(cs);  /* push group name */
       pushonenestedvalue(cs);
@@ -559,7 +894,7 @@ static int tablecap (CapState *cs) {
       n += k;
     }
   }
-  cs->cap++;  /* skip close entry */
+  skipclose(cs, head);
   return 1;  /* number of values pushed (only the table) */
 }
 
@@ -586,20 +921,20 @@ static int querycap (CapState *cs) {
 static int foldcap (CapState *cs) {
   int n;
   lua_State *L = cs->L;
-  int idx = cs->cap->idx;
-  if (isfullcap(cs->cap++) ||  /* no nested captures? */
-      isclosecap(cs->cap) ||  /* no nested captures (large subject)? */
+  Capture *head = cs->cap++;
+  int idx = head->idx;
+  if (isclosecap(cs->cap) ||  /* no nested captures (large subject)? */
       (n = pushcapture(cs)) == 0)  /* nested captures with no values? */
     return luaL_error(L, "no initial value for fold capture");
   if (n > 1)
     lua_pop(L, n - 1);  /* leave only one result for accumulator */
-  while (!isclosecap(cs->cap)) {
+  while (capinside(head, cs->cap)) {
     lua_pushvalue(L, updatecache(cs, idx));  /* get folding function */
     lua_insert(L, -2);  /* put it before accumulator */
     n = pushcapture(cs);  /* get next capture's values */
     lua_call(L, n + 1, 1);  /* call folding function */
   }
-  cs->cap++;  /* skip close entry */
+  skipclose(cs, head);
   return 1;  /* only accumulator left on the stack */
 }
 
@@ -614,6 +949,22 @@ static int functioncap (CapState *cs) {
   n = pushnestedvalues(cs, 0);  /* push nested captures */
   lua_call(cs->L, n, LUA_MULTRET);  /* call function */
   return lua_gettop(cs->L) - top;  /* return function's results */
+}
+
+
+/*
+** Accumulator capture
+*/
+static int accumulatorcap (CapState *cs) {
+  lua_State *L = cs->L;
+  int n;
+  if (lua_gettop(L) < cs->firstcap)
+    luaL_error(L, "no previous value for accumulator capture");
+  pushluaval(cs);  /* push function */
+  lua_insert(L, -2);  /* previous value becomes first argument */
+  n = pushnestedvalues(cs, 0);  /* push nested captures */
+  lua_call(L, n + 1, 1);  /* call function */
+  return 0;  /* did not add any extra value */
 }
 
 
@@ -654,19 +1005,19 @@ int finddyncap (Capture *cap, Capture *last) {
 
 
 /*
-** Calls a runtime capture. Returns number of captures removed by
-** the call, including the initial Cgroup. (Captures to be added are
-** on the Lua stack.)
+** Calls a runtime capture. Returns number of captures "removed" by the
+** call, that is, those inside the group capture. Captures to be added
+** are on the Lua stack.
 */
 int runtimecap (CapState *cs, Capture *close, const char *s, int *rem) {
   int n, id;
   lua_State *L = cs->L;
   int otop = lua_gettop(L);
-  Capture *open = findopen(close);
+  Capture *open = findopen(close);  /* get open group capture */
   assert(captype(open) == Cgroup);
   id = finddyncap(open, close);  /* get first dynamic capture argument */
   close->kind = Cclose;  /* closes the group */
-  close->s = s;
+  close->index = s - cs->s;
   cs->cap = open; cs->valuecached = 0;  /* prepare capture state */
   luaL_checkstack(L, 4, "too many runtime captures");
   pushluaval(cs);  /* push function to be called */
@@ -682,7 +1033,7 @@ int runtimecap (CapState *cs, Capture *close, const char *s, int *rem) {
   }
   else
     *rem = 0;  /* no dynamic captures removed */
-  return close - open;  /* number of captures of all kinds removed */
+  return close - open - 1;  /* number of captures to be removed */
 }
 
 
@@ -696,8 +1047,8 @@ typedef struct StrAux {
   union {
     Capture *cp;  /* if not a string, respective capture */
     struct {  /* if it is a string... */
-      const char *s;  /* ... starts here */
-      const char *e;  /* ... ends here */
+      Index_t idx;  /* starts here */
+      Index_t siz;  /* with this size */
     } s;
   } u;
 } StrAux;
@@ -712,24 +1063,23 @@ typedef struct StrAux {
 */
 static int getstrcaps (CapState *cs, StrAux *cps, int n) {
   int k = n++;
+  Capture *head = cs->cap++;
   cps[k].isstring = 1;  /* get string value */
-  cps[k].u.s.s = cs->cap->s;  /* starts here */
-  if (!isfullcap(cs->cap++)) {  /* nested captures? */
-    while (!isclosecap(cs->cap)) {  /* traverse them */
-      if (n >= MAXSTRCAPS)  /* too many captures? */
-        nextcap(cs);  /* skip extra captures (will not need them) */
-      else if (captype(cs->cap) == Csimple)  /* string? */
-        n = getstrcaps(cs, cps, n);  /* put info. into array */
-      else {
-        cps[n].isstring = 0;  /* not a string */
-        cps[n].u.cp = cs->cap;  /* keep original capture */
-        nextcap(cs);
-        n++;
-      }
+  cps[k].u.s.idx = head->index;  /* starts here */
+  while (capinside(head, cs->cap)) {
+    if (n >= MAXSTRCAPS)  /* too many captures? */
+      nextcap(cs);  /* skip extra captures (will not need them) */
+    else if (captype(cs->cap) == Csimple)  /* string? */
+      n = getstrcaps(cs, cps, n);  /* put info. into array */
+    else {
+      cps[n].isstring = 0;  /* not a string */
+      cps[n].u.cp = cs->cap;  /* keep original capture */
+      nextcap(cs);
+      n++;
     }
-    cs->cap++;  /* skip close */
   }
-  cps[k].u.s.e = closeaddr(cs->cap - 1);  /* ends here */
+  cps[k].u.s.siz = closesize(cs, head);
+  skipclose(cs, head);
   return n;
 }
 
@@ -751,7 +1101,7 @@ static void stringcap (luaL_Buffer *b, CapState *cs) {
   const char *fmt;  /* format string */
   fmt = lua_tolstring(cs->L, updatecache(cs, cs->cap->idx), &len);
   n = getstrcaps(cs, cps, 0) - 1;  /* collect nested captures */
-  for (i = 0; i < len; i++) {  /* traverse them */
+  for (i = 0; i < len; i++) {  /* traverse format string */
     if (fmt[i] != '%')  /* not an escape? */
       luaL_addchar(b, fmt[i]);  /* add it to buffer */
     else if (fmt[++i] < '0' || fmt[i] > '9')  /* not followed by a digit? */
@@ -761,7 +1111,7 @@ static void stringcap (luaL_Buffer *b, CapState *cs) {
       if (l > n)
         luaL_error(cs->L, "invalid capture index (%d)", l);
       else if (cps[l].isstring)
-        luaL_addlstring(b, cps[l].u.s.s, cps[l].u.s.e - cps[l].u.s.s);
+        luaL_addlstring(b, cs->s + cps[l].u.s.idx, cps[l].u.s.siz);
       else {
         Capture *curr = cs->cap;
         cs->cap = cps[l].u.cp;  /* go back to evaluate that nested capture */
@@ -778,22 +1128,20 @@ static void stringcap (luaL_Buffer *b, CapState *cs) {
 ** Substitution capture: add result to buffer 'b'
 */
 static void substcap (luaL_Buffer *b, CapState *cs) {
-  const char *curr = cs->cap->s;
-  if (isfullcap(cs->cap))  /* no nested captures? */
-    luaL_addlstring(b, curr, cs->cap->siz - 1);  /* keep original text */
-  else {
-    cs->cap++;  /* skip open entry */
-    while (!isclosecap(cs->cap)) {  /* traverse nested captures */
-      const char *next = cs->cap->s;
-      luaL_addlstring(b, curr, next - curr);  /* add text up to capture */
-      if (addonestring(b, cs, "replacement"))
-        curr = closeaddr(cs->cap - 1);  /* continue after match */
-      else  /* no capture value */
-        curr = next;  /* keep original text in final result */
-    }
-    luaL_addlstring(b, curr, cs->cap->s - curr);  /* add last piece of text */
+  const char *curr = cs->s + cs->cap->index;
+  Capture *head = cs->cap++;
+  while (capinside(head, cs->cap)) {
+    Capture *cap = cs->cap;
+    const char *caps = cs->s + cap->index;
+    luaL_addlstring(b, curr, caps - curr);  /* add text up to capture */
+    if (addonestring(b, cs, "replacement"))
+      curr = caps + capsize(cap, cs->cap - 1);  /* continue after match */
+    else  /* no capture value */
+      curr = caps;  /* keep original text in final result */
   }
-  cs->cap++;  /* go to next capture */
+  /* add last piece of text */
+  luaL_addlstring(b, curr, cs->s + head->index + closesize(cs, head) - curr);
+  skipclose(cs, head);
 }
 
 
@@ -809,13 +1157,16 @@ static int addonestring (luaL_Buffer *b, CapState *cs, const char *what) {
     case Csubst:
       substcap(b, cs);  /* add capture directly to buffer */
       return 1;
+    case Cacc:  /* accumulator capture? */
+      return luaL_error(cs->L, "invalid context for an accumulator capture");
     default: {
       lua_State *L = cs->L;
       int n = pushcapture(cs);
       if (n > 0) {
         if (n > 1) lua_pop(L, n - 1);  /* only one result */
         if (!lua_isstring(L, -1))
-          luaL_error(L, "invalid %s value (a %s)", what, luaL_typename(L, -1));
+          return luaL_error(L, "invalid %s value (a %s)",
+                               what, luaL_typename(L, -1));
         luaL_addvalue(b);
       }
       return n;
@@ -824,70 +1175,89 @@ static int addonestring (luaL_Buffer *b, CapState *cs, const char *what) {
 }
 
 
+#if !defined(MAXRECLEVEL)
+#define MAXRECLEVEL	200
+#endif
+
+
 /*
 ** Push all values of the current capture into the stack; returns
 ** number of values pushed
 */
 static int pushcapture (CapState *cs) {
   lua_State *L = cs->L;
+  int res;
   luaL_checkstack(L, 4, "too many captures");
+  if (cs->reclevel++ > MAXRECLEVEL)
+    return luaL_error(L, "subcapture nesting too deep");
   switch (captype(cs->cap)) {
     case Cposition: {
-      lua_pushinteger(L, cs->cap->s - cs->s + 1);
+      lua_pushinteger(L, cs->cap->index + 1);
       cs->cap++;
-      return 1;
+      res = 1;
+      break;
     }
     case Cconst: {
       pushluaval(cs);
       cs->cap++;
-      return 1;
+      res = 1;
+      break;
     }
     case Carg: {
       int arg = (cs->cap++)->idx;
       if (arg + FIXEDARGS > cs->ptop)
-        return luaL_error(L, "reference to absent argument #%d", arg);
+        return luaL_error(L, "reference to absent extra argument #%d", arg);
       lua_pushvalue(L, arg + FIXEDARGS);
-      return 1;
+      res = 1;
+      break;
     }
     case Csimple: {
       int k = pushnestedvalues(cs, 1);
       lua_insert(L, -k);  /* make whole match be first result */
-      return k;
+      res = k;
+      break;
     }
     case Cruntime: {
       lua_pushvalue(L, (cs->cap++)->idx);  /* value is in the stack */
-      return 1;
+      res = 1;
+      break;
     }
     case Cstring: {
       luaL_Buffer b;
       luaL_buffinit(L, &b);
       stringcap(&b, cs);
       luaL_pushresult(&b);
-      return 1;
+      res = 1;
+      break;
     }
     case Csubst: {
       luaL_Buffer b;
       luaL_buffinit(L, &b);
       substcap(&b, cs);
       luaL_pushresult(&b);
-      return 1;
+      res = 1;
+      break;
     }
     case Cgroup: {
       if (cs->cap->idx == 0)  /* anonymous group? */
-        return pushnestedvalues(cs, 0);  /* add all nested values */
+        res = pushnestedvalues(cs, 0);  /* add all nested values */
       else {  /* named group: add no values */
         nextcap(cs);  /* skip capture */
-        return 0;
+        res = 0;
       }
+      break;
     }
-    case Cbackref: return backrefcap(cs);
-    case Ctable: return tablecap(cs);
-    case Cfunction: return functioncap(cs);
-    case Cnum: return numcap(cs);
-    case Cquery: return querycap(cs);
-    case Cfold: return foldcap(cs);
-    default: assert(0); return 0;
+    case Cbackref: res = backrefcap(cs); break;
+    case Ctable: res = tablecap(cs); break;
+    case Cfunction: res = functioncap(cs); break;
+    case Cacc: res = accumulatorcap(cs); break;
+    case Cnum: res = numcap(cs); break;
+    case Cquery: res = querycap(cs); break;
+    case Cfold: res = foldcap(cs); break;
+    default: assert(0); res = 0;
   }
+  cs->reclevel--;
+  return res;
 }
 
 
@@ -902,13 +1272,16 @@ static int pushcapture (CapState *cs) {
 int getcaptures (lua_State *L, const char *s, const char *r, int ptop) {
   Capture *capture = (Capture *)lua_touserdata(L, caplistidx(ptop));
   int n = 0;
+  /* printcaplist(capture); */
   if (!isclosecap(capture)) {  /* is there any capture? */
     CapState cs;
-    cs.ocap = cs.cap = capture; cs.L = L;
+    cs.ocap = cs.cap = capture; cs.L = L; cs.reclevel = 0;
     cs.s = s; cs.valuecached = 0; cs.ptop = ptop;
+    cs.firstcap = lua_gettop(L) + 1;  /* where first value (if any) will go */
     do {  /* collect their values */
       n += pushcapture(&cs);
     } while (!isclosecap(cs.cap));
+    assert(lua_gettop(L) - cs.firstcap == n - 1);
   }
   if (n == 0) {  /* no capture values? */
     lua_pushinteger(L, r - s + 1);  /* return only end position */
@@ -918,15 +1291,23 @@ int getcaptures (lua_State *L, const char *s, const char *r, int ptop) {
 }
 
 
-/*
-** $Id: lpcode.c,v 1.18 2013/04/12 16:30:33 roberto Exp $
-** Copyright 2007, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
+
+
+/* ==========================================================================
+** File: lpcode.c
+** ==========================================================================
 */
+
 
 #include <limits.h>
 
 
+#include "lua.h"
+#include "lauxlib.h"
 
+/* #include "lptypes.h" -- stripped */
+/* #include "lpcode.h" -- stripped */
+/* #include "lpcset.h" -- stripped */
 
 
 /* signals a "no-instruction */
@@ -942,56 +1323,13 @@ static const Charset fullset_ =
 
 static const Charset *fullset = &fullset_;
 
+
 /*
 ** {======================================================
 ** Analysis and some optimizations
 ** =======================================================
 */
 
-/*
-** Check whether a charset is empty (IFail), singleton (IChar),
-** full (IAny), or none of those (ISet).
-*/
-static Opcode charsettype (const byte *cs, int *c) {
-  int count = 0;
-  int i;
-  int candidate = -1;  /* candidate position for a char */
-  for (i = 0; i < CHARSETSIZE; i++) {
-    int b = cs[i];
-    if (b == 0) {
-      if (count > 1) return ISet;  /* else set is still empty */
-    }
-    else if (b == 0xFF) {
-      if (count < (i * BITSPERCHAR))
-        return ISet;
-      else count += BITSPERCHAR;  /* set is still full */
-    }
-    else if ((b & (b - 1)) == 0) {  /* byte has only one bit? */
-      if (count > 0)
-        return ISet;  /* set is neither full nor empty */
-      else {  /* set has only one char till now; track it */
-        count++;
-        candidate = i;
-      }
-    }
-    else return ISet;  /* byte is neither empty, full, nor singleton */
-  }
-  switch (count) {
-    case 0: return IFail;  /* empty set */
-    case 1: {  /* singleton; find character bit inside byte */
-      int b = cs[candidate];
-      *c = candidate * BITSPERCHAR;
-      if ((b & 0xF0) != 0) { *c += 4; b >>= 4; }
-      if ((b & 0x0C) != 0) { *c += 2; b >>= 2; }
-      if ((b & 0x02) != 0) { *c += 1; }
-      return IChar;
-    }
-    default: {
-       assert(count == CHARSETSIZE * BITSPERCHAR);  /* full set */
-       return IAny;
-    }
-  }
-}
 
 /*
 ** A few basic operations on Charsets
@@ -1000,16 +1338,6 @@ static void cs_complement (Charset *cs) {
   loopset(i, cs->cs[i] = ~cs->cs[i]);
 }
 
-
-static int cs_equal (const byte *cs1, const byte *cs2) {
-  loopset(i, if (cs1[i] != cs2[i]) return 0);
-  return 1;
-}
-
-
-/*
-** computes whether sets cs1 and cs2 are disjoint
-*/
 static int cs_disjoint (const Charset *cs1, const Charset *cs2) {
   loopset(i, if ((cs1->cs[i] & cs2->cs[i]) != 0) return 0;)
   return 1;
@@ -1017,43 +1345,46 @@ static int cs_disjoint (const Charset *cs1, const Charset *cs2) {
 
 
 /*
-** Convert a 'char' pattern (TSet, TChar, TAny) to a charset
+** Visit a TCall node taking care to stop recursion. If node not yet
+** visited, return 'f(sib2(tree))', otherwise return 'def' (default
+** value)
 */
-int tocharset (TTree *tree, Charset *cs) {
-  switch (tree->tag) {
-    case TSet: {  /* copy set */
-      loopset(i, cs->cs[i] = treebuffer(tree)[i]);
-      return 1;
-    }
-    case TChar: {  /* only one char */
-      assert(0 <= tree->u.n && tree->u.n <= UCHAR_MAX);
-      loopset(i, cs->cs[i] = 0);  /* erase all chars */
-      setchar(cs->cs, tree->u.n);  /* add that one */
-      return 1;
-    }
-    case TAny: {
-      loopset(i, cs->cs[i] = 0xFF);  /* add all to the set */
-      return 1;
-    }
-    default: return 0;
+static int callrecursive (TTree *tree, int f (TTree *t), int def) {
+  int key = tree->key;
+  assert(tree->tag == TCall);
+  assert(sib2(tree)->tag == TRule);
+  if (key == 0)  /* node already visited? */
+    return def;  /* return default value */
+  else {  /* first visit */
+    int result;
+    tree->key = 0;  /* mark call as already visited */
+    result = f(sib2(tree));  /* go to called rule */
+    tree->key = key;  /* restore tree */
+    return result;
   }
 }
 
 
 /*
-** Checks whether a pattern has captures
+** Check whether a pattern tree has captures
 */
 int hascaptures (TTree *tree) {
  tailcall:
   switch (tree->tag) {
     case TCapture: case TRunTime:
       return 1;
+    case TCall:
+      return callrecursive(tree, hascaptures, 0);
+    case TRule:  /* do not follow siblings */
+      tree = sib1(tree); goto tailcall;
+    case TOpenCall: assert(0);
     default: {
       switch (numsiblings[tree->tag]) {
         case 1:  /* return hascaptures(sib1(tree)); */
           tree = sib1(tree); goto tailcall;
         case 2:
-          if (hascaptures(sib1(tree))) return 1;
+          if (hascaptures(sib1(tree)))
+            return 1;
           /* else return hascaptures(sib2(tree)); */
           tree = sib2(tree); goto tailcall;
         default: assert(numsiblings[tree->tag] == 0); return 0;
@@ -1077,14 +1408,14 @@ int hascaptures (TTree *tree) {
 **    p is nullable => nullable(p)
 **    nofail(p) => p cannot fail
 ** The function assumes that TOpenCall is not nullable;
-** this will be checked again when the grammar is fixed.)
+** this will be checked again when the grammar is fixed.
 ** Run-time captures can do whatever they want, so the result
 ** is conservative.
 */
 int checkaux (TTree *tree, int pred) {
  tailcall:
   switch (tree->tag) {
-    case TChar: case TSet: case TAny:
+    case TChar: case TSet: case TAny: case TUTFR:
     case TFalse: case TOpenCall:
       return 0;  /* not nullable */
     case TRep: case TTrue:
@@ -1108,50 +1439,55 @@ int checkaux (TTree *tree, int pred) {
       if (checkaux(sib2(tree), pred)) return 1;
       /* else return checkaux(sib1(tree), pred); */
       tree = sib1(tree); goto tailcall;
-    case TCapture: case TGrammar: case TRule:
+    case TCapture: case TGrammar: case TRule: case TXInfo:
       /* return checkaux(sib1(tree), pred); */
       tree = sib1(tree); goto tailcall;
     case TCall:  /* return checkaux(sib2(tree), pred); */
       tree = sib2(tree); goto tailcall;
     default: assert(0); return 0;
-  };
+  }
 }
 
 
 /*
 ** number of characters to match a pattern (or -1 if variable)
-** ('count' avoids infinite loops for grammars)
 */
-int fixedlenx (TTree *tree, int count, int len) {
+int fixedlen (TTree *tree) {
+  int len = 0;  /* to accumulate in tail calls */
  tailcall:
   switch (tree->tag) {
     case TChar: case TSet: case TAny:
       return len + 1;
+    case TUTFR:
+      return (tree->cap == sib1(tree)->cap) ? len + tree->cap : -1;
     case TFalse: case TTrue: case TNot: case TAnd: case TBehind:
       return len;
     case TRep: case TRunTime: case TOpenCall:
       return -1;
-    case TCapture: case TRule: case TGrammar:
-      /* return fixedlenx(sib1(tree), count); */
+    case TCapture: case TRule: case TGrammar: case TXInfo:
+      /* return fixedlen(sib1(tree)); */
       tree = sib1(tree); goto tailcall;
-    case TCall:
-      if (count++ >= MAXRULES)
-        return -1;  /* may be a loop */
-      /* else return fixedlenx(sib2(tree), count); */
-      tree = sib2(tree); goto tailcall;
+    case TCall: {
+      int n1 = callrecursive(tree, fixedlen, -1);
+      if (n1 < 0)
+        return -1;
+      else
+        return len + n1;
+    }
     case TSeq: {
-      len = fixedlenx(sib1(tree), count, len);
-      if (len < 0) return -1;
-      /* else return fixedlenx(sib2(tree), count, len); */
-      tree = sib2(tree); goto tailcall;
+      int n1 = fixedlen(sib1(tree));
+      if (n1 < 0)
+        return -1;
+      /* else return fixedlen(sib2(tree)) + len; */
+      len += n1; tree = sib2(tree); goto tailcall;
     }
     case TChoice: {
-      int n1, n2;
-      n1 = fixedlenx(sib1(tree), count, len);
-      if (n1 < 0) return -1;
-      n2 = fixedlenx(sib2(tree), count, len);
-      if (n1 == n2) return n1;
-      else return -1;
+      int n1 = fixedlen(sib1(tree));
+      int n2 = fixedlen(sib2(tree));
+      if (n1 != n2 || n1 < 0)
+        return -1;
+      else
+        return len + n1;
     }
     default: assert(0); return 0;
   };
@@ -1161,31 +1497,38 @@ int fixedlenx (TTree *tree, int count, int len) {
 /*
 ** Computes the 'first set' of a pattern.
 ** The result is a conservative aproximation:
-**   match p ax -> x' for some x ==> a in first(p).
+**   match p ax -> x (for some x) ==> a belongs to first(p)
+** or
+**   a not in first(p) ==> match p ax -> fail (for all x)
+**
 ** The set 'follow' is the first set of what follows the
 ** pattern (full set if nothing follows it).
-** The function returns 0 when this set can be used for
-** tests that avoid the pattern altogether.
+**
+** The function returns 0 when this resulting set can be used for
+** test instructions that avoid the pattern altogether.
 ** A non-zero return can happen for two reasons:
-** 1) match p '' -> ''            ==> returns 1.
-** (tests cannot be used because they always fail for an empty input)
-** 2) there is a match-time capture ==> returns 2.
-** (match-time captures should not be avoided by optimizations)
+** 1) match p '' -> ''            ==> return has bit 1 set
+** (tests cannot be used because they would always fail for an empty input);
+** 2) there is a match-time capture ==> return has bit 2 set
+** (optimizations should not bypass match-time captures).
 */
 static int getfirst (TTree *tree, const Charset *follow, Charset *firstset) {
  tailcall:
   switch (tree->tag) {
-    case TChar: case TSet: case TAny: {
+    case TChar: case TSet: case TAny: case TFalse: {
       tocharset(tree, firstset);
+      return 0;
+    }
+    case TUTFR: {
+      int c;
+      clearset(firstset->cs);  /* erase all chars */
+      for (c = tree->key; c <= sib1(tree)->key; c++)
+        setchar(firstset->cs, c);
       return 0;
     }
     case TTrue: {
       loopset(i, firstset->cs[i] = follow->cs[i]);
-      return 1;
-    }
-    case TFalse: {
-      loopset(i, firstset->cs[i] = 0);
-      return 0;
+      return 1;  /* accepts the empty string */
     }
     case TChoice: {
       Charset csaux;
@@ -1196,7 +1539,8 @@ static int getfirst (TTree *tree, const Charset *follow, Charset *firstset) {
     }
     case TSeq: {
       if (!nullable(sib1(tree))) {
-        /* return getfirst(sib1(tree), fullset, firstset); */
+        /* when p1 is not nullable, p2 has nothing to contribute;
+           return getfirst(sib1(tree), fullset, firstset); */
         tree = sib1(tree); follow = fullset; goto tailcall;
       }
       else {  /* FIRST(p1 p2, fl) = FIRST(p1, FIRST(p2, fl)) */
@@ -1214,7 +1558,7 @@ static int getfirst (TTree *tree, const Charset *follow, Charset *firstset) {
       loopset(i, firstset->cs[i] |= follow->cs[i]);
       return 1;  /* accept the empty string */
     }
-    case TCapture: case TGrammar: case TRule: {
+    case TCapture: case TGrammar: case TRule: case TXInfo: {
       /* return getfirst(sib1(tree), follow, firstset); */
       tree = sib1(tree); goto tailcall;
     }
@@ -1236,11 +1580,10 @@ static int getfirst (TTree *tree, const Charset *follow, Charset *firstset) {
       if (tocharset(sib1(tree), firstset)) {
         cs_complement(firstset);
         return 1;
-      }
-      /* else go through */
-    }
+      }  /* else */
+    }    /* FALLTHROUGH */
     case TBehind: {  /* instruction gives no new information */
-      /* call 'getfirst' to check for math-time captures */
+      /* call 'getfirst' only to check for math-time captures */
       int e = getfirst(sib1(tree), follow, firstset);
       loopset(i, firstset->cs[i] = follow->cs[i]);  /* uses follow */
       return e | 1;  /* always can accept the empty string */
@@ -1251,8 +1594,8 @@ static int getfirst (TTree *tree, const Charset *follow, Charset *firstset) {
 
 
 /*
-** If it returns true, then pattern can fail only depending on the next
-** character of the subject
+** If 'headfail(tree)' true, then 'tree' can fail only depending on the
+** next character of the subject.
 */
 static int headfail (TTree *tree) {
  tailcall:
@@ -1260,9 +1603,9 @@ static int headfail (TTree *tree) {
     case TChar: case TSet: case TAny: case TFalse:
       return 1;
     case TTrue: case TRep: case TRunTime: case TNot:
-    case TBehind:
+    case TBehind: case TUTFR:
       return 0;
-    case TCapture: case TGrammar: case TRule: case TAnd:
+    case TCapture: case TGrammar: case TRule: case TXInfo: case TAnd:
       tree = sib1(tree); goto tailcall;  /* return headfail(sib1(tree)); */
     case TCall:
       tree = sib2(tree); goto tailcall;  /* return headfail(sib2(tree)); */
@@ -1287,7 +1630,7 @@ static int headfail (TTree *tree) {
 static int needfollow (TTree *tree) {
  tailcall:
   switch (tree->tag) {
-    case TChar: case TSet: case TAny:
+    case TChar: case TSet: case TAny: case TUTFR:
     case TFalse: case TTrue: case TAnd: case TNot:
     case TRunTime: case TGrammar: case TCall: case TBehind:
       return 0;
@@ -1317,11 +1660,12 @@ static int needfollow (TTree *tree) {
 */
 int sizei (const Instruction *i) {
   switch((Opcode)i->i.code) {
-    case ISet: case ISpan: return CHARSETINSTSIZE;
-    case ITestSet: return CHARSETINSTSIZE + 1;
-    case ITestChar: case ITestAny: case IChoice: case IJmp:
-    case ICall: case IOpenCall: case ICommit: case IPartialCommit:
-    case IBackCommit: return 2;
+    case ISet: case ISpan: return 1 + i->i.aux2.set.size;
+    case ITestSet: return 2 + i->i.aux2.set.size;
+    case ITestChar: case ITestAny: case IChoice: case IJmp: case ICall:
+    case IOpenCall: case ICommit: case IPartialCommit: case IBackCommit:
+    case IUTFR:
+      return 2;
     default: return 1;
   }
 }
@@ -1338,32 +1682,77 @@ typedef struct CompileState {
 
 
 /*
-** code generation is recursive; 'opt' indicates that the code is
-** being generated under a 'IChoice' operator jumping to its end.
-** 'tt' points to a previous test protecting this code. 'fl' is
-** the follow set of the pattern.
+** code generation is recursive; 'opt' indicates that the code is being
+** generated as the last thing inside an optional pattern (so, if that
+** code is optional too, it can reuse the 'IChoice' already in place for
+** the outer pattern). 'tt' points to a previous test protecting this
+** code (or NOINST). 'fl' is the follow set of the pattern.
 */
 static void codegen (CompileState *compst, TTree *tree, int opt, int tt,
                      const Charset *fl);
 
 
-void reallocprog (lua_State *L, Pattern *p, int nsize) {
-  void *ud;
-  lua_Alloc f = lua_getallocf(L, &ud);
-  void *newblock = f(ud, p->code, p->codesize * sizeof(Instruction),
-                                  nsize * sizeof(Instruction));
-  if (newblock == NULL && nsize > 0)
+static void finishrelcode (lua_State *L, Pattern *p, Instruction *block,
+                                         int size) {
+  if (block == NULL)
     luaL_error(L, "not enough memory");
-  p->code = (Instruction *)newblock;
-  p->codesize = nsize;
+  block->codesize = size;
+  p->code = (Instruction *)block + 1;
 }
 
 
-static int nextinstruction (CompileState *compst) {
-  int size = compst->p->codesize;
-  if (compst->ncode >= size)
-    reallocprog(compst->L, compst->p, size * 2);
-  return compst->ncode++;
+/*
+** Initialize array 'p->code'
+*/
+static void newcode (lua_State *L, Pattern *p, int size) {
+  void *ud;
+  Instruction *block;
+  lua_Alloc f = lua_getallocf(L, &ud);
+  size++;  /* slot for 'codesize' */
+  block = (Instruction*) f(ud, NULL, 0, size * sizeof(Instruction));
+  finishrelcode(L, p, block, size);
+}
+
+
+void freecode (lua_State *L, Pattern *p) {
+  if (p->code != NULL) {
+    void *ud;
+    lua_Alloc f = lua_getallocf(L, &ud);
+    uint osize = p->code[-1].codesize;
+    f(ud, p->code - 1, osize * sizeof(Instruction), 0);  /* free block */
+  }
+}
+
+
+/*
+** Assume that 'nsize' is not zero and that 'p->code' already exists.
+*/
+static void realloccode (lua_State *L, Pattern *p, int nsize) {
+  void *ud;
+  lua_Alloc f = lua_getallocf(L, &ud);
+  Instruction *block = p->code - 1;
+  uint osize = block->codesize;
+  nsize++;  /* add the 'codesize' slot to size */
+  block = (Instruction*) f(ud, block, osize * sizeof(Instruction),
+                                      nsize * sizeof(Instruction));
+  finishrelcode(L, p, block, nsize);
+}
+
+
+/*
+** Add space for an instruction with 'n' slots and return its index.
+*/
+static int nextinstruction (CompileState *compst, int n) {
+  int size = compst->p->code[-1].codesize - 1;
+  int ncode = compst->ncode;
+  if (ncode > size - n) {
+    uint nsize = size + (size >> 1) + n;
+    if (nsize >= INT_MAX)
+      luaL_error(compst->L, "pattern code too large");
+    realloccode(compst->L, compst->p, nsize);
+  }
+  compst->ncode = ncode + n;
+  return ncode;
 }
 
 
@@ -1371,13 +1760,16 @@ static int nextinstruction (CompileState *compst) {
 
 
 static int addinstruction (CompileState *compst, Opcode op, int aux) {
-  int i = nextinstruction(compst);
+  int i = nextinstruction(compst, 1);
   getinstr(compst, i).i.code = op;
-  getinstr(compst, i).i.aux = aux;
+  getinstr(compst, i).i.aux1 = aux;
   return i;
 }
 
 
+/*
+** Add an instruction followed by space for an offset (to be set later)
+*/
 static int addoffsetinst (CompileState *compst, Opcode op) {
   int i = addinstruction(compst, op, 0);  /* instruction */
   addinstruction(compst, (Opcode)0, 0);  /* open space for offset */
@@ -1386,21 +1778,34 @@ static int addoffsetinst (CompileState *compst, Opcode op) {
 }
 
 
+/*
+** Set the offset of an instruction
+*/
 static void setoffset (CompileState *compst, int instruction, int offset) {
   getinstr(compst, instruction + 1).offset = offset;
+}
+
+
+static void codeutfr (CompileState *compst, TTree *tree) {
+  int i = addoffsetinst(compst, IUTFR);
+  int to = sib1(tree)->u.n;
+  assert(sib1(tree)->tag == TXInfo);
+  getinstr(compst, i + 1).offset = tree->u.n;
+  getinstr(compst, i).i.aux1 = to & 0xff;
+  getinstr(compst, i).i.aux2.key = to >> 8;
 }
 
 
 /*
 ** Add a capture instruction:
 ** 'op' is the capture instruction; 'cap' the capture kind;
-** 'key' the key into ktable; 'aux' is optional offset
+** 'key' the key into ktable; 'aux' is the optional capture offset
 **
 */
 static int addinstcap (CompileState *compst, Opcode op, int cap, int key,
                        int aux) {
   int i = addinstruction(compst, op, joinkindoff(cap, aux));
-  getinstr(compst, i).i.key = key;
+  getinstr(compst, i).i.aux2.key = key;
   return i;
 }
 
@@ -1410,12 +1815,18 @@ static int addinstcap (CompileState *compst, Opcode op, int cap, int key,
 #define target(code,i)		((i) + code[i + 1].offset)
 
 
+/*
+** Patch 'instruction' to jump to 'target'
+*/
 static void jumptothere (CompileState *compst, int instruction, int target) {
   if (instruction >= 0)
     setoffset(compst, instruction, target - instruction);
 }
 
 
+/*
+** Patch 'instruction' to jump to current position
+*/
 static void jumptohere (CompileState *compst, int instruction) {
   jumptothere(compst, instruction, gethere(compst));
 }
@@ -1427,7 +1838,7 @@ static void jumptohere (CompileState *compst, int instruction) {
 */
 static void codechar (CompileState *compst, int c, int tt) {
   if (tt >= 0 && getinstr(compst, tt).i.code == ITestChar &&
-                 getinstr(compst, tt).i.aux == c)
+                 getinstr(compst, tt).i.aux1 == c)
     addinstruction(compst, IAny, 0);
   else
     addinstruction(compst, IChar, c);
@@ -1435,45 +1846,63 @@ static void codechar (CompileState *compst, int c, int tt) {
 
 
 /*
-** Add a charset posfix to an instruction
+** Add a charset posfix to an instruction.
 */
-static void addcharset (CompileState *compst, const byte *cs) {
-  int p = gethere(compst);
+static void addcharset (CompileState *compst, int inst, charsetinfo *info) {
+  int p;
+  Instruction *I = &getinstr(compst, inst);
+  byte *charset;
+  int isize = instsize(info->size);  /* size in instructions */
   int i;
-  for (i = 0; i < (int)CHARSETINSTSIZE - 1; i++)
-    nextinstruction(compst);  /* space for buffer */
-  /* fill buffer with charset */
-  loopset(j, getinstr(compst, p).buff[j] = cs[j]);
+  I->i.aux2.set.offset = info->offset * 8;  /* offset in bits */
+  I->i.aux2.set.size = isize;
+  I->i.aux1 = info->deflt;
+  p = nextinstruction(compst, isize);  /* space for charset */
+  charset = getinstr(compst, p).buff;  /* charset buffer */
+  for (i = 0; i < isize * (int)sizeof(Instruction); i++)
+    charset[i] = getbytefromcharset(info, i);  /* copy the buffer */
 }
 
 
 /*
-** code a char set, optimizing unit sets for IChar, "complete"
-** sets for IAny, and empty sets for IFail; also use an IAny
-** when instruction is dominated by an equivalent test.
+** Check whether charset 'info' is dominated by instruction 'p'
 */
-static void codecharset (CompileState *compst, const byte *cs, int tt) {
-  int c = 0;  /* (=) to avoid warnings */
-  Opcode op = charsettype(cs, &c);
-  switch (op) {
-    case IChar: codechar(compst, c, tt); break;
-    case ISet: {  /* non-trivial set? */
-      if (tt >= 0 && getinstr(compst, tt).i.code == ITestSet &&
-          cs_equal(cs, getinstr(compst, tt + 2).buff))
-        addinstruction(compst, IAny, 0);
-      else {
-        addinstruction(compst, ISet, 0);
-        addcharset(compst, cs);
-      }
-      break;
+static int cs_equal (Instruction *p, charsetinfo *info) {
+  if (p->i.code != ITestSet)
+    return 0;
+  else if (p->i.aux2.set.offset != info->offset * 8 ||
+           p->i.aux2.set.size != instsize(info->size) ||
+           p->i.aux1 != info->deflt)
+    return 0;
+  else {
+    int i;
+    for (i = 0; i < instsize(info->size) * (int)sizeof(Instruction); i++) {
+      if ((p + 2)->buff[i] != getbytefromcharset(info, i))
+        return 0;
     }
-    default: addinstruction(compst, op, c); break;
+  }
+  return 1;
+}
+
+
+/*
+** Code a char set, using IAny when instruction is dominated by an
+** equivalent test.
+*/
+static void codecharset (CompileState *compst, TTree *tree, int tt) {
+  charsetinfo info;
+  tree2cset(tree, &info);
+  if (tt >= 0 && cs_equal(&getinstr(compst, tt), &info))
+    addinstruction(compst, IAny, 0);
+  else {
+    int i = addinstruction(compst, ISet, 0);
+    addcharset(compst, i, &info);
   }
 }
 
 
 /*
-** code a test set, optimizing unit sets for ITestChar, "complete"
+** Code a test set, optimizing unit sets for ITestChar, "complete"
 ** sets for ITestAny, and empty sets for IJmp (always fails).
 ** 'e' is true iff test should accept the empty string. (Test
 ** instructions in the current VM never accept the empty string.)
@@ -1481,22 +1910,22 @@ static void codecharset (CompileState *compst, const byte *cs, int tt) {
 static int codetestset (CompileState *compst, Charset *cs, int e) {
   if (e) return NOINST;  /* no test */
   else {
-    int c = 0;
-    Opcode op = charsettype(cs->cs, &c);
+    charsetinfo info;
+    Opcode op = charsettype(cs->cs, &info);
     switch (op) {
       case IFail: return addoffsetinst(compst, IJmp);  /* always jump */
       case IAny: return addoffsetinst(compst, ITestAny);
       case IChar: {
         int i = addoffsetinst(compst, ITestChar);
-        getinstr(compst, i).i.aux = c;
+        getinstr(compst, i).i.aux1 = info.offset;
         return i;
       }
-      case ISet: {
+      default: {  /* regular set */
         int i = addoffsetinst(compst, ITestSet);
-        addcharset(compst, cs->cs);
+        addcharset(compst, i, &info);
+        assert(op == ISet);
         return i;
       }
-      default: assert(0); return 0;
     }
   }
 }
@@ -1532,13 +1961,13 @@ static void codebehind (CompileState *compst, TTree *tree) {
 
 /*
 ** Choice; optimizations:
-** - when p1 is headfail
-** - when first(p1) and first(p2) are disjoint; than
-** a character not in first(p1) cannot go to p1, and a character
-** in first(p1) cannot go to p2 (at it is not in first(p2)).
-** (The optimization is not valid if p1 accepts the empty string,
+** - when p1 is headfail or when first(p1) and first(p2) are disjoint,
+** than a character not in first(p1) cannot go to p1 and a character
+** in first(p1) cannot go to p2, either because p1 will accept
+** (headfail) or because it is not in first(p2) (disjoint).
+** (The second case is not valid if p1 accepts the empty string,
 ** as then there is no character at all...)
-** - when p2 is empty and opt is true; a IPartialCommit can resuse
+** - when p2 is empty and opt is true; a IPartialCommit can reuse
 ** the Choice already active in the stack.
 */
 static void codechoice (CompileState *compst, TTree *p1, TTree *p2, int opt,
@@ -1565,7 +1994,7 @@ static void codechoice (CompileState *compst, TTree *p1, TTree *p2, int opt,
   }
   else {
     /* <p1 / p2> ==
-        test(fail(p1)) -> L1; choice L1; <p1>; commit L2; L1: <p2>; L2: */
+        test(first(p1)) -> L1; choice L1; <p1>; commit L2; L1: <p2>; L2: */
     int pcommit;
     int test = codetestset(compst, &cs1, e1);
     int pchoice = addoffsetinst(compst, IChoice);
@@ -1604,9 +2033,10 @@ static void codeand (CompileState *compst, TTree *tree, int tt) {
 
 
 /*
-** Captures: if pattern has fixed (and not too big) length, use
-** a single IFullCapture instruction after the match; otherwise,
-** enclose the pattern with OpenCapture - CloseCapture.
+** Captures: if pattern has fixed (and not too big) length, and it
+** has no nested captures, use a single IFullCapture instruction
+** after the match; otherwise, enclose the pattern with OpenCapture -
+** CloseCapture.
 */
 static void codecapture (CompileState *compst, TTree *tree, int tt,
                          const Charset *fl) {
@@ -1631,8 +2061,52 @@ static void coderuntime (CompileState *compst, TTree *tree, int tt) {
 
 
 /*
+** Create a jump to 'test' and fix 'test' to jump to next instruction
+*/
+static void closeloop (CompileState *compst, int test) {
+  int jmp = addoffsetinst(compst, IJmp);
+  jumptohere(compst, test);
+  jumptothere(compst, jmp, test);
+}
+
+
+/*
+** Try repetition of charsets:
+** For an empty set, repetition of fail is a no-op;
+** For any or char, code a tight loop;
+** For generic charset, use a span instruction.
+*/
+static int coderepcharset (CompileState *compst, TTree *tree) {
+  switch (tree->tag) {
+    case TFalse: return 1;  /* 'fail*' is a no-op */
+    case TAny: {  /* L1: testany -> L2; any; jmp L1; L2: */
+      int test = addoffsetinst(compst, ITestAny);
+      addinstruction(compst, IAny, 0);
+      closeloop(compst, test);
+      return 1;
+    }
+    case TChar: {  /* L1: testchar c -> L2; any; jmp L1; L2: */
+      int test = addoffsetinst(compst, ITestChar);
+      getinstr(compst, test).i.aux1 = tree->u.n;
+      addinstruction(compst, IAny, 0);
+      closeloop(compst, test);
+      return 1;
+    }
+    case TSet: {  /* regular set */
+      charsetinfo info;
+      int i = addinstruction(compst, ISpan, 0);
+      tree2cset(tree, &info);
+      addcharset(compst, i, &info);
+      return 1;
+    }
+    default: return 0;  /* not a charset */
+  }
+}
+
+
+/*
 ** Repetion; optimizations:
-** When pattern is a charset, can use special instruction ISpan.
+** When pattern is a charset, use special code.
 ** When pattern is head fail, or if it starts with characters that
 ** are disjoint from what follows the repetions, a simple test
 ** is enough (a fail inside the repetition would backtrack to fail
@@ -1642,21 +2116,14 @@ static void coderuntime (CompileState *compst, TTree *tree, int tt) {
 */
 static void coderep (CompileState *compst, TTree *tree, int opt,
                      const Charset *fl) {
-  Charset st;
-  if (tocharset(tree, &st)) {
-    addinstruction(compst, ISpan, 0);
-    addcharset(compst, st.cs);
-  }
-  else {
+  if (!coderepcharset(compst, tree)) {
+    Charset st;
     int e1 = getfirst(tree, fullset, &st);
     if (headfail(tree) || (!e1 && cs_disjoint(&st, fl))) {
       /* L1: test (fail(p1)) -> L2; <p>; jmp L1; L2: */
-      int jmp;
       int test = codetestset(compst, &st, 0);
-      codegen(compst, tree, opt, test, fullset);
-      jmp = addoffsetinst(compst, IJmp);
-      jumptohere(compst, test);
-      jumptothere(compst, jmp, test);
+      codegen(compst, tree, 0, test, fullset);
+      closeloop(compst, test);
     }
     else {
       /* test(fail(p1)) -> L2; choice L2; L1: <p>; partialcommit L1; L2: */
@@ -1713,7 +2180,7 @@ static void correctcalls (CompileState *compst, int *positions,
   Instruction *code = compst->p->code;
   for (i = from; i < to; i += sizei(&code[i])) {
     if (code[i].i.code == IOpenCall) {
-      int n = code[i].i.key;  /* rule number */
+      int n = code[i].i.aux2.key;  /* rule number */
       int rule = positions[n];  /* rule position */
       assert(rule == from || code[rule - 1].i.code == IRet);
       if (code[finaltarget(code, i + 2)].i.code == IRet)  /* call; ret ? */
@@ -1740,8 +2207,10 @@ static void codegrammar (CompileState *compst, TTree *grammar) {
   int start = gethere(compst);  /* here starts the initial rule */
   jumptohere(compst, firstcall);
   for (rule = sib1(grammar); rule->tag == TRule; rule = sib2(rule)) {
+    TTree *r = sib1(rule);
+    assert(r->tag == TXInfo);
     positions[rulenumber++] = gethere(compst);  /* save rule position */
-    codegen(compst, sib1(rule), 0, NOINST, fullset);  /* code rule */
+    codegen(compst, sib1(r), 0, NOINST, fullset);  /* code rule */
     addinstruction(compst, IRet, 0);
   }
   assert(rule->tag == TTrue);
@@ -1752,8 +2221,8 @@ static void codegrammar (CompileState *compst, TTree *grammar) {
 
 static void codecall (CompileState *compst, TTree *call) {
   int c = addoffsetinst(compst, IOpenCall);  /* to be corrected later */
-  getinstr(compst, c).i.key = sib2(call)->cap;  /* rule number */
-  assert(sib2(call)->tag == TRule);
+  assert(sib1(sib2(call))->tag == TXInfo);
+  getinstr(compst, c).i.aux2.key = sib1(sib2(call))->u.n;  /* rule number */
 }
 
 
@@ -1779,7 +2248,8 @@ static int codeseq1 (CompileState *compst, TTree *p1, TTree *p2,
 
 /*
 ** Main code-generation function: dispatch to auxiliar functions
-** according to kind of tree
+** according to kind of tree. ('needfollow' should return true
+** only for consructions that use 'fl'.)
 */
 static void codegen (CompileState *compst, TTree *tree, int opt, int tt,
                      const Charset *fl) {
@@ -1787,9 +2257,10 @@ static void codegen (CompileState *compst, TTree *tree, int opt, int tt,
   switch (tree->tag) {
     case TChar: codechar(compst, tree->u.n, tt); break;
     case TAny: addinstruction(compst, IAny, 0); break;
-    case TSet: codecharset(compst, treebuffer(tree), tt); break;
+    case TSet: codecharset(compst, tree, tt); break;
     case TTrue: break;
     case TFalse: addinstruction(compst, IFail, 0); break;
+    case TUTFR: codeutfr(compst, tree); break;
     case TChoice: codechoice(compst, sib1(tree), sib2(tree), opt, fl); break;
     case TRep: coderep(compst, sib1(tree), opt, fl); break;
     case TBehind: codebehind(compst, tree); break;
@@ -1822,6 +2293,7 @@ static void peephole (CompileState *compst) {
   Instruction *code = compst->p->code;
   int i;
   for (i = 0; i < compst->ncode; i += sizei(&code[i])) {
+   redo:
     switch (code[i].i.code) {
       case IChoice: case ICall: case ICommit: case IPartialCommit:
       case IBackCommit: case ITestChar: case ITestSet:
@@ -1835,7 +2307,7 @@ static void peephole (CompileState *compst) {
           case IRet: case IFail: case IFailTwice:
           case IEnd: {  /* instructions with unconditional implicit jumps */
             code[i] = code[ft];  /* jump becomes that instruction */
-            code[i + 1].i.code = IAny;  /* 'no-op' for target position */
+            code[i + 1].i.code = IEmpty;  /* 'no-op' for target position */
             break;
           }
           case ICommit: case IPartialCommit:
@@ -1843,8 +2315,7 @@ static void peephole (CompileState *compst) {
             int fft = finallabel(code, ft);
             code[i] = code[ft];  /* jump becomes that instruction... */
             jumptothere(compst, i, fft);  /* but must correct its offset */
-            i--;  /* reoptimize its label */
-            break;
+            goto redo;  /* reoptimize its label */
           }
           default: {
             jumptothere(compst, i, ft);  /* optimize label */
@@ -1861,15 +2332,16 @@ static void peephole (CompileState *compst) {
 
 
 /*
-** Compile a pattern
+** Compile a pattern. 'size' is the size of the pattern's tree,
+** which gives a hint for the size of the final code.
 */
-Instruction *compile (lua_State *L, Pattern *p) {
+Instruction *compile (lua_State *L, Pattern *p, uint size) {
   CompileState compst;
   compst.p = p;  compst.ncode = 0;  compst.L = L;
-  reallocprog(L, p, 2);  /* minimum initial size */
+  newcode(L, p, size/2u + 2);  /* set initial size */
   codegen(&compst, p->tree, 0, NOINST, fullset);
   addinstruction(&compst, IEnd, 0);
-  reallocprog(L, p, compst.ncode);  /* set final size */
+  realloccode(L, p, compst.ncode);  /* set final size */
   peephole(&compst);
   return p->code;
 }
@@ -1877,16 +2349,22 @@ Instruction *compile (lua_State *L, Pattern *p) {
 
 /* }====================================================== */
 
-/*
-** $Id: lpprint.c,v 1.7 2013/04/12 16:29:49 roberto Exp $
-** Copyright 2007, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
+
+
+/* ==========================================================================
+** File: lpprint.c
+** ==========================================================================
 */
+
 
 #include <ctype.h>
 #include <limits.h>
 #include <stdio.h>
 
 
+/* #include "lptypes.h" -- stripped */
+/* #include "lpprint.h" -- stripped */
+/* #include "lpcode.h" -- stripped */
 
 
 #if defined(LPEG_DEBUG)
@@ -1903,7 +2381,7 @@ void printcharset (const byte *st) {
   printf("[");
   for (i = 0; i <= UCHAR_MAX; i++) {
     int first = i;
-    while (testchar(st, i) && i <= UCHAR_MAX) i++;
+    while (i <= UCHAR_MAX && testchar(st, i)) i++;
     if (i - 1 == first)  /* unary range? */
       printf("(%02x)", first);
     else if (i - 1 > first)  /* non-empty range? */
@@ -1913,13 +2391,37 @@ void printcharset (const byte *st) {
 }
 
 
-static void printcapkind (int kind) {
+static void printIcharset (const Instruction *inst, const byte *buff) {
+  byte cs[CHARSETSIZE];
+  int i;
+  printf("(%02x-%d) ", inst->i.aux2.set.offset, inst->i.aux2.set.size);
+  clearset(cs);
+  for (i = 0; i < CHARSETSIZE * 8; i++) {
+    if (charinset(inst, buff, i))
+      setchar(cs, i);
+  }
+  printcharset(cs);
+}
+
+
+static void printTcharset (TTree *tree) {
+  byte cs[CHARSETSIZE];
+  int i;
+  printf("(%02x-%d) ", tree->u.set.offset, tree->u.set.size);
+  fillset(cs, tree->u.set.deflt);
+  for (i = 0; i < tree->u.set.size; i++)
+    cs[tree->u.set.offset + i] = treebuffer(tree)[i];
+  printcharset(cs);
+}
+
+
+static const char *capkind (int kind) {
   const char *const modes[] = {
     "close", "position", "constant", "backref",
-    "argument", "simple", "table", "function",
+    "argument", "simple", "table", "function", "accumulator",
     "query", "string", "num", "substitution", "fold",
     "runtime", "group"};
-  printf("%s", modes[kind]);
+  return modes[kind];
 }
 
 
@@ -1928,46 +2430,50 @@ static void printjmp (const Instruction *op, const Instruction *p) {
 }
 
 
-static void printinst (const Instruction *op, const Instruction *p) {
+void printinst (const Instruction *op, const Instruction *p) {
   const char *const names[] = {
     "any", "char", "set",
     "testany", "testchar", "testset",
-    "span", "behind",
+    "span", "utf-range", "behind",
     "ret", "end",
     "choice", "jmp", "call", "open_call",
     "commit", "partial_commit", "back_commit", "failtwice", "fail", "giveup",
-     "fullcapture", "opencapture", "closecapture", "closeruntime"
+     "fullcapture", "opencapture", "closecapture", "closeruntime",
+     "--"
   };
   printf("%02ld: %s ", (long)(p - op), names[p->i.code]);
   switch ((Opcode)p->i.code) {
     case IChar: {
-      printf("'%c'", p->i.aux);
+      printf("'%c' (%02x)", p->i.aux1, p->i.aux1);
       break;
     }
     case ITestChar: {
-      printf("'%c'", p->i.aux); printjmp(op, p);
+      printf("'%c' (%02x)", p->i.aux1, p->i.aux1); printjmp(op, p);
+      break;
+    }
+    case IUTFR: {
+      printf("%d - %d", p[1].offset, utf_to(p));
       break;
     }
     case IFullCapture: {
-      printcapkind(getkind(p));
-      printf(" (size = %d)  (idx = %d)", getoff(p), p->i.key);
+      printf("%s (size = %d)  (idx = %d)",
+             capkind(getkind(p)), getoff(p), p->i.aux2.key);
       break;
     }
     case IOpenCapture: {
-      printcapkind(getkind(p));
-      printf(" (idx = %d)", p->i.key);
+      printf("%s (idx = %d)", capkind(getkind(p)), p->i.aux2.key);
       break;
     }
     case ISet: {
-      printcharset((p+1)->buff);
+      printIcharset(p, (p+1)->buff);
       break;
     }
     case ITestSet: {
-      printcharset((p+2)->buff); printjmp(op, p);
+      printIcharset(p, (p+2)->buff); printjmp(op, p);
       break;
     }
     case ISpan: {
-      printcharset((p+1)->buff);
+      printIcharset(p, (p+1)->buff);
       break;
     }
     case IOpenCall: {
@@ -1975,7 +2481,7 @@ static void printinst (const Instruction *op, const Instruction *p) {
       break;
     }
     case IBehind: {
-      printf("%d", p->i.aux);
+      printf("%d", p->i.aux1);
       break;
     }
     case IJmp: case ICall: case ICommit: case IChoice:
@@ -1989,8 +2495,9 @@ static void printinst (const Instruction *op, const Instruction *p) {
 }
 
 
-void printpatt (Instruction *p, int n) {
+void printpatt (Instruction *p) {
   Instruction *op = p;
+  uint n = op[-1].codesize - 1;
   while (p < op + n) {
     printinst(op, p);
     p += sizei(p);
@@ -1998,20 +2505,39 @@ void printpatt (Instruction *p, int n) {
 }
 
 
-#if defined(LPEG_DEBUG)
-static void printcap (Capture *cap) {
-  printcapkind(cap->kind);
-  printf(" (idx: %d - size: %d) -> %p\n", cap->idx, cap->siz, cap->s);
+static void printcap (Capture *cap, int ident) {
+  while (ident--) printf(" ");
+  printf("%s (idx: %d - size: %d) -> %lu  (%p)\n",
+         capkind(cap->kind), cap->idx, cap->siz, (long)cap->index, (void*)cap);
 }
 
 
-void printcaplist (Capture *cap, Capture *limit) {
+/*
+** Print a capture and its nested captures
+*/
+static Capture *printcap2close (Capture *cap, int ident) {
+  Capture *head = cap++;
+  printcap(head, ident);  /* print head capture */
+  while (capinside(head, cap))
+    cap = printcap2close(cap, ident + 2);  /* print nested captures */
+  if (isopencap(head)) {
+    assert(isclosecap(cap));
+    printcap(cap++, ident);  /* print and skip close capture */
+  }
+  return cap;
+}
+
+
+void printcaplist (Capture *cap) {
+  {  /* for debugging, print first a raw list of captures */
+    Capture *c = cap;
+    while (c->index != MAXINDT) { printcap(c, 0); c++; }
+  }
   printf(">======\n");
-  for (; cap->s && (limit == NULL || cap < limit); cap++)
-    printcap(cap);
+  while (!isclosecap(cap))
+    cap = printcap2close(cap, 0);
   printf("=======\n");
 }
-#endif
 
 /* }====================================================== */
 
@@ -2024,11 +2550,11 @@ void printcaplist (Capture *cap, Capture *limit) {
 
 static const char *tagnames[] = {
   "char", "set", "any",
-  "true", "false",
+  "true", "false", "utf8.range",
   "rep",
   "seq", "choice",
   "not", "and",
-  "call", "opencall", "rule", "grammar",
+  "call", "opencall", "rule", "xinfo", "grammar",
   "behind",
   "capture", "run-time"
 };
@@ -2036,6 +2562,7 @@ static const char *tagnames[] = {
 
 void printtree (TTree *tree, int ident) {
   int i;
+  int sibs = numsiblings[tree->tag];
   for (i = 0; i < ident; i++) printf(" ");
   printf("%s", tagnames[tree->tag]);
   switch (tree->tag) {
@@ -2048,28 +2575,38 @@ void printtree (TTree *tree, int ident) {
       break;
     }
     case TSet: {
-      printcharset(treebuffer(tree));
+      printTcharset(tree);
       printf("\n");
       break;
     }
+    case TUTFR: {
+      assert(sib1(tree)->tag == TXInfo);
+      printf(" %d (%02x %d) - %d (%02x %d) \n",
+        tree->u.n, tree->key, tree->cap,
+        sib1(tree)->u.n, sib1(tree)->key, sib1(tree)->cap);
+      break;
+    }
     case TOpenCall: case TCall: {
-      printf(" key: %d\n", tree->key);
+      assert(sib1(sib2(tree))->tag == TXInfo);
+      printf(" key: %d  (rule: %d)\n", tree->key, sib1(sib2(tree))->u.n);
       break;
     }
     case TBehind: {
       printf(" %d\n", tree->u.n);
-        printtree(sib1(tree), ident + 2);
       break;
     }
     case TCapture: {
-      printf(" cap: %d  key: %d  n: %d\n", tree->cap, tree->key, tree->u.n);
-      printtree(sib1(tree), ident + 2);
+      printf(" kind: '%s'  key: %d\n", capkind(tree->cap), tree->key);
       break;
     }
     case TRule: {
-      printf(" n: %d  key: %d\n", tree->cap, tree->key);
-      printtree(sib1(tree), ident + 2);
-      break;  /* do not print next rule as a sibling */
+      printf(" key: %d\n", tree->key);
+      sibs = 1;  /* do not print 'sib2' (next rule) as a sibling */
+      break;
+    }
+    case TXInfo: {
+      printf(" n: %d\n", tree->u.n);
+      break;
     }
     case TGrammar: {
       TTree *rule = sib1(tree);
@@ -2079,28 +2616,27 @@ void printtree (TTree *tree, int ident) {
         rule = sib2(rule);
       }
       assert(rule->tag == TTrue);  /* sentinel */
+      sibs = 0;  /* siblings already handled */
       break;
     }
-    default: {
-      int sibs = numsiblings[tree->tag];
+    default:
       printf("\n");
-      if (sibs >= 1) {
-        printtree(sib1(tree), ident + 2);
-        if (sibs >= 2)
-          printtree(sib2(tree), ident + 2);
-      }
       break;
-    }
+  }
+  if (sibs >= 1) {
+    printtree(sib1(tree), ident + 2);
+    if (sibs >= 2)
+      printtree(sib2(tree), ident + 2);
   }
 }
 
 
 void printktable (lua_State *L, int idx) {
   int n, i;
-  lua_getfenv(L, idx);
+  lua_getuservalue(L, idx);
   if (lua_isnil(L, -1))  /* no ktable? */
     return;
-  n = lua_objlen(L, -1);
+  n = lua_rawlen(L, -1);
   printf("[");
   for (i = 1; i <= n; i++) {
     printf("%d = ", i);
@@ -2118,27 +2654,38 @@ void printktable (lua_State *L, int idx) {
 /* }====================================================== */
 
 #endif
-/*
-** $Id: lptree.c,v 1.10 2013/04/12 16:30:33 roberto Exp $
-** Copyright 2013, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
+
+
+/* ==========================================================================
+** File: lptree.c
+** ==========================================================================
 */
+
 
 #include <ctype.h>
 #include <limits.h>
 #include <string.h>
 
 
+#include "lua.h"
+#include "lauxlib.h"
 
+/* #include "lptypes.h" -- stripped */
+/* #include "lpcap.h" -- stripped */
+/* #include "lpcode.h" -- stripped */
+/* #include "lpprint.h" -- stripped */
+/* #include "lptree.h" -- stripped */
+/* #include "lpcset.h" -- stripped */
 
 
 /* number of siblings for each tree */
 const byte numsiblings[] = {
   0, 0, 0,	/* char, set, any */
-  0, 0,		/* true, false */
-  1,		/* rep */
+  0, 0, 0,	/* true, false, utf-range */
+  1,		/* acc */
   2, 2,		/* seq, choice */
   1, 1,		/* not, and */
-  0, 0, 2, 1,  /* call, opencall, rule, grammar */
+  0, 0, 2, 1, 1,  /* call, opencall, rule, prerule, grammar */
   1,  /* behind */
   1, 1  /* capture, runtime capture */
 };
@@ -2168,7 +2715,7 @@ static void fixonecall (lua_State *L, int postable, TTree *g, TTree *t) {
   int n;
   lua_rawgeti(L, -1, t->key);  /* get rule's name */
   lua_gettable(L, postable);  /* query name in position table */
-  n = (int)lua_tonumber(L, -1);  /* get (absolute) position */
+  n = lua_tonumber(L, -1);  /* get (absolute) position */
   lua_pop(L, 1);  /* remove position */
   if (n == 0) {  /* no position? */
     lua_rawgeti(L, -1, t->key);  /* get rule's name again */
@@ -2177,7 +2724,7 @@ static void fixonecall (lua_State *L, int postable, TTree *g, TTree *t) {
   t->tag = TCall;
   t->u.ps = n - (t - g);  /* position relative to node */
   assert(sib2(t)->tag == TRule);
-  sib2(t)->key = t->key;
+  sib2(t)->key = t->key;  /* fix rule's key */
 }
 
 
@@ -2239,6 +2786,189 @@ static void finalfix (lua_State *L, int postable, TTree *g, TTree *t) {
 }
 
 
+
+/*
+** {===================================================================
+** KTable manipulation
+**
+** - The ktable of a pattern 'p' can be shared by other patterns that
+** contain 'p' and no other constants. Because of this sharing, we
+** should not add elements to a 'ktable' unless it was freshly created
+** for the new pattern.
+**
+** - The maximum index in a ktable is USHRT_MAX, because trees and
+** patterns use unsigned shorts to store those indices.
+** ====================================================================
+*/
+
+/*
+** Create a new 'ktable' to the pattern at the top of the stack.
+*/
+static void newktable (lua_State *L, int n) {
+  lua_createtable(L, n, 0);  /* create a fresh table */
+  lua_setuservalue(L, -2);  /* set it as 'ktable' for pattern */
+}
+
+
+/*
+** Add element 'idx' to 'ktable' of pattern at the top of the stack;
+** Return index of new element.
+** If new element is nil, does not add it to table (as it would be
+** useless) and returns 0, as ktable[0] is always nil.
+*/
+static int addtoktable (lua_State *L, int idx) {
+  if (lua_isnil(L, idx))  /* nil value? */
+    return 0;
+  else {
+    int n;
+    lua_getuservalue(L, -1);  /* get ktable from pattern */
+    n = lua_rawlen(L, -1);
+    if (n >= USHRT_MAX)
+      luaL_error(L, "too many Lua values in pattern");
+    lua_pushvalue(L, idx);  /* element to be added */
+    lua_rawseti(L, -2, ++n);
+    lua_pop(L, 1);  /* remove 'ktable' */
+    return n;
+  }
+}
+
+
+/*
+** Return the number of elements in the ktable at 'idx'.
+** In Lua 5.2/5.3, default "environment" for patterns is nil, not
+** a table. Treat it as an empty table. In Lua 5.1, assumes that
+** the environment has no numeric indices (len == 0)
+*/
+static int ktablelen (lua_State *L, int idx) {
+  if (!lua_istable(L, idx)) return 0;
+  else return lua_rawlen(L, idx);
+}
+
+
+/*
+** Concatentate the contents of table 'idx1' into table 'idx2'.
+** (Assume that both indices are negative.)
+** Return the original length of table 'idx2' (or 0, if no
+** element was added, as there is no need to correct any index).
+*/
+static int concattable (lua_State *L, int idx1, int idx2) {
+  int i;
+  int n1 = ktablelen(L, idx1);
+  int n2 = ktablelen(L, idx2);
+  if (n1 + n2 > USHRT_MAX)
+    luaL_error(L, "too many Lua values in pattern");
+  if (n1 == 0) return 0;  /* nothing to correct */
+  for (i = 1; i <= n1; i++) {
+    lua_rawgeti(L, idx1, i);
+    lua_rawseti(L, idx2 - 1, n2 + i);  /* correct 'idx2' */
+  }
+  return n2;
+}
+
+
+/*
+** When joining 'ktables', constants from one of the subpatterns must
+** be renumbered; 'correctkeys' corrects their indices (adding 'n'
+** to each of them)
+*/
+static void correctkeys (TTree *tree, int n) {
+  if (n == 0) return;  /* no correction? */
+ tailcall:
+  switch (tree->tag) {
+    case TOpenCall: case TCall: case TRunTime: case TRule: {
+      if (tree->key > 0)
+        tree->key += n;
+      break;
+    }
+    case TCapture: {
+      if (tree->key > 0 && tree->cap != Carg && tree->cap != Cnum)
+        tree->key += n;
+      break;
+    }
+    default: break;
+  }
+  switch (numsiblings[tree->tag]) {
+    case 1:  /* correctkeys(sib1(tree), n); */
+      tree = sib1(tree); goto tailcall;
+    case 2:
+      correctkeys(sib1(tree), n);
+      tree = sib2(tree); goto tailcall;  /* correctkeys(sib2(tree), n); */
+    default: assert(numsiblings[tree->tag] == 0); break;
+  }
+}
+
+
+/*
+** Join the ktables from p1 and p2 the ktable for the new pattern at the
+** top of the stack, reusing them when possible.
+*/
+static void joinktables (lua_State *L, int p1, TTree *t2, int p2) {
+  int n1, n2;
+  lua_getuservalue(L, p1);  /* get ktables */
+  lua_getuservalue(L, p2);
+  n1 = ktablelen(L, -2);
+  n2 = ktablelen(L, -1);
+  if (n1 == 0 && n2 == 0)  /* are both tables empty? */
+    lua_pop(L, 2);  /* nothing to be done; pop tables */
+  else if (n2 == 0 || lp_equal(L, -2, -1)) {  /* 2nd table empty or equal? */
+    lua_pop(L, 1);  /* pop 2nd table */
+    lua_setuservalue(L, -2);  /* set 1st ktable into new pattern */
+  }
+  else if (n1 == 0) {  /* first table is empty? */
+    lua_setuservalue(L, -3);  /* set 2nd table into new pattern */
+    lua_pop(L, 1);  /* pop 1st table */
+  }
+  else {
+    lua_createtable(L, n1 + n2, 0);  /* create ktable for new pattern */
+    /* stack: new p; ktable p1; ktable p2; new ktable */
+    concattable(L, -3, -1);  /* from p1 into new ktable */
+    concattable(L, -2, -1);  /* from p2 into new ktable */
+    lua_setuservalue(L, -4);  /* new ktable becomes 'p' environment */
+    lua_pop(L, 2);  /* pop other ktables */
+    correctkeys(t2, n1);  /* correction for indices from p2 */
+  }
+}
+
+
+/*
+** copy 'ktable' of element 'idx' to new tree (on top of stack)
+*/
+static void copyktable (lua_State *L, int idx) {
+  lua_getuservalue(L, idx);
+  lua_setuservalue(L, -2);
+}
+
+
+/*
+** merge 'ktable' from 'stree' at stack index 'idx' into 'ktable'
+** from tree at the top of the stack, and correct corresponding
+** tree.
+*/
+static void mergektable (lua_State *L, int idx, TTree *stree) {
+  int n;
+  lua_getuservalue(L, -1);  /* get ktables */
+  lua_getuservalue(L, idx);
+  n = concattable(L, -1, -2);
+  lua_pop(L, 2);  /* remove both ktables */
+  correctkeys(stree, n);
+}
+
+
+/*
+** Create a new 'ktable' to the pattern at the top of the stack, adding
+** all elements from pattern 'p' (if not 0) plus element 'idx' to it.
+** Return index of new element.
+*/
+static int addtonewktable (lua_State *L, int p, int idx) {
+  newktable(L, 1);
+  if (p)
+    mergektable(L, p, NULL);
+  return addtoktable(L, idx);
+}
+
+/* }====================================================== */
+
+
 /*
 ** {======================================================
 ** Tree generation
@@ -2268,7 +2998,7 @@ static Pattern *getpattern (lua_State *L, int idx) {
 
 
 static int getsize (lua_State *L, int idx) {
-  return (lua_objlen(L, idx) - sizeof(Pattern)) / sizeof(TTree) + 1;
+  return (lua_rawlen(L, idx) - offsetof(Pattern, tree)) / sizeof(TTree);
 }
 
 
@@ -2281,14 +3011,18 @@ static TTree *gettree (lua_State *L, int idx, int *len) {
 
 
 /*
-** create a pattern
+** create a pattern followed by a tree with 'len' nodes. Set its
+** uservalue (the 'ktable') equal to its metatable. (It could be any
+** empty sequence; the metatable is at hand here, so we use it.)
 */
 static TTree *newtree (lua_State *L, int len) {
-  size_t size = (len - 1) * sizeof(TTree) + sizeof(Pattern);
-  Pattern *p = (Pattern *)lua_newuserdatauv(L, size, 1);
+  size_t size = offsetof(Pattern, tree) + len * sizeof(TTree);
+  Pattern *p = (Pattern *)lua_newuserdata(L, size);
   luaL_getmetatable(L, PATTERN_T);
+  lua_pushvalue(L, -1);
+  lua_setuservalue(L, -3);
   lua_setmetatable(L, -2);
-  p->code = NULL;  p->codesize = 0;
+  p->code = NULL;
   return p->tree;
 }
 
@@ -2300,45 +3034,49 @@ static TTree *newleaf (lua_State *L, int tag) {
 }
 
 
-static TTree *newcharset (lua_State *L) {
-  TTree *tree = newtree(L, bytes2slots(CHARSETSIZE) + 1);
-  tree->tag = TSet;
-  loopset(i, treebuffer(tree)[i] = 0);
-  return tree;
+/*
+** Create a tree for a charset, optimizing for special cases: empty set,
+** full set, and singleton set.
+*/
+static TTree *newcharset (lua_State *L, byte *cs) {
+  charsetinfo info;
+  Opcode op = charsettype(cs, &info);
+  switch (op) {
+    case IFail: return newleaf(L, TFalse);  /* empty set */
+    case IAny: return newleaf(L, TAny);  /* full set */
+    case IChar: {  /* singleton set */
+      TTree *tree =newleaf(L, TChar);
+      tree->u.n = info.offset;
+      return tree;
+    }
+    default: {  /* regular set */
+      int i;
+      int bsize =  /* tree size in bytes */
+                  (int)offsetof(TTree, u.set.bitmap) + info.size;
+      TTree *tree = newtree(L, bytes2slots(bsize));
+      assert(op == ISet);
+      tree->tag = TSet;
+      tree->u.set.offset = info.offset;
+      tree->u.set.size = info.size;
+      tree->u.set.deflt = info.deflt;
+      for (i = 0; i < info.size; i++) {
+        assert(&treebuffer(tree)[i] < (byte*)tree + bsize);
+        treebuffer(tree)[i] = cs[info.offset + i];
+      }
+      return tree;
+    }
+  }
 }
 
 
 /*
-** add to tree a sequence where first sibling is 'sib' (with size
-** 'sibsize'); returns position for second sibling
+** Add to tree a sequence where first sibling is 'sib' (with size
+** 'sibsize'); return position for second sibling.
 */
 static TTree *seqaux (TTree *tree, TTree *sib, int sibsize) {
   tree->tag = TSeq; tree->u.ps = sibsize + 1;
   memcpy(sib1(tree), sib, sibsize * sizeof(TTree));
   return sib2(tree);
-}
-
-
-/*
-** Add element 'idx' to 'ktable' of pattern at the top of the stack;
-** create new 'ktable' if necessary. Return index of new element.
-*/
-static int addtoktable (lua_State *L, int idx) {
-  if (idx == 0 || lua_isnil(L, idx))  /* no actual value to insert? */
-    return 0;
-  else {
-    int n;
-    lua_getfenv(L, -1);  /* get ktable from pattern */
-    n = lua_objlen(L, -1);
-    if (n == 0) {  /* is it empty/non-existent? */
-      lua_pop(L, 1);  /* remove it */
-      lua_createtable(L, 1, 0);  /* create a fresh table */
-    }
-    lua_pushvalue(L, idx);  /* element to be added */
-    lua_rawseti(L, -2, n + 1);
-    lua_setfenv(L, -2);  /* set it as ktable for pattern */
-    return n + 1;
-  }
 }
 
 
@@ -2417,7 +3155,7 @@ static TTree *getpatt (lua_State *L, int idx, int *len) {
     case LUA_TFUNCTION: {
       tree = newtree(L, 2);
       tree->tag = TRunTime;
-      tree->key = addtoktable(L, idx);
+      tree->key = addtonewktable(L, 0, idx);
       sib1(tree)->tag = TTrue;
       break;
     }
@@ -2429,123 +3167,6 @@ static TTree *getpatt (lua_State *L, int idx, int *len) {
   if (len)
     *len = getsize(L, idx);
   return tree;
-}
-
-
-/*
-** Return the number of elements in the ktable of pattern at 'idx'.
-** In Lua 5.2, default "environment" for patterns is nil, not
-** a table. Treat it as an empty table. In Lua 5.1, assumes that
-** the environment has no numeric indices (len == 0)
-*/
-static int ktablelen (lua_State *L, int idx) {
-  if (!lua_istable(L, idx)) return 0;
-  else return lua_objlen(L, idx);
-}
-
-
-/*
-** Concatentate the contents of table 'idx1' into table 'idx2'.
-** (Assume that both indices are negative.)
-** Return the original length of table 'idx2'
-*/
-static int concattable (lua_State *L, int idx1, int idx2) {
-  int i;
-  int n1 = ktablelen(L, idx1);
-  int n2 = ktablelen(L, idx2);
-  if (n1 == 0) return 0;  /* nothing to correct */
-  for (i = 1; i <= n1; i++) {
-    lua_rawgeti(L, idx1, i);
-    lua_rawseti(L, idx2 - 1, n2 + i);  /* correct 'idx2' */
-  }
-  return n2;
-}
-
-
-/*
-** Make a merge of ktables from p1 and p2 the ktable for the new
-** pattern at the top of the stack.
-*/
-static int joinktables (lua_State *L, int p1, int p2) {
-  int n1, n2;
-  lua_getfenv(L, p1);  /* get ktables */
-  lua_getfenv(L, p2);
-  n1 = ktablelen(L, -2);
-  n2 = ktablelen(L, -1);
-  if (n1 == 0 && n2 == 0) {  /* are both tables empty? */
-    lua_pop(L, 2);  /* nothing to be done; pop tables */
-    return 0;  /* nothing to correct */
-  }
-  if (n2 == 0 || lua_equal(L, -2, -1)) {  /* second table is empty or equal? */
-    lua_pop(L, 1);  /* pop 2nd table */
-    lua_setfenv(L, -2);  /* set 1st ktable into new pattern */
-    return 0;  /* nothing to correct */
-  }
-  if (n1 == 0) {  /* first table is empty? */
-    lua_setfenv(L, -3);  /* set 2nd table into new pattern */
-    lua_pop(L, 1);  /* pop 1st table */
-    return 0;  /* nothing to correct */
-  }
-  else {
-    lua_createtable(L, n1 + n2, 0);  /* create ktable for new pattern */
-    /* stack: new p; ktable p1; ktable p2; new ktable */
-    concattable(L, -3, -1);  /* from p1 into new ktable */
-    concattable(L, -2, -1);  /* from p2 into new ktable */
-    lua_setfenv(L, -4);  /* new ktable becomes p env */
-    lua_pop(L, 2);  /* pop other ktables */
-    return n1;  /* correction for indices from p2 */
-  }
-}
-
-
-static void correctkeys (TTree *tree, int n) {
-  if (n == 0) return;  /* no correction? */
- tailcall:
-  switch (tree->tag) {
-    case TOpenCall: case TCall: case TRunTime: case TRule: {
-      if (tree->key > 0)
-        tree->key += n;
-      break;
-    }
-    case TCapture: {
-      if (tree->key > 0 && tree->cap != Carg && tree->cap != Cnum)
-        tree->key += n;
-      break;
-    }
-    default: break;
-  }
-  switch (numsiblings[tree->tag]) {
-    case 1:  /* correctkeys(sib1(tree), n); */
-      tree = sib1(tree); goto tailcall;
-    case 2:
-      correctkeys(sib1(tree), n);
-      tree = sib2(tree); goto tailcall;  /* correctkeys(sib2(tree), n); */
-    default: assert(numsiblings[tree->tag] == 0); break;
-  }
-}
-
-
-/*
-** copy 'ktable' of element 'idx' to new tree (on top of stack)
-*/
-static void copyktable (lua_State *L, int idx) {
-  lua_getfenv(L, idx);
-  lua_setfenv(L, -2);
-}
-
-
-/*
-** merge 'ktable' from rule at stack index 'idx' into 'ktable'
-** from tree at the top of the stack, and correct corresponding
-** tree.
-*/
-static void mergektable (lua_State *L, int idx, TTree *rule) {
-  int n;
-  lua_getfenv(L, -1);  /* get ktables */
-  lua_getfenv(L, idx);
-  n = concattable(L, -1, -2);
-  lua_pop(L, 2);  /* remove both ktables */
-  correctkeys(rule, n);
 }
 
 
@@ -2577,7 +3198,7 @@ static TTree *newroot2sib (lua_State *L, int tag) {
   tree->u.ps =  1 + s1;
   memcpy(sib1(tree), tree1, s1 * sizeof(TTree));
   memcpy(sib2(tree), tree2, s2 * sizeof(TTree));
-  correctkeys(sib2(tree), joinktables(L, 1, 2));
+  joinktables(L, 1, sib2(tree), 2);
   return tree;
 }
 
@@ -2619,8 +3240,8 @@ static int lp_choice (lua_State *L) {
   TTree *t1 = getpatt(L, 1, NULL);
   TTree *t2 = getpatt(L, 2, NULL);
   if (tocharset(t1, &st1) && tocharset(t2, &st2)) {
-    TTree *t = newcharset(L);
-    loopset(i, treebuffer(t)[i] = st1.cs[i] | st2.cs[i]);
+    loopset(i, st1.cs[i] |= st2.cs[i]);
+    newcharset(L, st1.cs);
   }
   else if (nofail(t1) || t2->tag == TFalse)
     lua_pushvalue(L, 1);  /* true / x => true, x / false => x */
@@ -2637,8 +3258,8 @@ static int lp_choice (lua_State *L) {
 */
 static int lp_star (lua_State *L) {
   int size1;
-  int n = luaL_checkint(L, 2);
-  TTree *tree1 = gettree(L, 1, &size1);
+  int n = (int)luaL_checkinteger(L, 2);
+  TTree *tree1 = getpatt(L, 1, &size1);
   if (n >= 0) {  /* seq tree1 (seq tree1 ... (seq tree1 (rep tree1))) */
     TTree *tree = newtree(L, (n + 1) * (size1 + 1));
     if (nullable(tree1))
@@ -2696,8 +3317,8 @@ static int lp_sub (lua_State *L) {
   TTree *t1 = getpatt(L, 1, &s1);
   TTree *t2 = getpatt(L, 2, &s2);
   if (tocharset(t1, &st1) && tocharset(t2, &st2)) {
-    TTree *t = newcharset(L);
-    loopset(i, treebuffer(t)[i] = st1.cs[i] & ~st2.cs[i]);
+    loopset(i, st1.cs[i] &= ~st2.cs[i]);
+    newcharset(L, st1.cs);
   }
   else {
     TTree *tree = newtree(L, 2 + s1 + s2);
@@ -2706,7 +3327,7 @@ static int lp_sub (lua_State *L) {
     sib1(tree)->tag = TNot;  /* ...not... */
     memcpy(sib1(sib1(tree)), t2, s2 * sizeof(TTree));  /* ...t2 */
     memcpy(sib2(tree), t1, s1 * sizeof(TTree));  /* ... and t1 */
-    correctkeys(sib1(tree), joinktables(L, 1, 2));
+    joinktables(L, 1, sib1(tree), 2);
   }
   return 1;
 }
@@ -2715,11 +3336,13 @@ static int lp_sub (lua_State *L) {
 static int lp_set (lua_State *L) {
   size_t l;
   const char *s = luaL_checklstring(L, 1, &l);
-  TTree *tree = newcharset(L);
+  byte buff[CHARSETSIZE];
+  clearset(buff);
   while (l--) {
-    setchar(treebuffer(tree), (byte)(*s));
+    setchar(buff, (byte)(*s));
     s++;
   }
+  newcharset(L, buff);
   return 1;
 }
 
@@ -2727,14 +3350,68 @@ static int lp_set (lua_State *L) {
 static int lp_range (lua_State *L) {
   int arg;
   int top = lua_gettop(L);
-  TTree *tree = newcharset(L);
+  byte buff[CHARSETSIZE];
+  clearset(buff);
   for (arg = 1; arg <= top; arg++) {
     int c;
     size_t l;
     const char *r = luaL_checklstring(L, arg, &l);
     luaL_argcheck(L, l == 2, arg, "range must have two characters");
     for (c = (byte)r[0]; c <= (byte)r[1]; c++)
-      setchar(treebuffer(tree), c);
+      setchar(buff, c);
+  }
+  newcharset(L, buff);
+  return 1;
+}
+
+
+/*
+** Fills a tree node with basic information about the UTF-8 code point
+** 'cpu': its value in 'n', its length in 'cap', and its first byte in
+** 'key'
+*/
+static void codeutftree (lua_State *L, TTree *t, lua_Unsigned cpu, int arg) {
+  int len, fb, cp;
+  cp = (int)cpu;
+  if (cp <= 0x7f) {  /* one byte? */
+    len = 1;
+    fb = cp;
+  } else if (cp <= 0x7ff) {
+    len = 2;
+    fb = 0xC0 | (cp >> 6);
+  } else if (cp <= 0xffff) {
+    len = 3;
+    fb = 0xE0 | (cp >> 12);
+  }
+  else {
+    luaL_argcheck(L, cpu <= 0x10ffffu, arg, "invalid code point");
+    len = 4;
+    fb = 0xF0 | (cp >> 18);
+  }
+  t->u.n = cp;
+  t->cap = len;
+  t->key = fb;
+}
+
+
+static int lp_utfr (lua_State *L) {
+  lua_Unsigned from = (lua_Unsigned)luaL_checkinteger(L, 1);
+  lua_Unsigned to = (lua_Unsigned)luaL_checkinteger(L, 2);
+  luaL_argcheck(L, from <= to, 2, "empty range");
+  if (to <= 0x7f) {  /* ascii range? */
+    uint f;
+    byte buff[CHARSETSIZE];  /* code it as a regular charset */
+    clearset(buff);
+    for (f = (int)from; f <= to; f++)
+      setchar(buff, f);
+    newcharset(L, buff);
+  }
+  else {  /* multi-byte utf-8 range */
+    TTree *tree = newtree(L, 2);
+    tree->tag = TUTFR;
+    codeutftree(L, tree, from, 1);
+    sib1(tree)->tag = TXInfo;
+    codeutftree(L, sib1(tree), to, 2);
   }
   return 1;
 }
@@ -2747,8 +3424,8 @@ static int lp_behind (lua_State *L) {
   TTree *tree;
   TTree *tree1 = getpatt(L, 1, NULL);
   int n = fixedlen(tree1);
+  luaL_argcheck(L, n >= 0, 1, "pattern may not have fixed length");
   luaL_argcheck(L, !hascaptures(tree1), 1, "pattern have captures");
-  luaL_argcheck(L, n > 0, 1, "pattern may not have fixed length");
   luaL_argcheck(L, n <= MAXBEHIND, 1, "pattern too long to look behind");
   tree = newroot1sib(L, TBehind);
   tree->u.n = n;
@@ -2762,7 +3439,7 @@ static int lp_behind (lua_State *L) {
 static int lp_V (lua_State *L) {
   TTree *tree = newleaf(L, TOpenCall);
   luaL_argcheck(L, !lua_isnoneornil(L, 1), 1, "non-nil value expected");
-  tree->key = addtoktable(L, 1);
+  tree->key = addtonewktable(L, 0, 1);
   return 1;
 }
 
@@ -2775,28 +3452,40 @@ static int lp_V (lua_State *L) {
 static int capture_aux (lua_State *L, int cap, int labelidx) {
   TTree *tree = newroot1sib(L, TCapture);
   tree->cap = cap;
-  tree->key = addtoktable(L, labelidx);
+  tree->key = (labelidx == 0) ? 0 : addtonewktable(L, 1, labelidx);
   return 1;
 }
 
 
 /*
 ** Fill a tree with an empty capture, using an empty (TTrue) sibling.
+** (The 'key' field must be filled by the caller to finish the tree.)
 */
-static TTree *auxemptycap (lua_State *L, TTree *tree, int cap, int idx) {
+static TTree *auxemptycap (TTree *tree, int cap) {
   tree->tag = TCapture;
   tree->cap = cap;
-  tree->key = addtoktable(L, idx);
   sib1(tree)->tag = TTrue;
   return tree;
 }
 
 
 /*
-** Create a tree for an empty capture
+** Create a tree for an empty capture.
 */
-static TTree *newemptycap (lua_State *L, int cap, int idx) {
-  return auxemptycap(L, newtree(L, 2), cap, idx);
+static TTree *newemptycap (lua_State *L, int cap, int key) {
+  TTree *tree = auxemptycap(newtree(L, 2), cap);
+  tree->key = key;
+  return tree;
+}
+
+
+/*
+** Create a tree for an empty capture with an associated Lua value.
+*/
+static TTree *newemptycapkey (lua_State *L, int cap, int idx) {
+  TTree *tree = auxemptycap(newtree(L, 2), cap);
+  tree->key = addtonewktable(L, 0, idx);
+  return tree;
 }
 
 
@@ -2817,8 +3506,15 @@ static int lp_divcapture (lua_State *L) {
       tree->key = n;
       return 1;
     }
-    default: return luaL_argerror(L, 2, "invalid replacement value");
+    default:
+      return luaL_error(L, "unexpected %s as 2nd operand to LPeg '/'",
+                           luaL_typename(L, 2));
   }
+}
+
+
+static int lp_acccapture (lua_State *L) {
+  return capture_aux(L, Cacc, 2);
 }
 
 
@@ -2835,10 +3531,8 @@ static int lp_tablecapture (lua_State *L) {
 static int lp_groupcapture (lua_State *L) {
   if (lua_isnoneornil(L, 2))
     return capture_aux(L, Cgroup, 0);
-  else {
-    luaL_checkstring(L, 2);
+  else
     return capture_aux(L, Cgroup, 2);
-  }
 }
 
 
@@ -2860,17 +3554,16 @@ static int lp_poscapture (lua_State *L) {
 
 
 static int lp_argcapture (lua_State *L) {
-  int n = luaL_checkint(L, 1);
-  TTree *tree = newemptycap(L, Carg, 0);
-  tree->key = n;
+  int n = (int)luaL_checkinteger(L, 1);
   luaL_argcheck(L, 0 < n && n <= SHRT_MAX, 1, "invalid argument index");
+  newemptycap(L, Carg, n);
   return 1;
 }
 
 
 static int lp_backref (lua_State *L) {
-  luaL_checkstring(L, 1);
-  newemptycap(L, Cbackref, 1);
+  luaL_checkany(L, 1);
+  newemptycapkey(L, Cbackref, 1);
   return 1;
 }
 
@@ -2884,9 +3577,10 @@ static int lp_constcapture (lua_State *L) {
   if (n == 0)  /* no values? */
     newleaf(L, TTrue);  /* no capture */
   else if (n == 1)
-    newemptycap(L, Cconst, 1);  /* single constant capture */
+    newemptycapkey(L, Cconst, 1);  /* single constant capture */
   else {  /* create a group capture with all values */
     TTree *tree = newtree(L, 1 + 3 * (n - 1) + 2);
+    newktable(L, n);  /* create a 'ktable' for new tree */
     tree->tag = TCapture;
     tree->cap = Cgroup;
     tree->key = 0;
@@ -2894,10 +3588,12 @@ static int lp_constcapture (lua_State *L) {
     for (i = 1; i <= n - 1; i++) {
       tree->tag = TSeq;
       tree->u.ps = 3;  /* skip TCapture and its sibling */
-      auxemptycap(L, sib1(tree), Cconst, i);
+      auxemptycap(sib1(tree), Cconst);
+      sib1(tree)->key = addtoktable(L, i);
       tree = sib2(tree);
     }
-    auxemptycap(L, tree, Cconst, i);
+    auxemptycap(tree, Cconst);
+    tree->key = addtoktable(L, i);
   }
   return 1;
 }
@@ -2907,7 +3603,7 @@ static int lp_matchtime (lua_State *L) {
   TTree *tree;
   luaL_checktype(L, 2, LUA_TFUNCTION);
   tree = newroot1sib(L, TRunTime);
-  tree->key = addtoktable(L, 2);
+  tree->key = addtonewktable(L, 1, 2);
   return 1;
 }
 
@@ -2960,11 +3656,11 @@ static int collectrules (lua_State *L, int arg, int *totalsize) {
   int size;  /* accumulator for total size */
   lua_newtable(L);  /* create position table */
   getfirstrule(L, arg, postab);
-  size = 2 + getsize(L, postab + 2);  /* TGrammar + TRule + rule */
+  size = 3 + getsize(L, postab + 2);  /* TGrammar + TRule + TXInfo + rule */
   lua_pushnil(L);  /* prepare to traverse grammar table */
   while (lua_next(L, arg) != 0) {
     if (lua_tonumber(L, -2) == 1 ||
-        lua_equal(L, -2, postab + 1)) {  /* initial rule? */
+        lp_equal(L, -2, postab + 1)) {  /* initial rule? */
       lua_pop(L, 1);  /* remove value (keep key for lua_next) */
       continue;
     }
@@ -2974,11 +3670,11 @@ static int collectrules (lua_State *L, int arg, int *totalsize) {
     lua_pushvalue(L, -2);  /* push key (to insert into position table) */
     lua_pushinteger(L, size);
     lua_settable(L, postab);
-    size += 1 + getsize(L, -1);  /* update size */
+    size += 2 + getsize(L, -1);  /* add 'TRule + TXInfo + rule' to size */
     lua_pushvalue(L, -2);  /* push key (for next lua_next) */
     n++;
   }
-  *totalsize = size + 1;  /* TTrue to finish list of rules */
+  *totalsize = size + 1;  /* space for 'TTrue' finishing list of rules */
   return n;
 }
 
@@ -2990,11 +3686,13 @@ static void buildgrammar (lua_State *L, TTree *grammar, int frule, int n) {
     int ridx = frule + 2*i + 1;  /* index of i-th rule */
     int rulesize;
     TTree *rn = gettree(L, ridx, &rulesize);
+    TTree *pr = sib1(nd);  /* points to rule's prerule */
     nd->tag = TRule;
-    nd->key = 0;
-    nd->cap = i;  /* rule number */
-    nd->u.ps = rulesize + 1;  /* point to next rule */
-    memcpy(sib1(nd), rn, rulesize * sizeof(TTree));  /* copy rule */
+    nd->key = 0;  /* will be fixed when rule is used */
+    pr->tag = TXInfo;
+    pr->u.n = i;  /* rule number */
+    nd->u.ps = rulesize + 2;  /* point to next rule */
+    memcpy(sib1(pr), rn, rulesize * sizeof(TTree));  /* copy rule */
     mergektable(L, ridx, sib1(nd));  /* merge its ktable into new one */
     nd = sib2(nd);  /* move to next rule */
   }
@@ -3025,7 +3723,12 @@ static int checkloops (TTree *tree) {
 }
 
 
-static int verifyerror (lua_State *L, int *passed, int npassed) {
+/*
+** Give appropriate error message for 'verifyrule'. If a rule appears
+** twice in 'passed', there is path from it back to itself without
+** advancing the subject.
+*/
+static int verifyerror (lua_State *L, unsigned short *passed, int npassed) {
   int i, j;
   for (i = npassed - 1; i >= 0; i--) {  /* search for a repetition */
     for (j = i - 1; j >= 0; j--) {
@@ -3041,42 +3744,48 @@ static int verifyerror (lua_State *L, int *passed, int npassed) {
 
 /*
 ** Check whether a rule can be left recursive; raise an error in that
-** case; otherwise return 1 iff pattern is nullable. Assume ktable at
-** the top of the stack.
+** case; otherwise return 1 iff pattern is nullable.
+** The return value is used to check sequences, where the second pattern
+** is only relevant if the first is nullable.
+** Parameter 'nb' works as an accumulator, to allow tail calls in
+** choices. ('nb' true makes function returns true.)
+** Parameter 'passed' is a list of already visited rules, 'npassed'
+** counts the elements in 'passed'.
+** Assume ktable at the top of the stack.
 */
-static int verifyrule (lua_State *L, TTree *tree, int *passed, int npassed,
-                       int nullable) {
+static int verifyrule (lua_State *L, TTree *tree, unsigned short *passed,
+                                     int npassed, int nb) {
  tailcall:
   switch (tree->tag) {
     case TChar: case TSet: case TAny:
-    case TFalse:
-      return nullable;  /* cannot pass from here */
+    case TFalse: case TUTFR:
+      return nb;  /* cannot pass from here */
     case TTrue:
     case TBehind:  /* look-behind cannot have calls */
       return 1;
     case TNot: case TAnd: case TRep:
       /* return verifyrule(L, sib1(tree), passed, npassed, 1); */
-      tree = sib1(tree); nullable = 1; goto tailcall;
-    case TCapture: case TRunTime:
-      /* return verifyrule(L, sib1(tree), passed, npassed); */
+      tree = sib1(tree); nb = 1; goto tailcall;
+    case TCapture: case TRunTime: case TXInfo:
+      /* return verifyrule(L, sib1(tree), passed, npassed, nb); */
       tree = sib1(tree); goto tailcall;
     case TCall:
-      /* return verifyrule(L, sib2(tree), passed, npassed); */
+      /* return verifyrule(L, sib2(tree), passed, npassed, nb); */
       tree = sib2(tree); goto tailcall;
-    case TSeq:  /* only check 2nd child if first is nullable */
+    case TSeq:  /* only check 2nd child if first is nb */
       if (!verifyrule(L, sib1(tree), passed, npassed, 0))
-        return nullable;
-      /* else return verifyrule(L, sib2(tree), passed, npassed); */
+        return nb;
+      /* else return verifyrule(L, sib2(tree), passed, npassed, nb); */
       tree = sib2(tree); goto tailcall;
     case TChoice:  /* must check both children */
-      nullable = verifyrule(L, sib1(tree), passed, npassed, nullable);
-      /* return verifyrule(L, sib2(tree), passed, npassed, nullable); */
+      nb = verifyrule(L, sib1(tree), passed, npassed, nb);
+      /* return verifyrule(L, sib2(tree), passed, npassed, nb); */
       tree = sib2(tree); goto tailcall;
     case TRule:
-      if (npassed >= MAXRULES)
-        return verifyerror(L, passed, npassed);
+      if (npassed >= MAXRULES)  /* too many steps? */
+        return verifyerror(L, passed, npassed);  /* error */
       else {
-        passed[npassed++] = tree->key;
+        passed[npassed++] = tree->key;  /* add rule to path */
         /* return verifyrule(L, sib1(tree), passed, npassed); */
         tree = sib1(tree); goto tailcall;
       }
@@ -3088,7 +3797,7 @@ static int verifyrule (lua_State *L, TTree *tree, int *passed, int npassed,
 
 
 static void verifygrammar (lua_State *L, TTree *grammar) {
-  int passed[MAXRULES];
+  unsigned short passed[MAXRULES];
   TTree *rule;
   /* check left-recursive rules */
   for (rule = sib1(grammar); rule->tag == TRule; rule = sib2(rule)) {
@@ -3113,7 +3822,7 @@ static void verifygrammar (lua_State *L, TTree *grammar) {
 */
 static void initialrulename (lua_State *L, TTree *grammar, int frule) {
   if (sib1(grammar)->key == 0) {  /* initial rule is not referenced? */
-    int n = lua_objlen(L, -1) + 1;  /* index for name */
+    int n = lua_rawlen(L, -1) + 1;  /* index for name */
     lua_pushvalue(L, frule);  /* rule's name */
     lua_rawseti(L, -2, n);  /* ktable was on the top of the stack */
     sib1(grammar)->key = n;
@@ -3129,9 +3838,9 @@ static TTree *newgrammar (lua_State *L, int arg) {
   luaL_argcheck(L, n <= MAXRULES, arg, "grammar has too many rules");
   g->tag = TGrammar;  g->u.n = n;
   lua_newtable(L);  /* create 'ktable' */
-  lua_setfenv(L, -2);
+  lua_setuservalue(L, -2);
   buildgrammar(L, g, frule, n);
-  lua_getfenv(L, -1);  /* get 'ktable' for new tree */
+  lua_getuservalue(L, -1);  /* get 'ktable' for new tree */
   finalfix(L, frule - 1, g, sib1(g));
   initialrulename(L, g, frule);
   verifygrammar(L, g);
@@ -3145,10 +3854,10 @@ static TTree *newgrammar (lua_State *L, int arg) {
 
 
 static Instruction *prepcompile (lua_State *L, Pattern *p, int idx) {
-  lua_getfenv(L, idx);  /* push 'ktable' (may be used by 'finalfix') */
+  lua_getuservalue(L, idx);  /* push 'ktable' (may be used by 'finalfix') */
   finalfix(L, 0, NULL, p->tree);
   lua_pop(L, 1);  /* remove 'ktable' */
-  return compile(L, p);
+  return compile(L, p, getsize(L, idx));
 }
 
 
@@ -3156,7 +3865,7 @@ static int lp_printtree (lua_State *L) {
   TTree *tree = getpatt(L, 1, NULL);
   int c = lua_toboolean(L, 2);
   if (c) {
-    lua_getfenv(L, 1);  /* push 'ktable' (may be used by 'finalfix') */
+    lua_getuservalue(L, 1);  /* push 'ktable' (may be used by 'finalfix') */
     finalfix(L, 0, NULL, tree);
     lua_pop(L, 1);  /* remove 'ktable' */
   }
@@ -3171,7 +3880,7 @@ static int lp_printcode (lua_State *L) {
   printktable(L, 1);
   if (p->code == NULL)  /* not compiled yet? */
     prepcompile(L, p, 1);
-  printpatt(p->code, p->codesize);
+  printpatt(p->code);
   return 0;
 }
 
@@ -3207,9 +3916,10 @@ static int lp_match (lua_State *L) {
   const char *s = luaL_checklstring(L, SUBJIDX, &l);
   size_t i = initposition(L, l);
   int ptop = lua_gettop(L);
+  luaL_argcheck(L, l < MAXINDT, SUBJIDX, "subject too long");
   lua_pushnil(L);  /* initialize subscache */
   lua_pushlightuserdata(L, capture);  /* initialize caplistidx */
-  lua_getfenv(L, 1);  /* initialize penvidx */
+  lua_getuservalue(L, 1);  /* initialize ktableidx */
   r = match(L, s, s + i, s + l, code, capture, ptop);
   if (r == NULL) {
     lua_pushnil(L);
@@ -3226,17 +3936,15 @@ static int lp_match (lua_State *L) {
 ** =======================================================
 */
 
+/* maximum limit for stack size */
+#define MAXLIM		(INT_MAX / 100)
+
 static int lp_setmax (lua_State *L) {
-  luaL_optinteger(L, 1, -1);
+  lua_Integer lim = luaL_checkinteger(L, 1);
+  luaL_argcheck(L, 0 < lim && lim <= MAXLIM, 1, "out of range");
   lua_settop(L, 1);
   lua_setfield(L, LUA_REGISTRYINDEX, MAXSTACKIDX);
   return 0;
-}
-
-
-static int lp_version (lua_State *L) {
-  lua_pushstring(L, VERSION);
-  return 1;
 }
 
 
@@ -3251,17 +3959,22 @@ static int lp_type (lua_State *L) {
 
 int lp_gc (lua_State *L) {
   Pattern *p = getpattern(L, 1);
-  if (p->codesize > 0)
-    reallocprog(L, p, 0);
+  freecode(L, p);  /* delete code block */
   return 0;
 }
 
 
+/*
+** Create a charset representing a category of characters, given by
+** the predicate 'catf'.
+*/
 static void createcat (lua_State *L, const char *catname, int (catf) (int)) {
-  TTree *t = newcharset(L);
-  int i;
-  for (i = 0; i <= UCHAR_MAX; i++)
-    if (catf(i)) setchar(treebuffer(t), i);
+  int c;
+  byte buff[CHARSETSIZE];
+  clearset(buff);
+  for (c = 0; c <= UCHAR_MAX; c++)
+    if (catf(c)) setchar(buff, c);
+  newcharset(L, buff);
   lua_setfield(L, -2, catname);
 }
 
@@ -3309,8 +4022,9 @@ static struct luaL_Reg pattreg[] = {
   {"P", lp_P},
   {"S", lp_set},
   {"R", lp_range},
+  {"utfR", lp_utfr},
   {"locale", lp_locale},
-  {"version", lp_version},
+  {"version", NULL},
   {"setmaxstack", lp_setmax},
   {"type", lp_type},
   {NULL, NULL}
@@ -3324,46 +4038,97 @@ static struct luaL_Reg metareg[] = {
   {"__gc", lp_gc},
   {"__len", lp_and},
   {"__div", lp_divcapture},
+  {"__mod", lp_acccapture},
   {"__unm", lp_not},
   {"__sub", lp_sub},
   {NULL, NULL}
 };
 
 
-LUALIB_API int luaopen_lpeg (lua_State *L);
-LUALIB_API int luaopen_lpeg (lua_State *L) {
+int luaopen_lpeg (lua_State *L);
+int luaopen_lpeg (lua_State *L) {
   luaL_newmetatable(L, PATTERN_T);
   lua_pushnumber(L, MAXBACK);  /* initialize maximum backtracking */
   lua_setfield(L, LUA_REGISTRYINDEX, MAXSTACKIDX);
-  luaL_register(L, NULL, metareg);
-  luaL_register(L, "lpeg", pattreg);
+  luaL_setfuncs(L, metareg, 0);
+  luaL_newlib(L, pattreg);
   lua_pushvalue(L, -1);
   lua_setfield(L, -3, "__index");
+  lua_pushliteral(L, "LPeg " VERSION);
+  lua_setfield(L, -2, "version");
   return 1;
 }
 
 /* }====================================================== */
-/*
-** $Id: lpvm.c,v 1.5 2013/04/12 16:29:49 roberto Exp $
-** Copyright 2007, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
+
+
+/* ==========================================================================
+** File: lpvm.c
+** ==========================================================================
 */
+
 
 #include <limits.h>
 #include <string.h>
 
 
+#include "lua.h"
+#include "lauxlib.h"
 
+/* #include "lpcap.h" -- stripped */
+/* #include "lptypes.h" -- stripped */
+/* #include "lpvm.h" -- stripped */
+/* #include "lpprint.h" -- stripped */
 
 
 /* initial size for call/backtrack stack */
 #if !defined(INITBACK)
-#define INITBACK	100
+#define INITBACK	MAXBACK
 #endif
 
 
 #define getoffset(p)	(((p) + 1)->offset)
 
-static const Instruction giveup = {{IGiveup, 0, 0}};
+static const Instruction giveup = {{IGiveup, 0, {0}}};
+
+
+int charinset (const Instruction *i, const byte *buff, uint c) {
+  c -= i->i.aux2.set.offset;
+  if (c >= ((uint)i->i.aux2.set.size  /* size in instructions... */
+           * (uint)sizeof(Instruction)  /* in bytes... */
+           * 8u))  /* in bits */
+    return i->i.aux1;  /* out of range; return default value */
+  return testchar(buff, c);
+}
+
+
+/*
+** Decode one UTF-8 sequence, returning NULL if byte sequence is invalid.
+*/
+static const char *utf8_decode (const char *o, int *val) {
+  static const uint limits[] = {0xFF, 0x7F, 0x7FF, 0xFFFFu};
+  const unsigned char *s = (const unsigned char *)o;
+  uint c = s[0];  /* first byte */
+  uint res = 0;  /* final result */
+  if (c < 0x80)  /* ascii? */
+    res = c;
+  else {
+    int count = 0;  /* to count number of continuation bytes */
+    while (c & 0x40) {  /* still have continuation bytes? */
+      int cc = s[++count];  /* read next byte */
+      if ((cc & 0xC0) != 0x80)  /* not a continuation byte? */
+        return NULL;  /* invalid byte sequence */
+      res = (res << 6) | (cc & 0x3F);  /* add lower 6 bits from cont. byte */
+      c <<= 1;  /* to test next bit */
+    }
+    res |= (c & 0x7F) << (count * 5);  /* add first byte */
+    if (count > 3 || res > 0x10FFFFu || res <= limits[count])
+      return NULL;  /* invalid byte sequence */
+    s += count;  /* skip continuation bytes read */
+  }
+  *val = res;
+  return (const char *)s + 1;  /* +1 to include first byte */
+}
 
 
 /*
@@ -3384,16 +4149,38 @@ typedef struct Stack {
 
 
 /*
-** Double the size of the array of captures
+** Ensures the size of array 'capture' (with size '*capsize' and
+** 'captop' elements being used) is enough to accomodate 'n' extra
+** elements plus one.  (Because several opcodes add stuff to the capture
+** array, it is simpler to ensure the array always has at least one free
+** slot upfront and check its size later.)
 */
-static Capture *doublecap (lua_State *L, Capture *cap, int captop, int ptop) {
-  Capture *newc;
-  if (captop >= INT_MAX/((int)sizeof(Capture) * 2))
-    luaL_error(L, "too many captures");
-  newc = (Capture *)lua_newuserdatauv(L, captop * 2 * sizeof(Capture), 0);
-  memcpy(newc, cap, captop * sizeof(Capture));
-  lua_replace(L, caplistidx(ptop));
-  return newc;
+
+/* new size in number of elements cannot overflow integers, and new
+   size in bytes cannot overflow size_t. */
+#define MAXNEWSIZE  \
+    (((size_t)INT_MAX) <= (~(size_t)0 / sizeof(Capture)) ?  \
+     ((size_t)INT_MAX) : (~(size_t)0 / sizeof(Capture)))
+
+static Capture *growcap (lua_State *L, Capture *capture, int *capsize,
+                                       int captop, int n, int ptop) {
+  if (*capsize - captop > n)
+    return capture;  /* no need to grow array */
+  else {  /* must grow */
+    Capture *newc;
+    uint newsize = captop + n + 1;  /* minimum size needed */
+    if (newsize < (MAXNEWSIZE / 3) * 2)
+      newsize += newsize / 2;  /* 1.5 that size, if not too big */
+    else if (newsize < (MAXNEWSIZE / 9) * 8)
+      newsize += newsize / 8;  /* else, try 9/8 that size */
+    else
+      luaL_error(L, "too many captures");
+    newc = (Capture *)lua_newuserdata(L, newsize * sizeof(Capture));
+    memcpy(newc, capture, captop * sizeof(Capture));
+    *capsize = newsize;
+    lua_replace(L, caplistidx(ptop));
+    return newc;
+  }
 }
 
 
@@ -3409,10 +4196,10 @@ static Stack *doublestack (lua_State *L, Stack **stacklimit, int ptop) {
   max = lua_tointeger(L, -1);  /* maximum allowed size */
   lua_pop(L, 1);
   if (n >= max)  /* already at maximum size? */
-    luaL_error(L, "too many pending calls/choices");
+    luaL_error(L, "backtrack stack overflow (current limit is %d)", max);
   newn = 2 * n;  /* new size */
   if (newn > max) newn = max;
-  newstack = (Stack *)lua_newuserdatauv(L, newn * sizeof(Stack), 0);
+  newstack = (Stack *)lua_newuserdata(L, newn * sizeof(Stack));
   memcpy(newstack, stack, n * sizeof(Stack));
   lua_replace(L, stackidx(ptop));
   *stacklimit = newstack + newn;
@@ -3446,24 +4233,24 @@ static int resdyncaptures (lua_State *L, int fr, int curr, int limit) {
 
 
 /*
-** Add capture values returned by a dynamic capture to the capture list
-** 'base', nested inside a group capture. 'fd' indexes the first capture
-** value, 'n' is the number of values (at least 1).
+** Add capture values returned by a dynamic capture to the list
+** 'capture', nested inside a group. 'fd' indexes the first capture
+** value, 'n' is the number of values (at least 1). The open group
+** capture is already in 'capture', before the place for the new entries.
 */
-static void adddyncaptures (const char *s, Capture *base, int n, int fd) {
+static void adddyncaptures (Index_t index, Capture *capture, int n, int fd) {
   int i;
-  /* Cgroup capture is already there */
-  assert(base[0].kind == Cgroup && base[0].siz == 0);
-  base[0].idx = 0;  /* make it an anonymous group */
-  for (i = 1; i <= n; i++) {  /* add runtime captures */
-    base[i].kind = Cruntime;
-    base[i].siz = 1;  /* mark it as closed */
-    base[i].idx = fd + i - 1;  /* stack index of capture value */
-    base[i].s = s;
+  assert(capture[-1].kind == Cgroup && capture[-1].siz == 0);
+  capture[-1].idx = 0;  /* make group capture an anonymous group */
+  for (i = 0; i < n; i++) {  /* add runtime captures */
+    capture[i].kind = Cruntime;
+    capture[i].siz = 1;  /* mark it as closed */
+    capture[i].idx = fd + i;  /* stack index of capture value */
+    capture[i].index = index;
   }
-  base[i].kind = Cclose;  /* close group */
-  base[i].siz = 1;
-  base[i].s = s;
+  capture[n].kind = Cclose;  /* close group */
+  capture[n].siz = 1;
+  capture[n].index = index;
 }
 
 
@@ -3477,6 +4264,32 @@ static int removedyncap (lua_State *L, Capture *capture,
   if (id == 0) return 0;  /* no dynamic captures? */
   lua_settop(L, id - 1);  /* remove captures */
   return top - id + 1;  /* number of values removed */
+}
+
+
+/*
+** Find the corresponding 'open' capture before 'cap', when that capture
+** can become a full capture. If a full capture c1 is followed by an
+** empty capture c2, there is no way to know whether c2 is inside
+** c1. So, full captures can enclose only captures that start *before*
+** its end.
+*/
+static Capture *findopen (Capture *cap, Index_t currindex) {
+  int i;
+  cap--;  /* check last capture */
+  /* Must it be inside current one, but starts where current one ends? */
+  if (!isopencap(cap) && cap->index == currindex)
+    return NULL;  /* current one cannot be a full capture */
+  /* else, look for an 'open' capture */
+  for (i = 0; i < MAXLOP; i++, cap--) {
+    if (currindex - cap->index >= UCHAR_MAX)
+      return NULL;  /* capture too long for a full capture */
+    else if (isopencap(cap))  /* open capture? */
+      return cap;  /* that's the one to be closed */
+    else if (cap->kind == Cclose)
+      return NULL;  /* a full capture should not nest a non-full one */
+  }
+  return NULL;  /* not found within allowed search limit */
 }
 
 
@@ -3496,17 +4309,18 @@ const char *match (lua_State *L, const char *o, const char *s, const char *e,
   lua_pushlightuserdata(L, stackbase);
   for (;;) {
 #if defined(DEBUG)
-      printf("s: |%s| stck:%d, dyncaps:%d, caps:%d  ",
-             s, stack - getstackbase(L, ptop), ndyncap, captop);
-      printinst(op, p);
+      printf("-------------------------------------\n");
       printcaplist(capture, capture + captop);
+      printf("s: |%s| stck:%d, dyncaps:%d, caps:%d  ",
+             s, (int)(stack - getstackbase(L, ptop)), ndyncap, captop);
+      printinst(op, p);
 #endif
     assert(stackidx(ptop) + ndyncap == lua_gettop(L) && ndyncap <= captop);
     switch ((Opcode)p->i.code) {
       case IEnd: {
         assert(stack == getstackbase(L, ptop) + 1);
         capture[captop].kind = Cclose;
-        capture[captop].s = NULL;
+        capture[captop].index = MAXINDT;
         return s;
       }
       case IGiveup: {
@@ -3523,47 +4337,58 @@ const char *match (lua_State *L, const char *o, const char *s, const char *e,
         else goto fail;
         continue;
       }
+      case IUTFR: {
+        int codepoint;
+        if (s >= e)
+          goto fail;
+        s = utf8_decode (s, &codepoint);
+        if (s && p[1].offset <= codepoint && codepoint <= utf_to(p))
+          p += 2;
+        else
+          goto fail;
+        continue;
+      }
       case ITestAny: {
         if (s < e) p += 2;
         else p += getoffset(p);
         continue;
       }
       case IChar: {
-        if ((byte)*s == p->i.aux && s < e) { p++; s++; }
+        if ((byte)*s == p->i.aux1 && s < e) { p++; s++; }
         else goto fail;
         continue;
       }
       case ITestChar: {
-        if ((byte)*s == p->i.aux && s < e) p += 2;
+        if ((byte)*s == p->i.aux1 && s < e) p += 2;
         else p += getoffset(p);
         continue;
       }
       case ISet: {
-        int c = (byte)*s;
-        if (testchar((p+1)->buff, c) && s < e)
-          { p += CHARSETINSTSIZE; s++; }
+        uint c = (byte)*s;
+        if (charinset(p, (p+1)->buff, c) && s < e)
+          { p += 1 + p->i.aux2.set.size; s++; }
         else goto fail;
         continue;
       }
       case ITestSet: {
-        int c = (byte)*s;
-        if (testchar((p + 2)->buff, c) && s < e)
-          p += 1 + CHARSETINSTSIZE;
+        uint c = (byte)*s;
+        if (charinset(p, (p + 2)->buff, c) && s < e)
+          p += 2 + p->i.aux2.set.size;
         else p += getoffset(p);
         continue;
       }
       case IBehind: {
-        int n = p->i.aux;
+        int n = p->i.aux1;
         if (n > s - o) goto fail;
         s -= n; p++;
         continue;
       }
       case ISpan: {
         for (; s < e; s++) {
-          int c = (byte)*s;
-          if (!testchar((p+1)->buff, c)) break;
+          uint c = (byte)*s;
+          if (!charinset(p, (p+1)->buff, c)) break;
         }
-        p += CHARSETINSTSIZE;
+        p += 1 + p->i.aux2.set.size;
         continue;
       }
       case IJmp: {
@@ -3605,6 +4430,8 @@ const char *match (lua_State *L, const char *o, const char *s, const char *e,
       case IBackCommit: {
         assert(stack > getstackbase(L, ptop) && (stack - 1)->s != NULL);
         s = (--stack)->s;
+        if (ndyncap > 0)  /* are there matchtime captures? */
+          ndyncap -= removedyncap(L, capture, stack->caplevel, captop);
         captop = stack->caplevel;
         p += getoffset(p);
         continue;
@@ -3612,7 +4439,7 @@ const char *match (lua_State *L, const char *o, const char *s, const char *e,
       case IFailTwice:
         assert(stack > getstackbase(L, ptop));
         stack--;
-        /* go through */
+        /* FALLTHROUGH */
       case IFail:
       fail: { /* pattern failed: try to backtrack */
         do {  /* remove pending calls */
@@ -3623,64 +4450,67 @@ const char *match (lua_State *L, const char *o, const char *s, const char *e,
           ndyncap -= removedyncap(L, capture, stack->caplevel, captop);
         captop = stack->caplevel;
         p = stack->p;
+#if defined(DEBUG)
+        printf("**FAIL**\n");
+#endif
         continue;
       }
       case ICloseRunTime: {
         CapState cs;
         int rem, res, n;
         int fr = lua_gettop(L) + 1;  /* stack index of first result */
-        cs.s = o; cs.L = L; cs.ocap = capture; cs.ptop = ptop;
+        cs.reclevel = 0; cs.L = L;
+        cs.s = o; cs.ocap = capture; cs.ptop = ptop;
         n = runtimecap(&cs, capture + captop, s, &rem);  /* call function */
         captop -= n;  /* remove nested captures */
+        ndyncap -= rem;  /* update number of dynamic captures */
         fr -= rem;  /* 'rem' items were popped from Lua stack */
         res = resdyncaptures(L, fr, s - o, e - o);  /* get result */
         if (res == -1)  /* fail? */
           goto fail;
         s = o + res;  /* else update current position */
         n = lua_gettop(L) - fr + 1;  /* number of new captures */
-        ndyncap += n - rem;  /* update number of dynamic captures */
-        if (n > 0) {  /* any new capture? */
-          if ((captop += n + 2) >= capsize) {
-            capture = doublecap(L, capture, captop, ptop);
-            capsize = 2 * captop;
-          }
-          /* add new captures to 'capture' list */
-          adddyncaptures(s, capture + captop - n - 2, n, fr);
+        ndyncap += n;  /* update number of dynamic captures */
+        if (n == 0)  /* no new captures? */
+          captop--;  /* remove open group */
+        else {  /* new captures; keep original open group */
+          if (fr + n >= SHRT_MAX)
+            luaL_error(L, "too many results in match-time capture");
+          /* add new captures + close group to 'capture' list */
+          capture = growcap(L, capture, &capsize, captop, n + 1, ptop);
+          adddyncaptures(s - o, capture + captop, n, fr);
+          captop += n + 1;  /* new captures + close group */
         }
         p++;
         continue;
       }
       case ICloseCapture: {
-        const char *s1 = s;
+        Capture *open = findopen(capture + captop, s - o);
         assert(captop > 0);
-        /* if possible, turn capture into a full capture */
-        if (capture[captop - 1].siz == 0 &&
-            s1 - capture[captop - 1].s < UCHAR_MAX) {
-          capture[captop - 1].siz = s1 - capture[captop - 1].s + 1;
+        if (open) {  /* if possible, turn capture into a full capture */
+          open->siz = (s - o) - open->index + 1;
           p++;
           continue;
         }
-        else {
+        else {  /* must create a close capture */
           capture[captop].siz = 1;  /* mark entry as closed */
-          capture[captop].s = s;
+          capture[captop].index = s - o;
           goto pushcapture;
         }
       }
       case IOpenCapture:
         capture[captop].siz = 0;  /* mark entry as open */
-        capture[captop].s = s;
+        capture[captop].index = s - o;
         goto pushcapture;
       case IFullCapture:
         capture[captop].siz = getoff(p) + 1;  /* save capture size */
-        capture[captop].s = s - getoff(p);
+        capture[captop].index = s - o - getoff(p);
         /* goto pushcapture; */
       pushcapture: {
-        capture[captop].idx = p->i.key;
+        capture[captop].idx = p->i.aux2.key;
         capture[captop].kind = getkind(p);
-        if (++captop >= capsize) {
-          capture = doublecap(L, capture, captop, ptop);
-          capsize = 2 * captop;
-        }
+        captop++;
+        capture = growcap(L, capture, &capsize, captop, 0, ptop);
         p++;
         continue;
       }
@@ -3690,5 +4520,7 @@ const char *match (lua_State *L, const char *o, const char *s, const char *e,
 }
 
 /* }====================================================== */
+
+
 
 

--- a/nselib/re.lua
+++ b/nselib/re.lua
@@ -71,14 +71,14 @@ local m = require"lpeg"
 -- on 'mm'
 local mm = m
 
--- pattern's metatable
+-- patterns' metatable
 local mt = getmetatable(mm.P(0))
 
 
+local version = _VERSION
 
 -- No more global accesses after this point
-local version = _VERSION
-if version == "Lua 5.2" then _ENV = nil end
+_ENV = nil     -- does no harm in Lua 5.1
 
 
 local any = m.P(1)
@@ -132,13 +132,6 @@ updatelocale()
 local I = m.P(function (s,i) print(i, s:sub(1, i-1)); return i end)
 
 
-local function getdef (id, defs)
-  local c = defs and defs[id]
-  if not c then error("undefined name: " .. id) end
-  return c
-end
-
-
 local function patt_error (s, i)
   local msg = (#s < i + 20) and s:sub(i)
                              or s:sub(i,i+20) .. "..."
@@ -177,6 +170,20 @@ name = m.C(name)
 -- a defined name only have meaning in a given environment
 local Def = name * m.Carg(1)
 
+
+local function getdef (id, defs)
+  local c = defs and defs[id]
+  if not c then error("undefined name: " .. id) end
+  return c
+end
+
+-- match a name and return a group of its corresponding definition
+-- and 'f' (to be folded in 'Suffix')
+local function defwithfunc (f)
+  return m.Cg(Def / getdef * m.Cc(f))
+end
+
+
 local num = m.C(m.R"09"^1) * S / tonumber
 
 local String = "'" * m.C((any - "'")^0) * "'" +
@@ -191,12 +198,12 @@ end
 
 local Range = m.Cs(any * (m.P"-"/"") * (any - "]")) / mm.R
 
-local item = defined + Range + m.C(any)
+local item = (defined + Range + m.C(any)) / m.P
 
 local Class =
     "["
   * (m.C(m.P"^"^-1))    -- optional complement symbol
-  * m.Cf(item * (item - "]")^0, mt.__add) /
+  * (item * ((item % mt.__add) - "]")^0) /
                           function (c, p) return c == "^" and any - p or p end
   * "]"
 
@@ -222,13 +229,13 @@ end
 
 local exp = m.P{ "Exp",
   Exp = S * ( m.V"Grammar"
-            + m.Cf(m.V"Seq" * ("/" * S * m.V"Seq")^0, mt.__add) );
-  Seq = m.Cf(m.Cc(m.P"") * m.V"Prefix"^0 , mt.__mul)
+            + m.V"Seq" * ("/" * S * m.V"Seq" % mt.__add)^0 );
+  Seq = (m.Cc(m.P"") * (m.V"Prefix" % mt.__mul)^0)
         * (#seq_follow + patt_error);
   Prefix = "&" * S * m.V"Prefix" / mt.__len
          + "!" * S * m.V"Prefix" / mt.__unm
          + m.V"Suffix";
-  Suffix = m.Cf(m.V"Primary" * S *
+  Suffix = m.V"Primary" * S *
           ( ( m.P"+" * m.Cc(1, mt.__pow)
             + m.P"*" * m.Cc(0, mt.__pow)
             + m.P"?" * m.Cc(-1, mt.__pow)
@@ -237,11 +244,13 @@ local exp = m.P{ "Exp",
                     )
             + "->" * S * ( m.Cg((String + num) * m.Cc(mt.__div))
                          + m.P"{}" * m.Cc(nil, m.Ct)
-                         + m.Cg(Def / getdef * m.Cc(mt.__div))
+                         + defwithfunc(mt.__div)
                          )
-            + "=>" * S * m.Cg(Def / getdef * m.Cc(m.Cmt))
-            ) * S
-          )^0, function (a,b,f) return f(a,b) end );
+            + "=>" * S * defwithfunc(mm.Cmt)
+            + ">>" * S * defwithfunc(mt.__mod)
+            + "~>" * S * defwithfunc(mm.Cf)
+            ) % function (a,b,f) return f(a,b) end * S
+          )^0;
   Primary = "(" * m.V"Exp" * ")"
             + String / mm.P
             + Class
@@ -257,8 +266,7 @@ local exp = m.P{ "Exp",
             + (name * -arrow + "<" * name * ">") * m.Cb("G") / NT;
   Definition = name * arrow * m.V"Exp";
   Grammar = m.Cg(m.Cc(true), "G") *
-            m.Cf(m.V"Definition" / firstdef * m.Cg(m.V"Definition")^0,
-              adddef) / mm.P
+            ((m.V"Definition" / firstdef) * (m.V"Definition" % adddef)^0) / mm.P
 }
 
 local pattern = S * m.Cg(m.Cc(false), "G") * exp / mm.P * (-any + patt_error)
@@ -315,7 +323,6 @@ local re = {
   updatelocale = updatelocale,
 }
 
--- NSE uses Lua 5.2
---if version == "Lua 5.1" then _G.re = re end
+if version == "Lua 5.1" then _G.re = re end
 
 return re


### PR DESCRIPTION
This PR resolves issue #432 by updating the LPeg pattern-matching library used in the Nmap Scripting Engine (NSE) from version 0.12 to 1.1.0.
### Changes Included:
1. **LPeg Amalgamation Update**: Re-amalgamated LPeg C headers and source files for version 1.1.0 in `lpeg.c`.
   - Concatenated LPeg files in correct dependency order (specifically placing `lpvm.h` before `lpcset.h` to resolve `Opcode` type declaration errors).
   - Stripped local includes of the individual LPeg files (like `#include "lptypes.h"`) to prevent duplicate compilation.
2. **re.lua Update**: Merged Nmap's metadata/documentation comments with the new LPeg 1.1.0 `re.lua` implementation.
3. **Windows Platform Fixes**: Resolved Windows compile-time errors in `libnetutil/massdns.cc`:
   - Switched from `GetWindowsDirectory` to `GetWindowsDirectoryA` to resolve string conversion errors under Unicode settings.
   - Refactored `log_func` call inside static `etchosts_init` to `fprintf` to resolve non-static member variable references in a static context.
### Verification:
- Compiled successfully on Windows using MSBuild / Visual Studio 2022.
- Verified functionality using a custom NSE script invoking digits matching, the `re` module find function, and new LPeg 1.1.0 features like `utfR` UTF-8 character class matching (all test cases passed successfully).