### PR TITLE
Fix mksock_bind_addr EINVAL on FreeBSD in service/connect scans

### DIFF
--- a/nse_nsock.cc
+++ b/nse_nsock.cc
@@ -427,8 +427,12 @@ static nse_nsock_udata *check_nsock_udata (lua_State *L, int idx, bool open)
       } else if (0 == o.SourceSockAddr(&ss, &sslen)) {
         // Use the exact protocol-specific length.  Some platforms (e.g. FreeBSD)
         // reject sizeof(sockaddr_storage) passed to bind() with EINVAL.
-        sslen = (ss.ss_family == AF_INET6) ?
-          sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
+        if (ss.ss_family == AF_INET)
+          sslen = sizeof(struct sockaddr_in);
+#if HAVE_IPV6
+        else if (ss.ss_family == AF_INET6)
+          sslen = sizeof(struct sockaddr_in6);
+#endif
         nsock_iod_set_localaddr(nu->nsiod, &ss, sslen);
       }
       if (o.ipoptionslen)
@@ -554,8 +558,12 @@ static int connect (lua_State *L, int status, lua_KContext ctx)
   } else if (0 == o.SourceSockAddr(&ss, &sslen)) {
     // Use the exact protocol-specific length.  Some platforms (e.g. FreeBSD)
     // reject sizeof(sockaddr_storage) passed to bind() with EINVAL.
-    sslen = (ss.ss_family == AF_INET6) ?
-      sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
+    if (ss.ss_family == AF_INET)
+      sslen = sizeof(struct sockaddr_in);
+#if HAVE_IPV6
+    else if (ss.ss_family == AF_INET6)
+      sslen = sizeof(struct sockaddr_in6);
+#endif
     nsock_iod_set_localaddr(nu->nsiod, &ss, sslen);
   }
   if (o.ipoptionslen)

--- a/nse_nsock.cc
+++ b/nse_nsock.cc
@@ -425,6 +425,10 @@ static nse_nsock_udata *check_nsock_udata (lua_State *L, int idx, bool open)
       if (nu->source_addr.ss_family != AF_UNSPEC) {
         nsock_iod_set_localaddr(nu->nsiod, &nu->source_addr, nu->source_addrlen);
       } else if (0 == o.SourceSockAddr(&ss, &sslen)) {
+        // Use the exact protocol-specific length.  Some platforms (e.g. FreeBSD)
+        // reject sizeof(sockaddr_storage) passed to bind() with EINVAL.
+        sslen = (ss.ss_family == AF_INET6) ?
+          sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
         nsock_iod_set_localaddr(nu->nsiod, &ss, sslen);
       }
       if (o.ipoptionslen)
@@ -548,6 +552,10 @@ static int connect (lua_State *L, int status, lua_KContext ctx)
   if (nu->source_addr.ss_family != AF_UNSPEC) {
     nsock_iod_set_localaddr(nu->nsiod, &nu->source_addr, nu->source_addrlen);
   } else if (0 == o.SourceSockAddr(&ss, &sslen)) {
+    // Use the exact protocol-specific length.  Some platforms (e.g. FreeBSD)
+    // reject sizeof(sockaddr_storage) passed to bind() with EINVAL.
+    sslen = (ss.ss_family == AF_INET6) ?
+      sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
     nsock_iod_set_localaddr(nu->nsiod, &ss, sslen);
   }
   if (o.ipoptionslen)

