### PR TITLE
NSE: detect and enumerate AI infrastructure (MCP servers and LLM inference APIs)

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -14779,6 +14779,54 @@ match modbus m|^0\x84\0\0\0\x03\x02\x81[\x0a\x0b]| p/Modbus TCP/ i/gateway/
 
 softmatch ldap m|^0..?\x02\x01\x07e..?\n\x01.\x04\0\x04|s
 
+##############################NEXT PROBE##############################
+# Model Context Protocol (MCP) servers, Streamable HTTP transport: a JSON-RPC initialize
+# handshake (POST /mcp). The Content-Length (149) matches the JSON body byte-for-byte. For
+# capability/tool enumeration and risk flagging, use the mcp-info and mcp-enum NSE scripts.
+Probe TCP MCPInitialize q|POST /mcp HTTP/1.1\r\nHost: nmap\r\nUser-Agent: nmap-mcp\r\nContent-Type: application/json\r\nAccept: application/json, text/event-stream\r\nContent-Length: 149\r\nConnection: close\r\n\r\n{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"nmap","version":"1"}}}|
+rarity 7
+ports 3000,3001,5000,6274,8000,8080,8081,8888,9000
+
+# Full match: capture serverInfo name + version (order-tolerant within the object).
+match mcp m|"serverInfo"\s*:\s*\{[^}]*"name"\s*:\s*"([^"]+)"[^}]*"version"\s*:\s*"([^"]+)"|s p/$1/ v/$2/ i/Model Context Protocol server/ cpe:/a:modelcontextprotocol:mcp/
+# serverInfo in the other field order.
+match mcp m|"serverInfo"\s*:\s*\{[^}]*"version"\s*:\s*"([^"]+)"[^}]*"name"\s*:\s*"([^"]+)"|s p/$2/ v/$1/ i/Model Context Protocol server/ cpe:/a:modelcontextprotocol:mcp/
+# Softmatch: JSON-RPC initialize result without parseable serverInfo.
+softmatch mcp m|"jsonrpc"\s*:\s*"2\.0".*"protocolVersion"\s*:\s*"([0-9-]+)"|s i/MCP protocol $1/
+# Auth-gated MCP server advertising OAuth protected-resource metadata.
+match mcp m|WWW-Authenticate:\s*Bearer[^\r\n]*resource_metadata|s i/MCP server, OAuth-protected/ cpe:/a:modelcontextprotocol:mcp/
+
+##############################NEXT PROBE##############################
+# MCP legacy HTTP+SSE transport: GET /sse returns an `endpoint` event.
+Probe TCP MCPLegacySSE q|GET /sse HTTP/1.1\r\nHost: nmap\r\nUser-Agent: nmap-mcp\r\nAccept: text/event-stream\r\nConnection: close\r\n\r\n|
+rarity 7
+ports 3000,3001,5000,6274,8000,8080,8081,8888,9000
+
+match mcp m|event:\s*endpoint\s+data:\s*(\S+)|s i/MCP legacy HTTP+SSE, endpoint $1/ cpe:/a:modelcontextprotocol:mcp/
+softmatch mcp m|Content-Type:\s*text/event-stream|s i/MCP legacy HTTP+SSE (probable)/
+
+##############################NEXT PROBE##############################
+# LLM inference APIs. Read-only metadata requests; no inference is run. For active
+# confirmation, Anthropic detection, model enumeration, and risk flagging, use the llm-info
+# NSE script. Ollama: GET /api/tags lists installed models (name + digest + details).
+Probe TCP OllamaTags q|GET /api/tags HTTP/1.1\r\nHost: nmap\r\nUser-Agent: nmap-llm\r\nAccept: application/json\r\nConnection: close\r\n\r\n|
+rarity 7
+ports 11434
+
+match ollama m|"models"\s*:\s*\[.*"digest"\s*:\s*"[^"]+".*"parameter_size"|s p/Ollama/ i/LLM inference API/ cpe:/a:ollama:ollama/
+softmatch ollama m|"models"\s*:\s*\[.*"modified_at"|s p/Ollama/ i/LLM inference API/
+
+##############################NEXT PROBE##############################
+# OpenAI-compatible inference API (vLLM, LiteLLM, LocalAI, LM Studio, and similar):
+# GET /v1/models returns an object:list of object:model.
+Probe TCP OpenAIModels q|GET /v1/models HTTP/1.1\r\nHost: nmap\r\nUser-Agent: nmap-llm\r\nAccept: application/json\r\nConnection: close\r\n\r\n|
+rarity 7
+ports 1234,4000,5000,8000,8001,8080,8888,9000,30000
+
+match llm m|"object"\s*:\s*"list".*"object"\s*:\s*"model"|s p/OpenAI-compatible LLM API/ i/inference API/
+softmatch llm m|"object"\s*:\s*"list".*"data"\s*:\s*\[|s p/OpenAI-compatible LLM API/ i/inference API (probable)/
+
+
 # Ldap searchRequest for objectClass = * over TCP - Active Directory specific
 ##############################NEXT PROBE##############################
 Probe UDP LDAPSearchReqUDP q|\x30\x84\x00\x00\x00\x2d\x02\x01\x07\x63\x84\x00\x00\x00\x24\x04\x00\x0a\x01\x00\x0a\x01\x00\x02\x01\x00\x02\x01\x64\x01\x01\x00\x87\x0b\x6f\x62\x6a\x65\x63\x74\x43\x6c\x61\x73\x73\x30\x84\x00\x00\x00\x00|

--- a/nselib/llm.lua
+++ b/nselib/llm.lua
@@ -1,0 +1,620 @@
+---
+-- Shared library for fingerprinting LLM inference APIs exposed over HTTP(S).
+--
+-- Detects the common self-hosted and cloud inference frameworks by their read-only
+-- model-list and metadata endpoints: the OpenAI-compatible API (vLLM, SGLang, LiteLLM,
+-- LocalAI, LM Studio, text-generation-webui, and similar), Ollama, HuggingFace TGI and TEI,
+-- llama.cpp server, KoboldCpp, Triton/KServe (v2), and TorchServe. It also flags the
+-- common AI web UIs / gateways that front a backend (Open WebUI, LibreChat, NextChat,
+-- LobeChat, Flowise, AnythingLLM), reporting each UI's access posture (open /
+-- self-registration / login) since that determines whether the backend model can be
+-- reached without credentials. Reports the framework, version, model inventory,
+-- authentication posture, and notable information leaks (including model names exposed
+-- via a Prometheus /metrics endpoint).
+--
+-- By default the library also sends a single minimal "hello" completion (max_tokens = 1)
+-- to confirm an endpoint serves inference and to detect formats with no model-list endpoint
+-- (notably the Anthropic Messages API). Set llm.probe=false to keep detection strictly
+-- read-only. Authorised testing only.
+--
+-- @author Ben Williams <ben.williams@nccgroup.com>
+-- @copyright Same as Nmap--See https://nmap.org/book/man-legal.html
+
+local http = require "http"
+local json = require "json"
+local nmap = require "nmap"
+local shortport = require "shortport"
+local stdnse = require "stdnse"
+local string = require "string"
+local table = require "table"
+
+_ENV = stdnse.module("llm", stdnse.seeall)
+
+-- Neutral default User-Agent (a UA containing "nmap" is blocked by common WAFs).
+DEFAULT_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+
+-- Ports commonly hosting inference APIs / UIs (in addition to HTTP-fingerprinted ports).
+-- 11434 Ollama, 8000 vLLM/TGI/Triton, 30000 SGLang, 1234 LM Studio, 4000 LiteLLM,
+-- 5001 KoboldCpp, 8081 TorchServe mgmt, 7860/5000 gradio web-UIs, 8080/3000 Open WebUI /
+-- NextChat, 3080 LibreChat, 3001 AnythingLLM, 3210 LobeChat.
+PORTS = { 11434, 8000, 8080, 8081, 1234, 4000, 5000, 5001, 7860, 3000, 3001, 3080, 3210, 8888, 9000, 30000 }
+local PORTS_SET = {}
+for _, p in ipairs(PORTS) do PORTS_SET[p] = true end
+
+-- Build the options table from script-args, including any supplied credential. A bearer
+-- token (llm.token) and/or an arbitrary header (llm.header, e.g. "x-api-key: sk-...",
+-- "api-key: ...", "Cookie: session=...") let the scripts test authenticated APIs.
+function args()
+  local headers = {}
+  local token = stdnse.get_script_args("llm.token")
+  if token then headers["Authorization"] = "Bearer " .. token end
+  local raw = stdnse.get_script_args("llm.header")
+  if raw then
+    local k, v = tostring(raw):match("^%s*([^:%s]+)%s*:%s*(.+)$")
+    if k then headers[k] = v end
+  end
+  local probe = stdnse.get_script_args("llm.probe")
+  return {
+    timeout = tonumber(stdnse.get_script_args("llm.timeout")) or 7000,
+    ua = stdnse.get_script_args("llm.ua") or DEFAULT_UA,
+    headers = headers,
+    credentialed = (token ~= nil) or (raw ~= nil),
+    -- Active "hello" probe is ON by default; llm.probe=false makes the script read-only.
+    probe = not (probe == "false" or probe == "0"),
+  }
+end
+
+-- Shared portrule: HTTP-fingerprinted ports, the common inference port set, and any
+-- service -sV probed but could not identify (inference servers behind uvicorn/ASGI are
+-- often not recognised as HTTP). llm.allports forces a probe on every open TCP port.
+function portrule(host, port)
+  if port.protocol ~= "tcp" or port.state ~= "open" then return false end
+  if stdnse.get_script_args("llm.allports") then return true end
+  if shortport.http(host, port) then return true end
+  if PORTS_SET[port.number] then return true end
+  if port.version and port.version.service_fp then return true end
+  return false
+end
+
+-- Read-only HTTP GET, carrying any supplied credential. Returns (status, body,
+-- header-table) or nil on connection failure.
+local function get(host, port, path, opts)
+  local h = { ["User-Agent"] = opts.ua }
+  if opts.headers then for k, v in pairs(opts.headers) do h[k] = v end end
+  local resp = http.get(host, port, path, { header = h, timeout = opts.timeout, no_cache = true })
+  if not resp then return nil end
+  return resp.status, resp.body, resp.header
+end
+
+local function jparse(body)
+  if not body or body == "" then return nil end
+  local ok, obj = json.parse(body)
+  if ok and type(obj) == "table" then return obj end
+  return nil
+end
+
+--------------------------------------------------------------------------------
+-- Framework detectors. Each returns a result table or nil:
+--   { framework, endpoint, version, models={}, auth_required=bool, leaks={}, server }
+--------------------------------------------------------------------------------
+
+-- Ollama: /api/tags lists installed models; /api/version gives the version; the root
+-- path returns the literal banner "Ollama is running".
+local function detect_ollama(host, port, opts)
+  local st, body = get(host, port, "/api/tags", opts)
+  if st == 200 then
+    local doc = jparse(body)
+    if doc and type(doc.models) == "table" then
+      local models = {}
+      for _, m in ipairs(doc.models) do models[#models + 1] = m.name or m.model or "?" end
+      local r = { framework = "Ollama", endpoint = "/api/tags", models = models, auth_required = false, confidence = 90 }
+      local _, vb = get(host, port, "/api/version", opts)
+      local vd = jparse(vb)
+      if vd and vd.version then r.version = vd.version end
+      return r
+    end
+  elseif st == 401 or st == 403 then
+    return { framework = "Ollama", endpoint = "/api/tags", auth_required = true, confidence = 90 }
+  end
+  local st2, body2 = get(host, port, "/", opts)
+  if st2 == 200 and body2 and body2:find("Ollama is running", 1, true) then
+    return { framework = "Ollama", endpoint = "/", models = {}, auth_required = false, confidence = 80 }
+  end
+  return nil
+end
+
+-- OpenAI-compatible: GET /v1/models returns {"object":"list","data":[{"object":"model"}]}.
+-- This catches vLLM, LiteLLM, LocalAI, LM Studio, text-generation-webui, llama.cpp, etc.;
+-- secondary probes disambiguate the specific framework.
+local function detect_openai(host, port, opts)
+  local st, body, hdr = get(host, port, "/v1/models", opts)
+  if st == 401 or st == 403 then
+    return { framework = "OpenAI-compatible API", endpoint = "/v1/models", auth_required = true, confidence = 30 }
+  end
+  if st ~= 200 then return nil end
+  local doc = jparse(body)
+  if not (doc and doc.object == "list" and type(doc.data) == "table") then return nil end
+  local models = {}
+  for _, m in ipairs(doc.data) do models[#models + 1] = m.id or "?" end
+  local r = { framework = "OpenAI-compatible API", endpoint = "/v1/models",
+              models = models, auth_required = false, leaks = {}, confidence = 30 }
+  if hdr and hdr.server then r.server = hdr.server end
+
+  -- vLLM: GET /version -> {"version": "0.x"}
+  local _, vb = get(host, port, "/version", opts)
+  local vd = jparse(vb)
+  if vd and vd.version then r.framework = "vLLM (OpenAI-compatible)"; r.version = vd.version; r.confidence = 85 end
+
+  -- HuggingFace TGI / TEI: GET /info -> {"model_id": ..., "version": ...}. A model_type of
+  -- "embedding" identifies Text Embeddings Inference rather than text generation.
+  local _, ib = get(host, port, "/info", opts)
+  local idoc = jparse(ib)
+  if idoc and idoc.model_id then
+    if type(idoc.model_type) == "table" and idoc.model_type.embedding then
+      r.framework = "HF text-embeddings-inference"
+    else
+      r.framework = "HF text-generation-inference"
+    end
+    r.version = idoc.version or r.version
+    if #r.models == 0 then r.models = { idoc.model_id } end
+    r.confidence = 85
+  end
+
+  -- llama.cpp server: GET /props -> default_generation_settings / model_path / system_prompt
+  local _, pb = get(host, port, "/props", opts)
+  local pdoc = jparse(pb)
+  if pdoc and (pdoc.default_generation_settings or pdoc.model_path or pdoc.system_prompt ~= nil) then
+    r.framework = "llama.cpp server"
+    r.confidence = 85
+    if pdoc.model_path and #r.models == 0 then r.models = { pdoc.model_path } end
+    if type(pdoc.system_prompt) == "string" and pdoc.system_prompt ~= "" then
+      r.leaks[#r.leaks + 1] = "system prompt disclosed via /props"
+    end
+  end
+
+  -- SGLang: GET /get_model_info -> {"model_path": ..., "is_generation": ...}
+  local _, gb = get(host, port, "/get_model_info", opts)
+  local gdoc = jparse(gb)
+  if gdoc and gdoc.model_path then
+    r.framework = "SGLang (OpenAI-compatible)"
+    r.confidence = 85
+    if #r.models == 0 then r.models = { gdoc.model_path } end
+  end
+  return r
+end
+
+-- HuggingFace TGI / TEI without an OpenAI shim (older builds): GET /info. A model_type of
+-- "embedding" marks the Text Embeddings Inference server rather than text generation.
+local function detect_tgi(host, port, opts)
+  local st, body = get(host, port, "/info", opts)
+  if st == 200 then
+    local doc = jparse(body)
+    if doc and doc.model_id then
+      local fw = "HF text-generation-inference"
+      if type(doc.model_type) == "table" and doc.model_type.embedding then
+        fw = "HF text-embeddings-inference"
+      end
+      return { framework = fw, endpoint = "/info",
+               version = doc.version, models = { doc.model_id }, auth_required = false, confidence = 85 }
+    end
+  end
+  return nil
+end
+
+-- KoboldCpp / KoboldAI United: GET /api/extra/version -> {"result":"KoboldCpp","version":...};
+-- /api/v1/model names the loaded model. A real KoboldCpp simultaneously emulates the Ollama
+-- (/api/tags), OpenAI (/v1/models) and llama.cpp (/props) APIs, so several other detectors
+-- also fire on it. The /api/extra/version banner is unambiguous (no other framework serves
+-- it), so this is scored above all of them - including Ollama (90) - to keep identification
+-- correct and order-independent (confirmed by field-testing a real KoboldCpp 1.115.2).
+local function detect_koboldcpp(host, port, opts)
+  local st, body = get(host, port, "/api/extra/version", opts)
+  if st == 200 then
+    local doc = jparse(body)
+    if doc and type(doc.result) == "string" and doc.result:find("Kobold", 1, true) then
+      local r = { framework = "KoboldCpp", endpoint = "/api/extra/version",
+                  version = doc.version, models = {}, auth_required = false, confidence = 95 }
+      local _, mb = get(host, port, "/api/v1/model", opts)
+      local md = jparse(mb)
+      if md and type(md.result) == "string" then
+        r.models = { (md.result:gsub("^koboldcpp/", "")) }
+      end
+      return r
+    end
+  end
+  return nil
+end
+
+-- llama.cpp server without an OpenAI shim (older builds): GET /props.
+local function detect_llamacpp(host, port, opts)
+  local st, body = get(host, port, "/props", opts)
+  if st == 200 then
+    local doc = jparse(body)
+    if doc and (doc.default_generation_settings or doc.model_path) then
+      local r = { framework = "llama.cpp server", endpoint = "/props", auth_required = false, models = {}, leaks = {}, confidence = 85 }
+      if doc.model_path then r.models = { doc.model_path } end
+      if type(doc.system_prompt) == "string" and doc.system_prompt ~= "" then
+        r.leaks[#r.leaks + 1] = "system prompt disclosed via /props"
+      end
+      return r
+    end
+  end
+  return nil
+end
+
+-- NVIDIA Triton / KServe v2 inference protocol: GET /v2 server metadata, /v2/health/ready.
+local function detect_triton(host, port, opts)
+  local st, body = get(host, port, "/v2", opts)
+  if st == 200 then
+    local doc = jparse(body)
+    if doc and doc.name then
+      return { framework = "Triton/KServe (v2 inference)", endpoint = "/v2",
+               version = doc.version, models = {}, auth_required = false, server = doc.name, confidence = 85 }
+    end
+  end
+  local hs = get(host, port, "/v2/health/ready", opts)
+  if hs == 200 then
+    return { framework = "KServe/Triton (v2 inference)", endpoint = "/v2/health/ready",
+             models = {}, auth_required = false, confidence = 75 }
+  end
+  return nil
+end
+
+-- TorchServe management API: GET /models -> {"models":[{"modelName": ...}]}.
+local function detect_torchserve(host, port, opts)
+  local st, body = get(host, port, "/models", opts)
+  if st == 200 then
+    local doc = jparse(body)
+    if doc and type(doc.models) == "table" and doc.models[1] and doc.models[1].modelName then
+      local models = {}
+      for _, m in ipairs(doc.models) do models[#models + 1] = m.modelName end
+      return { framework = "TorchServe (management API)", endpoint = "/models",
+               models = models, auth_required = false, confidence = 75 }
+    end
+  end
+  return nil
+end
+
+-- LLM web UIs / gateways. These are front-ends that proxy to a backend inference server
+-- rather than serving inference themselves; an exposed instance often grants unauthenticated
+-- use of a real backend model. Reported distinctly (ui = true) and never sent an active
+-- inference probe. Where the UI publishes its auth posture in a read-only config endpoint,
+-- the access state is reported (access = open / self-registration / login / unknown), since
+-- that is what determines whether the backend can be reached without credentials:
+--   open               no authentication at all - anyone can use the backend model
+--   self-registration  signup is open - anyone can create an account and use the backend
+--   login              authentication required (access code / account)
+--   unknown            UI identified but its auth posture is not exposed in config
+local function detect_webui(host, port, opts)
+  -- Open WebUI / LibreChat / NextChat all publish a read-only /api/config with auth flags.
+  local st, body = get(host, port, "/api/config", opts)
+  if st == 200 then
+    local doc = jparse(body)
+    if doc and doc.name == "Open WebUI" then
+      -- features.auth=false means WEBUI_AUTH is disabled (fully open); enable_signup=true
+      -- means open self-registration.
+      -- features.auth=false means WEBUI_AUTH is disabled (fully open); onboarding=true means
+      -- no admin account exists yet, so the first visitor can claim admin; enable_signup=true
+      -- means open self-registration.
+      local f = type(doc.features) == "table" and doc.features or {}
+      local r = { framework = "Open WebUI", endpoint = "/api/config", ui = true,
+                  version = doc.version, models = {}, confidence = 90 }
+      if f.auth == false then
+        r.access = "open"; r.auth_required = false
+      elseif doc.onboarding == true then
+        r.access = "onboarding"; r.auth_required = false
+      elseif f.enable_signup == true then
+        r.access = "self-registration"; r.auth_required = false
+      else
+        r.access = "login"; r.auth_required = true
+      end
+      return r
+    end
+    if doc and (doc.appTitle or doc.registrationEnabled ~= nil or doc.emailLoginEnabled ~= nil
+        or doc.socialLogins) then
+      local r = { framework = "LibreChat", endpoint = "/api/config", ui = true,
+                  models = {}, confidence = 88 }
+      if doc.registrationEnabled == true then
+        r.access = "self-registration"; r.auth_required = false
+      else
+        r.access = "login"; r.auth_required = true
+      end
+      return r
+    end
+    -- NextChat / ChatGPT-Next-Web: /api/config -> {"needCode":bool,"hideUserApiKey":...}.
+    -- needCode=false means no access code is required: anyone can use the owner's backend.
+    if doc and doc.needCode ~= nil then
+      local r = { framework = "NextChat", endpoint = "/api/config",
+                  ui = true, models = {}, confidence = 85 }
+      if doc.needCode == false then
+        r.access = "open"; r.auth_required = false
+      else
+        r.access = "login"; r.auth_required = true
+      end
+      return r
+    end
+  end
+  -- LobeChat: GET /manifest.json (or .webmanifest) -> {"name":"LobeChat",...}. Auth posture
+  -- (an optional access code) is not exposed in config, so report access as unknown.
+  for _, mpath in ipairs({ "/manifest.json", "/manifest.webmanifest" }) do
+    local ms, mb = get(host, port, mpath, opts)
+    if ms == 200 then
+      local md = jparse(mb)
+      if md and type(md.name) == "string" and md.name:find("LobeChat", 1, true) then
+        return { framework = "LobeChat", endpoint = mpath, ui = true, models = {},
+                 auth_required = false, access = "unknown", confidence = 82 }
+      end
+    end
+  end
+  -- Flowise (LangChain flow builder / gateway): GET /api/v1/version -> {"version":...}.
+  -- Its chatflow prediction endpoints are often publicly callable, so flag it as a gateway.
+  local fs, fb = get(host, port, "/api/v1/version", opts)
+  if fs == 200 then
+    local fd = jparse(fb)
+    if fd and fd.version then
+      return { framework = "Flowise", endpoint = "/api/v1/version", ui = true, gateway = true,
+               version = fd.version, models = {}, auth_required = false, access = "unknown", confidence = 82 }
+    end
+  end
+  -- AnythingLLM: GET /api/ping -> {"online":true}; the served SPA confirms it.
+  local ps = get(host, port, "/api/ping", opts)
+  if ps == 200 then
+    local _, hb = get(host, port, "/", opts)
+    if hb and hb:find("AnythingLLM", 1, true) then
+      return { framework = "AnythingLLM", endpoint = "/api/ping", ui = true, models = {},
+               auth_required = false, access = "unknown", confidence = 80 }
+    end
+  end
+  return nil
+end
+
+local DETECTORS = {
+  detect_ollama, detect_openai, detect_tgi, detect_llamacpp, detect_koboldcpp,
+  detect_triton, detect_torchserve, detect_webui,
+}
+
+--------------------------------------------------------------------------------
+-- Active "hello" probe (on by default). Sends a single minimal completion request and
+-- looks for an inference-shaped response: it confirms the endpoint actually serves a model
+-- (not just lists them) and detects formats with no list endpoint, notably
+-- Anthropic's Messages API. Kept minimal (max_tokens = 1, prompt "hello").
+--------------------------------------------------------------------------------
+
+local function gen(obj)
+  local ok, s = pcall(json.generate, obj)
+  return ok and s or nil
+end
+
+local function post(host, port, path, extra, body, opts)
+  local h = { ["User-Agent"] = opts.ua, ["Content-Type"] = "application/json" }
+  if opts.headers then for k, v in pairs(opts.headers) do h[k] = v end end
+  if extra then for k, v in pairs(extra) do h[k] = v end end
+  local resp = http.post(host, port, path, { header = h, timeout = opts.timeout }, nil, body)
+  if not resp then return nil end
+  return resp.status, resp.body
+end
+
+-- OpenAI-compatible chat hello. Returns "confirmed" on a completion or an OpenAI-shaped
+-- error (either proves a chat inference endpoint), "auth" on a credential challenge.
+local function hello_openai(host, port, model, opts)
+  local body = gen({ model = model or "gpt-3.5-turbo",
+                     messages = { { role = "user", content = "hello" } }, max_tokens = 1 })
+  if not body then return nil end
+  local st, rb = post(host, port, "/v1/chat/completions", nil, body, opts)
+  if not st then return nil end
+  local doc = jparse(rb)
+  if st == 200 and doc and (doc.choices or doc.object == "chat.completion") then return "confirmed" end
+  if st == 401 or st == 403 then return "auth" end
+  if doc and type(doc.error) == "table" then return "confirmed" end
+  return nil
+end
+
+-- Ollama native generate hello.
+local function hello_ollama(host, port, model, opts)
+  local body = gen({ model = model or "llama3", prompt = "hello", stream = false,
+                     options = { num_predict = 1 } })
+  if not body then return nil end
+  local st, rb = post(host, port, "/api/generate", nil, body, opts)
+  if not st then return nil end
+  local doc = jparse(rb)
+  if st == 200 and doc and (doc.response ~= nil or doc.done ~= nil) then return "confirmed" end
+  if doc and doc.error then return "confirmed" end
+  return nil
+end
+
+-- Anthropic Messages API: no list endpoint exists, so a minimal /v1/messages request is the
+-- only fingerprint. Identified by the Anthropic message/error response shape; an
+-- unauthenticated server returns 401 WITHOUT running a model.
+local function probe_anthropic(host, port, opts)
+  local body = gen({ model = "claude-3-5-haiku-latest", max_tokens = 1,
+                     messages = { { role = "user", content = "hello" } } })
+  if not body then return nil end
+  local st, rb = post(host, port, "/v1/messages", { ["anthropic-version"] = "2023-06-01" }, body, opts)
+  if not st then return nil end
+  local doc = jparse(rb)
+  if doc and (doc.type == "message"
+      or (doc.type == "error" and type(doc.error) == "table" and doc.error.type)) then
+    return { framework = "Anthropic Messages API", endpoint = "/v1/messages",
+             models = {}, auth_required = (st == 401 or st == 403), confidence = 88,
+             inference = (st == 200) and "confirmed" or nil }
+  end
+  return nil
+end
+
+-- Known model IDs to probe on an API with no usable list endpoint (Anthropic) or one that
+-- is disabled. A small built-in set; a model that responds (rather than "model not found")
+-- is reported as present/accessible. Active and bounded - authorised assessments only.
+KNOWN_MODELS = {
+  anthropic = { "claude-3-5-sonnet-latest", "claude-3-5-haiku-latest",
+                "claude-3-opus-latest", "claude-3-haiku-20240307" },
+  openai = { "gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-3.5-turbo" },
+}
+
+local function enum_anthropic(host, port, opts)
+  local found = {}
+  for _, m in ipairs(KNOWN_MODELS.anthropic) do
+    local body = gen({ model = m, max_tokens = 1, messages = { { role = "user", content = "hi" } } })
+    local st, rb = post(host, port, "/v1/messages", { ["anthropic-version"] = "2023-06-01" }, body, opts)
+    local doc = jparse(rb)
+    if st == 200 then
+      found[#found + 1] = m
+    elseif doc and doc.type == "error" and type(doc.error) == "table"
+        and doc.error.type ~= "not_found_error" and st ~= 404 then
+      found[#found + 1] = m .. " (accessible; non-404 response)"
+    end
+  end
+  return found
+end
+
+local function enum_openai(host, port, opts)
+  local found = {}
+  for _, m in ipairs(KNOWN_MODELS.openai) do
+    local body = gen({ model = m, messages = { { role = "user", content = "hi" } }, max_tokens = 1 })
+    local st = post(host, port, "/v1/chat/completions", nil, body, opts)
+    if st == 200 then found[#found + 1] = m end
+  end
+  return found
+end
+
+-- Error-condition fingerprint: requesting a bogus model returns a model-not-found error
+-- WITHOUT running inference, and the body shape distinguishes frameworks/stacks:
+--   {"object":"error", "type":"NotFoundError"}      -> vLLM
+--   {"detail": ...}                                 -> FastAPI/Starlette-based server
+--   {"error":{"type":"invalid_request_error",...}}  -> canonical OpenAI format
+-- Returns { framework?, error_sig } or nil.
+local function refine_by_error(host, port, opts)
+  local body = gen({ model = "__nmap_probe_404__",
+                     messages = { { role = "user", content = "x" } }, max_tokens = 1 })
+  if not body then return nil end
+  local _, rb = post(host, port, "/v1/chat/completions", nil, body, opts)
+  local doc = jparse(rb)
+  if not doc then return nil end
+  if doc.object == "error" then
+    return { framework = "vLLM (OpenAI-compatible)", error_sig = "{object:error} type=" .. tostring(doc.type) }
+  elseif doc.detail ~= nil then
+    return { error_sig = "{detail} (FastAPI/Starlette)" }
+  elseif type(doc.error) == "table" then
+    return { error_sig = "{error} " .. tostring(doc.error.code or doc.error.type) }
+  end
+  return nil
+end
+
+-- Prometheus /metrics, exposed by several frameworks (vLLM, TGI, SGLang), frequently leaks the
+-- served model name in a metric label and confirms the framework from the metric-name prefix.
+-- Read-only GET. Returns { models={}, framework? } or nil.
+local function scan_metrics(host, port, opts)
+  local st, body = get(host, port, "/metrics", opts)
+  if st ~= 200 or not body or body == "" then return nil end
+  if not (body:find("model_name=", 1, true) or body:find("# TYPE", 1, true)) then return nil end
+  local out = { models = {} }
+  local seen = {}
+  for m in body:gmatch('model_name="([^"]+)"') do
+    if not seen[m] then seen[m] = true; out.models[#out.models + 1] = m end
+  end
+  if body:find("vllm:", 1, true) then out.framework = "vLLM (OpenAI-compatible)"
+  elseif body:find("sglang:", 1, true) then out.framework = "SGLang (OpenAI-compatible)"
+  elseif body:find("tgi_", 1, true) then out.framework = "HF text-generation-inference" end
+  return out
+end
+
+-- Probe a host:port for a known inference API. Every detector runs; the result is chosen by
+-- signal specificity (the `confidence` each detector assigns), not by detector order, so a
+-- server matching several signatures (e.g. Ollama, which also serves /v1/models) is reported
+-- by its most specific match. A positive (HTTP 200) identification always beats an auth-gated
+-- hint (a framework endpoint returning 401/403). Reordering DETECTORS cannot change the result.
+function detect(host, port, opts)
+  opts = opts or args()
+  local best_pos, best_gated
+  for _, d in ipairs(DETECTORS) do
+    local r = d(host, port, opts)
+    if r then
+      r.confidence = r.confidence or 0
+      if r.auth_required then
+        if not best_gated or r.confidence > best_gated.confidence then best_gated = r end
+      else
+        if not best_pos or r.confidence > best_pos.confidence then best_pos = r end
+      end
+    end
+  end
+  local result = best_pos or best_gated
+
+  -- Active "hello" probe (on by default): confirm inference on an identified endpoint, or
+  -- actively detect a list-less API (Anthropic) / otherwise-unidentified inference endpoint.
+  -- Never probe a web UI / gateway: it is a front-end, not an inference endpoint.
+  if opts.probe and not (result and result.ui) then
+    if result and not result.auth_required then
+      -- Confirm inference with a hello only when it adds information. Skip it for a framework
+      -- that already lists its models: the list already proves a live inference endpoint, and
+      -- a hello would force a slow on-demand model load (e.g. seconds on Ollama) for no new
+      -- signal. A generic OpenAI match, or a server with no listed models, still gets the hello.
+      local listed = result.models and #result.models > 0
+      if result.framework == "OpenAI-compatible API" or not listed then
+        local conf
+        if result.framework == "Ollama" then
+          conf = hello_ollama(host, port, result.models and result.models[1], opts)
+        else
+          conf = hello_openai(host, port, result.models and result.models[1], opts)
+        end
+        if conf then result.inference = conf end
+      end
+      -- Error-condition fingerprint: refine a generic OpenAI match and record an error sig.
+      if result.endpoint == "/v1/models" or result.endpoint == "/v1/chat/completions" then
+        local ref = refine_by_error(host, port, opts)
+        if ref then
+          if ref.framework and result.framework == "OpenAI-compatible API" then
+            result.framework = ref.framework
+            result.confidence = 60
+          end
+          if ref.error_sig then result.error_sig = ref.error_sig end
+        end
+      end
+    elseif not result then
+      result = probe_anthropic(host, port, opts)
+      if not result and hello_openai(host, port, nil, opts) then
+        result = { framework = "OpenAI-compatible API", endpoint = "/v1/chat/completions",
+                   models = {}, auth_required = false, confidence = 40, inference = "confirmed" }
+      end
+    end
+
+    -- Active model enumeration for an API with no usable list (Anthropic) or a disabled one:
+    -- probe a small set of known model IDs and report those that respond.
+    if result and not result.auth_required and (not result.models or #result.models == 0) then
+      local found
+      if result.framework:find("Anthropic", 1, true) then
+        found = enum_anthropic(host, port, opts)
+      elseif result.framework:find("OpenAI", 1, true) or result.endpoint == "/v1/chat/completions" then
+        found = enum_openai(host, port, opts)
+      end
+      if found and #found > 0 then result.models = found; result.models_enumerated = true end
+    end
+  end
+
+  -- Prometheus metrics leak (read-only): for OpenAI-family servers, /metrics often exposes the
+  -- served model name and confirms the framework. Recorded as a leak and a model source.
+  if result and not result.auth_required and result.framework
+      and (result.framework:find("OpenAI", 1, true) or result.framework:find("vLLM", 1, true)
+           or result.framework:find("SGLang", 1, true) or result.framework:find("text-generation", 1, true)) then
+    local m = scan_metrics(host, port, opts)
+    if m then
+      if m.framework and result.framework == "OpenAI-compatible API" then
+        result.framework = m.framework
+        if (result.confidence or 0) < 60 then result.confidence = 60 end
+      end
+      if #m.models > 0 then
+        result.leaks = result.leaks or {}
+        result.leaks[#result.leaks + 1] = "model name disclosed via /metrics"
+        if not result.models or #result.models == 0 then result.models = m.models end
+      end
+    end
+  end
+
+  -- Capture the Server response header of the matched endpoint as a secondary fingerprint
+  -- (uvicorn, TornadoServer, ...); it sometimes carries a version the API itself does not.
+  if result and not result.server then
+    local _, _, h = get(host, port, result.endpoint, opts)
+    if h and h["server"] then result.server = h["server"] end
+  end
+  return result
+end
+
+return _ENV

--- a/nselib/mcp.lua
+++ b/nselib/mcp.lua
@@ -1,0 +1,661 @@
+---
+-- Shared library for enumerating Model Context Protocol (MCP) servers over HTTP(S).
+--
+-- Provides transport handling for both the current Streamable HTTP transport and the
+-- legacy HTTP+SSE transport (2024-11-05), the JSON-RPC `initialize` handshake, OAuth
+-- protected-resource discovery, and read-only attack-surface enumeration
+-- (tools/resources/prompts). Used by the mcp-info and mcp-enum NSE scripts.
+--
+-- All operations are read-only: only the protocol handshake and `*/list` methods are
+-- ever called. `tools/call` is never invoked.
+--
+-- @author Ben Williams <ben.williams@nccgroup.com>
+-- @copyright Same as Nmap--See https://nmap.org/book/man-legal.html
+
+local http = require "http"
+local json = require "json"
+local nmap = require "nmap"
+local shortport = require "shortport"
+local stdnse = require "stdnse"
+local stringaux = require "stringaux"
+local string = require "string"
+local table = require "table"
+
+_ENV = stdnse.module("mcp", stdnse.seeall)
+
+-- Protocol version advertised by our client handshake.
+CLIENT_PROTO = "2025-06-18"
+
+-- Neutral default User-Agent. A UA containing "nmap" is blocked by common WAFs
+-- (e.g. AWS WAF/CloudFront returns 403), masking real MCP servers. Override with
+-- --script-args mcp.ua=...
+DEFAULT_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+
+-- Candidate Streamable HTTP endpoint paths, broadest-first.
+PATHS = {
+  "/mcp", "/", "/sse", "/messages", "/api/mcp", "/mcp/v1", "/v1/mcp", "/rpc",
+  "/jsonrpc", "/mcp/sse", "/mcp/message", "/mcp/messages", "/stream", "/api", "/server",
+}
+
+-- Legacy HTTP+SSE GET paths to try.
+SSE_PATHS = {"/sse", "/mcp/sse", "/mcp"}
+
+-- Ports where MCP servers are commonly bound (in addition to anything fingerprinted
+-- as HTTP). Includes dev-server defaults and the MCP Inspector (6274).
+PORTS = {
+  3000, 3001, 3333, 4000, 5000, 5173, 8000, 8001, 8080, 8081, 8082, 8088,
+  8123, 8765, 8888, 9000, 6274, 2024,
+}
+local PORTS_SET = {}
+for _, p in ipairs(PORTS) do PORTS_SET[p] = true end
+
+-- Heuristic substrings marking a tool as security-relevant attack surface.
+-- A tool's risk is assessed across its name, description, AND its JSON input schema
+-- (parameter names/descriptions/types), bucketed into categories. Two pattern maps are
+-- used: TEXT_RISK matches conservative phrases in free text (name + descriptions);
+-- PARAM_RISK matches tokens in tool-name / parameter-name identifiers (exact word-token
+-- match, so "file" hits "gzip-file" but not "profile"). Only plausibly free-form
+-- parameters (string/array/object, no enum) contribute parameter risk.
+
+-- Substrings in NAME or DESCRIPTION text implying a capability (kept specific).
+TEXT_RISK = {
+  ["code-exec"]    = { "exec", "shell", "command", "subprocess", "bash", "powershell",
+                       "eval", "arbitrary code", "interpreter", "run a command" },
+  ["file-access"]  = { "read_file", "write_file", "file_read", "readfile", "writefile",
+                       "read a file", "write a file", "filesystem", "delete", "unlink",
+                       "rmdir" },
+  ["network/ssrf"] = { "http_request", "fetch_url", "request_url", "ssrf", "make a request",
+                       "outbound", "webhook", "send a request" },
+  ["sql/db"]       = { "sql", "database", "psql" },
+  ["secrets"]      = { "secret", "credential", "private_key", "api_key", "password",
+                       "environment variable", "getenv", "dotenv" },
+  ["privileged"]   = { "sudo", "kubectl", "terraform", "docker", "deploy" },
+}
+
+-- Word-tokens in tool-name / parameter-name identifiers implying risky input.
+PARAM_RISK = {
+  ["code-exec"]    = { "cmd", "command", "exec", "script", "code", "eval", "program",
+                       "shell" },
+  ["file-access"]  = { "path", "file", "filename", "filepath", "dir", "directory",
+                       "folder" },
+  ["network/ssrf"] = { "url", "uri", "endpoint", "host", "hostname", "address",
+                       "webhook", "callback", "target" },
+  -- "query" intentionally excluded: it usually means a search query, not SQL.
+  ["sql/db"]       = { "sql", "statement" },
+  ["secrets"]      = { "token", "secret", "password", "apikey", "credential", "env",
+                       "key" },
+  ["privileged"]   = { "ssh", "sudo", "kubectl", "docker" },
+}
+
+--------------------------------------------------------------------------------
+-- Argument / helper plumbing
+--------------------------------------------------------------------------------
+
+-- Build an options table from script-args (shared by both scripts).
+function args()
+  local paths_arg = stdnse.get_script_args("mcp.paths")
+  local paths = PATHS
+  if paths_arg then
+    paths = type(paths_arg) == "table" and paths_arg or stringaux.strsplit(",", paths_arg)
+  end
+  return {
+    paths = paths,
+    timeout = tonumber(stdnse.get_script_args("mcp.timeout")) or 7000,
+    ua = stdnse.get_script_args("mcp.ua") or DEFAULT_UA,
+    sse_path = stdnse.get_script_args("mcp.sse_path"),
+    schemas = stdnse.get_script_args("mcp-enum.schemas"),
+    token = stdnse.get_script_args("mcp.token"),
+  }
+end
+
+-- Shared portrule. MCP servers run behind ASGI stacks (uvicorn/starlette) that nmap
+-- often fails to fingerprint as HTTP on non-standard ports, so in addition to
+-- HTTP-fingerprinted ports and the common MCP port set we also probe any service that
+-- -sV could not identify but which returned data (service_fp set). The mcp.allports
+-- script-arg forces a probe on every open TCP port.
+function portrule(host, port)
+  if port.protocol ~= "tcp" or port.state ~= "open" then
+    return false
+  end
+  if stdnse.get_script_args("mcp.allports") then
+    return true
+  end
+  if shortport.http(host, port) then
+    return true
+  end
+  if PORTS_SET[port.number] then
+    return true
+  end
+  -- -sV ran, returned data, but produced no service match: worth one MCP probe.
+  if port.version and port.version.service_fp then
+    return true
+  end
+  return false
+end
+
+-- Extract the first JSON-RPC object from a body, handling plain application/json
+-- and text/event-stream (SSE `data:` framing).
+function extract_json(body)
+  if not body or body == "" then
+    return nil
+  end
+  local ok, obj = json.parse(body)
+  if ok and type(obj) == "table" then
+    return obj
+  end
+  for chunk in body:gmatch("data:%s*(%b{})") do
+    local ok2, obj2 = json.parse(chunk)
+    if ok2 and type(obj2) == "table" then
+      return obj2
+    end
+  end
+  local first = body:match("(%b{})")
+  if first then
+    local ok3, obj3 = json.parse(first)
+    if ok3 and type(obj3) == "table" then
+      return obj3
+    end
+  end
+  return nil
+end
+
+function gen(obj)
+  local ok, s = pcall(json.generate, obj)
+  return ok and s or nil
+end
+
+-- Tokenize an identifier/string into a set of lowercase word-tokens, splitting on
+-- non-alphanumerics and camelCase boundaries ("filePath" -> {file, path}).
+local function tokenize(s)
+  local set = {}
+  if not s then return set end
+  s = s:gsub("(%l)(%u)", "%1 %2"):gsub("(%u)(%u%l)", "%1 %2")
+  for t in s:lower():gmatch("[%a%d]+") do set[t] = true end
+  return set
+end
+
+-- Negation cue words. A risk phrase inside a clause that also contains one of these is
+-- almost always a cautionary disclaimer ("do not include passwords", "does not run shell
+-- commands"), not a capability, so it should not count as risk.
+local NEG_WORDS = {
+  ["not"] = true, ["never"] = true, ["avoid"] = true, ["without"] = true,
+  ["exclude"] = true, ["cannot"] = true,
+}
+
+-- True if the match at byte position `s` in `hay` sits in a negated clause: scan back to
+-- the start of the current sentence (previous . ! ? or newline) and look for a negation
+-- cue word (or an n't contraction) before the match.
+local function negated(hay, s)
+  local clause_start = 1
+  for i = s - 1, 1, -1 do
+    local c = hay:sub(i, i)
+    if c == "." or c == "!" or c == "?" or c == "\n" then clause_start = i + 1; break end
+  end
+  local prefix = hay:sub(clause_start, s - 1)
+  if prefix:find("n't", 1, true) then return true end
+  for tok in prefix:gmatch("%a+") do
+    if NEG_WORDS[tok] then return true end
+  end
+  return false
+end
+
+-- Match TEXT_RISK phrase patterns against free text, recording hit categories in `into`.
+-- Occurrences inside a negated clause (safety disclaimers) are skipped.
+local function match_text_risk(text, into)
+  local hay = (text or ""):lower()
+  for cat, pats in pairs(TEXT_RISK) do
+    if not into[cat] then
+      for _, p in ipairs(pats) do
+        local init = 1
+        while true do
+          local s, e = hay:find(p, init, true)
+          if not s then break end
+          if not negated(hay, s) then into[cat] = true; break end
+          init = e + 1
+        end
+        if into[cat] then break end
+      end
+    end
+  end
+end
+
+-- Match PARAM_RISK tokens against an identifier's token set, recording categories.
+local function match_param_risk(identifier, into)
+  local toks = tokenize(identifier)
+  local matched = false
+  for cat, pats in pairs(PARAM_RISK) do
+    for _, p in ipairs(pats) do
+      if toks[p] then into[cat] = true; matched = true; break end
+    end
+  end
+  return matched
+end
+
+-- A parameter contributes risk only if it can carry free-form input: a string/array/
+-- object without an enum (numbers/booleans/enums are constrained, so far lower risk).
+local function param_is_freeform(prop)
+  if type(prop) ~= "table" then return true end
+  if prop.enum ~= nil then return false end
+  local t = prop.type
+  return t ~= "integer" and t ~= "number" and t ~= "boolean"
+end
+
+-- Assess a tool across name, description, and input schema. Returns
+-- { dangerous = bool, categories = {sorted}, params = {risky param name -> true} }.
+function assess_tool(tool)
+  local cats, risky = {}, {}
+  match_text_risk((tool.name or "") .. " " .. (tool.description or ""), cats)
+  match_param_risk(tool.name or "", cats)
+
+  local schema = type(tool.inputSchema) == "table" and tool.inputSchema or nil
+  local props = schema and type(schema.properties) == "table" and schema.properties or nil
+  if props then
+    for pname, prop in pairs(props) do
+      if param_is_freeform(prop) then
+        if match_param_risk(pname, cats) then risky[pname] = true end
+        if type(prop) == "table" and prop.description then
+          match_text_risk(prop.description, cats)
+        end
+      end
+    end
+  end
+
+  local list = {}
+  for c in pairs(cats) do list[#list + 1] = c end
+  table.sort(list)
+  return { dangerous = #list > 0, categories = list, params = risky }
+end
+
+-- Back-compat shim.
+function is_dangerous(name, desc)
+  return assess_tool({ name = name, description = desc }).dangerous
+end
+
+-- JSON-RPC params per method. `initialize` must carry protocolVersion + clientInfo;
+-- strict servers (e.g. FastMCP) reject an empty params object with -32602.
+local function rpc_params(method)
+  if method == "initialize" then
+    return {
+      protocolVersion = CLIENT_PROTO,
+      capabilities = {},
+      clientInfo = { name = "mcp-scan", version = "0.3" },
+    }
+  end
+  return {}
+end
+
+local function post_headers(ctx, opts)
+  local h = {
+    ["Content-Type"] = "application/json",
+    ["Accept"] = "application/json, text/event-stream",
+    ["User-Agent"] = opts.ua,
+  }
+  if ctx and ctx.session_id then h["Mcp-Session-Id"] = ctx.session_id end
+  if ctx and ctx.protocol then h["MCP-Protocol-Version"] = ctx.protocol end
+  if opts.token then h["Authorization"] = "Bearer " .. opts.token end
+  return h
+end
+
+local function list_array(obj, key)
+  if type(obj) == "table" and type(obj.result) == "table" and type(obj.result[key]) == "table" then
+    return obj.result[key]
+  end
+  return nil
+end
+
+--------------------------------------------------------------------------------
+-- OAuth 2.1 protected-resource metadata (RFC 9728)
+--------------------------------------------------------------------------------
+
+-- Fetch protected-resource metadata for an auth-gated server. Per RFC 9728 the
+-- document is hosted on the resource server itself, so we fetch its path against the
+-- host being scanned; any authorization servers it names are reported, never followed.
+function fetch_oauth_metadata(host, port, www, opts)
+  local options = { header = { ["Accept"] = "application/json", ["User-Agent"] = opts.ua }, timeout = opts.timeout }
+  local url = www and www:match('resource_metadata="?([^",%s]+)')
+  local path = url and url:gsub("^https?://[^/]+", "") or "/.well-known/oauth-protected-resource"
+  if path == "" then path = "/.well-known/oauth-protected-resource" end
+
+  local resp = http.get(host, port, path, options)
+  if not resp or resp.status ~= 200 or not resp.body then
+    return { metadata_url = path }
+  end
+  local ok, doc = json.parse(resp.body)
+  if not ok or type(doc) ~= "table" then
+    return { metadata_url = path }
+  end
+  local meta = { metadata_url = path }
+  if doc.resource then meta.resource = tostring(doc.resource) end
+  if type(doc.authorization_servers) == "table" then
+    meta.authorization_servers = table.concat(doc.authorization_servers, ", ")
+  end
+  if type(doc.scopes_supported) == "table" then
+    meta.scopes = table.concat(doc.scopes_supported, ", ")
+  end
+  if type(doc.bearer_methods_supported) == "table" then
+    meta.bearer_methods = table.concat(doc.bearer_methods_supported, ", ")
+  end
+  return meta
+end
+
+--------------------------------------------------------------------------------
+-- Raw-socket transport primitives (shared by streamable + legacy)
+--------------------------------------------------------------------------------
+
+-- Receive into buf until matcher(buf) returns non-nil, or the stream stalls.
+local function recv_until(sock, buf, matcher, max_reads)
+  for _ = 1, (max_reads or 40) do
+    local m = matcher(buf)
+    if m ~= nil then return m, buf end
+    local status, data = sock:receive()
+    if not status then break end
+    buf = buf .. data
+  end
+  return matcher(buf), buf
+end
+
+-- Find a JSON-RPC response with the given id anywhere in a raw response buffer,
+-- handling both SSE `data:` framing (possibly chunked) and a plain JSON body.
+local function find_response(buf, id)
+  for chunk in buf:gmatch("data:%s*(%b{})") do
+    local ok, parsed = json.parse(chunk)
+    if ok and type(parsed) == "table" and parsed.id == id
+        and (parsed.result ~= nil or parsed.error ~= nil) then
+      return parsed
+    end
+  end
+  local body = buf:match("\r\n\r\n(.*)$")
+  if body then
+    local first = body:match("(%b{})")
+    if first then
+      local ok, parsed = json.parse(first)
+      if ok and type(parsed) == "table" and parsed.id == id
+          and (parsed.result ~= nil or parsed.error ~= nil) then
+        return parsed
+      end
+    end
+  end
+  return nil
+end
+
+local function raw_status(buf)
+  return tonumber(buf:match("^HTTP/%d%.%d%s+(%d%d%d)"))
+end
+
+-- Build a correct Host header (incl. non-default port). MCP servers validate the Host
+-- header for DNS-rebinding protection (mandated by the spec) and return 421 if it is
+-- wrong, so the port must be present for non-default ports.
+local function host_header(host, port)
+  local h = host.targetname or host.ip
+  if port.number == 80 or port.number == 443 then
+    return h
+  end
+  return h .. ":" .. port.number
+end
+
+local function raw_header(buf, name)
+  local head = buf:match("^(.-)\r\n\r\n") or buf
+  for line in head:gmatch("[^\r\n]+") do
+    local k, v = line:match("^([%w%-]+):%s*(.*)$")
+    if k and k:lower() == name:lower() then return (v:gsub("%s+$", "")) end
+  end
+  return nil
+end
+
+--------------------------------------------------------------------------------
+-- Transport: Streamable HTTP
+--------------------------------------------------------------------------------
+
+-- One raw POST over a given TLS mode. Returns (obj, buf); buf is the raw response so
+-- the caller can detect whether a valid HTTP reply came back over this proto.
+local function raw_request(host, port, path, ctx, body, id, proto, opts)
+  local sock = nmap.new_socket()
+  sock:set_timeout(opts.timeout)
+  if not sock:connect(host, port, proto) then sock:close(); return nil, nil end
+  local hdr = {
+    "POST " .. path .. " HTTP/1.1",
+    "Host: " .. host_header(host, port),
+    "User-Agent: " .. opts.ua,
+    "Accept: application/json, text/event-stream",
+    "Content-Type: application/json",
+    "Content-Length: " .. #body,
+    "Connection: close",
+  }
+  if ctx and ctx.session_id then hdr[#hdr + 1] = "Mcp-Session-Id: " .. ctx.session_id end
+  if ctx and ctx.protocol then hdr[#hdr + 1] = "MCP-Protocol-Version: " .. ctx.protocol end
+  if opts.token then hdr[#hdr + 1] = "Authorization: Bearer " .. opts.token end
+  local req = table.concat(hdr, "\r\n") .. "\r\n\r\n" .. body
+  if not sock:send(req) then sock:close(); return nil, nil end
+  local m, buf = recv_until(sock, "", function(b)
+    if not b:find("\r\n\r\n", 1, true) then return nil end
+    if id == nil then return true end
+    return find_response(b, id)
+  end, 80)
+  sock:close()
+  return (id ~= nil) and m or nil, buf
+end
+
+-- Send a raw HTTP POST and read only until the JSON-RPC response for `id` appears
+-- (or, for notifications, until response headers arrive), then close. Using a raw
+-- socket avoids hanging on Streamable-HTTP servers (e.g. FastMCP/uvicorn) that keep
+-- the SSE response stream open after delivering the reply, which makes nmap's
+-- http.post block until timeout and discard the data already received. The TLS mode
+-- is auto-detected: the heuristically-preferred mode is tried first, and the other is
+-- tried if no valid HTTP status comes back; the working mode is cached on ctx.
+local function http_post_raw(host, port, path, ctx, body, id, opts)
+  local protos = (ctx and ctx.proto) and { ctx.proto }
+    or (shortport.ssl(host, port) and { "ssl", "tcp" } or { "tcp", "ssl" })
+  for _, proto in ipairs(protos) do
+    local obj, buf = raw_request(host, port, path, ctx, body, id, proto, opts)
+    if buf and raw_status(buf) then
+      if ctx then ctx.proto = proto end
+      return obj, buf
+    end
+  end
+  return nil, nil
+end
+
+local function streamable_rpc(host, port, path, ctx, method, id, opts)
+  local payload = { jsonrpc = "2.0", method = method, params = rpc_params(method) }
+  if id ~= nil then payload.id = id end
+  local body = gen(payload)
+  if not body then return nil, nil end
+  return http_post_raw(host, port, path, ctx, body, id, opts)
+end
+
+-- Try one path. Returns (transport, nil) on success, (nil, auth_hint) on a bearer
+-- challenge, or (nil, nil) otherwise.
+local function open_streamable_path(host, port, path, opts)
+  local ctx = { protocol = CLIENT_PROTO }
+  local obj, buf = streamable_rpc(host, port, path, ctx, "initialize", 1, opts)
+  if obj and type(obj.result) == "table" then
+    local r = obj.result
+    if r.serverInfo or r.protocolVersion or r.capabilities then
+      ctx.session_id = buf and raw_header(buf, "mcp-session-id") or nil
+      ctx.protocol = r.protocolVersion or CLIENT_PROTO
+      local t = {
+        name = "streamable-http",
+        endpoint = path,
+        server_info = type(r.serverInfo) == "table" and r.serverInfo or {},
+        protocol = ctx.protocol,
+        capabilities = r.capabilities,
+        session_stateful = ctx.session_id ~= nil,
+        authenticated = opts.token ~= nil,
+        request = function(_, method, id)
+          return (streamable_rpc(host, port, path, ctx, method, id, opts))
+        end,
+        close = function() end,
+      }
+      streamable_rpc(host, port, path, ctx, "notifications/initialized", nil, opts)
+      return t, nil
+    end
+  end
+  if buf then
+    local status = raw_status(buf)
+    local www = raw_header(buf, "www-authenticate")
+    if (status == 401 or status == 403) and www and www:lower():find("bearer") then
+      return nil, { path = path, www = www }
+    end
+  end
+  return nil, nil
+end
+
+--------------------------------------------------------------------------------
+-- Transport: legacy HTTP+SSE (2024-11-05)
+--------------------------------------------------------------------------------
+
+local function open_legacy_path(host, port, sse_path, proto, opts)
+  local sock = nmap.new_socket()
+  sock:set_timeout(opts.timeout)
+  if not sock:connect(host, port, proto) then
+    sock:close()
+    return nil
+  end
+  local get = "GET " .. sse_path .. " HTTP/1.1\r\nHost: " .. host_header(host, port) ..
+    "\r\nAccept: text/event-stream\r\nUser-Agent: " .. opts.ua ..
+    (opts.token and ("\r\nAuthorization: Bearer " .. opts.token) or "") .. "\r\n\r\n"
+  if not sock:send(get) then sock:close(); return nil end
+
+  local buf = ""
+  local msgpath
+  msgpath, buf = recv_until(sock, buf, function(b)
+    return b:match("endpoint.-data:%s*([^\r\n]+)")
+  end, 30)
+  if not msgpath then sock:close(); return nil end
+  msgpath = msgpath:gsub("%s+$", "")
+  if msgpath:match("^https?://") then
+    msgpath = msgpath:gsub("^https?://[^/]+", "")
+  end
+
+  local t = {
+    name = "http+sse (legacy 2024-11-05)",
+    endpoint = sse_path,
+    server_info = {},
+    protocol = nil,
+    capabilities = nil,
+    session_stateful = true,
+    authenticated = opts.token ~= nil,
+    _sock = sock,
+    _buf = buf,
+    _msgpath = msgpath,
+  }
+  t.request = function(self, method, id)
+    local payload = { jsonrpc = "2.0", method = method, params = rpc_params(method) }
+    if id ~= nil then payload.id = id end
+    http.post(host, port, self._msgpath,
+      { header = post_headers(nil, opts), timeout = opts.timeout }, nil, gen(payload))
+    if id == nil then return nil end
+    local parsed
+    parsed, self._buf = recv_until(self._sock, self._buf,
+      function(b) return find_response(b, id) end, 40)
+    return parsed
+  end
+  t.close = function(self) self._sock:close() end
+
+  local initobj = t:request("initialize", 1)
+  if not initobj or type(initobj.result) ~= "table" then sock:close(); return nil end
+  local r = initobj.result
+  t.protocol = r.protocolVersion
+  t.server_info = type(r.serverInfo) == "table" and r.serverInfo or {}
+  t.capabilities = r.capabilities
+  t:request("notifications/initialized", nil)
+  return t
+end
+
+local function open_legacy(host, port, opts)
+  local candidates, seen = {}, {}
+  if opts.sse_path then candidates[#candidates + 1] = opts.sse_path; seen[opts.sse_path] = true end
+  for _, p in ipairs(SSE_PATHS) do
+    if not seen[p] then candidates[#candidates + 1] = p; seen[p] = true end
+  end
+  local protos = shortport.ssl(host, port) and { "ssl", "tcp" } or { "tcp", "ssl" }
+  for _, proto in ipairs(protos) do
+    for _, p in ipairs(candidates) do
+      local t = open_legacy_path(host, port, p, proto, opts)
+      if t then return t end
+    end
+  end
+  return nil
+end
+
+--------------------------------------------------------------------------------
+-- Public: connect & enumerate
+--------------------------------------------------------------------------------
+
+-- Establish a transport to an MCP server. Returns (transport, nil) on success,
+-- (nil, auth_hint) when the server is MCP-behind-auth, or (nil, nil) when not MCP.
+-- auth_hint = { path = <string>, www = <WWW-Authenticate value> }.
+function connect(host, port, opts)
+  opts = opts or args()
+  local auth_hint
+  for _, path in ipairs(opts.paths) do
+    local t, hint = open_streamable_path(host, port, path, opts)
+    if t then return t, nil end
+    if hint then
+      auth_hint = auth_hint or hint
+      -- A challenge advertising MCP's OAuth resource_metadata is high-confidence MCP.
+      if hint.www and hint.www:lower():find("resource_metadata", 1, true) then
+        return nil, hint
+      end
+    end
+  end
+  local lt = open_legacy(host, port, opts)
+  if lt then return lt, nil end
+  return nil, auth_hint
+end
+
+-- Read-only attack-surface enumeration over an open transport. Returns a data table:
+-- { transport, server_info, protocol, authenticated,
+--   tools=[{name,description,params,dangerous,categories,risky_params,schema}],
+--   resources=[uri], prompts=[name], dangerous=[name], categories=[sorted] }.
+function enumerate(transport, opts)
+  opts = opts or args()
+  local data = {
+    transport = transport.name,
+    server_info = transport.server_info or {},
+    protocol = transport.protocol,
+    authenticated = transport.authenticated,
+    tools = {}, resources = {}, prompts = {}, dangerous = {},
+  }
+  local cat_set = {}
+
+  for _, tdef in ipairs(list_array(transport:request("tools/list", 2), "tools") or {}) do
+    local risk = assess_tool(tdef)
+    local params = {}
+    if type(tdef.inputSchema) == "table" and type(tdef.inputSchema.properties) == "table" then
+      for p in pairs(tdef.inputSchema.properties) do params[#params + 1] = p end
+      table.sort(params)
+    end
+    data.tools[#data.tools + 1] = {
+      name = tdef.name or "?",
+      description = tdef.description or "",
+      params = params,
+      dangerous = risk.dangerous,
+      categories = risk.categories,
+      risky_params = risk.params,
+      schema = tdef.inputSchema,
+    }
+    if risk.dangerous then
+      data.dangerous[#data.dangerous + 1] = tdef.name or "?"
+      for _, c in ipairs(risk.categories) do cat_set[c] = true end
+    end
+  end
+  data.categories = {}
+  for c in pairs(cat_set) do data.categories[#data.categories + 1] = c end
+  table.sort(data.categories)
+
+  for _, r in ipairs(list_array(transport:request("resources/list", 3), "resources") or {}) do
+    data.resources[#data.resources + 1] = r.uri or r.name or "?"
+  end
+  for _, r in ipairs(list_array(transport:request("resources/templates/list", 4), "resourceTemplates") or {}) do
+    data.resources[#data.resources + 1] = (r.uriTemplate or r.name or "?") .. " (template)"
+  end
+
+  for _, p in ipairs(list_array(transport:request("prompts/list", 5), "prompts") or {}) do
+    data.prompts[#data.prompts + 1] = p.name or "?"
+  end
+
+  return data
+end
+
+return _ENV

--- a/scripts/llm-info.nse
+++ b/scripts/llm-info.nse
@@ -1,0 +1,158 @@
+local llm = require "llm"
+local nmap = require "nmap"
+local stdnse = require "stdnse"
+local string = require "string"
+local table = require "table"
+
+description = [[
+Detects and fingerprints LLM inference APIs exposed over HTTP(S).
+
+Probes a target for the common self-hosted and cloud inference frameworks by their
+read-only model-list and metadata endpoints: the OpenAI-compatible API (vLLM, SGLang,
+LiteLLM, LocalAI, LM Studio, text-generation-webui, and similar), Ollama, HuggingFace TGI
+and TEI, llama.cpp server, KoboldCpp, Triton/KServe (v2), and TorchServe. It also flags the
+common AI web UIs / gateways that front a backend (Open WebUI, LibreChat, NextChat, LobeChat,
+Flowise, AnythingLLM), reporting each UI's access posture (open / self-registration / login),
+which determines whether the backend model can be used without credentials. On a match it
+reports the framework, version, model inventory, authentication posture, and notable
+information leaks (e.g. a llama.cpp system prompt exposed via /props, or a served model name
+exposed via a Prometheus /metrics endpoint). It augments service/version detection via -sV.
+
+By default the script also sends a single minimal "hello" completion request
+(max_tokens = 1) to confirm the endpoint actually serves inference and to detect formats
+with no model-list endpoint, notably Anthropic's Messages API (/v1/messages). Pass
+llm.probe=false for strictly read-only detection (model-list / metadata / health endpoints
+only, no inference request).
+
+A bearer token (llm.token) or arbitrary header (llm.header, e.g. an API key or session
+cookie) may be supplied to test an authenticated API. Shared logic lives in the llm nselib.
+]]
+
+---
+-- @usage nmap -p 11434,8000,1234 --script llm-info <target>
+-- @usage nmap -sV --script llm-info <target>
+-- @usage nmap --script llm-info --script-args llm.token=sk-... <target>
+-- @usage nmap --script llm-info --script-args 'llm.header=x-api-key: sk-...' <target>
+--
+-- @args llm.token   Bearer token, sent as "Authorization: Bearer <token>".
+-- @args llm.header  Arbitrary auth header "Name: value" (e.g. "x-api-key: sk-...",
+--                   "api-key: ...", "Cookie: session=..."), to test credentialed APIs.
+-- @args llm.probe   Send a minimal "hello" inference request to confirm the API and detect
+--                   list-less formats (Anthropic). Default true; set false for read-only.
+-- @args llm.timeout HTTP timeout in ms (default 7000).
+-- @args llm.ua      User-Agent to send (default a neutral browser UA).
+-- @args llm.allports Probe every open TCP port (ignore the port heuristic).
+--
+-- @output
+-- PORT      STATE SERVICE
+-- 11434/tcp open  llm-api
+-- | llm-info:
+-- |   framework: Ollama
+-- |   version: 0.3.14
+-- |   endpoint: /api/tags
+-- |   auth: NONE (unauthenticated)
+-- |   inference: confirmed (responded to a minimal hello)
+-- |   models (3): llama3:8b, qwen2.5:7b, nomic-embed-text:latest
+-- |_  SECURITY: unauthenticated inference API (Ollama) exposes 3 model(s); open to compute/cost abuse and model disclosure
+--
+-- @xmloutput
+-- <elem key="framework">Ollama</elem>
+-- <elem key="version">0.3.14</elem>
+-- <elem key="endpoint">/api/tags</elem>
+-- <elem key="auth">NONE (unauthenticated)</elem>
+-- <elem key="inference">confirmed (responded to a minimal hello)</elem>
+-- <table key="models (3)">
+--   <elem>llama3:8b</elem>
+--   <elem>qwen2.5:7b</elem>
+--   <elem>nomic-embed-text:latest</elem>
+-- </table>
+-- <elem key="SECURITY">unauthenticated inference API (Ollama) exposes 3 model(s); open to compute/cost abuse and model disclosure</elem>
+
+author = "Ben Williams <ben.williams@nccgroup.com>"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"discovery", "safe"}
+
+portrule = llm.portrule
+
+action = function(host, port)
+  local opts = llm.args()
+  local r = llm.detect(host, port, opts)
+  if not r then
+    return nil
+  end
+
+  local out = stdnse.output_table()
+  out.framework = r.framework
+  if r.ui then out.kind = "web UI (fronts a backend inference server)" end
+  if r.version then out.version = r.version end
+  if r.server then out.server = r.server end
+  out.endpoint = r.endpoint
+
+  if r.ui then
+    -- For a web UI the access posture (whether the backend can be used without credentials)
+    -- is the relevant state, not a key/token challenge.
+    local A = {
+      open = "open (no authentication required)",
+      onboarding = "no admin account yet (first visitor can claim admin)",
+      ["self-registration"] = "self-registration enabled (anyone can sign up)",
+      login = "login required",
+      unknown = "unknown (not exposed in config)",
+    }
+    out.access = A[r.access] or r.access or "unknown"
+  elseif r.auth_required then
+    out.auth = opts.credentialed and "REQUIRED (supplied credential rejected)"
+      or "REQUIRED (key/credentials)"
+  elseif opts.credentialed then
+    out.auth = "PROVIDED (credential accepted)"
+  else
+    out.auth = "NONE (unauthenticated)"
+  end
+
+  if r.inference then out.inference = "confirmed (responded to a minimal hello)" end
+  if r.error_sig then out.error_sig = r.error_sig end
+
+  if r.models and #r.models > 0 then
+    local label = "models (" .. #r.models .. ")"
+    if r.models_enumerated then label = label .. " [enumerated by probing known IDs]" end
+    out[label] = r.models
+  end
+  if r.leaks and #r.leaks > 0 then
+    out.leaks = r.leaks
+  end
+
+  if r.ui then
+    -- The UI finding is driven by the access posture: open and self-registration both grant
+    -- unauthenticated use of the backend model; login-gated UIs are reported without a finding.
+    if r.access == "open" then
+      out.SECURITY = string.format(
+        "unauthenticated LLM web UI (%s) grants open access to a backend inference server%s",
+        r.framework, r.gateway and "; prediction endpoints may be publicly callable" or "")
+    elseif r.access == "onboarding" then
+      out.SECURITY = string.format(
+        "unconfigured LLM web UI (%s) has no admin account yet; the first visitor can claim admin and use the backend inference server",
+        r.framework)
+    elseif r.access == "self-registration" then
+      out.SECURITY = string.format(
+        "LLM web UI (%s) allows self-registration for unauthenticated access to a backend inference server",
+        r.framework)
+    elseif r.access == "unknown" then
+      out.SECURITY = string.format(
+        "exposed LLM web UI (%s) fronting a backend inference server%s; verify whether unauthenticated use is permitted",
+        r.framework, r.gateway and " (prediction endpoints may be publicly callable)" or "")
+    end
+  elseif not r.auth_required and not opts.credentialed then
+    local n = (r.models and #r.models) or 0
+    out.SECURITY = string.format(
+      "unauthenticated inference API (%s) exposes %d model(s); open to compute/cost abuse and model disclosure",
+      r.framework, n)
+  end
+
+  -- Feed -sV.
+  port.version.name = r.ui and "llm-ui" or "llm-api"
+  port.version.product = r.framework
+  if r.version then port.version.version = r.version end
+  port.version.extrainfo = r.auth_required and "auth required" or "unauthenticated"
+  nmap.set_port_version(host, port, "hardmatched")
+
+  return out
+end

--- a/scripts/mcp-enum.nse
+++ b/scripts/mcp-enum.nse
@@ -1,0 +1,141 @@
+local mcp = require "mcp"
+local stdnse = require "stdnse"
+local string = require "string"
+local table = require "table"
+
+description = [[
+Enumerates the attack surface of a Model Context Protocol (MCP) server over HTTP(S),
+across both the current Streamable HTTP transport and the legacy HTTP+SSE transport.
+
+After completing the MCP `initialize` handshake the script invokes the read-only listing
+methods `tools/list`, `resources/list`, `resources/templates/list`, and `prompts/list`.
+It reports each tool's name, description, and input-parameter names; resource URIs; and
+prompt names. Each tool is risk-assessed across its name, description, AND its JSON input
+schema -- free-form parameters (string/array/object without an enum) named or described
+like commands, file paths, URLs/hosts, SQL, or secrets are flagged even when the tool's
+name and description look benign. Findings are bucketed into categories (code-exec,
+file-access, network/ssrf, sql/db, secrets, privileged); risk-contributing parameters are
+marked with a trailing `*`. If the server answered the handshake with no authentication,
+an unauthenticated-exposure security finding is emitted.
+
+Transport handling (shared with the `mcp` nselib):
+* Streamable HTTP - carries any issued `Mcp-Session-Id` and the negotiated
+  `MCP-Protocol-Version` header; parses both application/json and text/event-stream.
+* Legacy HTTP+SSE (2024-11-05) - opens the SSE stream with a raw socket, reads the
+  `endpoint` event, POSTs JSON-RPC to the message endpoint, and correlates the
+  asynchronous responses delivered back on the SSE stream by JSON-RPC id.
+
+This script is read-only: it never calls `tools/call`, so no server-side tool is actually
+executed. Run `mcp-info` first/alongside for transport and version fingerprinting.
+]]
+
+---
+-- @usage nmap -p 8000 --script mcp-enum <target>
+-- @usage nmap -sV --script "mcp-info,mcp-enum" -p- <target>
+-- @usage nmap --script mcp-enum --script-args mcp.paths=/mcp,mcp-enum.schemas=true <target>
+--
+-- @args mcp.paths          Comma-separated endpoint paths to probe.
+-- @args mcp.timeout        HTTP/socket timeout in ms (default 7000).
+-- @args mcp.ua             User-Agent to send (default a neutral browser UA).
+-- @args mcp.sse_path       Legacy SSE path to probe (default /sse).
+-- @args mcp-enum.schemas   If true, dump each tool's full JSON input schema.
+--
+-- @output
+-- | mcp-enum:
+-- |   transport: streamable-http
+-- |   server: acme-toolserver 1.4.2 (protocol 2025-06-18)
+-- |   tools (4):
+-- |     run_command [RISK: code-exec] - Execute a shell command on the host  (params: cmd*)
+-- |     read_file [RISK: file-access] - Read a file from disk  (params: path*)
+-- |     search_web - Search the web  (params: q)
+-- |     get_weather - Get the weather for a city  (params: city)
+-- |   resources (2): file:///etc/, db://customers
+-- |   prompts (1): summarize
+-- |_  SECURITY: unauthenticated server exposes 2 risky tool(s) [code-exec, file-access]: run_command, read_file
+--
+-- @xmloutput
+-- <elem key="transport">streamable-http</elem>
+-- <elem key="server">acme-toolserver 1.4.2 (protocol 2025-06-18)</elem>
+-- <table key="tools (4)">
+--   <elem>run_command [RISK: code-exec] - Execute a shell command on the host  (params: cmd*)</elem>
+--   <elem>read_file [RISK: file-access] - Read a file from disk  (params: path*)</elem>
+--   <elem>search_web - Search the web  (params: q)</elem>
+--   <elem>get_weather - Get the weather for a city  (params: city)</elem>
+-- </table>
+-- <table key="resources (2)">
+--   <elem>file:///etc/</elem>
+--   <elem>db://customers</elem>
+-- </table>
+-- <table key="prompts (1)">
+--   <elem>summarize</elem>
+-- </table>
+-- <elem key="SECURITY">unauthenticated server exposes 2 risky tool(s) [code-exec, file-access]: run_command, read_file</elem>
+
+author = "Ben Williams <ben.williams@nccgroup.com>"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"discovery", "safe"}
+
+portrule = mcp.portrule
+
+action = function(host, port)
+  local opts = mcp.args()
+  local transport = (mcp.connect(host, port, opts))
+  if not transport then
+    return nil
+  end
+
+  local data = mcp.enumerate(transport, opts)
+  if transport.close then transport:close() end
+
+  local out = stdnse.output_table()
+  out.transport = data.transport
+  local si = data.server_info or {}
+  if si.name then
+    out.server = (si.version and (si.name .. " " .. si.version) or si.name) ..
+      " (protocol " .. (data.protocol or "?") .. ")"
+  end
+
+  if #data.tools > 0 then
+    local lines = {}
+    for _, t in ipairs(data.tools) do
+      local line = t.name
+      if t.dangerous then
+        line = line .. " [RISK: " .. table.concat(t.categories, ", ") .. "]"
+      end
+      if t.description ~= "" then line = line .. " - " .. t.description:gsub("%s+", " ") end
+      if opts.schemas and t.schema then
+        line = line .. "  schema=" .. (mcp.gen(t.schema) or "?")
+      elseif #t.params > 0 then
+        -- mark risk-contributing params with a trailing *
+        local marked = {}
+        for _, p in ipairs(t.params) do
+          marked[#marked + 1] = (t.risky_params and t.risky_params[p]) and (p .. "*") or p
+        end
+        line = line .. "  (params: " .. table.concat(marked, ", ") .. ")"
+      end
+      lines[#lines + 1] = line
+    end
+    out["tools (" .. #data.tools .. ")"] = lines
+  end
+
+  if #data.resources > 0 then
+    out["resources (" .. #data.resources .. ")"] = data.resources
+  end
+  if #data.prompts > 0 then
+    out["prompts (" .. #data.prompts .. ")"] = data.prompts
+  end
+
+  if not data.authenticated then
+    if #data.dangerous > 0 then
+      local cats = (data.categories and #data.categories > 0)
+        and (" [" .. table.concat(data.categories, ", ") .. "]") or ""
+      out.SECURITY = string.format(
+        "unauthenticated server exposes %d risky tool(s)%s: %s",
+        #data.dangerous, cats, table.concat(data.dangerous, ", "))
+    else
+      out.SECURITY = "unauthenticated MCP server (no credentials required to enumerate)"
+    end
+  end
+
+  return out
+end

--- a/scripts/mcp-info.nse
+++ b/scripts/mcp-info.nse
@@ -1,0 +1,119 @@
+local mcp = require "mcp"
+local nmap = require "nmap"
+local stdnse = require "stdnse"
+local table = require "table"
+
+description = [[
+Detects and fingerprints Model Context Protocol (MCP) servers exposed over HTTP(S).
+
+The script attempts an MCP JSON-RPC `initialize` handshake (Streamable HTTP transport)
+against a list of candidate endpoint paths, sending the spec-required
+`Accept: application/json, text/event-stream` header. A response carrying a JSON-RPC
+`initialize` result (serverInfo / protocolVersion / capabilities) is treated as a
+high-confidence MCP match. The script also falls back to the legacy HTTP+SSE transport
+and, for auth-gated servers, parses the OAuth 2.1 protected-resource metadata
+(RFC 9728) to reveal the authorization server(s) and scopes.
+
+On a match it reports the transport, endpoint path, server implementation name/version,
+negotiated protocol version, advertised capabilities, session statefulness, and
+authentication posture. It augments service/version detection via `-sV`.
+
+This script is read-only: it issues only the protocol `initialize` handshake and never
+invokes tools (`tools/call`). For attack-surface enumeration (tools/resources/prompts)
+see the companion script `mcp-enum`. Shared logic lives in the `mcp` nselib.
+]]
+
+---
+-- @usage nmap -p 8000,3000,8080 --script mcp-info <target>
+-- @usage nmap -sV --script mcp-info -p- <target>
+-- @usage nmap --script mcp-info --script-args mcp.paths=/custom,mcp.ua=curl/8 <target>
+--
+-- @args mcp.paths   Comma-separated list of endpoint paths to probe.
+-- @args mcp.timeout HTTP timeout in ms (default 7000).
+-- @args mcp.ua      User-Agent to send (default a neutral browser UA; a UA containing
+--                   "nmap" is blocked by common WAFs).
+--
+-- @output
+-- PORT     STATE SERVICE
+-- 8000/tcp open  mcp
+-- | mcp-info:
+-- |   transport: streamable-http
+-- |   endpoint: /mcp
+-- |   protocolVersion: 2025-06-18
+-- |   server: acme-toolserver 1.4.2
+-- |   capabilities: logging, prompts, resources, tools
+-- |   session: stateful (Mcp-Session-Id issued)
+-- |_  auth: NONE (unauthenticated)
+--
+-- @xmloutput
+-- <elem key="transport">streamable-http</elem>
+-- <elem key="endpoint">/mcp</elem>
+-- <elem key="protocolVersion">2025-06-18</elem>
+-- <elem key="server">acme-toolserver 1.4.2</elem>
+-- <elem key="auth">NONE (unauthenticated)</elem>
+
+author = "Ben Williams <ben.williams@nccgroup.com>"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"discovery", "safe", "version"}
+
+portrule = mcp.portrule
+
+action = function(host, port)
+  local opts = mcp.args()
+  local out = stdnse.output_table()
+
+  local transport, auth = mcp.connect(host, port, opts)
+
+  if transport then
+    out.transport = transport.name
+    out.endpoint = transport.endpoint
+    if transport.protocol then out.protocolVersion = transport.protocol end
+    local si = transport.server_info or {}
+    if si.name then
+      out.server = si.version and (si.name .. " " .. si.version) or si.name
+    end
+    if type(transport.capabilities) == "table" then
+      local names = {}
+      for k in pairs(transport.capabilities) do names[#names + 1] = tostring(k) end
+      table.sort(names)
+      if #names > 0 then out.capabilities = table.concat(names, ", ") end
+    end
+    out.session = transport.session_stateful and "stateful (Mcp-Session-Id issued)" or "stateless"
+    local authed = opts.token ~= nil
+    out.auth = authed and "PROVIDED (Bearer token accepted)" or "NONE (unauthenticated)"
+
+    -- Feed -sV.
+    local legacy = transport.name:find("legacy") ~= nil
+    port.version.name = "mcp"
+    port.version.product = si.name or (legacy and "MCP server (legacy SSE)" or "MCP server")
+    if si.version then port.version.version = si.version end
+    port.version.extrainfo = "MCP " .. (transport.protocol or "?") ..
+      (authed and ", authenticated (token)" or ", unauthenticated")
+    nmap.set_port_version(host, port, "hardmatched")
+
+    if transport.close then transport:close() end
+    return out
+  end
+
+  if auth then
+    out.transport = "streamable-http"
+    out.endpoint = auth.path
+    out.auth = "REQUIRED (OAuth/Bearer)"
+    out.www_authenticate = auth.www
+    local meta = mcp.fetch_oauth_metadata(host, port, auth.www, opts)
+    if meta then
+      if meta.resource then out.oauth_resource = meta.resource end
+      if meta.authorization_servers then out.oauth_authorization_servers = meta.authorization_servers end
+      if meta.scopes then out.oauth_scopes = meta.scopes end
+      if meta.bearer_methods then out.oauth_bearer_methods = meta.bearer_methods end
+      if meta.metadata_url then out.oauth_metadata_url = meta.metadata_url end
+    end
+    port.version.name = "mcp"
+    port.version.product = "MCP server (auth required)"
+    port.version.extrainfo = "OAuth-protected"
+    nmap.set_port_version(host, port, "hardmatched")
+    return out
+  end
+
+  return nil
+end

--- a/scripts/script.db
+++ b/scripts/script.db
@@ -336,11 +336,14 @@ Entry { filename = "ldap-novell-getpass.nse", categories = { "discovery", "safe"
 Entry { filename = "ldap-rootdse.nse", categories = { "discovery", "safe", } }
 Entry { filename = "ldap-search.nse", categories = { "discovery", "safe", } }
 Entry { filename = "lexmark-config.nse", categories = { "discovery", "safe", } }
+Entry { filename = "llm-info.nse", categories = { "discovery", "safe", } }
 Entry { filename = "llmnr-resolve.nse", categories = { "broadcast", "discovery", "safe", } }
 Entry { filename = "lltd-discovery.nse", categories = { "broadcast", "discovery", "safe", } }
 Entry { filename = "lu-enum.nse", categories = { "brute", "intrusive", } }
 Entry { filename = "maxdb-info.nse", categories = { "default", "safe", "version", } }
 Entry { filename = "mcafee-epo-agent.nse", categories = { "safe", "version", } }
+Entry { filename = "mcp-enum.nse", categories = { "discovery", "safe", } }
+Entry { filename = "mcp-info.nse", categories = { "discovery", "safe", "version", } }
 Entry { filename = "membase-brute.nse", categories = { "brute", "intrusive", } }
 Entry { filename = "membase-http-info.nse", categories = { "discovery", "safe", } }
 Entry { filename = "memcached-info.nse", categories = { "discovery", "safe", } }


### PR DESCRIPTION
## Summary

Adds three NSE scripts and two shared libraries to discover, fingerprint, and enumerate two
classes of AI infrastructure that nmap currently cannot detect, both increasingly deployed on
dev and production networks and frequently left unauthenticated.

**MCP (Model Context Protocol) servers** expose LLM-callable tools, resources, and prompts.

- **`mcp-info`** (`discovery, safe, version`) - JSON-RPC `initialize` handshake over Streamable
  HTTP with a legacy HTTP+SSE fallback. Reports transport, endpoint, server name/version,
  protocol version, capabilities, session statefulness, and auth posture. For auth-gated
  servers it parses OAuth 2.1 protected-resource metadata (RFC 9728) to surface the
  authorization server and scopes. Integrates with `-sV` via `set_port_version`.
- **`mcp-enum`** (`discovery, safe`) - completes the handshake and calls the read-only
  `tools/list`, `resources/list`, `resources/templates/list`, `prompts/list`. Reports the
  tool/resource/prompt attack surface and risk-assesses each tool across its name, description,
  and JSON input schema (categories: code-exec, file-access, network/ssrf, sql/db, secrets,
  privileged), flagging unauthenticated exposure.

**LLM inference APIs** serve model inference; an exposed unauthenticated endpoint means free
compute on someone else's bill, model-name disclosure, and in some stacks leaked system prompts.

- **`llm-info`** (`discovery, safe`) - detects the common self-hosted and cloud frameworks by
  their read-only model-list / metadata endpoints: OpenAI-compatible (vLLM, SGLang, LiteLLM,
  LocalAI, LM Studio, text-generation-webui), Ollama, HuggingFace TGI and TEI, llama.cpp,
  KoboldCpp, Triton/KServe (v2), TorchServe, and Anthropic. Identification is order-independent
  (every detector runs; the result is chosen by signal specificity, so a server emulating
  several APIs is reported by its most specific match). Reports framework, version, model
  inventory (listed, or enumerated by probing a small built-in set of known model IDs for
  list-less APIs), auth state, and information leaks (a llama.cpp system prompt via `/props`; a
  served model name via a Prometheus `/metrics` endpoint). It also fingerprints the stack from
  error-response shapes and flags the common AI web UIs / gateways that front a backend (Open
  WebUI, LibreChat, NextChat, LobeChat, Flowise, AnythingLLM), reporting each UI's access
  posture (open / self-registration / login).

**Shared libraries** - `nselib/mcp.lua` (both MCP transports over raw sockets, handshake, OAuth
discovery, enumeration) and `nselib/llm.lua` (framework detectors, auth, the active hello probe,
model enumeration).

Optional credentials enable authenticated testing of gated services: `mcp.token` (MCP), and
`llm.token` / `llm.header` (inference, e.g. a bearer token, `x-api-key`, or session cookie).

## Safety

- The MCP scripts are read-only: only `initialize` and `*/list` - `tools/call` is never invoked,
  with or without a token.
- `llm-info` detection is read-only. By default it also sends a single minimal "hello"
  completion (`max_tokens=1`) to confirm an endpoint serves inference and to detect formats with
  no list endpoint (notably Anthropic); `llm.probe=false` makes it strictly read-only. The
  active probe and model-ID enumeration are bounded; web UIs are never sent an inference request.
- Both scripts use a neutral default User-Agent (a UA containing "nmap" is blocked by common
  WAFs) and honour timeouts.

## Why raw sockets (MCP)

Real Streamable-HTTP servers (FastMCP/uvicorn) hold the SSE response stream open after replying,
which makes `http.post` block until timeout and discard data already received. The library
speaks HTTP over a raw socket and stops reading the moment the JSON-RPC reply arrives. It also
sends a port-qualified `Host` header (servers return `421` for DNS-rebinding protection
otherwise), sends valid `initialize` params (strict servers reject empty params with `-32602`),
and auto-detects TLS.

## Testing

Bundled dependency-free mocks and regression matrices (in the standalone repo below):

- MCP, 23 checks: protocol versions 2024-11-05 / 2025-03-26 / 2025-06-18, all three transports,
  both auth states, and tools/resources/prompts content.
- Inference, 57 checks: every framework, order-independent identification, the hello probe,
  credentials, model listing + enumeration, error-shape fingerprinting, the Prometheus
  `/metrics` leak, and the web UI access postures.

Field-tested against real software, not just the mocks:

- MCP: official Python SDK (FastMCP) and `@modelcontextprotocol/server-everything` (streamable +
  legacy SSE); live public servers read-only - DeepWiki, Context7, Cloudflare docs MCP, and
  OAuth-gated GitHub / Sentry / Linear (auth-required fingerprint + RFC 9728 discovery,
  unauthenticated).
- Inference: Ollama 0.30.7, KoboldCpp 1.115.2 (which simultaneously emulates the Ollama, OpenAI,
  and llama.cpp APIs, exercising the order-independent identification), and Open WebUI 0.9.6
  (both auth configurations).

Tested with nmap 7.94SVN / Lua 5.4; script load verified against the current master tree.

Standalone repo with the mocks, tests, and usage docs:
https://github.com/insidetrust/nmap-ai-recon

## Bare `-sV` detection (nmap-service-probes)

The PR also adds four TCP probes to `nmap-service-probes` so `-sV` identifies these services
without `--script`:

- `MCPInitialize` (POST /mcp initialize handshake; captures serverInfo name + version and the
  protocol version, and flags an OAuth-protected server) and `MCPLegacySSE` (GET /sse).
- `OllamaTags` (GET /api/tags) and `OpenAIModels` (GET /v1/models, for vLLM / LiteLLM /
  LocalAI / LM Studio and similar).

All are rarity 7 (default intensity) and gated to the relevant ports; the metadata requests are
read-only (no MCP tool is called and no inference is run). Ollama's port 11434/tcp is already
registered in `nmap-services`, so no `nmap-services` change is needed.

## Notes for review

The two feature sets are cleanly separable into two PRs (no cross-dependency between the
nselibs) if a reviewer prefers. The MCP and LLM service probes target common web ports
(3000/8000/8080/...), so they add a small amount of `-sV` traffic on those ports by design;
happy to adjust rarity or the port lists.

## Licensing

Offered under the NPSL with the standard Nmap contribution/relicensing terms (per `HACKING`).
Each file carries the standard `license =` header.