### PR TITLE
Avoid fatal() in retransmitProbe for unsupported probe types

### DIFF
--- a/scan_engine.cc
+++ b/scan_engine.cc
@@ -2385,8 +2385,9 @@ static void retransmitProbe(UltraScanInfo *USI, HostScanStats *hss,
   } else if (probe->type == UltraProbe::UP_ND) {
     newProbe = sendNDScanProbe(USI, hss, tryno);
   } else {
-    /* TODO: Support any other probe types */
-    fatal("%s: unsupported probe type %d", __func__, probe->type);
+    error("WARNING: %s: unsupported probe type %d, skipping retransmit",
+          __func__, probe->type);
+    return;
   }
   if (newProbe)
     newProbe->prevSent = probe->sent;


### PR DESCRIPTION
Replace `fatal()` with `error()` + `return` in `retransmitProbe()`
when an unsupported probe type is encountered.

All 4 known probe types (UP_IP, UP_CONNECT, UP_ARP, UP_ND) are already
handled. The default branch was unreachable in normal operation but
would terminate the entire scan if ever reached. With this change the
scan continues gracefully after logging a warning.

## Testing
- Clean build: 0 errors, 0 warnings
- Regression: TCP connect scans produce identical output
- Forced error path: verified stderr warning appears without crash