### PR TITLE
rsync updates for protocol 32

### DIFF
--- a/nselib/rsync.lua
+++ b/nselib/rsync.lua
@@ -62,7 +62,9 @@ Helper = {
     if ( not(status) ) then
       return false, data
     end
-    if ( not(data:match("^@RSYNCD: [%.%d]+$")) ) then
+    -- The version greeting may carry trailing data: protocol 32 servers
+    -- (rsync 3.2.7+) greet with "@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4"
+    if ( not(data:match("^@RSYNCD: [%.%d]+")) ) then
       return false, "Protocol error"
     end
     return true


### PR DESCRIPTION
Early 2025 rsync released protocol 32 which changed the banner. This PR updates the module to work against newer versions.

Related to https://github.com/rapid7/metasploit-framework/pull/21793

Docker modules to tests against are located in the metasploit docs: https://github.com/rapid7/metasploit-framework/pull/21793/changes#diff-8285191c7c762648306aa3b78e7003bd91b65a08d8475cc0dd361fe6799862f3R8

### Before

```
$ nmap -p 873 -sV -script=rsync-list-modules 127.0.0.1 
Starting Nmap 7.99 ( https://nmap.org ) at 2026-08-19 12:19 -0400
Warning: File ./nmap-services exists, but Nmap is using /usr/share/nmap/nmap-services for security and consistency reasons.  set NMAPDIR=. to give priority to files in your local directory (may affect the other data files too).
Nmap scan report for localhost (127.0.0.1)
Host is up (0.00014s latency).

PORT    STATE SERVICE VERSION
873/tcp open  rsync   (protocol version 32)

Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
Nmap done: 1 IP address (1 host up) scanned in 0.59 seconds
```

### After

```
$ sudo ./nmap -p 873 -sV -script=rsync-list-modules 127.0.0.1
Starting Nmap 7.991SVN ( https://nmap.org ) at 2026-08-19 12:22 -0400
Nmap scan report for localhost (127.0.0.1)
Host is up (0.00013s latency).

PORT    STATE SERVICE VERSION
873/tcp open  rsync   (protocol version 32)
| rsync-list-modules: 
|   public              open share
|_  locked              password-protected share

Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
Nmap done: 1 IP address (1 host up) scanned in 0.44 seconds
```

### Disclosure

klm-5.2 assisted with this change.