### PR TITLE
Don't define strlcat for libdnet

### DIFF
--- a/libdnet-stripped/acconfig.h
+++ b/libdnet-stripped/acconfig.h
@@ -19,10 +19,6 @@
 int inet_pton(int, const char *, void *);
 #endif
 
-#ifndef HAVE_STRLCAT
-int strlcat(char *, const char *, int);
-#endif
-
 #ifndef HAVE_STRLCPY
 int strlcpy(char *, const char *, int);
 #endif


### PR DESCRIPTION
Without this fix an `autoreconf` run will just undo the change made in commit 1c2402122251d237e2b7af3fa8582d33f0d15a4f.