### PR TITLE
Fix incorrect year offset in struct tm

### DIFF
--- a/nse_ssl_cert.cc
+++ b/nse_ssl_cert.cc
@@ -325,9 +325,8 @@ static int time_to_tm(const ASN1_TIME *t, struct tm *result)
        is 2050 or later."
        http://www.cs.auckland.ac.nz/~pgut001/pubs/x509guide.txt */
     if (year < 50)
-      result->tm_year = 2000 + year;
-    else
-      result->tm_year = 1900 + year;
+      year += 100;
+    result->tm_year = year;
     p = t->data + 2;
   } else if (t->length == 15 && t->data[t->length - 1] == 'Z') {
     /* yyyymmddhhmmssZ */
@@ -366,7 +365,7 @@ static void tm_to_table(lua_State *L, const struct tm *tm)
 #define NSE_NUM_TM_FIELDS 6
   lua_createtable(L, 0, NSE_NUM_TM_FIELDS);
 
-  lua_pushinteger(L, tm->tm_year);
+  lua_pushinteger(L, tm->tm_year + 1900);
   lua_setfield(L, -2, "year");
   /* Lua uses one-indexed months. */
   lua_pushinteger(L, tm->tm_mon + 1);


### PR DESCRIPTION
Values in field `tm_year` in `struct tm` are meant to be relative to year 1900. However, routine `time_to_tm()` in `nse_ssl_cert.cc` has been populating the field with absolute values, such as 2026, instead of 126. This deviation was not an issue historically because the consuming code in `tm_to_table()` was making the same incorrect assumption, so the two deviations were cancelling each other. The output from script ssl-cert was indeed correct:
```
PORT    STATE SERVICE
443/tcp open  https
| ssl-cert:
...
| Not valid before: 2020-08-10T20:42:22
| Not valid after:  2020-09-09T20:42:22
...
```
The issue surfaced when commit 538764bb6ac3e1a3410acf4f708c25b4b44f8d2d started populating `struct tm` correctly via `ASN1_TIME_to_tm()`:
```
PORT    STATE SERVICE
443/tcp open  https
| ssl-cert:
...
| Not valid before: 120-08-10T20:42:22
| Not valid after:  120-09-09T20:42:22
...
```
This PR modifies the code so that the year is calculated properly regardless of the state of `HAVE_OPAQUE_STRUCTS` (which determines how `struct tm` gets populated).