### PR TITLE
fix http-fetch regex parsing from URLs

### DIFF
--- a/scripts/http-fetch.nse
+++ b/scripts/http-fetch.nse
@@ -73,6 +73,14 @@ local function build_path(file, url)
   return path:gsub('//', '/')
 end
 
+-- Strip the directory prefix from a file component. The directory comes
+-- from a crawled URL and may contain '%' escapes (e.g. %2f), which gsub
+-- would misread as capture backreferences ("invalid capture index"), so
+-- compare and slice as plain text instead of using it as a pattern.
+local function strip_dir(file, dir)
+  return file:sub(1, #dir) == dir and file:sub(#dir + 1) or file
+end
+
 local function create_directory(path)
   local status, err = lfs.mkdir(path)
   if status then
@@ -100,7 +108,7 @@ local function  save_file(content, file_name, destination, url)
     if url:getDir() == url:getFile() then
       file_path = file_path .. "index.html"
     else
-      file_path = file_path .. stringaux.filename_escape(url:getFile():gsub(url:getDir(),""))
+      file_path = file_path .. stringaux.filename_escape(strip_dir(url:getFile(), url:getDir()))
     end
   end
 
@@ -138,7 +146,7 @@ local function fetch_recursively(host, port, url, destination, patterns, output)
     end
     local body = r.response.body
     local url_string = tostring(r.url)
-    local file = r.url:getFile():gsub(r.url:getDir(),"")
+    local file = strip_dir(r.url:getFile(), r.url:getDir())
     if body and r.response.status == 200 and patterns then
       for _, pattern in pairs(patterns) do
         if file:find(pattern, nil, true) then


### PR DESCRIPTION
the `http-fetch` script has a bug where if the URL contains a `%<number>` its treated as a regex back-ref and crashes the script.

This PR fixes that bug.

## Testing

Use the following test script:

```python
#!/usr/bin/env python3

import argparse
import http.server
import socketserver

# index.html is fetched first (proves the mirror starts), the %-path is the
# poison, the last link proves post-poison files are lost on unfixed builds.
PAGE = b"""<html><body>
<a href="/normal/nested/file.html">safe</a>
<a href="/a%2fb/poison.html">pattern-injection</a>
</body></html>"""


class Handler(http.server.BaseHTTPRequestHandler):
    def do_GET(self):
        body = PAGE if self.path == "/" else b"content-of:" + self.path.encode()
        self.send_response(200)
        self.send_header("Content-Type",
                         "text/html" if self.path == "/" else "text/plain")
        self.send_header("Content-Length", str(len(body)))
        self.end_headers()
        self.wfile.write(body)

    def log_message(self, *a):
        pass


class Server(socketserver.ThreadingTCPServer):
    allow_reuse_address = True  # must be set before bind, i.e. as class attr
    daemon_threads = True


def main():
    ap = argparse.ArgumentParser(description="nmap http-fetch pattern-injection DoS listener")
    ap.add_argument("--bind", default="0.0.0.0")
    ap.add_argument("--port", type=int, default=8080,
                    help="shortport.http matches 8080 out of the box")
    args = ap.parse_args()

    with Server((args.bind, args.port), Handler) as srv:
        target = "127.0.0.1" if args.bind == "0.0.0.0" else args.bind
        print("[*] nmap http-fetch %%-pattern script DoS (script-level; scan survives)")
        print("[*] serving: index with /normal/... and the /a%%2fb/ poison link")
        print("[*] listening on %s:%d — run:" % (args.bind, args.port))
        print("    nmap -p %d --script http-fetch --script-args "
              "'http-fetch.destination=/tmp/mirror/' -Pn -n %s" % (args.port, target))
        srv.serve_forever()


if __name__ == "__main__":
    main()

```

### Pre

```
$ nmap -p 8080 --script http-fetch --script-args 'http-fetch.destination=/tmp/mirror/' -Pn -n 0.0.0.0 -d
Starting Nmap 7.99 ( https://nmap.org ) at 2026-08-26 13:33 -0400
Warning: File ./nmap-services exists, but Nmap is using /usr/share/nmap/nmap-services for security and consistency reasons.  set NMAPDIR=. to give priority to files in your local directory(may affect the other data files too).
--------------- Timing report ---------------
  hostgroups: min 1, max 100000
  rtt-timeouts: init 1000, min 100, max 10000
  max-scan-delay: TCP 1000, UDP 1000, SCTP 1000
  parallelism: min 0, max 0
  max-retries: 10, host-timeout: 0
  min-rate: 0, max-rate: 0
---------------------------------------------
NSE: Using Lua 5.4.
NSE: Arguments from CLI: http-fetch.destination=/tmp/mirror/
NSE: Arguments parsed: http-fetch.destination=/tmp/mirror/
NSE: Loaded 1 scripts for scanning.
NSE: Script Pre-scanning.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 13:33
Completed NSE at 13:33, 0.00s elapsed
Initiating SYN Stealth Scan at 13:33
Scanning 0.0.0.0 [1 port]
Packet capture filter (device lo): dst host 127.0.0.1 and (icmp or icmp6 or ((tcp or udp or sctp) and (src host 0.0.0.0)))
Discovered open port 8080/tcp on 0.0.0.0
Completed SYN Stealth Scan at 13:33, 0.02s elapsed (1 total ports)
Overall sending rates: 47.03 packets / s, 2069.22 bytes / s.
NSE: Script scanning 0.0.0.0.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 13:33
NSE: Starting http-fetch against 0.0.0.0:8080.
NSE: [http-fetch 0.0.0.0:8080] Processing url.......http://0.0.0.0:8080/
NSE: [http-fetch 0.0.0.0:8080] File Already Exists
NSE: http-fetch against 0.0.0.0:8080 threw an error!
/usr/share/nmap/scripts/http-fetch.nse:141: invalid capture index %2
stack traceback:
        [C]: in function 'string.gsub'
        /usr/share/nmap/scripts/http-fetch.nse:141: in upvalue 'fetch_recursively'
        /usr/share/nmap/scripts/http-fetch.nse:235: in function </usr/share/nmap/scripts/http-fetch.nse:198>
        (...tail calls...)

NSE: 2 orphans left!
Completed NSE at 13:33, 0.02s elapsed
Nmap scan report for 0.0.0.0
Host is up, received user-set (0.00017s latency).
Scanned at 2026-08-26 13:33:48 EDT for 0s

PORT     STATE SERVICE    REASON
8080/tcp open  http-proxy syn-ack ttl 64
Final times for host: srtt: 166 rttvar: 5000  to: 100000

NSE: Script Post-scanning.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 13:33
Completed NSE at 13:33, 0.00s elapsed
Read from /usr/share/nmap: nmap-protocols nmap-services.
Nmap done: 1 IP address (1 host up) scanned in 0.41 seconds
           Raw packets sent: 1 (44B) | Rcvd: 1 (44B)
```

### Post

```
$ sudo ./nmap -p 8080 --script http-fetch --script-args 'http-fetch.destination=/tmp/mirror/' -Pn -n 0.0.0.0 -d
Starting Nmap 7.991SVN ( https://nmap.org ) at 2026-08-26 13:34 -0400
--------------- Timing report ---------------
  hostgroups: min 1, max 100000
  rtt-timeouts: init 1000, min 100, max 10000
  max-scan-delay: TCP 1000, UDP 1000, SCTP 1000
  parallelism: min 0, max 0
  max-retries: 10, host-timeout: 0
  min-rate: 0, max-rate: 0
---------------------------------------------
NSE: Using Lua 5.4.
NSE: Arguments from CLI: http-fetch.destination=/tmp/mirror/
NSE: Arguments parsed: http-fetch.destination=/tmp/mirror/
NSE: Loaded 1 scripts for scanning.
NSE: Script Pre-scanning.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 13:34
Completed NSE at 13:34, 0.00s elapsed
Initiating SYN Stealth Scan at 13:34
Scanning 0.0.0.0 [1 port]
Packet capture filter (device lo): dst host 127.0.0.1 and (icmp or icmp6 or ((tcp or udp or sctp) and (src host 0.0.0.0)))
Discovered open port 8080/tcp on 0.0.0.0
Completed SYN Stealth Scan at 13:34, 0.02s elapsed (1 total ports)
Overall sending rates: 53.93 packets / s, 2372.86 bytes / s.
NSE: Script scanning 0.0.0.0.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 13:34
NSE: Starting http-fetch against 0.0.0.0:8080.
NSE: [http-fetch 0.0.0.0:8080] Processing url.......http://0.0.0.0:8080/
NSE: [http-fetch 0.0.0.0:8080] File Already Exists
NSE: [http-fetch 0.0.0.0:8080] Processing url.......http://0.0.0.0:8080/a%2Fb/poison.html
NSE: [http-fetch 0.0.0.0:8080] File Already Exists
NSE: [http-fetch 0.0.0.0:8080] Processing url.......http://0.0.0.0:8080/normal/nested/file.html
NSE: [http-fetch 0.0.0.0:8080] File Already Exists
NSE: Finished http-fetch against 0.0.0.0:8080.
Completed NSE at 13:34, 0.01s elapsed
Nmap scan report for 0.0.0.0
Host is up, received user-set (0.000099s latency).
Scanned at 2026-08-26 13:34:57 EDT for 0s

PORT     STATE SERVICE    REASON
8080/tcp open  http-proxy syn-ack ttl 64
| http-fetch: 
|   Successfully Downloaded: 
|     http://0.0.0.0:8080/ as /tmp/mirror/0.0.0.0/8080/index.html
|     http://0.0.0.0:8080/a%2Fb/poison.html as /tmp/mirror/0.0.0.0/8080/a%2Fb/poison.html
|_    http://0.0.0.0:8080/normal/nested/file.html as /tmp/mirror/0.0.0.0/8080/normal/nested/file.html
Final times for host: srtt: 99 rttvar: 5000  to: 100000

NSE: Script Post-scanning.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 13:34
Completed NSE at 13:34, 0.00s elapsed
Read from /home/h00die/nmap: nmap-protocols nmap-services.
Nmap done: 1 IP address (1 host up) scanned in 0.20 seconds
           Raw packets sent: 1 (44B) | Rcvd: 1 (44B)
```