### PR TITLE
fix(massdns): guard ptrToIp against out-of-bounds read for short names

### DIFF
--- a/libnetutil/massdns.cc
+++ b/libnetutil/massdns.cc
@@ -1713,8 +1713,11 @@ bool DNS::Factory::ptrToIp(const std::string &ptr, sockaddr_storage &ip)
 
   memset(&ip, 0, sizeof(sockaddr_storage));
 
-  // Check whether the name ends with the IPv4 PTR domain
-  if (NULL != (p = strcasestr(cptr + ptr.length() + 1 - sizeof(C_IPV4_PTR_DOMAIN), C_IPV4_PTR_DOMAIN)))
+  // Check whether the name ends with the IPv4 PTR domain. The length check
+  // keeps the search from starting before the beginning of the name: a name
+  // shorter than the suffix cannot end with it.
+  if (ptr.length() >= sizeof(C_IPV4_PTR_DOMAIN) - 1
+      && NULL != (p = strcasestr(cptr + ptr.length() + 1 - sizeof(C_IPV4_PTR_DOMAIN), C_IPV4_PTR_DOMAIN)))
   {
     struct sockaddr_in *ip4 = (struct sockaddr_in *)&ip;
     static const u8 place_value[] = {1, 10, 100};
@@ -1749,7 +1752,8 @@ bool DNS::Factory::ptrToIp(const std::string &ptr, sockaddr_storage &ip)
     ip.ss_family = AF_INET;
   }
   // If not, check IPv6
-  else if (NULL != (p = strcasestr(cptr + ptr.length() + 1 - sizeof(C_IPV6_PTR_DOMAIN), C_IPV6_PTR_DOMAIN)))
+  else if (ptr.length() >= sizeof(C_IPV6_PTR_DOMAIN) - 1
+      && NULL != (p = strcasestr(cptr + ptr.length() + 1 - sizeof(C_IPV6_PTR_DOMAIN), C_IPV6_PTR_DOMAIN)))
   {
     struct sockaddr_in6 *ip6 = (struct sockaddr_in6 *)&ip;
     u8 alt = 0;

--- a/tests/nmap_dns_test.cc
+++ b/tests/nmap_dns_test.cc
@@ -252,6 +252,26 @@ o.debugging = 1;
   TEST_INCR(a->length == 0x01, ret, tot);
   TEST_INCR(a->ttl == 86392, ret, tot);
 
+  // Names shorter than the PTR suffixes must not be treated as PTR names.
+  // The root label above ("." from a server-supplied answer) is the shortest
+  // such name; ptrToIp must reject these without searching before the start
+  // of the name.
+  sockaddr_storage short_ip;
+  const char *short_names[] = { ".", "a.com", "x", "ip6.arpa" };
+  for (size_t si = 0; si < sizeof(short_names) / sizeof(short_names[0]); si++) {
+    DNS::Factory::ptrToIp(short_names[si], short_ip);
+    TEST_INCR(short_ip.ss_family == AF_UNSPEC, ret, tot);
+  }
+
+  // Well-formed PTR names still resolve, in either case.
+  sockaddr_storage case_ip;
+  TEST_INCR(DNS::Factory::ptrToIp("156.32.33.45.in-addr.arpa", case_ip), ret, tot);
+  TEST_INCR(case_ip.ss_family == AF_INET, ret, tot);
+  TEST_INCR(((sockaddr_in *)&case_ip)->sin_addr.s_addr == htonl(0x2d21209c), ret, tot);
+  TEST_INCR(DNS::Factory::ptrToIp("156.32.33.45.IN-ADDR.ARPA", case_ip), ret, tot);
+  TEST_INCR(case_ip.ss_family == AF_INET, ret, tot);
+  TEST_INCR(((sockaddr_in *)&case_ip)->sin_addr.s_addr == htonl(0x2d21209c), ret, tot);
+
   if(ret) std::cout << "Testing nmap_dns finished with errors" << std::endl;
   else std::cout << "Testing nmap_dns finished without errors" << std::endl;
   std::cout << "Ran " << tot << " tests. " << ret << " failures." << std::endl;


### PR DESCRIPTION
## What

`DNS::Factory::ptrToIp()` (in `libnetutil/massdns.cc`) finds the reverse-DNS suffix by starting a `strcasestr` at a fixed offset from the end of the name:

```c
strcasestr(cptr + ptr.length() + 1 - sizeof(C_IPV4_PTR_DOMAIN), C_IPV4_PTR_DOMAIN)
```

`sizeof(".in-addr.arpa")` is 14, so the search starts at `cptr + len - 13`. When `len < 13` this pointer is **before the start of the name**, and `strcasestr` reads from it. The IPv6 branch has the same issue with `sizeof(".ip6.arpa")` = 10 (`cptr + len - 9`).

## Reachability

The argument is the answer/CNAME owner name decoded straight off the wire — `process_result(a.name, ...)` and the CNAME branch — with no length check on either path. A root label decodes to `"."` (length 1) since [`8769ab35f` "Correctly handle root domain label"](https://github.com/nmap/nmap/commit/8769ab35f), so a DNS server can return a short owner name and trigger this during a normal reverse-DNS lookup.

## Impact

Low, but real on `libc++` targets. On **libc++** (the default C++ library on macOS and the BSDs) the short-string buffer sits near the start of the `std::string` object, so the computed pointer lands **outside** it. Building the function against libc++ with AddressSanitizer, exercised through the real `std::string` API:

```
$ clang++ -stdlib=libc++ -fsanitize=address,undefined ...
ERROR: AddressSanitizer: stack-buffer-overflow
READ of size 1 ...
    [256, 280) 's' <== Memory access ... underflows this variable
```

With the guards in this PR, the same inputs are clean. On **libstdc++** (the default on Linux) the inline buffer sits high enough in the object that the read stays inside it, so the access is inert there — but it is still undefined pointer arithmetic.

It is a bounded (≤ 12 bytes), read-only access whose decoded value is only compared against the address that was requested and rejected on mismatch, so there is no write and no code execution.

## The fix

Guard each `strcasestr` on the name being at least as long as the suffix it is compared against. A name shorter than the suffix cannot end with it, so results for all valid inputs are unchanged:

```c
if (ptr.length() >= sizeof(C_IPV4_PTR_DOMAIN) - 1
    && NULL != (p = strcasestr(cptr + ptr.length() + 1 - sizeof(C_IPV4_PTR_DOMAIN), C_IPV4_PTR_DOMAIN)))
```

## Tests

Added short-name (including the root label `"."`) and uppercase-suffix cases to `tests/nmap_dns_test.cc`. `make check-nmap` goes from 43 to 53 assertions, 0 failures. (The in-tree suite builds with libstdc++, where the pre-fix read is inert, so these serve as regression guards; the libc++ ASan run above is the reproduction of the fault itself.)
