### PR TITLE
Do not reuse the raw scan source port for service scan connections

### DIFF
--- a/service_scan.cc
+++ b/service_scan.cc
@@ -2137,6 +2137,16 @@ static void startNextProbe(nsock_pool nsp, nsock_iod nsi, ServiceGroup *SG,
         fatal("Failed to allocate Nsock I/O descriptor in %s()", __func__);
       }
       if (0 == svc->target->SourceSockAddr(&ss, &ss_len)) {
+        /* The port in the source address belongs to the raw packet scans.
+           Reusing it for every connect() socket means a second probe to the
+           same target reuses the same 4-tuple as the first, which is still in
+           TIME_WAIT: connect() then fails with EADDRNOTAVAIL and service
+           detection for the port is aborted. Bind the source address only and
+           let the kernel pick the source port. */
+        if (ss.ss_family == AF_INET)
+          ((struct sockaddr_in *) &ss)->sin_port = 0;
+        else if (ss.ss_family == AF_INET6)
+          ((struct sockaddr_in6 *) &ss)->sin6_port = 0;
         nsock_iod_set_localaddr(svc->niod, &ss, ss_len);
       }
       if (o.ipoptionslen)


### PR DESCRIPTION
## Summary

Since eb79c42b057c7cb2654d0a86213edb3494b8d4fb ("Bind to source with -e, not only -S",
#2122), the service scan binds the source address for every probe connection, not only
when `-S` was given. In a privileged scan that source address carries the **source port**
used by the raw packet scans, so every `connect()` for a given target uses the same
source port.

A second service probe to the same host and port therefore reuses the 4-tuple of the
first while it is still in `TIME_WAIT`. `connect()` fails with `EADDRNOTAVAIL` and
service detection for the port is abandoned.

This is a third symptom of that commit, alongside #3438 / #3439 (which address the
`addrlen` passed to `bind()` on FreeBSD — a different problem in the same code).

## Reproducing

Any service whose first probe produces only a **softmatch** triggers it, because that
is what makes nmap open a second connection to look for a hard match. With
`--version-trace` against such a host:

```
[0.4130s]  mksock_bind_addr(): Binding to 10.138.33.243:33075 (IOD #1)
[6.6010s]  READ SUCCESS for EID 34 (19 bytes)
           Service scan soft match (Probe TerminalServerCookie matched with
           TerminalServer line 15182): <host>:3389 is ms-wbt-server.
[11.5060s] nsock_iod_delete (IOD #1)
[11.5070s] nsock_iod_new (IOD #2)
[11.5070s] mksock_bind_addr(): Binding to 10.138.33.243:33075 (IOD #2)   <-- same port
[11.5070s] CONNECT ERROR [Cannot assign requested address (99)] for EID 48
           Got nsock CONNECT response with status ERROR - aborting this service

3389/tcp open  ms-wbt-server?
```

The port is then reported from the port table (`method="table" conf="3"`) even though
the service replied.

Notes on scope:

* Deterministic — 2/2 runs per host across several hosts.
* Privileged scans only. The same scan with `-sT` or `--unprivileged` succeeds, because
  no source address is set and the kernel picks an ephemeral port each time.
* 7.99 is unaffected: the bind there was guarded by `if (o.spoofsource)`, so it only
  happened when the user asked for it.
* Not visible from a NAT'd container. In plain Docker on macOS the bind is always `:0`,
  with or without `-sS` or `-g`, because nmap never takes the raw scan path that resolves
  a source address for the target. The fixed port does appear in a Kubernetes pod.

## Fix

Keep binding the source address — that is the intent of eb79c42 and of `-e` — but clear
the port so the kernel assigns an ephemeral one per connection. The raw scan's source
port has no meaning for the service scan's `connect()` sockets.

## Testing

`service_scan.o` compiles clean with `-Wall`.

Two builds from one 7.991 source tree — the first unpatched, the second with only this
patch applied and an incremental rebuild — scanning a target that softmatches, from a
Kubernetes pod:

```
### unpatched ###
  mksock_bind_addr(): Binding to 10.12.113.225:56381 (IOD #1)
  Service scan soft match (Probe TerminalServerCookie matched with TerminalServer line 15182): is ms-wbt-server.
  mksock_bind_addr(): Binding to 10.12.113.225:56381 (IOD #2)

### patched ###
  mksock_bind_addr(): Binding to 10.12.113.225:0 (IOD #1)
  Service scan soft match (Probe TerminalServerCookie matched with TerminalServer line 15182): is ms-wbt-server.
  mksock_bind_addr(): Binding to 10.12.113.225:0 (IOD #2)
```

So the patch removes the reuse: the second service-scan connection no longer requests the
same local port.

What is not shown is the `EADDRNOTAVAIL` clearing. The failure is reliable against the
host it was found on, but against a listener I control the collision never fires even when
the trace matches the failing one — same fixed port on both IODs, same ~11s gap, nmap
closing first. I assume the socket is torn down without leaving a TIME_WAIT entry for that
4-tuple, but I have not confirmed it, so treat that as unexplained rather than understood.

#3487 is the related change referred to above: on `NSE_STATUS_ERROR` the connect handler
calls `end_svcprobe(PROBESTATE_INCOMPLETE, ...)`, discarding a softmatch an earlier probe
already produced, which is what turns this into a total loss of the service name rather
than a missing product string. The two are independent.
