### PR TITLE
Fix Plesk Onyx BIND misidentification of hardened BIND servers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 #Nmap Changelog ($Id$); -*-text-*-
 
+o [GH#3266] Fixed a nmap-service-probes match that misidentified any ISC
+  BIND server configured with version disclosure disabled as "Plesk Onyx
+  BIND". Nothing in the matched response is actually Plesk-specific and
+  it now correctly identifies the generic ISC BIND. [0xShred]
+
 o [NSE][GH#3447] IP options parsing by the packet library no longer crashes
   on incomplete options. IP header data after EOOL are no longer parsed as
   options. [nnposter]

--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -12813,7 +12813,7 @@ match domain m|^(?:..)?\0\x06\x81\x84\0\x01\0\0\0\0\0\x01\x07version\x04bind\0\0
 match domain m|^(?:..)?\0\x06\x85\x02\0\x01\0\0\0\0\0\0\x07version\x04bind\0\0\x10\0\x03| p/PowerDNS/ cpe:/a:powerdns:powerdns/
 match domain m|^(?:..)?\0\x06\x81\x05\0\x01\0\0\0\0\0\0\x07version\x04bind\0\0\x10\0\x03| p/NLnet Labs NSD/ cpe:/a:nlnetlabs:nsd/
 match domain m|^(?:..)?\0\x06\x81\x83\0\x01\0\0\0\0\0\0\x07version\x04bind\0\0\x10\0\x03| p/dnsmasq/ cpe:/a:thekelleys:dnsmasq/
-match domain m|^(?:\0=)?\0\x06\x85\0\0\x01\0\x01\0\x01\0\0\x07version\x04bind\0\0\x10\0\x03\xc0\x0c\0\x10\0\x03\0\0\0\0\0\x05\x04none\xc0\x0c\0\x02\0\x03\0\0\0\0\0\x02\xc0\x0c| p/Plesk Onyx BIND/ cpe:/a:isc:bind/ cpe:/a:parallels:plesk_onyx/
+match domain m|^(?:\0=)?\0\x06\x85\0\0\x01\0\x01\0\x01\0\0\x07version\x04bind\0\0\x10\0\x03\xc0\x0c\0\x10\0\x03\0\0\0\0\0\x05\x04none\xc0\x0c\0\x02\0\x03\0\0\0\0\0\x02\xc0\x0c| p/ISC BIND/ cpe:/a:isc:bind/
 
 # EDNS OPT records
 match domain m|^(?:\0\.)?\0\x06\x85\x80\0\x01\0\x01\0\0\0\0\x07version\x04bind\0\0\x10\0\x03\xc0\x0c\0\x01\0\x01\0\0\0\x02\0\x04\0\0\0\0$| p/pi-hole FTLDNS/ cpe:/a:pi-hole:ftldns/


### PR DESCRIPTION
nmap-service-probes matched any ISC BIND CHAOS-class version.bind
response with a hidden version ("none") as "Plesk Onyx BIND". Every
byte in that match - DNS header, echoed question, the "none" TXT
answer, the self-referential NS record - is standard BIND behavior
when version disclosure is disabled (options { version "none"; }),
a common hardening practice unrelated to Plesk.

Retarget the match's output to generic ISC BIND / cpe:/a:isc:bind/,
consistent with neighboring no-version BIND signatures.

Fixes [#3266](https://github.com/nmap/nmap/issues/3266).