### PR TITLE
fix http-config-backup bad ref

### DIFF
--- a/scripts/http-config-backup.nse
+++ b/scripts/http-config-backup.nse
@@ -4,6 +4,7 @@ local io = require "io"
 local shortport = require "shortport"
 local stdnse = require "stdnse"
 local string = require "string"
+local stringaux = require "stringaux"
 local table = require "table"
 local url = require "url"
 
@@ -75,7 +76,7 @@ local grep_php = make_grep("<%?php");
 local grep_cgipath = make_grep("CGIPath");
 
 local function check_htaccess(s)
-  return string.match("<Files") or string.match(s, "RewriteRule")
+  return string.match(s, "<Files") or string.match(s, "RewriteRule")
 end
 
 local CONFIGS = {
@@ -217,7 +218,7 @@ action = function (host, port)
       if response.status == 200 and http.page_exists(response, result_404, known_404, url_path) then
         -- check it if is valid before inserting
         if cfg.check(response.body) then
-          local filename = stdnse.escape_filename((host.targetname or host.ip) .. url_path)
+          local filename = stringaux.filename_escape((host.targetname or host.ip) .. url_path)
 
           -- save the content
           if save then

--- a/scripts/http-config-backup.nse
+++ b/scripts/http-config-backup.nse
@@ -230,7 +230,11 @@ action = function (host, port)
             end
           end
 
-          table.insert(backups, url_path .. " " .. response["status-line"]);
+          -- Trim the trailing CRLF: response["status-line"] keeps it, and
+          -- format_output's line splitter cannot step over the \r, so a raw
+          -- status-line renders every entry as a blank row.
+          table.insert(backups, url_path .. " "
+            .. response["status-line"]:match("^[^\r\n]+"));
         else
           stdnse.debug1("%s: found but not matching: %s",
             host.targetname or host.ip, url_path);


### PR DESCRIPTION
`http-config-backup.nse`  calls `stdnse.escape_filename`, however when that function was introduced in 2013 it was called actually `stdnse.filename_escape`.  Thus, this branch of the code never worked in the ~13 years of its life.

However that was moved to `stringaux` via `0500811f5` (2018-10-18).

This PR Fixes the function call. Once that was fixed, it exposed another bug which causes output  like this:
```
PORT     STATE SERVICE    REASON
8080/tcp open  http-proxy syn-ack ttl 64
| http-config-backup: 
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|_  
Final times for host: srtt: 137 rttvar: 5000  to: 100000
```

So now we fix up that code branch to handle everything as intended.

## Testing

Test script:

```python
#!/usr/bin/env python3

import argparse
import http.server
import socketserver

PHP_BODY = b"""<?php
// database settings
define('DB_NAME', 'demo');
define('DB_USER', 'demo');
define('DB_PASSWORD', 'hunter2');
define('DB_HOST', 'localhost');
?>

The candidate marker is any of these config names; the backup suffixes
probed include .bak, php.bak, ~, #...#, ' copy', 'Copy of ', .save,
.swp, .old
"""

CANDIDATES = ("wp-config", "config.php", "configuration.php",
              "LocalSettings.php", "settings.php", "mt-config")


class Handler(http.server.BaseHTTPRequestHandler):
    def do_GET(self):
        # Serve a qualifying PHP backup body for any config-candidate path.
        # Keep .htaccess candidates as 404 so the demo hits crash #1
        # (escape_filename) rather than crash #2 (check_htaccess) first.
        if any(c in self.path for c in CANDIDATES):
            body, code = PHP_BODY, 200
        else:
            body, code = b"not found", 404
        self.send_response(code)
        self.send_header("Content-Type", "text/plain")
        self.send_header("Content-Length", str(len(body)))
        self.end_headers()
        self.wfile.write(body)

    def log_message(self, *a):
        pass


class Server(socketserver.ThreadingTCPServer):
    allow_reuse_address = True  # must be set before bind, i.e. as class attr
    daemon_threads = True


def main():
    ap = argparse.ArgumentParser(description="nmap http-config-backup nil-call crash listener")
    ap.add_argument("--bind", default="0.0.0.0")
    ap.add_argument("--port", type=int, default=8080)
    args = ap.parse_args()

    with Server((args.bind, args.port), Handler) as srv:
        print("[*] nmap http-config-backup nil-call crash (script-level; scan survives)")
        print("[*] serving qualifying PHP backup bodies for config candidates")
        print("[*] listening on %s:%d — run:" % (args.bind, args.port))
        print("    nmap -p %d --script http-config-backup -Pn -n %s" % (args.port, args.bind))
        srv.serve_forever()


if __name__ == "__main__":
    main()

```

### Function call fixed, branch still wonky.

```
$ nmap -p 8080 --script http-config-backup -Pn -n 0.0.0.0 -d
Starting Nmap 7.99 ( https://nmap.org ) at 2026-08-26 13:45 -0400
Warning: File ./nmap-services exists, but Nmap is using /usr/share/nmap/nmap-services for security and consistency reasons.  set NMAPDIR=. to give priority to files in your local directory (may affect the other data files too).
--------------- Timing report ---------------
  hostgroups: min 1, max 100000
  rtt-timeouts: init 1000, min 100, max 10000
  max-scan-delay: TCP 1000, UDP 1000, SCTP 1000
  parallelism: min 0, max 0
  max-retries: 10, host-timeout: 0
  min-rate: 0, max-rate: 0
---------------------------------------------
NSE: Using Lua 5.4.
NSE: Arguments from CLI: 
NSE: Loaded 1 scripts for scanning.
NSE: Script Pre-scanning.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 13:45
Completed NSE at 13:45, 0.00s elapsed
Initiating SYN Stealth Scan at 13:45
Scanning 0.0.0.0 [1 port]
Packet capture filter (device lo): dst host 127.0.0.1 and (icmp or icmp6 or ((tcp or udp or sctp) and (src host 0.0.0.0)))
Discovered open port 8080/tcp on 0.0.0.0
Completed SYN Stealth Scan at 13:45, 0.03s elapsed (1 total ports)
Overall sending rates: 35.44 packets / s, 1559.18 bytes / s.
NSE: Script scanning 0.0.0.0.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 13:45
NSE: Starting http-config-backup against 0.0.0.0:8080.
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Host returns proper 404 result.
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/wp-config.bak)
NSE: http-config-backup against 0.0.0.0:8080 threw an error!
/usr/share/nmap/scripts/http-config-backup.nse:220: variable 'escape_filename' is not declared
stack traceback:
        [C]: in function 'error'
        /usr/share/nmap/nselib/strict.lua:80: in metamethod 'index'
        /usr/share/nmap/scripts/http-config-backup.nse:220: in function </usr/share/nmap/scripts/http-config-backup.nse:181>
        (...tail calls...)

Completed NSE at 13:45, 0.01s elapsed
Nmap scan report for 0.0.0.0
Host is up, received user-set (0.00013s latency).
Scanned at 2026-08-26 13:45:39 EDT for 0s

PORT     STATE SERVICE    REASON
8080/tcp open  http-proxy syn-ack ttl 64
Final times for host: srtt: 130 rttvar: 5000  to: 100000

NSE: Script Post-scanning.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 13:45
Completed NSE at 13:45, 0.00s elapsed
Read from /usr/share/nmap: nmap-protocols nmap-services.
Nmap done: 1 IP address (1 host up) scanned in 0.21 seconds
           Raw packets sent: 1 (44B) | Rcvd: 1 (44B)
```

### Post

```
$ sudo ./nmap -p 8080 --script http-config-backup -Pn -n 0.0.0.0 -d
Starting Nmap 7.991SVN ( https://nmap.org ) at 2026-08-26 13:45 -0400
--------------- Timing report ---------------
  hostgroups: min 1, max 100000
  rtt-timeouts: init 1000, min 100, max 10000
  max-scan-delay: TCP 1000, UDP 1000, SCTP 1000
  parallelism: min 0, max 0
  max-retries: 10, host-timeout: 0
  min-rate: 0, max-rate: 0
---------------------------------------------
NSE: Using Lua 5.4.
NSE: Arguments from CLI: 
NSE: Loaded 1 scripts for scanning.
NSE: Script Pre-scanning.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 13:45
Completed NSE at 13:45, 0.00s elapsed
Initiating SYN Stealth Scan at 13:45
Scanning 0.0.0.0 [1 port]
Packet capture filter (device lo): dst host 127.0.0.1 and (icmp or icmp6 or ((tcp or udp or sctp) and (src host 0.0.0.0)))
Discovered open port 8080/tcp on 0.0.0.0
Completed SYN Stealth Scan at 13:45, 0.03s elapsed (1 total ports)
Overall sending rates: 36.03 packets / s, 1585.13 bytes / s.
NSE: Script scanning 0.0.0.0.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 13:45
NSE: Starting http-config-backup against 0.0.0.0:8080.
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Host returns proper 404 result.
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/wp-config.bak)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/wp-config.php.bak)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/wp-config.php~)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/%23wp-config.php%23)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/wp-config%20copy.php)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/Copy%20of%20wp-config.php)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/wp-config.php.save)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/.wp-config.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/wp-config.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/wp-config.php.old)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/config.php.bak)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/config.php~)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/%23config.php%23)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/Copy%20of%20config.php)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/config.php.save)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/.config.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/config.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/config.php.old)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/configuration.php.bak)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/configuration.php~)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/%23configuration.php%23)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/Copy%20of%20configuration.php)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/configuration.php.save)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/.configuration.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/configuration.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/configuration.php.old)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/LocalSettings.php.bak)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/LocalSettings.php~)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/%23LocalSettings.php%23)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/Copy%20of%20LocalSettings.php)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/LocalSettings.php.save)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/.LocalSettings.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/LocalSettings.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/LocalSettings.php.old)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mediawiki/LocalSettings.php.bak)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mediawiki/LocalSettings.php~)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mediawiki/%23LocalSettings.php%23)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mediawiki/Copy%20of%20LocalSettings.php)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mediawiki/LocalSettings.php.save)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mediawiki/.LocalSettings.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mediawiki/LocalSettings.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mediawiki/LocalSettings.php.old)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-config.bak)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-config.bak
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-config.cgi.bak)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-config.cgi.bak
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-config.cgi~)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-config.cgi~
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/%23mt-config.cgi%23)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /%23mt-config.cgi%23
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-config%20copy.cgi)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-config%20copy.cgi
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/Copy%20of%20mt-config.cgi)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /Copy%20of%20mt-config.cgi
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-config.cgi.save)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-config.cgi.save
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/.mt-config.cgi.swp)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /.mt-config.cgi.swp
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-config.cgi.swp)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-config.cgi.swp
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-config.cgi.old)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-config.cgi.old
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/mt-config.bak)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/mt-config.bak
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/mt-config.cgi.bak)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/mt-config.cgi.bak
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/mt-config.cgi~)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/mt-config.cgi~
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/%23mt-config.cgi%23)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/%23mt-config.cgi%23
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/mt-config%20copy.cgi)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/mt-config%20copy.cgi
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/Copy%20of%20mt-config.cgi)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/Copy%20of%20mt-config.cgi
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/mt-config.cgi.save)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/mt-config.cgi.save
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/.mt-config.cgi.swp)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/.mt-config.cgi.swp
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/mt-config.cgi.swp)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/mt-config.cgi.swp
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/mt-config.cgi.old)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/mt-config.cgi.old
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/settings.php.bak)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/settings.php~)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/%23settings.php%23)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/Copy%20of%20settings.php)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/settings.php.save)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/.settings.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/settings.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/settings.php.old)
NSE: Finished http-config-backup against 0.0.0.0:8080.
Completed NSE at 13:45, 0.39s elapsed
Nmap scan report for 0.0.0.0
Host is up, received user-set (0.00014s latency).
Scanned at 2026-08-26 13:45:42 EDT for 1s

PORT     STATE SERVICE    REASON
8080/tcp open  http-proxy syn-ack ttl 64
| http-config-backup: 
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|   
|_  
Final times for host: srtt: 137 rttvar: 5000  to: 100000

NSE: Script Post-scanning.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 13:45
Completed NSE at 13:45, 0.00s elapsed
Read from /home/h00die/nmap: nmap-protocols nmap-services.
Nmap done: 1 IP address (1 host up) scanned in 0.75 seconds
           Raw packets sent: 1 (44B) | Rcvd: 1 (44B)
```

### Final Fix

```
$ sudo ./nmap -p 8080 --script http-config-backup -Pn -n 0.0.0.0 -d
[sudo] password for h00die: 
Starting Nmap 7.991SVN ( https://nmap.org ) at 2026-08-26 14:06 -0400
--------------- Timing report ---------------
  hostgroups: min 1, max 100000
  rtt-timeouts: init 1000, min 100, max 10000
  max-scan-delay: TCP 1000, UDP 1000, SCTP 1000
  parallelism: min 0, max 0
  max-retries: 10, host-timeout: 0
  min-rate: 0, max-rate: 0
---------------------------------------------
NSE: Using Lua 5.4.
NSE: Arguments from CLI: 
NSE: Loaded 1 scripts for scanning.
NSE: Script Pre-scanning.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 14:06
Completed NSE at 14:06, 0.00s elapsed
Initiating SYN Stealth Scan at 14:06
Scanning 0.0.0.0 [1 port]
Packet capture filter (device lo): dst host 127.0.0.1 and (icmp or icmp6 or ((tcp or udp or sctp) and (src host 0.0.0.0)))
Discovered open port 8080/tcp on 0.0.0.0
Completed SYN Stealth Scan at 14:06, 0.03s elapsed (1 total ports)
Overall sending rates: 36.03 packets / s, 1585.30 bytes / s.
NSE: Script scanning 0.0.0.0.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 14:06
NSE: Starting http-config-backup against 0.0.0.0:8080.
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Host returns proper 404 result.
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/wp-config.bak)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/wp-config.php.bak)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/wp-config.php~)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/%23wp-config.php%23)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/wp-config%20copy.php)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/Copy%20of%20wp-config.php)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/wp-config.php.save)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/.wp-config.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/wp-config.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/wp-config.php.old)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/config.php.bak)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/config.php~)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/%23config.php%23)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/Copy%20of%20config.php)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/config.php.save)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/.config.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/config.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/config.php.old)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/configuration.php.bak)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/configuration.php~)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/%23configuration.php%23)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/Copy%20of%20configuration.php)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/configuration.php.save)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/.configuration.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/configuration.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/configuration.php.old)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/LocalSettings.php.bak)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/LocalSettings.php~)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/%23LocalSettings.php%23)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/Copy%20of%20LocalSettings.php)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/LocalSettings.php.save)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/.LocalSettings.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/LocalSettings.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/LocalSettings.php.old)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mediawiki/LocalSettings.php.bak)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mediawiki/LocalSettings.php~)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mediawiki/%23LocalSettings.php%23)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mediawiki/Copy%20of%20LocalSettings.php)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mediawiki/LocalSettings.php.save)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mediawiki/.LocalSettings.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mediawiki/LocalSettings.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mediawiki/LocalSettings.php.old)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-config.bak)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-config.bak
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-config.cgi.bak)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-config.cgi.bak
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-config.cgi~)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-config.cgi~
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/%23mt-config.cgi%23)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /%23mt-config.cgi%23
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-config%20copy.cgi)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-config%20copy.cgi
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/Copy%20of%20mt-config.cgi)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /Copy%20of%20mt-config.cgi
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-config.cgi.save)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-config.cgi.save
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/.mt-config.cgi.swp)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /.mt-config.cgi.swp
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-config.cgi.swp)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-config.cgi.swp
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-config.cgi.old)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-config.cgi.old
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/mt-config.bak)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/mt-config.bak
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/mt-config.cgi.bak)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/mt-config.cgi.bak
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/mt-config.cgi~)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/mt-config.cgi~
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/%23mt-config.cgi%23)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/%23mt-config.cgi%23
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/mt-config%20copy.cgi)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/mt-config%20copy.cgi
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/Copy%20of%20mt-config.cgi)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/Copy%20of%20mt-config.cgi
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/mt-config.cgi.save)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/mt-config.cgi.save
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/.mt-config.cgi.swp)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/.mt-config.cgi.swp
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/mt-config.cgi.swp)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/mt-config.cgi.swp
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/mt-static/mt-config.cgi.old)
NSE: [http-config-backup 0.0.0.0:8080] 0.0.0.0: found but not matching: /mt-static/mt-config.cgi.old
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/settings.php.bak)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/settings.php~)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/%23settings.php%23)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/Copy%20of%20settings.php)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/settings.php.save)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/.settings.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/settings.php.swp)
NSE: [http-config-backup 0.0.0.0:8080] HTTP: Page was '200 OK', it exists! (/settings.php.old)
NSE: Finished http-config-backup against 0.0.0.0:8080.
Completed NSE at 14:06, 0.37s elapsed
Nmap scan report for 0.0.0.0
Host is up, received user-set (0.00016s latency).
Scanned at 2026-08-26 14:06:13 EDT for 1s

PORT     STATE SERVICE    REASON
8080/tcp open  http-proxy syn-ack ttl 64
| http-config-backup: 
|   /wp-config.bak HTTP/1.0 200 OK
|   /wp-config.php.bak HTTP/1.0 200 OK
|   /wp-config.php~ HTTP/1.0 200 OK
|   /%23wp-config.php%23 HTTP/1.0 200 OK
|   /wp-config%20copy.php HTTP/1.0 200 OK
|   /Copy%20of%20wp-config.php HTTP/1.0 200 OK
|   /wp-config.php.save HTTP/1.0 200 OK
|   /.wp-config.php.swp HTTP/1.0 200 OK
|   /wp-config.php.swp HTTP/1.0 200 OK
|   /wp-config.php.old HTTP/1.0 200 OK
|   /config.php.bak HTTP/1.0 200 OK
|   /config.php~ HTTP/1.0 200 OK
|   /%23config.php%23 HTTP/1.0 200 OK
|   /Copy%20of%20config.php HTTP/1.0 200 OK
|   /config.php.save HTTP/1.0 200 OK
|   /.config.php.swp HTTP/1.0 200 OK
|   /config.php.swp HTTP/1.0 200 OK
|   /config.php.old HTTP/1.0 200 OK
|   /configuration.php.bak HTTP/1.0 200 OK
|   /configuration.php~ HTTP/1.0 200 OK
|   /%23configuration.php%23 HTTP/1.0 200 OK
|   /Copy%20of%20configuration.php HTTP/1.0 200 OK
|   /configuration.php.save HTTP/1.0 200 OK
|   /.configuration.php.swp HTTP/1.0 200 OK
|   /configuration.php.swp HTTP/1.0 200 OK
|   /configuration.php.old HTTP/1.0 200 OK
|   /LocalSettings.php.bak HTTP/1.0 200 OK
|   /LocalSettings.php~ HTTP/1.0 200 OK
|   /%23LocalSettings.php%23 HTTP/1.0 200 OK
|   /Copy%20of%20LocalSettings.php HTTP/1.0 200 OK
|   /LocalSettings.php.save HTTP/1.0 200 OK
|   /.LocalSettings.php.swp HTTP/1.0 200 OK
|   /LocalSettings.php.swp HTTP/1.0 200 OK
|   /LocalSettings.php.old HTTP/1.0 200 OK
|   /mediawiki/LocalSettings.php.bak HTTP/1.0 200 OK
|   /mediawiki/LocalSettings.php~ HTTP/1.0 200 OK
|   /mediawiki/%23LocalSettings.php%23 HTTP/1.0 200 OK
|   /mediawiki/Copy%20of%20LocalSettings.php HTTP/1.0 200 OK
|   /mediawiki/LocalSettings.php.save HTTP/1.0 200 OK
|   /mediawiki/.LocalSettings.php.swp HTTP/1.0 200 OK
|   /mediawiki/LocalSettings.php.swp HTTP/1.0 200 OK
|   /mediawiki/LocalSettings.php.old HTTP/1.0 200 OK
|   /settings.php.bak HTTP/1.0 200 OK
|   /settings.php~ HTTP/1.0 200 OK
|   /%23settings.php%23 HTTP/1.0 200 OK
|   /Copy%20of%20settings.php HTTP/1.0 200 OK
|   /settings.php.save HTTP/1.0 200 OK
|   /.settings.php.swp HTTP/1.0 200 OK
|   /settings.php.swp HTTP/1.0 200 OK
|_  /settings.php.old HTTP/1.0 200 OK
Final times for host: srtt: 157 rttvar: 5000  to: 100000

NSE: Script Post-scanning.
NSE: Starting runlevel 1 (of 1) scan.
Initiating NSE at 14:06
Completed NSE at 14:06, 0.00s elapsed
Read from /home/h00die/nmap: nmap-protocols nmap-services.
Nmap done: 1 IP address (1 host up) scanned in 0.77 seconds
           Raw packets sent: 1 (44B) | Rcvd: 1 (44B)
```