### PR TITLE
Fix Zenmap vulnerability icon level calculation

### DIFF
--- a/zenmap/zenmapGUI/Icons.py
+++ b/zenmap/zenmapGUI/Icons.py
@@ -162,6 +162,6 @@ def get_os(host):
 
 
 def get_vulnerability_logo(open_ports):
-    ports = min(int(open_ports), 10)
-    lvl = (ports // 2) + 1
+    ports = int(open_ports)
+    lvl = min(max((ports + 1) // 2, 1), 5)
     return ICONS['vl_%d_logo' % (lvl,)]


### PR DESCRIPTION
Fixes #3431

## Summary

The direct pixbuf refactor changed the vulnerability-icon thresholds and allowed 10 or more open ports to select nonexistent `vl_6_logo`, crashing the host details view.

Clamp the computed level to the five available icons while restoring the previous thresholds:

- 0–2 open ports: level 1
- 3–4: level 2
- 5–6: level 3
- 7–8: level 4
- 9 or more: level 5

## Testing

- Verified threshold parity across negative, boundary, and large port counts
- Imported `zenmapGUI.Icons` with GTK bindings stubbed and verified the selected pixmap filenames
- Verified Python syntax and `git diff --check`