### PR TITLE
Match all RDP_NEG_RSP flag combinations for ms-wbt-server

### DIFF
--- a/nmap-service-probes
+++ b/nmap-service-probes
@@ -13908,10 +13908,13 @@ rarity 7
 ports 3388,3389
 fallback TerminalServer
 
-# varies on flags:
-# 0x10 - Remote Credential Guard (Windows 10 1607 or later)
+# The flags byte is a bitfield over a 0x07 base, so match every
+# combination of the optional bits rather than a few observed values:
 # 0x08 - Restricted Admin mode (Windows 8.1 or later)
-match ms-wbt-server m|^\x03\0\0\x13\x0e\xd0\0\0\x124\0\x02[\x07\x0f\x1f]\x08\0\x02\0\0\0| p/Microsoft Terminal Services/ o/Windows/ cpe:/o:microsoft:windows/a
+# 0x10 - Remote Credential Guard (Windows 10 1607 or later)
+# 0x20 - observed on Windows Server 2025 / Windows 11 24H2 (build
+#        26100); not documented in MS-RDPBCGR
+match ms-wbt-server m|^\x03\0\0\x13\x0e\xd0\0\0\x124\0\x02[\x07\x0f\x17\x1f\x27\x2f\x37\x3f]\x08\0\x02\0\0\0| p/Microsoft Terminal Services/ o/Windows/ cpe:/o:microsoft:windows/a
 match ms-wbt-server m|^\x03\0\0\x0b\x06\xd0\0\0\x124\0$| p/Microsoft Terminal Services/ o/Windows XP/ cpe:/o:microsoft:windows_xp/a
 
 ##############################NEXT PROBE##############################


### PR DESCRIPTION
## Summary

`ms-wbt-server` hosts running Windows Server 2025 / Windows 11 24H2 (build 26100) are
not version-matched. They fall through to the generic softmatch and are reported as
`ms-wbt-server` with no product, instead of `Microsoft Terminal Services`.

## Cause

The `flags` field of `RDP_NEG_RSP` ([MS-RDPBCGR 2.2.1.2.1][spec]) is a bitfield: a
`0x07` base (`EXTENDED_CLIENT_DATA_SUPPORTED | DYNVC_GFX_PROTOCOL_SUPPORTED |
NEGRSP_FLAG_RESERVED`) plus any combination of the optional bits. The match line
enumerates only three values:

```
match ms-wbt-server m|^\x03\0\0\x13\x0e\xd0\0\0\x124\0\x02[\x07\x0f\x1f]\x08\0\x02\0\0\0| ...
```

Any other combination fails to match. Two are observed in the wild:

* **`0x2f`** and **`0x3f`** — Windows Server 2025 / 24H2 sets a `0x20` bit that is not
  documented in MS-RDPBCGR. Captured from several unrelated hosts, e.g. in response to
  the exact `TerminalServerCookie` probe bytes (`requestedProtocols = 0x03`):

  ```
  03 00 00 13 0e d0 00 00 12 34 00 02 2f 08 00 02 00 00 00
                                       ^^ flags = 0x2f
  ```
  `selectedProtocol` is still `2` (`PROTOCOL_HYBRID`) — only the flags byte differs
  from earlier Windows releases, which send `0x0f` or `0x1f`.

* **`0x17`** — Remote Credential Guard (`0x10`) without Restricted Admin (`0x08`).
  This combination is valid per the spec and has never been matched by any release.

The spec describes `NEGRSP_FLAG_RESERVED` as a bit the client SHOULD ignore, and
FreeRDP keeps the field opaque rather than validating it
([`nego.c`][freerdp] stores it via `FreeRDP_NegotiationFlags`), which is why other
RDP clients are unaffected.

## Fix

Enumerate all eight combinations of the three optional bits, and document the `0x20`
bit as observed-but-undocumented.

## Testing

Replayed the captured responses against a local listener, and confirmed against live
hosts on the internet:

| reply flags | before | after |
| --- | --- | --- |
| `0x0f`, `0x1f` | `Microsoft Terminal Services` | unchanged |
| `0x17` | softmatch only, no product | `Microsoft Terminal Services` |
| `0x2f`, `0x3f` (Server 2025) | softmatch only, no product | `Microsoft Terminal Services` |

Live host, Windows Server 2025, before and after (`-sV`, XML output):

```
before:  name="ms-wbt-server" method="table"  conf="3"
after:   name="ms-wbt-server" method="probed" conf="10" product="Microsoft Terminal Services"
```

No change in behaviour for hosts already matched.

[spec]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/b2975bdc-6d56-49ee-9c57-f2ff3a0b6817
[freerdp]: https://github.com/FreeRDP/FreeRDP/blob/master/libfreerdp/core/nego.c
