### PR TITLE
Keep a softmatch when a later service scan connection fails

### DIFF
--- a/service_scan.cc
+++ b/service_scan.cc
@@ -2405,7 +2405,10 @@ static void servicescan_connect_handler(nsock_pool nsp, nsock_event nse, void *m
         // and move it to the finished bin.
         if (o.debugging)
           error("Got nsock CONNECT response with status %s - aborting this service", nse_status2str(status));
-        end_svcprobe(PROBESTATE_INCOMPLETE, SG, svc, nsi);
+        /* A softmatch from an earlier probe is still valid: a failure to open
+           a further connection says nothing about what already answered. */
+        end_svcprobe(svc->softMatchFound ? PROBESTATE_FINISHED_SOFTMATCHED
+                                         : PROBESTATE_INCOMPLETE, SG, svc, nsi);
         break;
 
       case NSE_STATUS_KILL:


### PR DESCRIPTION
## Summary

When a service scan connection fails or times out, the connect handler ends the probe
with `PROBESTATE_INCOMPLETE`, discarding a softmatch that an earlier probe already
produced. The port is then reported from the port table rather than as the service that
actually answered.

## Why it matters

A softmatch is information the scan already earned from a reply on the wire. Failing to
open a *further* connection says nothing about what already answered — the peer may be
rate-limiting, the port may now be filtered, or the local side may be unable to open
another socket.

Concretely, with `--version-trace` against a Windows Server 2025 host:

```
[6.6010s]  READ SUCCESS for EID 34 (19 bytes)
           Service scan soft match (Probe TerminalServerCookie matched with
           TerminalServer line 15182): <host>:3389 is ms-wbt-server.
[11.5070s] CONNECT ERROR [...] for EID 48
           Got nsock CONNECT response with status ERROR - aborting this service

3389/tcp open  ms-wbt-server?
```

nmap knew the service at 6.6s and discarded it at 11.5s. The result is
`method="table" conf="3"` — indistinguishable from a port that never replied at all,
which matters for anything consuming the XML rather than reading the terminal output.

## Fix

Keep the softmatch when one exists, exactly as the two sites that end a probe once its
probes are exhausted already do:

```c
end_svcprobe((svc->softMatchFound)? PROBESTATE_FINISHED_SOFTMATCHED
                                  : PROBESTATE_FINISHED_NOMATCH, SG, svc, NULL);
```

so this is existing behaviour applied consistently rather than a new policy.

## Scope and deliberate limits

* Applies to `NSE_STATUS_TIMEOUT`, `NSE_STATUS_ERROR` and `NSE_STATUS_PROXYERROR`.
* `NSE_STATUS_KILL` is left alone: that is the host-timeout shutdown path, where
  reporting a partial result may not be wanted.
* Hosts with no softmatch are unaffected — they still end as `PROBESTATE_INCOMPLETE`.
* `end_svcprobe()` still lets `tcpwrap_possible` override the state, so tcpwrapped
  detection is unchanged.

Compiles clean with `-Wall`.

Related: #3486 fixes one cause of such a connect failure (the service scan reusing the
raw scan source port). This change is independent of it — it limits the damage when a
later connection fails for any reason.
