### PR TITLE
Fix missing XML hostnames when --unique is used (#3409)

### DIFF
--- a/Target.cc
+++ b/Target.cc
@@ -356,6 +356,16 @@ void Target::setTargetName(const char *name) {
   }
 }
 
+void Target::addTargetNameAlias(const char *name) {
+  if (name)
+    target_aliases.push_back(std::string(name));
+}
+
+const std::vector<std::string> &Target::getTargetNameAliases() const {
+  return target_aliases;
+}
+
+
  /* Generates a printable string consisting of the host's IP
      address and hostname (if available).  Eg "www.insecure.org
      (64.71.184.53)" or "fe80::202:e3ff:fe14:1102".  The name is

--- a/Target.h
+++ b/Target.h
@@ -184,6 +184,11 @@ class Target {
      order
   */
   void setTargetName(const char *name);
+  /* Add an additional user-supplied name that resolved to the same IP as this
+  target (recorded when --unique suppresses duplicate scanning). */
+  void addTargetNameAlias(const char *name);
+  /* Returns the list of additional user-supplied names for this target. */
+  const std::vector<std::string> &getTargetNameAliases() const;
 
   /* If the host is directly connected on a network, set and retrieve
      that information here.  directlyConnected() will abort if it hasn't
@@ -262,6 +267,8 @@ class Target {
   struct timeout_info to;
   char *hostname; // Null if unable to resolve or unset
   char * targetname; // The name of the target host given on the command line if it is a named host
+  std::vector<std::string> target_aliases; /* Additional user-supplied names that resolved to this
+  same IP, collected when --unique suppresses duplicate scanning. */
 
   struct probespec traceroute_probespec;
   std::list <TracerouteHop> traceroute_hops;

--- a/output.cc
+++ b/output.cc
@@ -1281,6 +1281,14 @@ static void write_xml_initial_hostinfo(const Target *currenths,
       xml_close_empty_tag();
       xml_newline();
     }
+    /* Print additional names collected when --unique suppressed duplicate scanning. */
+    for (const std::string &alias : currenths->getTargetNameAliases()) {
+      xml_open_start_tag("hostname");
+      xml_attribute("name", "%s", alias.c_str());
+      xml_attribute("type", "user");
+      xml_close_empty_tag();
+      xml_newline();
+    }
     if (*currenths->HostName()) {
       xml_open_start_tag("hostname");
       xml_attribute("name", "%s", currenths->HostName());

--- a/output.cc
+++ b/output.cc
@@ -1271,7 +1271,7 @@ static void write_xml_initial_hostinfo(const Target *currenths,
   print_MAC_XML_Info(currenths);
   /* Output a hostnames element whenever we have a name to write or the target
      is up. */
-  if (currenths->TargetName() != NULL || *currenths->HostName() || strcmp(status, "up") == 0) {
+  if (currenths->TargetName() != NULL || *currenths->HostName() || strcmp(status, "up") == 0 || !currenths->getTargetNameAliases().empty()) {
     xml_start_tag("hostnames");
     xml_newline();
     if (currenths->TargetName() != NULL) {
@@ -1282,9 +1282,10 @@ static void write_xml_initial_hostinfo(const Target *currenths,
       xml_newline();
     }
     /* Print additional names collected when --unique suppressed duplicate scanning. */
-    for (const std::string &alias : currenths->getTargetNameAliases()) {
+    for (std::vector<std::string>::const_iterator alias = currenths->getTargetNameAliases().begin();
+         alias != currenths->getTargetNameAliases().end(); ++alias) {
       xml_open_start_tag("hostname");
-      xml_attribute("name", "%s", alias.c_str());
+      xml_attribute("name", "%s", alias->c_str());
       xml_attribute("type", "user");
       xml_close_empty_tag();
       xml_newline();

--- a/targets.cc
+++ b/targets.cc
@@ -473,6 +473,26 @@ bool HostGroupState::get_next_host(struct sockaddr_storage *ss, size_t *sslen, s
         return false;
       }
     }
+    /* This IP is already in the exclude list (a --unique duplicate).
+       At this point *ss holds the excluded IP. If it came from a named
+       host, attach that name as an alias on the existing Target in the
+       current batch so it appears in XML output.
+
+       Note: Nmap's streaming XML architecture finalizes and closes <host> blocks
+       after each batch. Therefore, it is impossible to attach aliases to duplicates
+       that occur in a later batch than the original target without buffering
+       all XML in memory. We restrict our search to the current batch. */
+    if (o.unique && current_group.get_namedhost() && current_group.is_resolved_address(ss)) {
+      const char *skipped_name = current_group.get_resolved_name();
+      if (skipped_name) {
+        for (int i = 0; i < current_batch_sz; i++) {
+          if (sockaddr_storage_cmp(hostbatch[i]->TargetSockAddr(), ss) == 0) {
+            hostbatch[i]->addTargetNameAlias(skipped_name);
+            break;
+          }
+        }
+      }
+    }
   } while (true);
 
   return true;

--- a/targets.cc
+++ b/targets.cc
@@ -481,6 +481,7 @@ bool HostGroupState::get_next_host(struct sockaddr_storage *ss, size_t *sslen, s
        Note: Nmap's streaming XML architecture finalizes and closes <host> blocks
        after each batch. Therefore, it is impossible to attach aliases to duplicates
        that occur in a later batch than the original target without buffering
+
        all XML in memory. We restrict our search to the current batch. */
     if (o.unique && current_group.get_namedhost() && current_group.is_resolved_address(ss)) {
       const char *skipped_name = current_group.get_resolved_name();

--- a/targets.h
+++ b/targets.h
@@ -66,6 +66,7 @@
 
 #include "TargetGroup.h"
 #include <list>
+#include <string>
 #include <nbase.h>
 class Target;
 


### PR DESCRIPTION
Fixes #3409.

### Description
When using the `--unique` flag, Nmap skips duplicate IPs to avoid redundant scanning. However, if a user provided multiple aliases for the same IP on the command line (e.g., `nmap --unique 127.0.0.1 localhost localhost1`), the aliases for the skipped IPs were silently discarded. This resulted in missing `<hostname type="user">` tags in the XML output, meaning user-supplied context was lost.

This PR addresses the root of the data flow by ensuring Nmap tracks multiple hostnames for a single `Target` and correctly attaches them when `--unique` suppresses duplicate scanning.

### Architectural Changes
1. **`Target` Class Extension**: Added a `std::vector<std::string> target_aliases` to the `Target` class (in `Target.h` and `Target.cc`), along with `addTargetNameAlias()` and `getTargetNameAliases()` helper methods.
2. **Duplicate Handling in `targets.cc`**: Inside `HostGroupState::get_next_host`, when an IP is identified as a duplicate and skipped due to `--unique`, the logic now checks if the skipped host was named. If so, it locates the existing `Target` in the current hostbatch and securely attaches the skipped name as an alias.
3. **XML Output**: Updated `write_xml_initial_hostinfo` in `output.cc` to iterate through all recorded aliases and print them as `<hostname type="user">` tags.

### Verification
**Command:**
`./nmap --unique 127.0.0.1 localhost localhost1 -p 80 -oX unique_scan.xml -Pn`

**Previous output (bug):**
```xml
<hostnames>
<hostname name="localhost" type="PTR"/>
</hostnames>
```

**New output (with fix):**
```xml
<hostnames>
<hostname name="localhost" type="user"/>
<hostname name="localhost" type="PTR"/>
</hostnames>
```