--- a/scan_engine_connect.cc
+++ b/scan_engine_connect.cc
@@ -434,6 +434,10 @@ static void init_socket(int sd, const HostScanStats *hss, UltraScanInfo *USI) {
 #endif
 
   if (!bind_failed && 0 == o.SourceSockAddr(&ss, &sslen)) {
+    // Use the exact protocol-specific length.  Some platforms (e.g. FreeBSD)
+    // reject sizeof(sockaddr_storage) passed to bind() with EINVAL.
+    sslen = (ss.ss_family == AF_INET6) ?
+      sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
     if (::bind(sd, (struct sockaddr*)&ss, sslen) != 0) {
       error("%s: Problem binding source address (%s), errno: %d", __func__, inet_socktop_safe(&ss), socket_errno());
       perror("bind");

--- a/scan_engine_connect.cc
+++ b/scan_engine_connect.cc
@@ -436,8 +436,12 @@ static void init_socket(int sd, const HostScanStats *hss, UltraScanInfo *USI) {
   if (!bind_failed && 0 == o.SourceSockAddr(&ss, &sslen)) {
     // Use the exact protocol-specific length.  Some platforms (e.g. FreeBSD)
     // reject sizeof(sockaddr_storage) passed to bind() with EINVAL.
-    sslen = (ss.ss_family == AF_INET6) ?
-      sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
+    if (ss.ss_family == AF_INET)
+      sslen = sizeof(struct sockaddr_in);
+#if HAVE_IPV6
+    else if (ss.ss_family == AF_INET6)
+      sslen = sizeof(struct sockaddr_in6);
+#endif
     if (::bind(sd, (struct sockaddr*)&ss, sslen) != 0) {
       error("%s: Problem binding source address (%s), errno: %d", __func__, inet_socktop_safe(&ss), socket_errno());
       perror("bind");

--- a/service_scan.cc
+++ b/service_scan.cc
@@ -2137,6 +2137,10 @@ static void startNextProbe(nsock_pool nsp, nsock_iod nsi, ServiceGroup *SG,
         fatal("Failed to allocate Nsock I/O descriptor in %s()", __func__);
       }
       if (0 == svc->target->SourceSockAddr(&ss, &ss_len)) {
+        // Use the exact protocol-specific length.  Some platforms (e.g. FreeBSD)
+        // reject sizeof(sockaddr_storage) passed to bind() with EINVAL.
+        ss_len = (ss.ss_family == AF_INET6) ?
+          sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
         nsock_iod_set_localaddr(svc->niod, &ss, ss_len);
       }
       if (o.ipoptionslen)

--- a/service_scan.cc
+++ b/service_scan.cc
@@ -2139,8 +2139,12 @@ static void startNextProbe(nsock_pool nsp, nsock_iod nsi, ServiceGroup *SG,
       if (0 == svc->target->SourceSockAddr(&ss, &ss_len)) {
         // Use the exact protocol-specific length.  Some platforms (e.g. FreeBSD)
         // reject sizeof(sockaddr_storage) passed to bind() with EINVAL.
-        ss_len = (ss.ss_family == AF_INET6) ?
-          sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
+        if (ss.ss_family == AF_INET)
+          ss_len = sizeof(struct sockaddr_in);
+#if HAVE_IPV6
+        else if (ss.ss_family == AF_INET6)
+          ss_len = sizeof(struct sockaddr_in6);
+#endif
         nsock_iod_set_localaddr(svc->niod, &ss, ss_len);
       }
       if (o.ipoptionslen)


### PR DESCRIPTION
## Summary
Fixes #3438 — `mksock_bind_addr(): Bind to <IP>:0 failed ... Invalid argument (22)` 
on FreeBSD when running `-sV` (service version scan).

## Root Cause
After commit eb79c42, `nsock_iod_set_localaddr()` is called for every service
probe whenever a source address can be determined via routing — not only when
the user explicitly requests source binding via `-S` or `-e`.

On FreeBSD, the subsequent `bind()` call fails with `EINVAL` because the stored
`addrlen` may equal `sizeof(sockaddr_storage)` (128 bytes) rather than the
protocol-specific size the POSIX-strict kernel requires:
- `sizeof(sockaddr_in)`  = **16** for `AF_INET`
- `sizeof(sockaddr_in6)` = **28** for `AF_INET6`

Linux silently accepts oversized `addrlen` values, which masked the bug there.

## Fix
Recompute the correct protocol-specific length from `ss_family` immediately
before each call to `nsock_iod_set_localaddr()` or `bind()` in:
- `service_scan.cc`
- `nse_nsock.cc` (2 instances)
- `scan_engine_connect.cc`

This preserves the intended behavior of eb79c42 (binding on `-e` as well as
`-S`) while making the code correct on all platforms.

## Tested on
- **FreeBSD 15.1-RELEASE amd64** — bug confirmed fixed
- `nmap -p 22 --open -sV <subnet>` produces clean output with no NSOCK errors