### PR TITLE
Add NSE scripts for CVE-2026-48908 and CVE-2026-14345

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -70,6 +70,14 @@ o [Nping] Fix a out-of-bounds access in Nping Echo client allowing a malicious N
 o Fix a 1-byte overrun (read) while reading certain crafted DNS labels,
   reported by Peter Parker. [Daniel Miller]
 
+o [NSE] Added http-vuln-cve2026-48908.nse for CVE-2026-48908, an
+  unauthenticated remote code execution in SP Page Builder for Joomla.
+  [Aditya Agrawal]
+
+o [NSE] Added http-vuln-cve2026-14345.nse for CVE-2026-14345, an
+  unauthenticated remote code execution in WPFunnels for WordPress.
+  [Aditya Agrawal]
+
 o [NSE][GH#3317] Function url.build_path was mangling special characters in URL
   path segments. [nnposter]
 

--- a/scripts/http-vuln-cve2026-14345.nse
+++ b/scripts/http-vuln-cve2026-14345.nse
@@ -4,6 +4,7 @@ local stdnse = require "stdnse"
 local string = require "string"
 local table = require "table"
 local json = require "json"
+local rand = require "rand"
 local vulns = require "vulns"
 
 description = [[
@@ -76,6 +77,17 @@ local EP_ACTION_BLOCKED = 2
 local EP_ACTION_ABSENT = 3
 
 local COMMON_WP_PATHS = {"", "/wordpress", "/wp", "/blog", "/site", "/cms"}
+
+local NONCE_PATTERNS = {
+  '["\']nonce["\']%s*:%s*["\']([A-Za-z0-9_%-]+)["\']',
+  '["\']wpfnl_nonce["\']%s*:%s*["\']([A-Za-z0-9_%-]+)["\']',
+  '["\']security["\']%s*:%s*["\']([A-Za-z0-9_%-]+)["\']',
+  'data%-nonce=["\']([A-Za-z0-9_%-]+)["\']',
+}
+
+local NONCE_PARAM_NAMES = {"_wpnonce", "security", "wpfnl_nonce"}
+
+local NONCE_FETCH_PATHS = {"/", "/checkout/", "/cart/", "/checkout", "/cart"}
 
 local function version_ge(v1, v2)
   local function split(v)
@@ -155,7 +167,7 @@ local function classify_ajax_response(resp)
   if trimmed and string.sub(trimmed, 1, 1) == "<" then
     return nil
   end
-  return EP_ACTION_ACTIVE
+  return nil
 end
 
 local function try_get_version(host, port, base_path)
@@ -189,6 +201,7 @@ end
 local function find_base_path(host, port)
   local path_arg = stdnse.get_script_args(SCRIPT_NAME .. ".path")
   if path_arg and #path_arg > 0 then
+    path_arg = string.match(path_arg, "^(.-)/*$") or path_arg
     return path_arg
   end
   for _, p in ipairs(COMMON_WP_PATHS) do
@@ -199,6 +212,50 @@ local function find_base_path(host, port)
     end
   end
   return ""
+end
+
+local function url_encode(s)
+  if not s then return "" end
+  local result = ""
+  for i = 1, #s do
+    local c = string.byte(s, i)
+    if (c >= 48 and c <= 57) or (c >= 65 and c <= 90) or (c >= 97 and c <= 122) or c == 45 or c == 46 or c == 95 or c == 126 then
+      result = result .. string.char(c)
+    else
+      result = result .. string.format("%%%02X", c)
+    end
+  end
+  return result
+end
+
+local function extract_nonce(host, port, base_path)
+  for _, rel_path in ipairs(NONCE_FETCH_PATHS) do
+    local url = base_path .. rel_path
+    local resp = http.get(host, port, url)
+    if resp and resp.status == 200 and resp.body then
+      for _, pattern in ipairs(NONCE_PATTERNS) do
+        local nonce = string.match(resp.body, pattern)
+        if nonce and #nonce >= 8 then
+          return nonce
+        end
+      end
+    end
+  end
+  return nil
+end
+
+local function try_ajax_with_nonce(host, port, ajax_path, probe_value, nonce)
+  local param = NONCE_PARAM_NAMES[1]
+  local content = "action=wpfnl_log&postData=" .. url_encode(probe_value) .. "&" .. param .. "=" .. url_encode(nonce)
+  local resp = http.post(host, port, ajax_path, {
+    header = {["Content-Type"] = "application/x-www-form-urlencoded"},
+    content = content,
+  })
+  local ep = classify_ajax_response(resp)
+  if ep == EP_ACTION_ACTIVE then
+    return ep
+  end
+  return nil
 end
 
 action = function(host, port)
@@ -228,12 +285,21 @@ is subsequently executed via include_once when an admin views the log (CVSS 9.8)
       return report:make_output(vuln)
     end
   end
+  local probe_value = rand.random_alpha(12)
   local ajax_path = base_path .. "/wp-admin/admin-ajax.php"
-  local resp = http.post(host, port, ajax_path, {
-    header = {["Content-Type"] = "application/x-www-form-urlencoded"},
-    content = "action=wpfnl_log&postData=CVE-2026-14345-probe",
-  })
-  local ep_class = classify_ajax_response(resp)
+  local nonce = extract_nonce(host, port, base_path)
+  local ep_class
+  if nonce then
+    ep_class = try_ajax_with_nonce(host, port, ajax_path, probe_value, nonce)
+  end
+  if not ep_class then
+    local content = "action=wpfnl_log&postData=" .. probe_value
+    local resp = http.post(host, port, ajax_path, {
+      header = {["Content-Type"] = "application/x-www-form-urlencoded"},
+      content = content,
+    })
+    ep_class = classify_ajax_response(resp)
+  end
   if ep_class == EP_ACTION_ACTIVE or ep_class == EP_ACTION_BLOCKED then
     if found_version then
       vuln.state = vulns.STATE.VULN

--- a/scripts/http-vuln-cve2026-14345.nse
+++ b/scripts/http-vuln-cve2026-14345.nse
@@ -1,0 +1,249 @@
+local http = require "http"
+local shortport = require "shortport"
+local stdnse = require "stdnse"
+local string = require "string"
+local table = require "table"
+local json = require "json"
+local vulns = require "vulns"
+
+description = [[
+Detects CVE-2026-14345, an unauthenticated remote code execution vulnerability in
+WPFunnels, a WordPress funnel builder plugin by getwpfunnels.com. Versions up to
+and including 3.12.7 allow unauthenticated attackers to inject arbitrary PHP code
+into a server-side log file via the postData parameter. When an administrator
+subsequently views the log through the plugin's Log Settings UI, the injected
+code is executed via PHP's include_once.
+
+The vulnerability exists because the plugin fails to sanitize attacker-controlled
+values written to a .log file (CWE-434). The nonce required to reach the
+vulnerable optin endpoint is publicly emitted on every funnel step page, making
+the injection step fully unauthenticated.
+
+Detection works in two layers:
+1. Version manifest check — retrieves the plugin version from
+   /wp-content/plugins/wpfunnels/readme.txt (or the plugin header as fallback)
+   and compares against the fixed version (3.12.8).
+2. Endpoint probe — POSTs to /wp-admin/admin-ajax.php with action=wpfnl_log and
+   postData when the version is within the vulnerable range or unobtainable.
+   WordPress AJAX returns "0" for unregistered actions, "-1" when the handler
+   enforces a nonce check that fails, and the handler's output otherwise.
+   A non-"0" response confirms the vulnerable action handler is registered;
+   if the version is unknown, it is reported as LIKELY_VULN to avoid false
+   positives on patched installations.
+
+The base path is auto-detected by trying common WordPress installation directories.
+Override with: --script-args http-vuln-cve2026-14345.path=/custom/path
+]]
+
+---
+-- @usage
+-- nmap -p80,443 --script http-vuln-cve2026-14345 <target>
+-- nmap -p80,443 --script http-vuln-cve2026-14345 --script-args http-vuln-cve2026-14345.path=/wordpress <target>
+--
+-- @output
+-- | http-vuln-cve2026-14345:
+-- |   VULNERABLE:
+-- |   WPFunnels WordPress Unauthenticated RCE
+-- |     State: VULNERABLE
+-- |     IDs:  CVE:CVE-2026-14345
+-- |       WPFunnels plugin for WordPress versions up to 3.12.7 allow
+-- |       unauthenticated attackers to inject PHP code via the postData
+-- |       parameter into a log file that is subsequently executed via
+-- |       include_once when an admin views the log (CVSS 9.8).
+-- |
+-- |     Disclosure date: 2026-07-06
+-- |     References:
+-- |       https://nvd.nist.gov/vuln/detail/CVE-2026-14345
+-- |       https://wordpress.org/plugins/wpfunnels/
+-- |_      https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-14345
+--
+-- @xmloutput
+-- <elem key="title">WPFunnels WordPress Unauthenticated RCE</elem>
+-- <elem key="state">VULNERABLE</elem>
+-- <elem key="cve">CVE-2026-14345</elem>
+--
+-- @args http-vuln-cve2026-14345.path Base path to WordPress installation (auto-detected if not provided)
+--
+
+author = "Aditya Agrawal"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"vuln", "intrusive"}
+
+portrule = shortport.http
+
+local EP_ACTION_ACTIVE = 1
+local EP_ACTION_BLOCKED = 2
+local EP_ACTION_ABSENT = 3
+
+local COMMON_WP_PATHS = {"", "/wordpress", "/wp", "/blog", "/site", "/cms"}
+
+local function version_ge(v1, v2)
+  local function split(v)
+    local parts = {}
+    for part in v:gmatch("%d+") do
+      parts[#parts + 1] = tonumber(part)
+    end
+    return parts
+  end
+  local p1, p2 = split(v1), split(v2)
+  for i = 1, math.max(#p1, #p2) do
+    local a, b = p1[i] or 0, p2[i] or 0
+    if a ~= b then
+      return a > b
+    end
+  end
+  return true
+end
+
+local function version_lt(v1, v2)
+  local function split(v)
+    local parts = {}
+    for part in v:gmatch("%d+") do
+      parts[#parts + 1] = tonumber(part)
+    end
+    return parts
+  end
+  local p1, p2 = split(v1), split(v2)
+  for i = 1, math.max(#p1, #p2) do
+    local a, b = p1[i] or 0, p2[i] or 0
+    if a ~= b then
+      return a < b
+    end
+  end
+  return false
+end
+
+local function strip_bom_and_whitespace(body)
+  if not body or #body == 0 then
+    return body
+  end
+  if #body >= 3 then
+    local b1, b2, b3 = string.byte(body, 1), string.byte(body, 2), string.byte(body, 3)
+    if b1 == 0xEF and b2 == 0xBB and b3 == 0xBF then
+      body = string.sub(body, 4)
+    end
+  end
+  body = string.match(body, "^%s*(.-)%s*$")
+  return body or ""
+end
+
+local function classify_ajax_response(resp)
+  if not resp then
+    return nil
+  end
+  if resp.status ~= 200 then
+    return nil
+  end
+  if not resp.body or #resp.body == 0 then
+    return nil
+  end
+  local body = strip_bom_and_whitespace(resp.body)
+  if #body == 0 then
+    return nil
+  end
+  if string.match(body, "^%s*0%s*$") then
+    return EP_ACTION_ABSENT
+  end
+  local ok, data = json.parse(body)
+  if ok and type(data) == "table" then
+    return EP_ACTION_ACTIVE
+  end
+  if string.match(body, "^%s*-1%s*$") then
+    return EP_ACTION_BLOCKED
+  end
+  local trimmed = string.match(body, "^%s*(.*)")
+  if trimmed and string.sub(trimmed, 1, 1) == "<" then
+    return nil
+  end
+  return EP_ACTION_ACTIVE
+end
+
+local function try_get_version(host, port, base_path)
+  local readme_path = base_path .. "/wp-content/plugins/wpfunnels/readme.txt"
+  local resp = http.get(host, port, readme_path)
+  if resp and resp.status == 200 and resp.body then
+    local ver = string.match(resp.body, "Stable tag:%s*([%d.]+)")
+    if ver then
+      ver = string.match(ver, "%d[%d%.]*")
+      if ver then
+        return ver
+      end
+    end
+  end
+  local plugin_path = base_path .. "/wp-content/plugins/wpfunnels/wpfunnels.php"
+  resp = http.get(host, port, plugin_path)
+  if resp and resp.status == 200 and resp.body then
+    if string.find(resp.body, "Plugin Name:%s*WPFunnels") then
+      local ver = string.match(resp.body, "[Vv]ersion:%s*([%d.]+)")
+      if ver then
+        ver = string.match(ver, "%d[%d%.]*")
+        if ver then
+          return ver
+        end
+      end
+    end
+  end
+  return nil
+end
+
+local function find_base_path(host, port)
+  local path_arg = stdnse.get_script_args(SCRIPT_NAME .. ".path")
+  if path_arg and #path_arg > 0 then
+    return path_arg
+  end
+  for _, p in ipairs(COMMON_WP_PATHS) do
+    local readme = p .. "/wp-content/plugins/wpfunnels/readme.txt"
+    local resp = http.get(host, port, readme)
+    if resp and resp.status == 200 then
+      return p
+    end
+  end
+  return ""
+end
+
+action = function(host, port)
+  local vuln = {
+    title = "WPFunnels WordPress Unauthenticated RCE",
+    state = vulns.STATE.NOT_VULN,
+    description = [[
+WPFunnels plugin for WordPress versions up to 3.12.7 allow unauthenticated
+attackers to inject PHP code via the postData parameter into a log file that
+is subsequently executed via include_once when an admin views the log (CVSS 9.8).
+]],
+    IDS = {CVE = "CVE-2026-14345"},
+    references = {
+      "https://nvd.nist.gov/vuln/detail/CVE-2026-14345",
+      "https://wordpress.org/plugins/wpfunnels/",
+    },
+    dates = {disclosure = {year = "2026", month = "07", day = "06"}},
+  }
+  local report = vulns.Report:new(SCRIPT_NAME, host, port)
+  local base_path = find_base_path(host, port)
+  local found_version = try_get_version(host, port, base_path)
+  if found_version then
+    if version_ge(found_version, "3.12.8") then
+      return report:make_output(vuln)
+    end
+    if version_lt(found_version, "1.0.0") then
+      return report:make_output(vuln)
+    end
+  end
+  local ajax_path = base_path .. "/wp-admin/admin-ajax.php"
+  local resp = http.post(host, port, ajax_path, {
+    header = {["Content-Type"] = "application/x-www-form-urlencoded"},
+    content = "action=wpfnl_log&postData=CVE-2026-14345-probe",
+  })
+  local ep_class = classify_ajax_response(resp)
+  if ep_class == EP_ACTION_ACTIVE or ep_class == EP_ACTION_BLOCKED then
+    if found_version then
+      vuln.state = vulns.STATE.VULN
+    else
+      vuln.state = vulns.STATE.LIKELY_VULN
+    end
+  elseif ep_class == EP_ACTION_ABSENT then
+    if found_version then
+      vuln.state = vulns.STATE.LIKELY_VULN
+    end
+  end
+  return report:make_output(vuln)
+end

--- a/scripts/http-vuln-cve2026-48908.nse
+++ b/scripts/http-vuln-cve2026-48908.nse
@@ -86,6 +86,12 @@ local LOGIN_PATH_INDICATORS = {
 
 local COMMON_JOOMLA_PATHS = {"", "/joomla", "/cms", "/site", "/joomla3", "/joomla4"}
 
+local MANIFEST_PATHS = {
+  "administrator/components/com_sppagebuilder/sp_page_builder.xml",
+  "administrator/components/com_sppagebuilder/sppagebuilder.xml",
+  "administrator/components/com_sppagebuilder/com_sppagebuilder.xml",
+}
+
 local function version_ge(v1, v2)
   local function split(v)
     local parts = {}
@@ -229,10 +235,27 @@ local function is_controller_response(resp)
   if not is_joomla_json_format(data) then
     return false
   end
-  if indicates_auth(data) then
+  return not indicates_auth(data)
+end
+
+local function is_auth_response(resp)
+  if not resp or not resp.body or #resp.body == 0 then
     return false
   end
-  return true
+  if body_is_html(resp.body) then
+    return false
+  end
+  if not has_json_content_type(resp) and not response_looks_like_json(resp.body) then
+    return false
+  end
+  local ok, data = json.parse(resp.body)
+  if not ok or type(data) ~= "table" then
+    return false
+  end
+  if not is_joomla_json_format(data) then
+    return false
+  end
+  return indicates_auth(data)
 end
 
 local function is_login_redirect(resp)
@@ -245,10 +268,16 @@ local function is_login_redirect(resp)
       return true
     end
   end
-  local set_cookie = resp.header["set-cookie"] or ""
-  if string.find(string.lower(set_cookie), "session", 1, true) or
-     string.find(string.lower(set_cookie), "joomla", 1, true) then
-    return true
+  if resp.rawheader then
+    for _, line in ipairs(resp.rawheader) do
+      local lower = string.lower(line)
+      if string.find(lower, "^set%-cookie:", 1) then
+        if string.find(lower, "session", 1, true) or
+           string.find(lower, "joomla", 1, true) then
+          return true
+        end
+      end
+    end
   end
   return false
 end
@@ -257,8 +286,13 @@ local function classify_endpoint(resp)
   if not resp then
     return nil
   end
-  if resp.status == 200 and is_controller_response(resp) then
-    return EP_UNPROTECTED
+  if resp.status == 200 then
+    if is_controller_response(resp) then
+      return EP_UNPROTECTED
+    end
+    if is_auth_response(resp) then
+      return EP_AUTH_ENFORCED
+    end
   end
   if resp.status == 401 or resp.status == 403 then
     return EP_AUTH_ENFORCED
@@ -282,14 +316,16 @@ local function classify_endpoint(resp)
 end
 
 local function try_get_version(host, port, base_path)
-  local manifest_path = base_path .. "/administrator/components/com_sppagebuilder/sp_page_builder.xml"
-  local resp = http.get(host, port, manifest_path)
-  if resp and resp.status == 200 and resp.body then
-    local ver = string.match(resp.body, "<version>([^<]+)</version>")
-    if ver then
-      ver = string.match(ver, "%d[%d%.]*")
+  for _, manifest_rel in ipairs(MANIFEST_PATHS) do
+    local manifest_path = base_path .. "/" .. manifest_rel
+    local resp = http.get(host, port, manifest_path)
+    if resp and resp.status == 200 and resp.body then
+      local ver = string.match(resp.body, "<version>([^<]+)</version>")
       if ver then
-        return ver
+        ver = string.match(ver, "%d[%d%.]*")
+        if ver then
+          return ver
+        end
       end
     end
   end
@@ -299,6 +335,7 @@ end
 local function find_base_path(host, port)
   local path_arg = stdnse.get_script_args(SCRIPT_NAME .. ".path")
   if path_arg and #path_arg > 0 then
+    path_arg = string.match(path_arg, "^(.-)/*$") or path_arg
     return path_arg
   end
   for _, p in ipairs(COMMON_JOOMLA_PATHS) do
@@ -309,6 +346,62 @@ local function find_base_path(host, port)
     end
   end
   return ""
+end
+
+local function build_probe_parts()
+  local boundary = "----NseB" .. rand.random_alpha(8)
+  local empty_zip = string.char(
+    0x50, 0x4B, 0x05, 0x06,
+    0x00, 0x00,
+    0x00, 0x00,
+    0x00, 0x00,
+    0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00
+  )
+  local parts = {}
+  table.insert(parts, "--" .. boundary)
+  table.insert(parts, 'Content-Disposition: form-data; name="custom_icon"; filename="icon.zip"')
+  table.insert(parts, "Content-Type: application/zip")
+  table.insert(parts, "")
+  table.insert(parts, empty_zip)
+  table.insert(parts, "--" .. boundary .. "--")
+  return boundary, table.concat(parts, "\r\n")
+end
+
+local function probe_endpoint(host, port, base_path, probe_suffixes)
+  local boundary, body = build_probe_parts()
+  local best = nil
+  for _, suffix in ipairs(probe_suffixes) do
+    local url = base_path .. suffix
+    local resp = http.post(host, port, url, {
+      header = {["Content-Type"] = "multipart/form-data; boundary=" .. boundary},
+      content = body,
+    })
+    local ep = classify_endpoint(resp)
+    if ep == EP_UNPROTECTED then
+      return EP_UNPROTECTED
+    end
+    if ep ~= nil and ep ~= EP_ABSENT then
+      return ep
+    end
+    if ep == EP_ABSENT and best == nil then
+      best = EP_ABSENT
+    end
+  end
+  return best
+end
+
+local function combine_classifications(c1, c2)
+  if c1 == EP_UNPROTECTED or c2 == EP_UNPROTECTED then
+    return EP_UNPROTECTED
+  end
+  if c1 == nil then return c2 end
+  if c2 == nil then return c1 end
+  if c1 == EP_ABSENT then return c2 end
+  if c2 == EP_ABSENT then return c1 end
+  return math.min(c1, c2)
 end
 
 action = function(host, port)
@@ -330,38 +423,19 @@ leading to PHP code execution and full server compromise (CVSS 10.0).
   local report = vulns.Report:new(SCRIPT_NAME, host, port)
   local base_path = find_base_path(host, port)
   local found_version = try_get_version(host, port, base_path)
-  if found_version then
-    if version_ge(found_version, "6.6.2") then
-      return report:make_output(vuln)
-    end
-    if version_lt(found_version, "1.0.0") then
-      return report:make_output(vuln)
-    end
+  if found_version and version_lt(found_version, "1.0.0") then
+    return report:make_output(vuln)
   end
-  local boundary = "----NseB" .. rand.random_alpha(8)
-  local empty_zip = string.char(
-    0x50, 0x4B, 0x05, 0x06,
-    0x00, 0x00,
-    0x00, 0x00,
-    0x00, 0x00,
-    0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00
-  )
-  local probe_parts = {}
-  table.insert(probe_parts, "--" .. boundary)
-  table.insert(probe_parts, 'Content-Disposition: form-data; name="custom_icon"; filename="icon.zip"')
-  table.insert(probe_parts, "Content-Type: application/zip")
-  table.insert(probe_parts, "")
-  table.insert(probe_parts, empty_zip)
-  table.insert(probe_parts, "--" .. boundary .. "--")
-  local probe_path = base_path .. "/index.php?option=com_sppagebuilder&task=asset.uploadCustomIcon"
-  local resp = http.post(host, port, probe_path, {
-    header = {["Content-Type"] = "multipart/form-data; boundary=" .. boundary},
-    content = table.concat(probe_parts, "\r\n"),
+  local ep_class = probe_endpoint(host, port, base_path, {
+    "/index.php?option=com_sppagebuilder&task=asset.uploadCustomIcon",
   })
-  local ep_class = classify_endpoint(resp)
+  if ep_class ~= EP_UNPROTECTED then
+    local ep_class2 = probe_endpoint(host, port, base_path, {
+      "/index.php?option=com_sppagebuilder&task=editor.uploadIcons",
+      "/administrator/index.php?option=com_sppagebuilder&task=editor.uploadIcons",
+    })
+    ep_class = combine_classifications(ep_class, ep_class2)
+  end
   if ep_class == EP_UNPROTECTED then
     if found_version then
       vuln.state = vulns.STATE.VULN
@@ -369,15 +443,15 @@ leading to PHP code execution and full server compromise (CVSS 10.0).
       vuln.state = vulns.STATE.LIKELY_VULN
     end
   elseif ep_class == EP_AUTH_ENFORCED then
-    if found_version then
+    if found_version and version_ge(found_version, "6.6.2") then
+      vuln.state = vulns.STATE.NOT_VULN
+    else
       vuln.state = vulns.STATE.LIKELY_VULN
     end
   elseif ep_class == EP_PRESENT_METHOD_REJECTED then
-    if found_version then
-      vuln.state = vulns.STATE.LIKELY_VULN
-    end
+    vuln.state = vulns.STATE.LIKELY_VULN
   elseif ep_class == EP_ABSENT then
-    if found_version then
+    if found_version and not version_ge(found_version, "6.6.2") then
       vuln.state = vulns.STATE.LIKELY_VULN
     end
   end

--- a/scripts/http-vuln-cve2026-48908.nse
+++ b/scripts/http-vuln-cve2026-48908.nse
@@ -1,0 +1,385 @@
+local http = require "http"
+local shortport = require "shortport"
+local stdnse = require "stdnse"
+local string = require "string"
+local table = require "table"
+local json = require "json"
+local rand = require "rand"
+local vulns = require "vulns"
+
+description = [[
+Detects CVE-2026-48908, an unauthenticated remote code execution vulnerability in
+SP Page Builder for Joomla by JoomShaper. Versions 1.0.0 through 6.6.1 allow
+unauthenticated attackers to upload arbitrary files via the asset.uploadCustomIcon
+task, leading to PHP code execution and full server compromise.
+
+The vulnerability resides in com_sppagebuilder's asset controller which performs
+no authentication or file-type validation on the icon upload endpoint.
+
+Detection first checks the extension version manifest; only if the version is
+within the vulnerable range (or unobtainable) does it probe the upload controller
+with a multipart request carrying an empty ZIP archive. The response is classified
+by authentication behavior and JSON semantics:
+  - Controller reached + no auth enforced + version vulnerable   → VULN
+  - Controller reached + no auth enforced + version unknown      → LIKELY_VULN
+  - Controller reached + auth enforced (401, 403, login redirect) → LIKELY_VULN
+
+The base path is auto-detected by trying common Joomla installation directories.
+Override with: --script-args http-vuln-cve2026-48908.path=/custom/path
+]]
+
+---
+-- @usage
+-- nmap -p80,443 --script http-vuln-cve2026-48908 <target>
+-- nmap -p80,443 --script http-vuln-cve2026-48908 --script-args http-vuln-cve2026-48908.path=/joomla <target>
+--
+-- @output
+-- | http-vuln-cve2026-48908:
+-- |   VULNERABLE:
+-- |   SP Page Builder for Joomla Unauthenticated RCE
+-- |     State: VULNERABLE
+-- |     IDs:  CVE:CVE-2026-48908
+-- |       SP Page Builder for Joomla versions 1.0.0 through 6.6.1 allow
+-- |       unauthenticated attackers to upload arbitrary files via the
+-- |       asset.uploadCustomIcon task, leading to PHP code execution
+-- |       and full server compromise (CVSS 10.0).
+-- |
+-- |     Disclosure date: 2026-06-20
+-- |     References:
+-- |       https://nvd.nist.gov/vuln/detail/CVE-2026-48908
+-- |       https://www.joomshaper.com/page-builder
+-- |_      https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-48908
+--
+-- @xmloutput
+-- <elem key="title">SP Page Builder for Joomla Unauthenticated RCE</elem>
+-- <elem key="state">VULNERABLE</elem>
+-- <elem key="cve">CVE-2026-48908</elem>
+--
+-- @args http-vuln-cve2026-48908.path Base path to Joomla installation (auto-detected if not provided)
+--
+
+author = "Aditya Agrawal"
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+categories = {"vuln", "intrusive"}
+
+portrule = shortport.http
+
+local EP_UNPROTECTED = 1
+local EP_AUTH_ENFORCED = 2
+local EP_PRESENT_METHOD_REJECTED = 3
+local EP_ABSENT = 4
+
+local AUTH_KEYWORDS = {
+  "login", "log in",
+  "authoris", "authoriz",
+  "permission", "permit",
+  "denied", "deny",
+  "token", "csrf",
+  "not allowed", "not authorised", "not authorized",
+  "unauthenticated", "unauthorized", "unauthorised",
+}
+
+local LOGIN_PATH_INDICATORS = {
+  "login", "com_users", "return", "administrator",
+  "auth", "signin", "sign-in", "logon", "log-on",
+}
+
+local COMMON_JOOMLA_PATHS = {"", "/joomla", "/cms", "/site", "/joomla3", "/joomla4"}
+
+local function version_ge(v1, v2)
+  local function split(v)
+    local parts = {}
+    for part in v:gmatch("%d+") do
+      parts[#parts + 1] = tonumber(part)
+    end
+    return parts
+  end
+  local p1, p2 = split(v1), split(v2)
+  for i = 1, math.max(#p1, #p2) do
+    local a, b = p1[i] or 0, p2[i] or 0
+    if a ~= b then
+      return a > b
+    end
+  end
+  return true
+end
+
+local function version_lt(v1, v2)
+  local function split(v)
+    local parts = {}
+    for part in v:gmatch("%d+") do
+      parts[#parts + 1] = tonumber(part)
+    end
+    return parts
+  end
+  local p1, p2 = split(v1), split(v2)
+  for i = 1, math.max(#p1, #p2) do
+    local a, b = p1[i] or 0, p2[i] or 0
+    if a ~= b then
+      return a < b
+    end
+  end
+  return false
+end
+
+local function body_is_html(body)
+  if not body or #body == 0 then
+    return false
+  end
+  local sample = string.sub(body, 1, math.min(#body, 500))
+  if #sample >= 3 then
+    local b1, b2, b3 = string.byte(sample, 1), string.byte(sample, 2), string.byte(sample, 3)
+    if b1 == 0xEF and b2 == 0xBB and b3 == 0xBF then
+      sample = string.sub(sample, 4)
+    end
+  end
+  sample = string.match(sample, "^%s*(.*)") or sample
+  local lower = string.lower(sample)
+  for _, tag in ipairs({"<!doctype", "<html", "<head", "<body"}) do
+    if string.find(lower, tag, 1, true) then
+      return true
+    end
+  end
+  return false
+end
+
+local function has_json_content_type(resp)
+  if resp and resp.header then
+    local ct = resp.header["content-type"] or ""
+    return string.find(string.lower(ct), "json") ~= nil
+  end
+  return false
+end
+
+local function response_looks_like_json(body)
+  if not body then
+    return false
+  end
+  local trimmed = string.match(body, "^%s*(.*)")
+  if not trimmed or trimmed == "" then
+    return false
+  end
+  return string.sub(trimmed, 1, 1) == "{"
+end
+
+local function is_joomla_json_format(data)
+  if type(data) ~= "table" then
+    return false
+  end
+  if data.success ~= nil then
+    return true
+  end
+  if data.status ~= nil then
+    return true
+  end
+  if data.message ~= nil or data.msg ~= nil then
+    return true
+  end
+  if data.data ~= nil then
+    return true
+  end
+  return false
+end
+
+local function indicates_auth(json_data)
+  if type(json_data) ~= "table" then
+    return false
+  end
+  for _, key in ipairs({"auth", "authenticated", "authorized", "authorised",
+                         "login", "token", "csrf"}) do
+    if type(json_data[key]) == "string" then
+      return true
+    end
+  end
+  local function collect_strings(tbl, out)
+    for _, v in pairs(tbl) do
+      if type(v) == "string" then
+        table.insert(out, string.lower(v))
+      elseif type(v) == "table" then
+        collect_strings(v, out)
+      end
+    end
+  end
+  local all_strings = {}
+  collect_strings(json_data, all_strings)
+  for _, msg in ipairs(all_strings) do
+    for _, kw in ipairs(AUTH_KEYWORDS) do
+      if string.find(msg, kw, 1, true) then
+        return true
+      end
+    end
+  end
+  return false
+end
+
+local function is_controller_response(resp)
+  if not resp or not resp.body or #resp.body == 0 then
+    return false
+  end
+  if body_is_html(resp.body) then
+    return false
+  end
+  if not has_json_content_type(resp) and not response_looks_like_json(resp.body) then
+    return false
+  end
+  local ok, data = json.parse(resp.body)
+  if not ok or type(data) ~= "table" then
+    return false
+  end
+  if not is_joomla_json_format(data) then
+    return false
+  end
+  if indicates_auth(data) then
+    return false
+  end
+  return true
+end
+
+local function is_login_redirect(resp)
+  if not resp or not resp.header then
+    return false
+  end
+  local loc = string.lower(resp.header["location"] or "")
+  for _, indicator in ipairs(LOGIN_PATH_INDICATORS) do
+    if string.find(loc, indicator, 1, true) then
+      return true
+    end
+  end
+  local set_cookie = resp.header["set-cookie"] or ""
+  if string.find(string.lower(set_cookie), "session", 1, true) or
+     string.find(string.lower(set_cookie), "joomla", 1, true) then
+    return true
+  end
+  return false
+end
+
+local function classify_endpoint(resp)
+  if not resp then
+    return nil
+  end
+  if resp.status == 200 and is_controller_response(resp) then
+    return EP_UNPROTECTED
+  end
+  if resp.status == 401 or resp.status == 403 then
+    return EP_AUTH_ENFORCED
+  end
+  if resp.status >= 300 and resp.status < 400 then
+    if is_login_redirect(resp) then
+      return EP_AUTH_ENFORCED
+    end
+    return EP_ABSENT
+  end
+  if resp.status == 404 then
+    return EP_ABSENT
+  end
+  if resp.status == 405 then
+    return EP_PRESENT_METHOD_REJECTED
+  end
+  if resp.status >= 500 then
+    return nil
+  end
+  return nil
+end
+
+local function try_get_version(host, port, base_path)
+  local manifest_path = base_path .. "/administrator/components/com_sppagebuilder/sp_page_builder.xml"
+  local resp = http.get(host, port, manifest_path)
+  if resp and resp.status == 200 and resp.body then
+    local ver = string.match(resp.body, "<version>([^<]+)</version>")
+    if ver then
+      ver = string.match(ver, "%d[%d%.]*")
+      if ver then
+        return ver
+      end
+    end
+  end
+  return nil
+end
+
+local function find_base_path(host, port)
+  local path_arg = stdnse.get_script_args(SCRIPT_NAME .. ".path")
+  if path_arg and #path_arg > 0 then
+    return path_arg
+  end
+  for _, p in ipairs(COMMON_JOOMLA_PATHS) do
+    local manifest = p .. "/administrator/components/com_sppagebuilder/sp_page_builder.xml"
+    local resp = http.get(host, port, manifest)
+    if resp and resp.status == 200 then
+      return p
+    end
+  end
+  return ""
+end
+
+action = function(host, port)
+  local vuln = {
+    title = "SP Page Builder for Joomla Unauthenticated RCE",
+    state = vulns.STATE.NOT_VULN,
+    description = [[
+SP Page Builder for Joomla versions 1.0.0 through 6.6.1 allow unauthenticated
+attackers to upload arbitrary files via the asset.uploadCustomIcon task,
+leading to PHP code execution and full server compromise (CVSS 10.0).
+]],
+    IDS = {CVE = "CVE-2026-48908"},
+    references = {
+      "https://nvd.nist.gov/vuln/detail/CVE-2026-48908",
+      "https://www.joomshaper.com/page-builder",
+    },
+    dates = {disclosure = {year = "2026", month = "06", day = "20"}},
+  }
+  local report = vulns.Report:new(SCRIPT_NAME, host, port)
+  local base_path = find_base_path(host, port)
+  local found_version = try_get_version(host, port, base_path)
+  if found_version then
+    if version_ge(found_version, "6.6.2") then
+      return report:make_output(vuln)
+    end
+    if version_lt(found_version, "1.0.0") then
+      return report:make_output(vuln)
+    end
+  end
+  local boundary = "----NseB" .. rand.random_alpha(8)
+  local empty_zip = string.char(
+    0x50, 0x4B, 0x05, 0x06,
+    0x00, 0x00,
+    0x00, 0x00,
+    0x00, 0x00,
+    0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00
+  )
+  local probe_parts = {}
+  table.insert(probe_parts, "--" .. boundary)
+  table.insert(probe_parts, 'Content-Disposition: form-data; name="custom_icon"; filename="icon.zip"')
+  table.insert(probe_parts, "Content-Type: application/zip")
+  table.insert(probe_parts, "")
+  table.insert(probe_parts, empty_zip)
+  table.insert(probe_parts, "--" .. boundary .. "--")
+  local probe_path = base_path .. "/index.php?option=com_sppagebuilder&task=asset.uploadCustomIcon"
+  local resp = http.post(host, port, probe_path, {
+    header = {["Content-Type"] = "multipart/form-data; boundary=" .. boundary},
+    content = table.concat(probe_parts, "\r\n"),
+  })
+  local ep_class = classify_endpoint(resp)
+  if ep_class == EP_UNPROTECTED then
+    if found_version then
+      vuln.state = vulns.STATE.VULN
+    else
+      vuln.state = vulns.STATE.LIKELY_VULN
+    end
+  elseif ep_class == EP_AUTH_ENFORCED then
+    if found_version then
+      vuln.state = vulns.STATE.LIKELY_VULN
+    end
+  elseif ep_class == EP_PRESENT_METHOD_REJECTED then
+    if found_version then
+      vuln.state = vulns.STATE.LIKELY_VULN
+    end
+  elseif ep_class == EP_ABSENT then
+    if found_version then
+      vuln.state = vulns.STATE.LIKELY_VULN
+    end
+  end
+  return report:make_output(vuln)
+end

--- a/scripts/script.db
+++ b/scripts/script.db
@@ -277,6 +277,8 @@ Entry { filename = "http-vuln-cve2017-1001000.nse", categories = { "safe", "vuln
 Entry { filename = "http-vuln-cve2017-5638.nse", categories = { "vuln", } }
 Entry { filename = "http-vuln-cve2017-5689.nse", categories = { "auth", "exploit", "vuln", } }
 Entry { filename = "http-vuln-cve2017-8917.nse", categories = { "intrusive", "vuln", } }
+Entry { filename = "http-vuln-cve2026-14345.nse", categories = { "intrusive", "vuln", } }
+Entry { filename = "http-vuln-cve2026-48908.nse", categories = { "intrusive", "vuln", } }
 Entry { filename = "http-vuln-misfortune-cookie.nse", categories = { "intrusive", "vuln", } }
 Entry { filename = "http-vuln-wnr1000-creds.nse", categories = { "exploit", "intrusive", "vuln", } }
 Entry { filename = "http-waf-detect.nse", categories = { "discovery", "intrusive", } }


### PR DESCRIPTION
This PR adds two NSE scripts for recently disclosed high-severity vulnerabilities.

http-vuln-cve2026-48908.nse

Detects CVE-2026-48908, an unauthenticated remote code execution vulnerability affecting SP Page Builder for Joomla (versions 1.0.0 through 6.6.1). The script combines version detection with a non-destructive probe (empty ZIP archive via
multipart POST) to identify vulnerable installations while minimizing false positives.

http-vuln-cve2026-14345.nse

Detects CVE-2026-14345, an unauthenticated remote code execution vulnerability affecting WPFunnels for WordPress (versions up to 3.12.7). The script performs version detection followed by a non-destructive POST to the wpfnl_log AJAX
action to distinguish vulnerable installations.

Both scripts:

- Automatically discover common Joomla and WordPress installation paths.
- Perform version-based checks before issuing probe requests.
- Validate HTTP status codes, JSON responses, and authentication requirements.
- Handle redirects, Byte Order Mark (BOM), whitespace, and error pages gracefully.
- Use vulns.Report for consistent NSE vulnerability reporting.
- Use non-destructive probes and do not attempt exploitation.

Tested against Python mock servers simulating both vulnerable targets.