### PR TITLE
NSE: Fix potential crashes in ms-sql scripts and refactor deprecated format_output

### DIFF
--- a/scripts/ms-sql-brute.nse
+++ b/scripts/ms-sql-brute.nse
@@ -82,8 +82,7 @@ dependencies = {"broadcast-ms-sql-discover", "ms-sql-empty-password"}
 --- Returns formatted output for the given instance
 local function create_instance_output_table( instance )
 
-  local instanceOutput = {}
-  instanceOutput["name"] = string.format( "[%s]", instance:GetName() )
+  local instanceOutput = stdnse.output_table()
   if ( instance.ms_sql_brute.credentials ) then
     local credsOutput = {}
     credsOutput["name"] = "Credentials found:"
@@ -126,7 +125,7 @@ local function create_instance_output_table( instance )
     end
   end
 
-  return stdnse.format_output(true, instanceOutput)
+  return instanceOutput
 
 end
 

--- a/scripts/ms-sql-config.nse
+++ b/scripts/ms-sql-config.nse
@@ -125,8 +125,8 @@ local function process_instance( instance )
 
   helper:Disconnect()
 
-  -- TODO: structured output instead of format_output
-  return stdnse.format_output(true, result)
+  -- Return structured output directly
+  return result
 end
 
 action, portrule, hostrule = mssql.Helper.InitScript(process_instance)

--- a/scripts/ms-sql-hasdbaccess.nse
+++ b/scripts/ms-sql-hasdbaccess.nse
@@ -142,8 +142,8 @@ local function process_instance( instance )
     end
   end
 
-  -- TODO: structured output, not format_output
-  return stdnse.format_output(true, output)
+  -- Return structured output directly
+  return output
 end
 
 

--- a/scripts/ms-sql-query.nse
+++ b/scripts/ms-sql-query.nse
@@ -99,9 +99,13 @@ do_action, portrule, hostrule = mssql.Helper.InitScript(process_instance)
 action = function(...)
   local scriptOutput = do_action(...)
 
+  if not scriptOutput then
+    return nil
+  end
+
   if ( not( stdnse.get_script_args( {'ms-sql-query.query', 'mssql-query.query' } ) ) ) then
     table.insert(scriptOutput, 1, "(Use --script-args=ms-sql-query.query='<QUERY>' to change query.)")
   end
 
-  return stdnse.format_output( true, scriptOutput )
+  return scriptOutput
 end

--- a/scripts/ms-sql-tables.nse
+++ b/scripts/ms-sql-tables.nse
@@ -241,12 +241,8 @@ local function process_instance( instance )
   end
 
 
-  local instanceOutput = {}
-  instanceOutput["name"] = string.format( "[%s]", instance:GetName() )
-  table.insert( instanceOutput, output )
-
-  return stdnse.format_output(true, instanceOutput)
-
+  -- Return structured output directly
+  return output
 end
 
 

--- a/scripts/ms-sql-xp-cmdshell.nse
+++ b/scripts/ms-sql-xp-cmdshell.nse
@@ -145,9 +145,12 @@ do_action, portrule, hostrule = mssql.Helper.InitScript(process_instance)
 
 action = function(...)
   local scriptOutput = do_action(...)
+  if not scriptOutput then
+    return nil
+  end
   if ( not(stdnse.get_script_args( {'ms-sql-xp-cmdshell.cmd', 'mssql-xp-cmdshell.cmd'} ) ) ) then
     table.insert(scriptOutput, 1, "(Use --script-args=ms-sql-xp-cmdshell.cmd='<CMD>' to change command.)")
   end
 
-  return stdnse.format_output( true, scriptOutput )
+  return scriptOutput
 end


### PR DESCRIPTION
This pull request addresses remaining bugs and refactoring tasks associated with Issue #2622 (and related issues #2571, #2572, and #2784) for the Microsoft SQL Server NSE scripts.

While the primary library-level bugs in nselib/mssql.lua (such as GetDiscoveredInstances call format and #output > 0 checks on non-list tables) have been fixed in the codebase, several issues remained in the individual scripts themselves:

Runtime Crashes: Scripts like ms-sql-query.nse and ms-sql-xp-cmdshell.nse could crash with a bad argument #1 to 'insert' (table expected, got nil) error if no SQL Server instances were discovered.
Deprecated Formatting API: The scripts were still using stdnse.format_output, which is officially deprecated, returns flat text, and prevents scripts from producing clean XML/structured output.

Changes
----------
Crash Prevention: Added safety checks in ms-sql-query.nse and ms-sql-xp-cmdshell.nse to verify scriptOutput is not nil before inserting usage hints.
Structured Output Refactoring: Refactored the following scripts to return structured tables directly, enabling native Nmap text and XML output serialization:
ms-sql-query.nse
ms-sql-xp-cmdshell.nse
ms-sql-brute.nse
ms-sql-config.nse
ms-sql-hasdbaccess.nse
ms-sql-tables.nse
Double Header Removal: Removed redundant manual name header fields in ms-sql-brute.nse and ms-sql-tables.nse to prevent duplicate instance name printing in console output.
Verification
Validated script compilation and run-time safety against closed ports:

bash
--------
nmap --script-help ms-sql-*
nmap -p 1433 --script ms-sql-query 127.0.0.1