### PR TITLE
Tolerate TLS peers that do not send close_notify

### DIFF
--- a/nsock/src/nsock_ssl.c
+++ b/nsock/src/nsock_ssl.c
@@ -208,6 +208,9 @@ static nsock_ssl_ctx nsock_pool_ssl_init_helper(SSL_CTX *ctx, int flags) {
   SSL_CTX_clear_options(ctx, SSL_OP_NO_SSLv2);
   if (flags & NSOCK_SSL_MAX_SPEED) {
     SSL_CTX_set_options(ctx, SSL_OP_ALL);
+#ifdef SSL_OP_IGNORE_UNEXPECTED_EOF
+    SSL_CTX_set_options(ctx, SSL_OP_IGNORE_UNEXPECTED_EOF);
+#endif
 
     if (!SSL_CTX_set_cipher_list(ctx, CIPHERS_FAST))
       fatal("Unable to set OpenSSL cipher list: %s",


### PR DESCRIPTION
TLS requires that each party sends a close_notify alert before closing the write side of the underlying transport. See [RFC 8446, section 6.1](https://datatracker.ietf.org/doc/html/rfc8446#section-6.1) and/or [RFC 5246, section 7.2.1](https://datatracker.ietf.org/doc/html/rfc5246#section-7.2.1) for details.

When using OpenSSL 3.x or higher, Nmap fails to communicate with many TLS targets that do not send this alert, which substantially limits its interoperability.

This PR rectifies the issue by tolerating this non-compliance.