### PR TITLE
Fix duplicate test method and invalid assertion in NmapOptionsTest

### DIFF
--- a/zenmap/zenmapCore/NmapOptions.py
+++ b/zenmap/zenmapCore/NmapOptions.py
@@ -920,9 +920,9 @@ class NmapOptionsTest(unittest.TestCase):
     def test_default_executable(self):
         """Test that there is a default executable member set."""
         ops = NmapOptions()
-        self.assertNotNull(ops.executable)
+        self.assertIsNotNone(ops.executable)
 
-    def test_default_executable(self):
+    def test_set_executable(self):
         """Test that you can set the executable."""
         ops = NmapOptions()
         ops.executable = "foo"


### PR DESCRIPTION
Fixes #3470.

### Description
`NmapOptionsTest` in `zenmap/zenmapCore/NmapOptions.py` defined `test_default_executable` twice (lines 920 and 925). In Python, the second definition silently shadows the first, so only 20 of the 21 authored test methods were ever collected by the test runner. This bug has been present since commit `ed2ba4e16808` (2011-11-16).

The dead first definition also called `self.assertNotNull()`, which does not exist in `unittest.TestCase` — it would raise `AttributeError` if it ever ran.

### Changes
1. **Renamed** the second `test_default_executable` → `test_set_executable`, matching its own docstring ("Test that you can set the executable.").
2. **Replaced** `self.assertNotNull` with the correct `self.assertIsNotNone` in the first test.

### Verification
Before fix — pytest collected **20 items** from `NmapOptionsTest`.
After fix — pytest collects **21 items**, both tests pass:
