### PR TITLE
Fix compilation when NOLUA flag is defined

### DIFF
--- a/nmap.cc
+++ b/nmap.cc
@@ -1858,7 +1858,9 @@ void nmap_free_mem() {
   AllProbes::service_scan_free();
   traceroute_hop_cache_clear();
   nsock_set_default_engine(NULL);
+#ifndef NOLUA
   close_nse();
+#endif
 }
 
 int nmap_main(int argc, char *argv[]) {


### PR DESCRIPTION
Commit a24082e added a call to function ```close_nse()```, which is declared 
in file ```nse_main.h```; this file is included conditionally when NOLUA flag 
is not defined. 
https://github.com/nmap/nmap/blob/e1ce99d5a266b541a3651904c4a5a417681d26af/nmap.cc#L94-L96
If the condition is not met, a compilation error occurs. 
Fixing by adding conditional compilation for the function call.

Fixes: a24082eee41fcabf7fa180020e1771af3226b358