### PR TITLE
Update build.yml to fix NetBSD dbus issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
           prepare: |
             export PATH=/usr/sbin:/usr/pkg/sbin:/usr/pkg/bin:$PATH
             export PKG_PATH="http://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r | cut -d_ -f1)/All"
-            pkg_add -u gcc13 clang autoconf automake pkgconf libpcap libnet gmake dbus
+            pkg_add -u gcc13 clang autoconf automake pkgconf libpcap libnet gmake
           run: |
             ./configure
             gmake


### PR DESCRIPTION
NetBSD's dbus binary package recently started requiring X11 libraries to be installed. It is possible we don't even need to install dbus, so this PR intends to remove it so we can verify that the build succeeds without it.