### PR TITLE
update credential usage in afp-* scripts

### DIFF
--- a/scripts/afp-brute.nse
+++ b/scripts/afp-brute.nse
@@ -5,6 +5,8 @@ local stdnse = require "stdnse"
 local string = require "string"
 local table = require "table"
 local unpwdb = require "unpwdb"
+local creds = require "creds"
+local brute = require "brute"
 
 -- we don't really need openssl here, but let's attempt to load it as a way
 -- to simply prevent the script from running, in case we don't have it
@@ -49,10 +51,47 @@ categories = {"intrusive", "brute"}
 
 portrule = shortport.port_or_service(548, "afp")
 
-action = function( host, port )
+Driver = {
 
+  new = function(self, host, port)
+    local o = { helper = afp.Helper:new(host, port) }
+    setmetatable(o, self)
+    self.__index = self
+    return o
+  end,
+
+  connect = function( self )
+    return self.helper:connect()
+  end,
+
+  login = function( self, username, password )
+    local status, resp = self.helper:Login( username, password )
+
+    if status then
+      -- Add credentials for other afp scripts to use via brute
+      if password:len()>0
+        return true, creds.Account:new(username, password, creds.State.VALID)
+      else
+        return true, creds.Account:new(username, "", creds.State.VALID)
+        end
+      break
+    else
+      local err = brute.Error:new( response.data )
+      err:setRetry( true )
+      helper:CloseSession()
+      return true, err
+    end
+  end,
+
+  disconnect = function(self)
+    return self.helper:close()
+  end,
+
+}
+
+local function validateAuth(host, port)
   local result, response, status = {}, nil, nil
-  local valid_accounts, found_users = {}, {}
+  local valid_accounts = {}
   local helper
   local usernames, passwords
 
@@ -71,41 +110,35 @@ action = function( host, port )
 
         if ( not(status) ) then
           stdnse.debug1("OpenSession failed")
-          return
+          return 
         end
-
 
         stdnse.debug1("Trying %s/%s ...", username, password)
-        status, response = helper:Login( username, password )
-
-        -- if the response is "Parameter error." we're dealing with Netatalk
-        -- This basically means that the user account does not exist
-        -- In this case, why bother continuing? Simply abort and thank Netatalk for the fish
-        if response:match("Parameter error.") then
-          stdnse.debug1("Netatalk told us the user does not exist! Thanks.")
-          -- mark it as "found" to skip it
-          found_users[username] = true
+        status, result = helper:login()
+        if ( status ) then
+          return true, "Brute Successful"
+        else
+          return false, "Brute Unsuccessful"
         end
-
-        if status then
-          -- Add credentials for other afp scripts to use
-          if nmap.registry.afp == nil then
-            nmap.registry.afp = {}
-          end
-          nmap.registry.afp[username]=password
-          found_users[username] = true
-
-          table.insert( valid_accounts, string.format("%s:%s => Valid credentials", username, password:len()>0 and password or "<empty>" ) )
-          break
-        end
-        helper:CloseSession()
+        return status, result
       end
     end
-    usernames("reset")
+  end
+end
+
+action = function(host, port)
+
+  local status, result = validateAuth(host, port)
+  if ( not(status) ) then
+    return result
   end
 
-  local output = stdnse.format_output(true, valid_accounts)
+  local engine = brute.Engine:new(Driver, host, port )
 
-  return output
+  engine.options.script_name = SCRIPT_NAME
+  engine.options.firstonly = true
 
+  local result
+  status, result = engine:start()
+  return result
 end

--- a/scripts/afp-brute.nse
+++ b/scripts/afp-brute.nse
@@ -13,18 +13,21 @@ local brute = require "brute"
 local openssl = stdnse.silent_require("openssl")
 
 description = [[
-Performs password guessing against Apple Filing Protocol (AFP).
+Performs brute force password guessing against Apple Filing Protocol (AFP).
 ]]
 
 ---
 -- @usage
--- nmap -p 548 --script afp-brute <host>
+-- nmap -p 548 --script afp-brute
 --
 -- @output
 -- PORT    STATE SERVICE
 -- 548/tcp open  afp
 -- | afp-brute:
--- |_  admin:KenSentMe => Valid credentials
+-- |   Accounts
+-- |     admin:KenSentMe => Valid credentials
+-- |   Statistics
+-- |_    Performed 5000 guesses in 3 seconds, average tps: 1666
 
 -- Information on AFP implementations
 --

--- a/scripts/afp-ls.nse
+++ b/scripts/afp-ls.nse
@@ -3,6 +3,7 @@ local nmap = require "nmap"
 local shortport = require "shortport"
 local stdnse = require "stdnse"
 local ls = require "ls"
+local creds = require "creds"
 
 description = [[
 Attempts to get useful information about files from AFP volumes.
@@ -115,10 +116,13 @@ action = function(host, port)
   local users = nmap.registry.afp or { ['nil'] = 'nil' }
   local maxfiles = ls.config("maxfiles")
   local output = ls.new_listing()
+  users = {}
 
-  if ( args['afp.username'] ) then
-    users = {}
-    users[args['afp.username']] = args['afp.password']
+  local c = creds.Credentials:new(creds.ALL_DATA, host, port)
+  local states = creds.State.VALID + creds.State.PARAM
+
+  for cred in c:getCredentials(states) do
+    users[args[cred.user]] = args[cred.pass]
   end
 
   for username, password in pairs(users) do

--- a/scripts/afp-path-vuln.nse
+++ b/scripts/afp-path-vuln.nse
@@ -4,6 +4,7 @@ local shortport = require "shortport"
 local stdnse = require "stdnse"
 local table = require "table"
 local vulns = require "vulns"
+local creds = require "creds"
 
 description = [[
 Detects the Mac OS X AFP directory traversal vulnerability, CVE-2010-0533.
@@ -156,9 +157,12 @@ Directory traversal vulnerability in AFP Server in Apple Mac OS X before
 
   local report = vulns.Report:new(SCRIPT_NAME, host, port)
 
-  if ( args['afp.username'] ) then
-    users = {}
-    users[args['afp.username']] = args['afp.password']
+  users = {}
+  local c = creds.Credentials:new(creds.ALL_DATA, host, port)
+  local states = creds.State.VALID + creds.State.PARAM
+
+  for cred in c:getCredentials(states) do
+    users[args[cred.user]] = args[cred.pass]
   end
 
   for username, password in pairs(users) do

--- a/scripts/afp-showmount.nse
+++ b/scripts/afp-showmount.nse
@@ -3,6 +3,7 @@ local nmap = require "nmap"
 local shortport = require "shortport"
 local stdnse = require "stdnse"
 local table = require "table"
+local creds = require "creds"
 
 description = [[
 Shows AFP shares and ACLs.
@@ -51,9 +52,12 @@ action = function(host, port)
   local args = nmap.registry.args
   local users = nmap.registry.afp or { ['nil'] = 'nil' }
 
-  if ( args['afp.username'] ) then
-    users = {}
-    users[args['afp.username']] = args['afp.password']
+  users = {}
+  local c = creds.Credentials:new(creds.ALL_DATA, host, port)
+  local states = creds.State.VALID + creds.State.PARAM
+
+  for cred in c:getCredentials(states) do
+    users[args[cred.user]] = args[cred.pass]
   end
 
   for username, password in pairs(users) do


### PR DESCRIPTION
Update `afp` related scripts to use `creds` from `afp-brute` and update `afp-brute` to follow existing patterns in e.g. `redis-brute`. 

Mainly as a follow-up to #651.

Closes #650 