### PR TITLE
ndiff: use importlib instead of the removed imp module

### DIFF
--- a/ndiff/ndifftest.py
+++ b/ndiff/ndifftest.py
@@ -12,10 +12,14 @@ xml.__path__ = [x for x in xml.__path__ if "_xmlplus" not in x]
 
 import xml.dom.minidom
 
-import imp
+import importlib.util
 dont_write_bytecode = sys.dont_write_bytecode
 sys.dont_write_bytecode = True
-ndiff = imp.load_source("ndiff", "ndiff.py")
+# imp.load_source() was removed in Python 3.12; importlib is the replacement.
+_ndiff_spec = importlib.util.spec_from_file_location("ndiff", "ndiff.py")
+ndiff = importlib.util.module_from_spec(_ndiff_spec)
+sys.modules["ndiff"] = ndiff
+_ndiff_spec.loader.exec_module(ndiff)
 for x in dir(ndiff):
     if not x.startswith("_"):
         globals()[x] = getattr(ndiff, x)


### PR DESCRIPTION
Fixes #3468.

`ndiff/ndifftest.py` does `import imp`. That module was deprecated in Python 3.4
and **removed in 3.12**, so the Ndiff test suite dies at import on any
interpreter from 3.12 onward. `ndiff.py` itself is unaffected — this is purely
the harness's module-loading shim.

`importlib.util.spec_from_file_location()` + `exec_module()` is the documented
replacement. The module is registered in `sys.modules` to preserve
`imp.load_source()`'s side effect.

### Measured, before and after, on this branch

| Interpreter | Before | After |
|---|---|---|
| 3.9.6 | `Ran 57 tests ... OK` | `Ran 57 tests ... OK` |
| 3.14.7 | `ModuleNotFoundError: No module named 'imp'` | `Ran 57 tests ... OK` |

I also confirmed 3.11.15 passes before the change, so the boundary really is
3.12, not "recent Python" generally.

### Scope

- This **restores** the 57 tests that already passed on ≤3.11. It adds no
  coverage.
- It does not affect CI: `.github/workflows/build.yml` does not run `make check`
  on any of its legs.
- It is masked whenever `configure`'s python3 lacks `setuptools`/`build`, since
  Ndiff is then skipped and `check-ndiff` is omitted from the generated `check:`
  target.

### Prior art

This looks like the remaining half of #2649, whose own CHANGELOG entry is
explicitly packaging-only ("Zenmap and Ndiff now use setuptools, not distutils
for packaging"). The Python 3 port of Ndiff (`12d41ec2cd`, "Closes #1807") also
passed over this line.

Two distributions already carry this patch downstream, which is the main argument
for fixing it upstream:

- **GNU Guix** — "gnu: nmap: Fix tests under python@3.12." (2026-02-07) makes the
  same `importlib.util` substitution.
- **BLFS** — `sed -e '/import imp/d' -e 's/^ndiff = .*$/import ndiff/' -i ndiff/ndifftest.py`

Tested on macOS 26 (arm64).
