### PR TITLE
Fix the operator behavior when comparing strings of different lengths

### DIFF
--- a/string_pool.cc
+++ b/string_pool.cc
@@ -90,7 +90,7 @@ class StringPoolItem {
 
 // asdfq <> asdf
     bool operator< (const StringPoolItem& other) const {
-      return this->len < other.len || memcmp(this->str, other.str, other.len) < 0;
+      return this->len < other.len || this->len == other.len && memcmp(this->str, other.str, other.len) < 0;
     }
 };
 


### PR DESCRIPTION
Member function `operator<` of class `StringPoolItem` does not meet the criteria of a strict weak ordering, specifically the asymmetry, because "hopopt" < "icmp" is true but "icmp" < "hopopt" is also true.

This can result in suboptimal utilization of `StringPool`. Consider the following case:
```C++
string_pool_insert("icmp");
// inserted a string

string_pool_insert("hopopt");
// inserted another string, possibly before the first one because "hopopt" < "icmp"

string_pool_insert("icmp");
// possibly inserted the first string again, before the second one, because "icmp" < "hopopt"
```
This PR rectifies the issue.
